### PR TITLE
docs(knowledge): daloopa/investing gap analysis (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-05-16
+
+### #78 daloopa/investing gap analysis
+
+Added `knowledge/wiki/daloopa-gap-analysis.md`: gap analysis of daloopa/investing (institutional fundamental data MCP) vs our current data setup. Conclusion: 1 adopt (REST API design lessons for #2), 2 defer (MCP integration + `hd_fundamentals()` wrapper pending paid account), 4 reject as out-of-scope (15 analyst-workflow skills and standalone earnings/SEC features). Full analysis at `knowledge/wiki/daloopa-gap-analysis.md`.
+
 ## 2026-05-15
 
 ### #150 Option C — top-100 market-cap restriction on stk_universe


### PR DESCRIPTION
## Summary

Gap analysis of [daloopa/investing](https://github.com/daloopa/investing) vs the project's current data setup. Full analysis at `knowledge/wiki/daloopa-gap-analysis.md` (local disk, not pushed per wiki-storage-policy).

## Recommendation Table

| # | Verdict | Topic | Reasoning |
|---|---------|-------|-----------|
| 1 | **Adopt** | REST API design lessons for #2 | Daloopa's MCP-first architecture (4 tools → full coverage) and `/companies`/`/status`/`/series-continuation` endpoint patterns map directly onto our planned public API. Zero code cost — incorporate into #2 design planning. |
| 2 | **Defer** | `hd_fundamentals()` wrapper (Phase 3, #78) | Highest-value data gap: enables fundamental-weighted factors (#75). Blocked on paid Daloopa account. Treat as `low-priority`, multi-week effort — same bucket as #150 Option A. |
| 3 | **Defer** | MCP server in `.mcp.json` (Phase 2, #78) | Enables natural-language fundamental queries during dev sessions. Blocked on free account signup + OAuth flow verification. Low effort once account exists. |
| 4 | **Reject** | All 15 analyst-workflow skills (`/earnings`, `/dcf`, `/comps`, `/ib-deck`, etc.) | Equity research deliverables (.docx, .pdf, .xlsx) are out of scope for a backtesting library. No adoption recommended. |
| 4 | **Reject** | Standalone earnings tracking and SEC search | Tangential without a concrete factor-construction use case. If `hd_fundamentals()` is built, earnings data becomes relevant as factor input — not as standalone features. |

**Bottom line:** 1 adopt / 2 defer / 4 reject. Daloopa fills our zero-coverage on fundamentals; we exceed them on macro, factors, commodities, and volatility surfaces. The two are complementary. Most of daloopa's analyst-workflow surface is out-of-scope.

Closes #78