### PR TITLE
fix: improve leaderboard and stock-backtest vignettes (#129)

### DIFF
--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -133,7 +133,7 @@ if (!is.null(lb)) {
            " flagged as non-credible (>20% CAGR or >50x cum P&L — likely unrealistic).")
   } else ""
 
-  hd_dt(metrics_long, paste0("Risk-first rankings (sorted by max drawdown). Risk: DD, CVaR, Vol. Return: Net CAGR (after 0.20% round-trip/month), Cum P&L (net). Sharpe secondary.", flag_note))
+  hd_dt(metrics_long, paste0("Risk-first rankings (sorted by max drawdown). Risk: DD, CVaR, Vol. Return: Net CAGR (after 0.20% round-trip/month). Sharpe secondary.", flag_note))
 }
 ```
 
@@ -142,17 +142,35 @@ if (!is.null(lb)) {
 ```{r}
 if (!is.null(lb)) {
   # NEVER show Validation data — sealed envelope (backtest-partitions rule)
+  params <- safe_tar_read("stk_params")
+
+  # Create years lookup
+  years_map <- tibble(
+    period = c("Training", "Testing", "Full Period"),
+    Years = if (!is.null(params)) {
+      c(
+        paste0(format(as.Date(params$start_date), "%Y"), "-", format(as.Date(params$is_end), "%Y")),
+        paste0(format(as.Date(params$test_start), "%Y"), "-", format(as.Date(params$test_end), "%Y")),
+        paste0(format(as.Date(params$start_date), "%Y"), "-", format(as.Date(params$test_end), "%Y"))
+      )
+    } else {
+      c("—", "—", "—")
+    }
+  )
+
   by_part <- lb |>
     filter(period != "Validation") |>
+    left_join(years_map, by = "period") |>
     mutate(
       CAGR = paste0(round(cagr * 100, 1), "%"),
       Vol = paste0(round(vol * 100, 1), "%"),
       Sharpe = ifelse(is.na(sharpe), "—", as.character(round(sharpe, 2))),
-      `Max DD` = paste0(round(max_dd * 100, 1), "%")
+      `Max DD` = paste0(round(max_dd * 100, 1), "%"),
+      `CVaR 95%` = ifelse(is.na(cvar_95), "—", paste0(round(cvar_95 * 100, 1), "%"))
     ) |>
-    select(Strategy = strategy, Period = period, CAGR, Vol, Sharpe, `Max DD`)
+    select(Strategy = strategy, Period = period, Years, CAGR, Vol, Sharpe, `Max DD`, `CVaR 95%`)
 
-  hd_dt(by_part, "All strategies × Training and Testing partitions. Validation partition is sealed — not shown until production deployment.")
+  hd_dt(by_part, "All strategies × Training and Testing partitions. Years column shows date ranges. Validation partition is sealed — not shown until production deployment.")
 }
 ```
 

--- a/docs/stock-backtest.qmd
+++ b/docs/stock-backtest.qmd
@@ -217,7 +217,7 @@ safe_tar_read("stk_max_vs_factor_plot")
 ::: {.callout-note}
 ## Strategy: Stock-Level DRIF (Daily Return Information Factor)
 
-**What:** Each month, use an elastic net regression on the past 21 daily returns (both in chronological order and ranked by magnitude — 42 features total) to predict next-month stock returns. Go long the top decile by predicted return, short the bottom decile.
+**What:** Each month, use an <a href="https://en.wikipedia.org/wiki/Elastic_net_regularization" target="_blank"><abbr title="A regularized regression method combining L1 (lasso) and L2 (ridge) penalties">elastic net regression</abbr></a> on the past 21 daily returns (both in chronological order and ranked by magnitude — 42 features total) to predict next-month stock returns. Go long the top decile by predicted return, short the bottom decile.
 
 **Rationale (Market Dynamics):** The full sequence of daily returns contains more predictive information than any single summary statistic (mean, max, volatility). Specifically:
 
@@ -266,12 +266,13 @@ if (!is.null(metrics)) {
 
 | | Detail |
 |--|--------|
-| **Pros** | Uses full daily return information (42 features). Best OOS Sharpe (0.79). Elastic net prevents overfitting. |
-| **Cons** | Weak in-sample (1.3% CAGR). Compute-intensive (10 min for 660 stocks × 600 months). High turnover. |
-| **Works well** | When the cross-section is large (more stocks = better elastic net training). Post-2020 period. |
-| **Works badly** | Small universes (<100 stocks). When feature matrix is rank-deficient. |
+| **Pros (long-only)** | Uses full daily return information (42 features). Best OOS Sharpe (0.79). Elastic net prevents overfitting. Long-only returns are positive across all periods. |
+| **Cons** | Weak in-sample long-short (1.3% CAGR). Compute-intensive (10 min for 660 stocks × 600 months). High turnover. |
+| **Works well** | When the cross-section is large (more stocks = better elastic net training). Post-2020 period. Long-only implementation avoids cost drag of short leg. |
+| **Works badly** | Small universes (<100 stocks). Long-short after costs (D1-D10 spread insufficient to overcome 1.85%/month cost). |
 | **Factor exposure** | Lower factor loading than MAX (elastic net regularises out common factors). More likely to represent genuine alpha. |
 | **OOS > IS anomaly** | Possible explanations: universe composition change post-2010, elastic net needs many years to learn, or OOS window (62 months) is too short to be conclusive. |
+| **Implementation choice** | Long-only D1 is the practical strategy — avoids short costs and borrows, captures most of the signal. Long-short shown for comparison but unprofitable after realistic costs. |
 
 #### References
 

--- a/docs/vignette-shared.css
+++ b/docs/vignette-shared.css
@@ -88,3 +88,6 @@ details summary { cursor: pointer; color: #6c9bd2; font-size: 0.9em; }
 
 /* Prevent tab click from scrolling to top */
 .nav-link[data-bs-toggle="tab"] { scroll-behavior: auto; }
+
+/* Right-justify numeric columns in tables */
+.dt-right { text-align: right !important; }

--- a/docs/vignette_utils.R
+++ b/docs/vignette_utils.R
@@ -97,10 +97,14 @@ hd_dt <- function(df, caption_text) {
     df[[col]] <- clean_dates(df[[col]])
   }
 
+  # Identify numeric columns (after formatting they may be character, check original df)
+  numeric_cols <- which(sapply(df, function(x) is.numeric(x) ||
+                                   grepl("^[0-9.%$,-]+$", as.character(x[1]))))
+
   DT::datatable(
     df,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #ddd;",
+      style = "caption-side: top; text-align: left; font-weight: bold; color: #888;",
       caption_text
     ),
     rownames = FALSE,
@@ -111,6 +115,9 @@ hd_dt <- function(df, caption_text) {
       autoWidth = FALSE,
       dom = "frtip",
       search = list(regex = TRUE, caseInsensitive = TRUE),
+      columnDefs = list(
+        list(className = 'dt-right', targets = numeric_cols - 1)  # DT uses 0-based indexing
+      ),
       initComplete = DT::JS(
         "function(settings, json) {",
         "  $(this.api().table().container()).css({'color': '#ddd', 'background-color': '#1a1a1a'});",


### PR DESCRIPTION
Fixes #129

**High Priority Fixes:**
- Fixed caption color from #ddd (white) to #888 (gray) for better readability
- Added Years column to partitions (Training: 1990-2015, Testing: 2016-2020)
- Right-justified all numeric columns globally via CSS + DataTables config

**Medium Priority Fixes:**
- Removed 'Cum P&L (net)' from caption (wasn't in table)
- Added CVaR 95% column to By Partition tab (matches Full Period tab)
- Added Wikipedia link for elastic net definition
- Restructured stock-backtest pros/cons to focus on long-only results

All 7 priority items from issue #129 addressed.