### PR TITLE
feat(stk_universe): restrict to top-100 current market cap (#150 Option C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2026-05-15
+
+### #150 Option C — top-100 market-cap restriction on stk_universe
+
+**Context:** Option B (disclosure banner) deployed 2026-05-12. Option C narrows `stk_universe` from 667 to top-100 by current market cap to limit *forward* survivorship exposure. Backtest results remain survivorship-biased — see Known Limitations.
+
+**Completed:**
+
+- New `stk_top_tickers` target reads `hd_datasets()[["metadata"]]` and slices the top-100 by `market_cap` (cue=always so the universe refreshes with external metadata).
+- `stk_params$top_n_market_cap = 100L` parameter exposes N.
+- `stk_universe` filters to `ticker %in% stk_top_tickers`.
+- `disclosure_survivorship()` rewritten to dynamically reflect N and reframe as "limit forward exposure" rather than "reduce bias" — the historical bias is unchanged.
+
+**Spike findings (read-only, equal-weighted proxy):** Full universe (667) Sharpe 0.884; top-100 Sharpe 1.036 (+0.15, +17%); top-50 1.077; top-200 0.987. Higher Sharpe at smaller N reflects mega-cap concentration, not bias removal. Cap cutoff at top-100: $155B. Median history of top-100: ~33 years. Only 13/100 have full 56-year history.
+
+### Known Limitations
+
+- **Option A (point-in-time data acquisition) remains open.** Top-100 restriction does not retroactively add Lehman/Bear/Enron/etc. to the universe. Strategies still need a banner.
+- **Validation seal already broken on stk_max family (#114 work).** Option C does not change that — N is chosen from current metadata, not from validation results, but the same validation window has been used for prior tuning.
+
 ## 2026-05-14
 
 ### HRP allocator + ADV-cap cost realism (4 commits, 3 issues touched)

--- a/R/disclosures.R
+++ b/R/disclosures.R
@@ -5,15 +5,21 @@
 #' at every site. See issue #150.
 #' @export
 disclosure_survivorship <- function() {
+  n <- tryCatch(
+    length(targets::tar_read(stk_top_tickers)),
+    error = function(e) NA_integer_
+  )
+  size_phrase <- if (is.na(n)) "top-N" else paste0("top-", n)
   paste0(
-    "**⚠ Survivorship-biased universe.** The 672-ticker `stk_universe` ",
-    "(S&P 500 + STOXX 600) contains only currently-listed members with ",
-    "history backfilled — delisted firms (Lehman, Bear Stearns, Enron, ",
-    "WorldCom, old GM, etc.) are absent. Stock-level Sharpe / CAGR / DD ",
-    "shown here overstates achievable returns; literature estimates the ",
-    "bias at +1 to +3 pp/year for long-only US equity. ",
-    "See [issue #150](https://github.com/JohnGavin/historical/issues/150) ",
-    "for remediation status."
+    "**⚠ Survivorship-biased universe.** `stk_universe` now restricts to the ",
+    size_phrase, " tickers by *current* market cap (#150 Option C) ",
+    "to limit forward survivorship exposure. Historical backtest results ",
+    "remain survivorship-biased — delisted firms (Lehman, Bear Stearns, ",
+    "Enron, WorldCom, old GM, etc.) were never in the dataset and cannot ",
+    "be reconstructed without point-in-time membership data. ",
+    "Literature estimates residual bias at +1 to +3 pp/year for long-only ",
+    "US equity. See [issue #150](https://github.com/JohnGavin/historical/issues/150) ",
+    "for remediation status (Option A — point-in-time data — remains open)."
   )
 }
 

--- a/R/plan_stock_backtest.R
+++ b/R/plan_stock_backtest.R
@@ -318,11 +318,29 @@ plan_stock_backtest <- function() {
         borrow_rate_annual = 0.03,    # 3% annualised borrow cost for shorts (Option 5)
         max_monthly_ret = 0.20,       # Winsorise at ±20% (Option 2)
         hrp_lookback_months = 36L,    # HRP covariance lookback for stock-level long-short
-        adv_pct_cap = 0.10            # ADV participation cap: 10% of ADV-weighted share × n
+        adv_pct_cap = 0.10,           # ADV participation cap: 10% of ADV-weighted share × n
+        top_n_market_cap = 100L       # #150 Option C: restrict to top-N by current market cap
       )
     }),
 
-    # ── Group 1: Universe — all non-ETF stocks with sufficient history ──
+    # ── Group 1: Top-N tickers by current market cap (#150 Option C) ──
+    targets::tar_target(stk_top_tickers, {
+      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
+      library(dplyr)
+
+      duckplyr_path <- Sys.glob("/nix/store/*-r-duckplyr-*/library")
+      duckplyr_path <- duckplyr_path[file.exists(file.path(duckplyr_path, "duckplyr"))]
+      if (length(duckplyr_path) > 0) .libPaths(c(.libPaths(), duckplyr_path[[1]]))
+
+      meta_url <- hd_datasets()[["metadata"]]$url
+      duckplyr::read_parquet_duckdb(meta_url) |>
+        filter(dataset == "equity_daily", !is.na(market_cap), !grepl("\\.L$", ticker)) |>
+        collect() |>
+        slice_max(market_cap, n = stk_params$top_n_market_cap) |>
+        pull(ticker)
+    }, cue = targets::tar_cue(mode = "always")),
+
+    # ── Group 1: Universe — top-N non-ETF stocks with sufficient history ──
     targets::tar_target(stk_universe, {
       pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
@@ -333,9 +351,9 @@ plan_stock_backtest <- function() {
 
       ds <- hd_datasets()[["equity_daily"]]
 
-      # All daily data for non-LSE-ETF tickers
+      # All daily data for non-LSE-ETF tickers, restricted to top-N by market cap (#150 Option C)
       all_data <- duckplyr::read_parquet_duckdb(ds$url) |>
-        filter(!grepl("\\.L$", ticker)) |>
+        filter(!grepl("\\.L$", ticker), ticker %in% stk_top_tickers) |>
         select(date, ticker, close, adjusted, volume) |>
         collect()
 


### PR DESCRIPTION
## Summary

- Adds `stk_top_tickers` target reading `hd_datasets()[["metadata"]]` and slicing top-100 by `market_cap` (N configurable via `stk_params$top_n_market_cap`).
- `stk_universe` filters to `ticker %in% stk_top_tickers` — reduces forward survivorship exposure.
- `disclosure_survivorship()` reworded to reflect the restriction *and* keep the historical-bias caveat. Banner phrasing now says "limit forward survivorship exposure" rather than "reduce bias" — the historical backtest bias is unchanged.

Refs #150 Option C. Option A (point-in-time data acquisition) remains open and tracked via #158 PIT scoring.

## Spike findings (equal-weighted proxy, read-only)

| N | Cap cutoff | Median history | Full 56yr | Sharpe | Δ |
|---|-----------|----------------|-----------|--------|---|
| 667 (full) | $0.2B | — | 26 | 0.884 | — |
| 200 | $80B | 31yr | 18 | 0.987 | +0.10 |
| **100** | **$155B** | **33yr** | **13** | **1.036** | **+0.15** |
| 50 | $282B | 31yr | 8 | 1.077 | +0.19 |

Top-100 chosen: $155B cutoff, ~33yr median history, materially above the survivorship-prone tail. Higher Sharpe at smaller N reflects mega-cap concentration; it is NOT bias removal.

## Critical framing

Both universes (full and top-100) remain survivorship-biased — Lehman, Bear Stearns, Enron, WorldCom, old GM are absent from `equity_daily` and cannot be reconstructed without point-in-time membership data. This PR limits **forward** false-confidence (mega-caps have lower future delisting rates), not retroactive bias.

The `survivorship_biased = TRUE` flags on `stk_max_metrics`, `stk_drif_metrics`, `xgb_drif_metrics`, and the `leaderboard` rows stay TRUE.

## Test plan

- [ ] `parse("_targets.R")` succeeds (verified locally — `parse OK`)
- [ ] `disclosure_survivorship()` output contains "limit forward survivorship exposure" and "Option A" (verified locally)
- [ ] `tar_make(stk_top_tickers)` returns 100 tickers — verify on next pipeline run
- [ ] `tar_make(stk_universe)` rebuilds cleanly with restricted universe — verify on next pipeline run
- [ ] Re-rendered `docs/stock-backtest.qmd` and `docs/leaderboard.qmd` show updated banner — verify on next render
- [ ] Stock MAX / Stock DRIF Sharpe numbers re-computed on restricted universe (separate follow-up; expect material changes per the spike's equal-weighted proxy)

## Known follow-ups

- Re-render vignettes once the pipeline rebuilds (separate commit; CI/scheduler likely handles it).
- Mean reversion, ETF replication, and falsification inputs are unchanged in this PR — they load `equity_daily` independently. File a follow-up if symmetry is wanted.
- Option A (PIT data) tracked via #158 PIT scoring criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)