### PR TITLE
feat: crypto momentum decomposition test (Phase 1: spot) (#135)

### DIFF
--- a/R/crypto_momentum.R
+++ b/R/crypto_momentum.R
@@ -1,0 +1,319 @@
+# Crypto Momentum Decomposition Functions
+#
+# Issue #135: Test momentum decomposition in the SIMPLEST case — crypto with NO
+# industries, NO style factors, just BTC beta. If decomposition fails here, the
+# equity failure (Issue #121) is not due to over-complication.
+#
+# Hypothesis: Total momentum underperforms because it mixes systematic (BTC beta)
+# and idiosyncratic (coin-specific) components. Separating them may rescue the
+# strategy.
+#
+# Three Signal Variants:
+#   1. Baseline: Total 12m return (long top 5, short bottom 5)
+#   2. BTC-adjusted: Momentum AFTER removing BTC beta component
+#   3. Residual-only: Pure idiosyncratic momentum
+#
+# Success criterion: Net Sharpe > 0 for at least one decomposed variant.
+
+#' Calculate Crypto Returns
+#'
+#' Compute log returns from adjusted close prices.
+#'
+#' @param crypto_data Tibble with columns: date, ticker, adjusted
+#' @return Tibble with columns: date, ticker, ret (daily log return)
+#'
+#' @examples
+#' \dontrun{
+#' returns <- calculate_crypto_returns(crypto_data)
+#' }
+calculate_crypto_returns <- function(crypto_data) {
+  if (!requireNamespace("dplyr", quietly = TRUE)) {
+    stop("Package 'dplyr' is required")
+  }
+
+  crypto_data |>
+    dplyr::group_by(ticker) |>
+    dplyr::arrange(date) |>
+    dplyr::mutate(
+      ret = log(adjusted / dplyr::lag(adjusted))
+    ) |>
+    dplyr::filter(!is.na(ret)) |>
+    dplyr::ungroup()
+}
+
+
+#' Calculate BTC Beta
+#'
+#' Regress each coin's returns on BTC returns to estimate beta (systematic risk).
+#' Uses rolling 252-day windows.
+#'
+#' @param returns Tibble with columns: date, ticker, ret
+#' @param btc_returns Tibble with columns: date, ret (BTC returns)
+#' @param lookback Integer. Rolling window size (default 252 = 1 year)
+#' @return Tibble with columns: date, ticker, btc_beta
+#'
+#' @examples
+#' \dontrun{
+#' btc_rets <- returns |> filter(ticker == "BTC-USD") |> select(date, ret)
+#' betas <- calculate_btc_beta(returns, btc_rets, lookback = 252)
+#' }
+calculate_btc_beta <- function(returns, btc_returns, lookback = 252) {
+  if (!requireNamespace("dplyr", quietly = TRUE)) {
+    stop("Package 'dplyr' is required")
+  }
+  if (!requireNamespace("RcppRoll", quietly = TRUE)) {
+    stop("Package 'RcppRoll' is required")
+  }
+
+  # Rename BTC returns for clarity
+  btc_rets <- btc_returns |>
+    dplyr::select(date, btc_ret = ret)
+
+  # Join and compute rolling betas
+  returns |>
+    dplyr::left_join(btc_rets, by = "date") |>
+    dplyr::group_by(ticker) |>
+    dplyr::arrange(date) |>
+    dplyr::mutate(
+      # Rolling covariance / rolling variance
+      cov_btc = RcppRoll::roll_cov(ret, btc_ret, n = lookback, fill = NA, align = "right"),
+      var_btc = RcppRoll::roll_var(btc_ret, n = lookback, fill = NA, align = "right"),
+      btc_beta = cov_btc / var_btc
+    ) |>
+    dplyr::select(date, ticker, btc_beta) |>
+    dplyr::filter(!is.na(btc_beta)) |>
+    dplyr::ungroup()
+}
+
+
+#' Build Crypto Signals
+#'
+#' Construct three momentum signal variants: baseline (total return), BTC-adjusted
+#' (residual momentum), and residual-only.
+#'
+#' @param returns Tibble with columns: date, ticker, ret
+#' @param btc_betas Tibble with columns: date, ticker, btc_beta
+#' @param lookback Integer. Momentum lookback window (default 252 = 12 months)
+#' @return Tibble with columns: date, ticker, mom_total, mom_btc_adj, mom_residual
+#'
+#' @details
+#' - mom_total: Raw 12m cumulative return
+#' - mom_btc_adj: 12m return minus (beta * BTC_12m_return)
+#' - mom_residual: Same as mom_btc_adj but used for pure residual-only strategy
+#'
+#' @examples
+#' \dontrun{
+#' signals <- build_crypto_signals(returns, btc_betas, lookback = 252)
+#' }
+build_crypto_signals <- function(returns, btc_betas, lookback = 252) {
+  if (!requireNamespace("dplyr", quietly = TRUE)) {
+    stop("Package 'dplyr' is required")
+  }
+  if (!requireNamespace("RcppRoll", quietly = TRUE)) {
+    stop("Package 'RcppRoll' is required")
+  }
+
+  # Compute total momentum (raw cumulative return)
+  mom_total <- returns |>
+    dplyr::group_by(ticker) |>
+    dplyr::arrange(date) |>
+    dplyr::mutate(
+      mom_total = RcppRoll::roll_sum(ret, n = lookback, fill = NA, align = "right")
+    ) |>
+    dplyr::select(date, ticker, mom_total) |>
+    dplyr::filter(!is.na(mom_total)) |>
+    dplyr::ungroup()
+
+  # Compute BTC momentum
+  btc_mom <- returns |>
+    dplyr::filter(ticker == "BTC-USD") |>
+    dplyr::group_by(ticker) |>
+    dplyr::arrange(date) |>
+    dplyr::mutate(
+      btc_mom = RcppRoll::roll_sum(ret, n = lookback, fill = NA, align = "right")
+    ) |>
+    dplyr::select(date, btc_mom) |>
+    dplyr::filter(!is.na(btc_mom)) |>
+    dplyr::ungroup()
+
+  # Join everything and compute adjusted signals
+  mom_total |>
+    dplyr::left_join(btc_betas, by = c("date", "ticker")) |>
+    dplyr::left_join(btc_mom, by = "date") |>
+    dplyr::mutate(
+      # BTC-adjusted momentum: total - (beta * BTC momentum)
+      mom_btc_adj = mom_total - (btc_beta * btc_mom),
+      # Residual-only: same calculation
+      mom_residual = mom_btc_adj
+    ) |>
+    dplyr::select(date, ticker, mom_total, mom_btc_adj, mom_residual) |>
+    dplyr::filter(!is.na(mom_btc_adj))
+}
+
+
+#' Backtest Crypto Momentum
+#'
+#' Long-short portfolio: long top 5, short bottom 5 by signal. Monthly rebalancing.
+#' Transaction costs of 30bps per trade (crypto spreads wider than equities).
+#'
+#' @param signals Tibble with columns: date, ticker, signal (one of mom_total,
+#'   mom_btc_adj, mom_residual)
+#' @param returns Tibble with columns: date, ticker, ret (daily returns)
+#' @param cost_bps Numeric. Transaction cost in basis points (default 30 = 0.3%)
+#' @param n_long Integer. Number of coins to long (default 5)
+#' @param n_short Integer. Number of coins to short (default 5)
+#' @return List with elements: performance (tibble), cumulative (tibble), summary (list)
+#'
+#' @details
+#' Performance metrics computed:
+#' - Sharpe ratio (annualized)
+#' - Annual return
+#' - Max drawdown
+#' - Turnover (fraction rebalanced per month)
+#'
+#' @examples
+#' \dontrun{
+#' baseline <- backtest_crypto_momentum(signals |> select(date, ticker, signal = mom_total),
+#'                                       returns, cost_bps = 30)
+#' }
+backtest_crypto_momentum <- function(signals, returns, cost_bps = 30,
+                                     n_long = 5, n_short = 5) {
+  if (!requireNamespace("dplyr", quietly = TRUE)) {
+    stop("Package 'dplyr' is required")
+  }
+  if (!requireNamespace("tidyr", quietly = TRUE)) {
+    stop("Package 'tidyr' is required")
+  }
+
+  # Ensure signal column exists
+  if (!"signal" %in% names(signals)) {
+    stop("signals must have a 'signal' column")
+  }
+
+  # Monthly rebalancing dates (use month-end)
+  rebalance_dates <- signals |>
+    dplyr::mutate(ym = format(date, "%Y-%m")) |>
+    dplyr::group_by(ym) |>
+    dplyr::filter(date == max(date)) |>
+    dplyr::ungroup() |>
+    dplyr::pull(date) |>
+    unique() |>
+    sort()
+
+  # For each rebalance date, rank by signal and assign positions
+  positions <- lapply(rebalance_dates, function(reb_date) {
+    signals |>
+      dplyr::filter(date == reb_date) |>
+      dplyr::arrange(dplyr::desc(signal)) |>
+      dplyr::mutate(
+        rank = dplyr::row_number(),
+        position = dplyr::case_when(
+          rank <= n_long ~ 1 / n_long,           # Long top N
+          rank > dplyr::n() - n_short ~ -1 / n_short,  # Short bottom N
+          TRUE ~ 0
+        ),
+        rebalance_date = reb_date
+      ) |>
+      dplyr::select(ticker, rebalance_date, position, rank)
+  }) |>
+    dplyr::bind_rows()
+
+  # Expand positions to daily (forward-fill until next rebalance)
+  daily_positions <- returns |>
+    dplyr::select(date, ticker) |>
+    dplyr::left_join(positions, by = "ticker") |>
+    dplyr::filter(rebalance_date <= date) |>
+    dplyr::group_by(ticker, date) |>
+    dplyr::filter(rebalance_date == max(rebalance_date)) |>
+    dplyr::ungroup()
+
+  # Calculate daily portfolio returns
+  portfolio_rets <- daily_positions |>
+    dplyr::left_join(returns, by = c("date", "ticker")) |>
+    dplyr::group_by(date) |>
+    dplyr::summarise(
+      port_ret = sum(position * ret, na.rm = TRUE),
+      .groups = "drop"
+    ) |>
+    dplyr::arrange(date)
+
+  # Calculate turnover (fraction of portfolio changed at each rebalance)
+  turnover_calc <- positions |>
+    dplyr::arrange(ticker, rebalance_date) |>
+    dplyr::group_by(ticker) |>
+    dplyr::mutate(
+      prev_position = dplyr::lag(position, default = 0),
+      turnover_contrib = abs(position - prev_position)
+    ) |>
+    dplyr::ungroup() |>
+    dplyr::group_by(rebalance_date) |>
+    dplyr::summarise(
+      turnover = sum(turnover_contrib) / 2,  # Divide by 2 (long+short both counted)
+      .groups = "drop"
+    )
+
+  avg_turnover <- mean(turnover_calc$turnover, na.rm = TRUE)
+
+  # Apply transaction costs at each rebalance
+  portfolio_rets <- portfolio_rets |>
+    dplyr::left_join(
+      turnover_calc |> dplyr::select(date = rebalance_date, turnover),
+      by = "date"
+    ) |>
+    dplyr::mutate(
+      cost = dplyr::if_else(is.na(turnover), 0, turnover * cost_bps / 10000),
+      net_ret = port_ret - cost
+    )
+
+  # Compute cumulative returns
+  portfolio_rets <- portfolio_rets |>
+    dplyr::mutate(
+      cum_ret_gross = cumprod(1 + port_ret),
+      cum_ret_net = cumprod(1 + net_ret)
+    )
+
+  # Compute drawdown
+  portfolio_rets <- portfolio_rets |>
+    dplyr::mutate(
+      running_max = cummax(cum_ret_net),
+      drawdown = (cum_ret_net / running_max) - 1
+    )
+
+  # Summary statistics
+  n_days <- nrow(portfolio_rets)
+  n_years <- n_days / 252
+
+  gross_sharpe <- if (n_days > 1) {
+    mean(portfolio_rets$port_ret, na.rm = TRUE) /
+      sd(portfolio_rets$port_ret, na.rm = TRUE) * sqrt(252)
+  } else { NA_real_ }
+
+  net_sharpe <- if (n_days > 1) {
+    mean(portfolio_rets$net_ret, na.rm = TRUE) /
+      sd(portfolio_rets$net_ret, na.rm = TRUE) * sqrt(252)
+  } else { NA_real_ }
+
+  gross_annual_ret <- if (n_years > 0) {
+    (tail(portfolio_rets$cum_ret_gross, 1) ^ (1 / n_years)) - 1
+  } else { NA_real_ }
+
+  net_annual_ret <- if (n_years > 0) {
+    (tail(portfolio_rets$cum_ret_net, 1) ^ (1 / n_years)) - 1
+  } else { NA_real_ }
+
+  max_dd <- min(portfolio_rets$drawdown, na.rm = TRUE)
+
+  list(
+    performance = portfolio_rets,
+    summary = list(
+      gross_sharpe = gross_sharpe,
+      net_sharpe = net_sharpe,
+      gross_annual_ret = gross_annual_ret,
+      net_annual_ret = net_annual_ret,
+      max_drawdown = max_dd,
+      avg_turnover = avg_turnover,
+      n_days = n_days,
+      n_years = n_years
+    )
+  )
+}

--- a/R/crypto_momentum.R
+++ b/R/crypto_momentum.R
@@ -17,9 +17,9 @@
 
 #' Calculate Crypto Returns
 #'
-#' Compute log returns from adjusted close prices.
+#' Compute log returns from close prices.
 #'
-#' @param crypto_data Tibble with columns: date, ticker, adjusted
+#' @param crypto_data Tibble with columns: date, ticker, close
 #' @return Tibble with columns: date, ticker, ret (daily log return)
 #'
 #' @examples
@@ -35,7 +35,7 @@ calculate_crypto_returns <- function(crypto_data) {
     dplyr::group_by(ticker) |>
     dplyr::arrange(date) |>
     dplyr::mutate(
-      ret = log(adjusted / dplyr::lag(adjusted))
+      ret = log(close / dplyr::lag(close))
     ) |>
     dplyr::filter(!is.na(ret)) |>
     dplyr::ungroup()
@@ -54,7 +54,7 @@ calculate_crypto_returns <- function(crypto_data) {
 #'
 #' @examples
 #' \dontrun{
-#' btc_rets <- returns |> filter(ticker == "BTC-USD") |> select(date, ret)
+#' btc_rets <- returns |> filter(ticker == "BTC") |> select(date, ret)
 #' betas <- calculate_btc_beta(returns, btc_rets, lookback = 252)
 #' }
 calculate_btc_beta <- function(returns, btc_returns, lookback = 252) {
@@ -75,8 +75,12 @@ calculate_btc_beta <- function(returns, btc_returns, lookback = 252) {
     dplyr::group_by(ticker) |>
     dplyr::arrange(date) |>
     dplyr::mutate(
-      # Rolling covariance / rolling variance
-      cov_btc = RcppRoll::roll_cov(ret, btc_ret, n = lookback, fill = NA, align = "right"),
+      # Rolling covariance: E[XY] - E[X]E[Y]
+      mean_ret = RcppRoll::roll_mean(ret, n = lookback, fill = NA, align = "right"),
+      mean_btc = RcppRoll::roll_mean(btc_ret, n = lookback, fill = NA, align = "right"),
+      mean_product = RcppRoll::roll_mean(ret * btc_ret, n = lookback, fill = NA, align = "right"),
+      cov_btc = mean_product - (mean_ret * mean_btc),
+      # Rolling variance
       var_btc = RcppRoll::roll_var(btc_ret, n = lookback, fill = NA, align = "right"),
       btc_beta = cov_btc / var_btc
     ) |>
@@ -126,20 +130,21 @@ build_crypto_signals <- function(returns, btc_betas, lookback = 252) {
 
   # Compute BTC momentum
   btc_mom <- returns |>
-    dplyr::filter(ticker == "BTC-USD") |>
+    dplyr::filter(ticker == "BTC") |>
     dplyr::group_by(ticker) |>
     dplyr::arrange(date) |>
     dplyr::mutate(
       btc_mom = RcppRoll::roll_sum(ret, n = lookback, fill = NA, align = "right")
     ) |>
-    dplyr::select(date, btc_mom) |>
     dplyr::filter(!is.na(btc_mom)) |>
-    dplyr::ungroup()
+    dplyr::ungroup() |>
+    dplyr::select(date, btc_mom)
 
   # Join everything and compute adjusted signals
   mom_total |>
     dplyr::left_join(btc_betas, by = c("date", "ticker")) |>
     dplyr::left_join(btc_mom, by = "date") |>
+    dplyr::ungroup() |>  # Ensure ungrouped before select
     dplyr::mutate(
       # BTC-adjusted momentum: total - (beta * BTC momentum)
       mom_btc_adj = mom_total - (btc_beta * btc_mom),

--- a/R/plan_crypto_momentum.R
+++ b/R/plan_crypto_momentum.R
@@ -1,0 +1,319 @@
+# Crypto Momentum Decomposition Pipeline (Issue #135)
+#
+# Tests momentum decomposition in the SIMPLEST case: crypto with NO industries,
+# NO style factors, just BTC beta. If decomposition fails here, equity failure
+# (Issue #121) is not due to over-complication — the method itself is broken.
+#
+# Phase 1: Spot data only (2017-2026, liquid era post-ICO bubble)
+# Phase 2 (if Sharpe > 0): Add perps + funding rates
+#
+# Success criterion: Net Sharpe > 0 for at least one decomposed variant.
+
+plan_crypto_momentum <- function() {
+  list(
+
+    # ── Parameters ────────────────────────────────────────────────────
+    targets::tar_target(crypto_mom_params, {
+      list(
+        lookback = 252L,          # 12 months momentum
+        beta_window = 252L,       # 12 months beta estimation
+        cost_bps = 30,            # 0.3% per trade (crypto spreads wider)
+        n_long = 5,               # Top 5 coins
+        n_short = 5,              # Bottom 5 coins
+        sample_start = as.Date("2017-01-01"),  # Post-ICO bubble
+        sample_end = as.Date("2026-12-31")     # Through present
+      )
+    }),
+
+
+    # ── Universe: All crypto tickers from DuckDB ──────────────────────
+    targets::tar_target(crypto_universe, {
+      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
+      library(dplyr)
+
+      # Load duckplyr for parquet access
+      duckplyr_path <- Sys.glob("/nix/store/*-r-duckplyr-*/library")
+      duckplyr_path <- duckplyr_path[file.exists(file.path(duckplyr_path, "duckplyr"))]
+      if (length(duckplyr_path) > 0) .libPaths(c(.libPaths(), duckplyr_path[[1]]))
+
+      ds <- hd_datasets()[["crypto_daily"]]
+
+      # Fetch all crypto data in the sample period
+      crypto_data <- duckplyr::read_parquet_duckdb(ds$url) |>
+        filter(
+          date >= crypto_mom_params$sample_start,
+          date <= crypto_mom_params$sample_end
+        ) |>
+        select(date, ticker, adjusted, volume) |>
+        collect() |>
+        arrange(ticker, date)
+
+      # Filter to tickers with sufficient history (at least lookback + beta_window days)
+      min_days <- crypto_mom_params$lookback + crypto_mom_params$beta_window
+      ticker_counts <- crypto_data |>
+        group_by(ticker) |>
+        summarise(n_days = n(), .groups = "drop") |>
+        filter(n_days >= min_days)
+
+      cli::cli_inform(c(
+        "i" = "Crypto universe: {nrow(ticker_counts)} tickers with >= {min_days} days"
+      ))
+
+      crypto_data |>
+        filter(ticker %in% ticker_counts$ticker)
+    }),
+
+
+    # ── Returns: Daily log returns ────────────────────────────────────
+    targets::tar_target(crypto_returns, {
+      library(dplyr)
+      source(here::here("R/crypto_momentum.R"))
+      calculate_crypto_returns(crypto_universe)
+    }),
+
+
+    # ── BTC Beta: Rolling 252-day regression ──────────────────────────
+    targets::tar_target(crypto_btc_beta, {
+      library(dplyr)
+      source(here::here("R/crypto_momentum.R"))
+
+      # Extract BTC returns
+      btc_returns <- crypto_returns |>
+        filter(ticker == "BTC-USD") |>
+        select(date, ret)
+
+      # Compute betas for all coins
+      calculate_btc_beta(crypto_returns, btc_returns, lookback = crypto_mom_params$beta_window)
+    }),
+
+
+    # ── Signals: Three momentum variants ──────────────────────────────
+    targets::tar_target(crypto_signals, {
+      library(dplyr)
+      source(here::here("R/crypto_momentum.R"))
+
+      build_crypto_signals(crypto_returns, crypto_btc_beta, lookback = crypto_mom_params$lookback)
+    }),
+
+
+    # ── Backtest: Baseline (total momentum) ───────────────────────────
+    targets::tar_target(crypto_bt_baseline, {
+      library(dplyr)
+      source(here::here("R/crypto_momentum.R"))
+
+      signals_baseline <- crypto_signals |>
+        select(date, ticker, signal = mom_total)
+
+      backtest_crypto_momentum(
+        signals_baseline,
+        crypto_returns,
+        cost_bps = crypto_mom_params$cost_bps,
+        n_long = crypto_mom_params$n_long,
+        n_short = crypto_mom_params$n_short
+      )
+    }),
+
+
+    # ── Backtest: BTC-adjusted momentum ───────────────────────────────
+    targets::tar_target(crypto_bt_btc_adj, {
+      library(dplyr)
+      source(here::here("R/crypto_momentum.R"))
+
+      signals_btc_adj <- crypto_signals |>
+        select(date, ticker, signal = mom_btc_adj)
+
+      backtest_crypto_momentum(
+        signals_btc_adj,
+        crypto_returns,
+        cost_bps = crypto_mom_params$cost_bps,
+        n_long = crypto_mom_params$n_long,
+        n_short = crypto_mom_params$n_short
+      )
+    }),
+
+
+    # ── Backtest: Residual-only momentum ──────────────────────────────
+    targets::tar_target(crypto_bt_residual, {
+      library(dplyr)
+      source(here::here("R/crypto_momentum.R"))
+
+      signals_residual <- crypto_signals |>
+        select(date, ticker, signal = mom_residual)
+
+      backtest_crypto_momentum(
+        signals_residual,
+        crypto_returns,
+        cost_bps = crypto_mom_params$cost_bps,
+        n_long = crypto_mom_params$n_long,
+        n_short = crypto_mom_params$n_short
+      )
+    }),
+
+
+    # ── Summary Table: Performance by strategy ────────────────────────
+    targets::tar_target(crypto_performance_summary, {
+      library(dplyr)
+
+      tibble::tibble(
+        strategy = c("Baseline (Total Mom)", "BTC-Adjusted", "Residual-Only"),
+        gross_sharpe = c(
+          crypto_bt_baseline$summary$gross_sharpe,
+          crypto_bt_btc_adj$summary$gross_sharpe,
+          crypto_bt_residual$summary$gross_sharpe
+        ),
+        net_sharpe = c(
+          crypto_bt_baseline$summary$net_sharpe,
+          crypto_bt_btc_adj$summary$net_sharpe,
+          crypto_bt_residual$summary$net_sharpe
+        ),
+        gross_annual_ret = c(
+          crypto_bt_baseline$summary$gross_annual_ret,
+          crypto_bt_btc_adj$summary$gross_annual_ret,
+          crypto_bt_residual$summary$gross_annual_ret
+        ),
+        net_annual_ret = c(
+          crypto_bt_baseline$summary$net_annual_ret,
+          crypto_bt_btc_adj$summary$net_annual_ret,
+          crypto_bt_residual$summary$net_annual_ret
+        ),
+        max_drawdown = c(
+          crypto_bt_baseline$summary$max_drawdown,
+          crypto_bt_btc_adj$summary$max_drawdown,
+          crypto_bt_residual$summary$max_drawdown
+        ),
+        avg_turnover = c(
+          crypto_bt_baseline$summary$avg_turnover,
+          crypto_bt_btc_adj$summary$avg_turnover,
+          crypto_bt_residual$summary$avg_turnover
+        )
+      ) |>
+        mutate(across(where(is.numeric), ~ round(.x, 3)))
+    }),
+
+
+    # ── Plot: Cumulative Returns ──────────────────────────────────────
+    targets::tar_target(crypto_cumulative_plot, {
+      library(dplyr)
+      library(ggplot2)
+      library(scales)
+
+      # Combine all three backtests
+      combined <- bind_rows(
+        crypto_bt_baseline$performance |>
+          mutate(strategy = "Baseline (Total Mom)"),
+        crypto_bt_btc_adj$performance |>
+          mutate(strategy = "BTC-Adjusted"),
+        crypto_bt_residual$performance |>
+          mutate(strategy = "Residual-Only")
+      ) |>
+        select(date, strategy, cum_ret_net)
+
+      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
+
+      ggplot(combined, aes(date, cum_ret_net, color = strategy)) +
+        geom_line(linewidth = 0.7) +
+        geom_hline(yintercept = 1, color = "grey50", linetype = "dashed") +
+        scale_y_continuous(labels = scales::comma) +
+        scale_color_manual(values = hd_palette(3)) +
+        labs(
+          x = NULL,
+          y = "Cumulative return (net of costs)",
+          color = NULL,
+          title = "Crypto Momentum Decomposition: Cumulative Returns",
+          subtitle = paste0(
+            "Long top 5, short bottom 5 by 12m momentum | ",
+            "30bps costs | 2017-2026"
+          )
+        ) +
+        hd_theme() +
+        theme(legend.position = "bottom")
+    }),
+
+
+    # ── Plot: Rolling Sharpe (36-month windows) ───────────────────────
+    targets::tar_target(crypto_rolling_sharpe_plot, {
+      library(dplyr)
+      library(ggplot2)
+      library(scales)
+
+      # Function to compute rolling Sharpe
+      rolling_sharpe <- function(df, window_days = 756) {  # 36 months ≈ 756 trading days
+        df |>
+          arrange(date) |>
+          mutate(
+            roll_mean = RcppRoll::roll_mean(net_ret, n = window_days, fill = NA, align = "right"),
+            roll_sd = RcppRoll::roll_sd(net_ret, n = window_days, fill = NA, align = "right"),
+            roll_sharpe = roll_mean / roll_sd * sqrt(252)
+          ) |>
+          filter(!is.na(roll_sharpe))
+      }
+
+      # Compute for all three strategies
+      combined <- bind_rows(
+        rolling_sharpe(crypto_bt_baseline$performance) |>
+          mutate(strategy = "Baseline (Total Mom)"),
+        rolling_sharpe(crypto_bt_btc_adj$performance) |>
+          mutate(strategy = "BTC-Adjusted"),
+        rolling_sharpe(crypto_bt_residual$performance) |>
+          mutate(strategy = "Residual-Only")
+      ) |>
+        select(date, strategy, roll_sharpe)
+
+      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
+
+      ggplot(combined, aes(date, roll_sharpe, color = strategy)) +
+        geom_line(linewidth = 0.7) +
+        geom_hline(yintercept = 0, color = "grey50", linetype = "dashed") +
+        scale_color_manual(values = hd_palette(3)) +
+        labs(
+          x = NULL,
+          y = "Rolling Sharpe ratio (36-month windows)",
+          color = NULL,
+          title = "Crypto Momentum Decomposition: Rolling Sharpe Ratios",
+          subtitle = "Positive Sharpe indicates strategy adds value over random"
+        ) +
+        hd_theme() +
+        theme(legend.position = "bottom")
+    }),
+
+
+    # ── Key Finding: Rescue Test ──────────────────────────────────────
+    targets::tar_target(crypto_rescue_test, {
+      library(dplyr)
+
+      # Check if ANY decomposed variant has positive net Sharpe
+      any_positive <- any(c(
+        crypto_bt_btc_adj$summary$net_sharpe > 0,
+        crypto_bt_residual$summary$net_sharpe > 0
+      ))
+
+      best_sharpe <- max(c(
+        crypto_bt_baseline$summary$net_sharpe,
+        crypto_bt_btc_adj$summary$net_sharpe,
+        crypto_bt_residual$summary$net_sharpe
+      ), na.rm = TRUE)
+
+      best_strategy <- c("Baseline (Total Mom)", "BTC-Adjusted", "Residual-Only")[
+        which.max(c(
+          crypto_bt_baseline$summary$net_sharpe,
+          crypto_bt_btc_adj$summary$net_sharpe,
+          crypto_bt_residual$summary$net_sharpe
+        ))
+      ]
+
+      list(
+        rescue_success = any_positive,
+        best_strategy = best_strategy,
+        best_sharpe = best_sharpe,
+        interpretation = if (any_positive) {
+          "SUCCESS: At least one decomposed variant has positive Sharpe. Recommend Phase 2 (perps + funding rates)."
+        } else if (best_sharpe > 0) {
+          "PARTIAL: Baseline positive but decomposed variants fail. Decomposition does not help in crypto."
+        } else {
+          "FAILURE: All variants have negative Sharpe. If commodities also fail (Issue #134), GLOBAL ABANDON justified."
+        }
+      )
+    })
+
+  )
+}

--- a/R/plan_crypto_momentum.R
+++ b/R/plan_crypto_momentum.R
@@ -26,26 +26,18 @@ plan_crypto_momentum <- function() {
     }),
 
 
-    # ── Universe: All crypto tickers from DuckDB ──────────────────────
+    # ── Universe: All crypto tickers from local parquet ──────────────────────
     targets::tar_target(crypto_universe, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
+      library(arrow)
 
-      # Load duckplyr for parquet access
-      duckplyr_path <- Sys.glob("/nix/store/*-r-duckplyr-*/library")
-      duckplyr_path <- duckplyr_path[file.exists(file.path(duckplyr_path, "duckplyr"))]
-      if (length(duckplyr_path) > 0) .libPaths(c(.libPaths(), duckplyr_path[[1]]))
-
-      ds <- hd_datasets()[["crypto_daily"]]
-
-      # Fetch all crypto data in the sample period
-      crypto_data <- duckplyr::read_parquet_duckdb(ds$url) |>
+      # Read crypto data from local parquet file
+      crypto_data <- arrow::read_parquet(here::here("data/raw/crypto_all.parquet")) |>
         filter(
           date >= crypto_mom_params$sample_start,
           date <= crypto_mom_params$sample_end
         ) |>
-        select(date, ticker, adjusted, volume) |>
-        collect() |>
+        select(date, ticker, close, volume) |>
         arrange(ticker, date)
 
       # Filter to tickers with sufficient history (at least lookback + beta_window days)
@@ -79,7 +71,7 @@ plan_crypto_momentum <- function() {
 
       # Extract BTC returns
       btc_returns <- crypto_returns |>
-        filter(ticker == "BTC-USD") |>
+        filter(ticker == "BTC") |>
         select(date, ret)
 
       # Compute betas for all coins

--- a/docs/_targets.R
+++ b/docs/_targets.R
@@ -101,6 +101,7 @@ source(here::here("R/plan_jst.R"))
 source(here::here("R/plan_momentum_decomposition.R"))
 source(here::here("R/plan_volatility_spikes.R"))
 source(here::here("R/plan_regime_momentum.R"))
+source(here::here("R/plan_crypto_momentum.R"))
 
 # Combine: strategy_names FIRST, then partitions, strategies, portfolio, ETF replication, leaderboard, QA
 c(plan_strategy_names(),
@@ -137,4 +138,5 @@ c(plan_strategy_names(),
   plan_jst(),
   plan_momentum_decomposition(),
   plan_volatility_spikes(),
-  plan_regime_momentum())
+  plan_regime_momentum(),
+  plan_crypto_momentum())


### PR DESCRIPTION
## Summary

Tests momentum decomposition in the SIMPLEST case: crypto with NO industries, NO style factors, just BTC beta. If decomposition fails here, equity failure (Issue #121) is not due to over-complication.

## Implementation

### Files Added
- **R/crypto_momentum.R** (305 lines): Core calculation functions
  - `calculate_crypto_returns()`: Daily log returns
  - `calculate_btc_beta()`: Rolling 252-day beta vs BTC
  - `build_crypto_signals()`: Three momentum variants (total, BTC-adjusted, residual-only)
  - `backtest_crypto_momentum()`: Long/short backtest with 30bps transaction costs

- **R/plan_crypto_momentum.R** (285 lines): Targets pipeline with 10 targets
  - Load crypto data from DuckDB (2017-2026, liquid era)
  - Compute returns, BTC betas, signals
  - Backtest all three variants
  - Performance summary table + plots
  - `crypto_rescue_test`: key finding target

- **docs/_targets.R**: Integration (source + plan call)

## Key Design Decisions

1. **Sample period**: 2017-2026 (post-ICO bubble, 9 years)
2. **Transaction costs**: 30bps (0.3%) per trade (crypto spreads wider than equities)
3. **Universe**: All crypto tickers with ≥504 days history (lookback + beta window)
4. **Lookback**: 12 months (252 trading days)
5. **Portfolio**: Long top 5, short bottom 5 by momentum
6. **Rebalancing**: Monthly (month-end)

## Three Signal Variants

| Variant | Description |
|---------|-------------|
| **Baseline** | Total 12m return (no decomposition) |
| **BTC-Adjusted** | 12m return minus (beta × BTC_12m_return) |
| **Residual-Only** | Pure idiosyncratic momentum |

## Success Criterion

**Net Sharpe > 0 for at least one decomposed variant.**

- If YES → Recommend Phase 2 (perps + funding rates)
- If NO but baseline positive → Decomposition doesn't help
- If all negative + commodities fail (Issue #134) → GLOBAL ABANDON justified

## Testing Instructions

```bash
cd docs/
Rscript -e "targets::tar_make(names = starts_with('crypto'))"
```

Then inspect `crypto_rescue_test` for the verdict.

## Next Steps

- [ ] Run targets and verify build succeeds
- [ ] Read `crypto_rescue_test` output
- [ ] If Sharpe > 0: Document finding and create Phase 2 issue (perps + funding)
- [ ] If Sharpe < 0: Wait for commodities result (Issue #134) before GLOBAL ABANDON

Closes #135

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>