### PR TITLE
feat(data-validation): pairwise alignment regression matrix (#149)

### DIFF
--- a/R/dataset_registry.R
+++ b/R/dataset_registry.R
@@ -1,7 +1,7 @@
 # Dataset registry for cross-series alignment validation
 #
 # Enumerates dataset-shaped targets that have a date axis and may be joined
-# across series. Phase 1 scope: 33 targets known to be joined cross-series.
+# across series. Phase 1 scope: 34 targets known to be joined cross-series.
 # Used by dv_join_key_types, dv_frequency_alignment, dv_monthly_convention
 # (existing), and dv_pairwise_alignment_matrix (Phase 2, #149).
 #

--- a/R/dataset_registry.R
+++ b/R/dataset_registry.R
@@ -1,54 +1,65 @@
 # Dataset registry for cross-series alignment validation
 #
 # Enumerates dataset-shaped targets that have a date axis and may be joined
-# across series. Phase 1 scope: ~15 targets already known to be joined
-# cross-series. Used by `dv_join_key_types` (and future pairwise probes
-# per #149).
+# across series. Phase 1 scope: 33 targets known to be joined cross-series.
+# Used by dv_join_key_types, dv_frequency_alignment, dv_monthly_convention
+# (existing), and dv_pairwise_alignment_matrix (Phase 2, #149).
+#
+# Schema:
+#   target_name  — targets store name
+#   kind         — ohlcv / macro / returns / derived / factors
+#   freq         — daily / weekly / monthly / quarterly / annual
+#   date_anchor  — trading_day / mid_month / end_bizday / end_calendar / release_day
+#   currency     — ISO-4217 (USD / EUR / local) or NA when not applicable
+#   units        — decimal / percent / bps / price / count / index or NA
+#   identity_col — join-key column for cross-sectional series (ticker / factor_name)
+#                  NA for aggregate (one-row-per-date) series
+#   notes        — free-text; NA when nothing to flag
 
 DATASET_REGISTRY <- tibble::tribble(
-  ~target_name,            ~kind,      ~freq,       ~date_anchor,    ~notes,
+  ~target_name,            ~kind,      ~freq,       ~date_anchor,    ~currency, ~units,    ~identity_col,   ~notes,
   # --- daily macro and equity ---
-  "stk_universe",          "ohlcv",    "daily",     "trading_day",   "672 stocks; survivorship-biased per #150",
-  "vix_daily",             "macro",    "daily",     "trading_day",   "VIXCLS from FRED via hd_macro",
-  "vol_spikes",            "derived",  "daily",     "trading_day",   "from R/volatility_spike_analysis.R",
-  "vix_ma_3m",             "derived",  "daily",     "trading_day",   "63-day rolling mean via roll_mean_safe",
-  # --- monthly strategy returns (the #146 / #147 cluster) ---
-  "fals_avoid_worst_input","returns",  "daily",     "trading_day",   NA,
-  "fals_drif_input",       "returns",  "monthly",   "mid_month",     "convention #147 — to migrate",
-  "fals_fac_max_input",    "returns",  "monthly",   "end_bizday",    NA,
-  "fals_ltr_input",        "returns",  "monthly",   "end_calendar",  "POSIXct stamps! see #146 close",
-  "fals_rsc_input",        "returns",  "daily",     "trading_day",   NA,
+  "stk_universe",          "ohlcv",    "daily",     "trading_day",   "USD",     "price",   "ticker",        "672 stocks; survivorship-biased per #150",
+  "vix_daily",             "macro",    "daily",     "trading_day",   NA,        "index",   NA,              "VIXCLS from FRED via hd_macro",
+  "vol_spikes",            "derived",  "daily",     "trading_day",   NA,        "count",   NA,              "from R/volatility_spike_analysis.R",
+  "vix_ma_3m",             "derived",  "daily",     "trading_day",   NA,        "index",   NA,              "63-day rolling mean via roll_mean_safe",
+  # --- falsification bridge inputs (the #146 / #147 cluster) ---
+  "fals_avoid_worst_input","returns",  "daily",     "trading_day",   "USD",     "decimal", NA,              NA,
+  "fals_drif_input",       "returns",  "monthly",   "mid_month",     "USD",     "decimal", NA,              "convention #147 — to migrate",
+  "fals_fac_max_input",    "returns",  "monthly",   "end_bizday",    "USD",     "decimal", NA,              NA,
+  "fals_ltr_input",        "returns",  "monthly",   "end_calendar",  "USD",     "decimal", NA,              "POSIXct stamps! see #146 close",
+  "fals_rsc_input",        "returns",  "daily",     "trading_day",   "USD",     "decimal", NA,              NA,
   # --- circuit breaker (currently broken — see #145) ---
-  "cb_data",               "macro",    "weekly",    "release_day",   "broken until #145 layer 2",
-  "cb_regime",             "derived",  "weekly",    "release_day",   "depends on cb_data",
+  "cb_data",               "macro",    "weekly",    "release_day",   NA,        "index",   NA,              "broken until #145 layer 2",
+  "cb_regime",             "derived",  "weekly",    "release_day",   NA,        "count",   NA,              "depends on cb_data",
   # --- daily factor returns (Fama-French / momentum) ---
-  "drif_daily",            "factors",  "daily",     "trading_day",   "FF5+Mom daily via hd_factors; used in DRIF plan",
-  "fm_daily",              "factors",  "daily",     "trading_day",   "FF5+Mom daily via hd_factors; used in Factor MAX plan",
-  "aw_daily_ff",           "factors",  "daily",     "trading_day",   "Mkt-RF + RF daily via hd_factors; 1926+ from French",
-  "fals_factors",          "factors",  "daily",     "trading_day",   "FF5+Mom daily for falsification tests",
-  "fals_rf",               "macro",    "daily",     "trading_day",   "daily risk-free rate (RF) from FF5 via hd_factors",
+  "drif_daily",            "factors",  "daily",     "trading_day",   "USD",     "percent", "factor_name",   "FF5+Mom daily via hd_factors; used in DRIF plan",
+  "fm_daily",              "factors",  "daily",     "trading_day",   "USD",     "percent", "factor_name",   "FF5+Mom daily via hd_factors; used in Factor MAX plan",
+  "aw_daily_ff",           "factors",  "daily",     "trading_day",   "USD",     "percent", NA,              "Mkt-RF + RF daily via hd_factors; 1926+ from French",
+  "fals_factors",          "factors",  "daily",     "trading_day",   "USD",     "percent", "factor_name",   "FF5+Mom daily for falsification tests",
+  "fals_rf",               "macro",    "daily",     "trading_day",   "USD",     "percent", NA,              "daily risk-free rate (RF) from FF5 via hd_factors",
   # --- daily equity universe data ---
-  "aw_daily_returns",      "ohlcv",    "daily",     "trading_day",   "SPY/QQQ/IWM/DIA daily returns via hd_ohlcv",
-  "aw_vix_daily",          "macro",    "daily",     "trading_day",   "SPY + VIXCLS joined; VIX from hd_macro",
-  "etf_daily",             "ohlcv",    "daily",     "trading_day",   "VLUE/MTUM/QUAL/USMV/VTV/IWD factor ETFs daily",
-  "ltr_universe",          "ohlcv",    "daily",     "trading_day",   "US non-ETF equity universe; ~672 tickers",
-  "stk_daily_ret",         "ohlcv",    "daily",     "trading_day",   "stock-level daily returns from stk_universe",
-  "mr_daily",              "ohlcv",    "daily",     "trading_day",   "30-ticker mean-reversion universe daily returns",
-  "vmo_daily",             "ohlcv",    "daily",     "trading_day",   "TLT/GLD/DBC/UUP + VIX; macro overlay inputs",
-  "vvix_daily",            "macro",    "daily",     "trading_day",   "VVIX from CBOE parquet; vol-of-vol series",
-  "rsc_data",              "macro",    "daily",     "trading_day",   "SPY+VIXCLS+VIX3M+VVIX+RF joined; rsc inputs",
+  "aw_daily_returns",      "ohlcv",    "daily",     "trading_day",   "USD",     "decimal", "ticker",        "SPY/QQQ/IWM/DIA daily returns via hd_ohlcv",
+  "aw_vix_daily",          "macro",    "daily",     "trading_day",   NA,        "index",   NA,              "SPY + VIXCLS joined; VIX from hd_macro",
+  "etf_daily",             "ohlcv",    "daily",     "trading_day",   "USD",     "price",   "ticker",        "VLUE/MTUM/QUAL/USMV/VTV/IWD factor ETFs daily",
+  "ltr_universe",          "ohlcv",    "daily",     "trading_day",   "USD",     "price",   "ticker",        "US non-ETF equity universe; ~672 tickers",
+  "stk_daily_ret",         "ohlcv",    "daily",     "trading_day",   "USD",     "decimal", "ticker",        "stock-level daily returns from stk_universe",
+  "mr_daily",              "ohlcv",    "daily",     "trading_day",   "USD",     "price",   "ticker",        "30-ticker mean-reversion universe daily returns",
+  "vmo_daily",             "ohlcv",    "daily",     "trading_day",   "USD",     "price",   "ticker",        "TLT/GLD/DBC/UUP + VIX; macro overlay inputs",
+  "vvix_daily",            "macro",    "daily",     "trading_day",   NA,        "index",   NA,              "VVIX from CBOE parquet; vol-of-vol series",
+  "rsc_data",              "macro",    "daily",     "trading_day",   NA,        "index",   NA,              "SPY+VIXCLS+VIX3M+VVIX+RF joined; rsc inputs",
   # --- monthly aggregates and strategy portfolios ---
   # NOTE: fm_monthly excluded — uses `last_date` not `date` as its date column.
   # Re-add when the registry schema gains a `date_col` field (or fm_monthly is renamed).
-  "fm_portfolio",          "returns",  "monthly",   "end_bizday",    "Factor MAX monthly portfolio returns",
-  "drif_portfolio",        "returns",  "monthly",   "mid_month",     "DRIF factor-level monthly portfolio; date=last_date",
-  "bt_prices",             "ohlcv",    "monthly",   "end_bizday",    "multi-ticker monthly snapshot prices from bt plan",
-  "bt_returns",            "returns",  "monthly",   "end_bizday",    "monthly returns from bt_prices via lag(adjusted)",
-  "etf_monthly",           "ohlcv",    "monthly",   "end_bizday",    "factor ETF monthly returns; end-of-month price",
-  "stk_monthly",           "ohlcv",    "monthly",   "end_bizday",    "stock-level monthly returns from stk_universe",
-  "ltr_portfolio",         "returns",  "monthly",   "end_bizday",    "LambdaMART long-short monthly; pre-computed parquet",
-  "rafi_data",             "factors",  "monthly",   "end_calendar",  "FF5+Mom wide-format monthly; date=first-of-month",
-  "nyt_keywords",          "macro",    "monthly",   "mid_month",     "NYT article counts per keyword; 12-month rolling avg",
+  "fm_portfolio",          "returns",  "monthly",   "end_bizday",    "USD",     "decimal", NA,              "Factor MAX monthly portfolio returns",
+  "drif_portfolio",        "returns",  "monthly",   "mid_month",     "USD",     "decimal", NA,              "DRIF factor-level monthly portfolio; date=last_date",
+  "bt_prices",             "ohlcv",    "monthly",   "end_bizday",    "USD",     "price",   "ticker",        "multi-ticker monthly snapshot prices from bt plan",
+  "bt_returns",            "returns",  "monthly",   "end_bizday",    "USD",     "decimal", "ticker",        "monthly returns from bt_prices via lag(adjusted)",
+  "etf_monthly",           "ohlcv",    "monthly",   "end_bizday",    "USD",     "price",   "ticker",        "factor ETF monthly returns; end-of-month price",
+  "stk_monthly",           "ohlcv",    "monthly",   "end_bizday",    "USD",     "decimal", "ticker",        "stock-level monthly returns from stk_universe",
+  "ltr_portfolio",         "returns",  "monthly",   "end_bizday",    "USD",     "decimal", NA,              "LambdaMART long-short monthly; pre-computed parquet",
+  "rafi_data",             "factors",  "monthly",   "end_calendar",  "USD",     "percent", "factor_name",   "FF5+Mom wide-format monthly; date=first-of-month",
+  "nyt_keywords",          "macro",    "monthly",   "mid_month",     NA,        "count",   "keyword",       "NYT article counts per keyword; 12-month rolling avg",
   # --- annual / low-frequency ---
   # NOTE: jst_raw excluded — panel data (year × country), not a single time series
   # with a `date` join key. Schema is keyed by (year, country); not a candidate
@@ -58,8 +69,11 @@ DATASET_REGISTRY <- tibble::tribble(
 #' Dataset registry for cross-series alignment validation
 #'
 #' Enumerates dataset-shaped targets that have a date axis and may be joined
-#' across series. Used by `dv_join_key_types` (and future pairwise probes per #149).
+#' across series. Used by `dv_join_key_types`, `dv_frequency_alignment`,
+#' `dv_monthly_convention`, and `dv_pairwise_alignment_matrix` (#149).
 #'
-#' @return Tibble with one row per registered target.
+#' @return Tibble with one row per registered target. Columns:
+#'   `target_name`, `kind`, `freq`, `date_anchor`, `currency`, `units`,
+#'   `identity_col`, `notes`.
 #' @export
 dataset_registry <- function() DATASET_REGISTRY

--- a/R/plan_data_validation.R
+++ b/R/plan_data_validation.R
@@ -1,0 +1,66 @@
+# Plan: Pairwise dataset alignment regression matrix (#149 Phase 1)
+#
+# Builds a summary tibble of pairwise alignment probes across all registered
+# datasets. Each pair is probed on Dimension 1 (date_class). Future PRs will
+# extend to Dimension 2-4 (freq, value, schema) per the issue spec.
+#
+# cue = "always": this target re-runs on every tar_make() so new data
+# sources that change type or convention are caught immediately.
+#
+# NOT wired into docs/_targets.R in Phase 1 — manual step after reviewing
+# the registry. See #149 PR description.
+#
+# Probe function: probe_pairwise_alignment() in R/utils_validation.R
+# Registry:       dataset_registry()            in R/dataset_registry.R
+
+plan_data_validation <- function() {
+  list(
+
+    targets::tar_target(
+      dv_pairwise_alignment_matrix,
+      {
+        reg <- dataset_registry()
+
+        # All unique pairs (indices into registry rows)
+        n   <- nrow(reg)
+        idx <- utils::combn(seq_len(n), 2L, simplify = FALSE)
+
+        # Probe each pair; skip pairs where both targets are excluded from
+        # the live store (e.g. cb_data / cb_regime pending #145).
+        # probe_pairwise_alignment() handles cache-miss gracefully.
+        results <- purrr::map(idx, function(pair_idx) {
+          reg_slice <- reg[pair_idx, ]
+          probe_pairwise_alignment(reg_slice)
+        })
+
+        result <- dplyr::bind_rows(results)
+
+        # Emit a summary count — informational, does not abort
+        n_warn    <- sum(result$status == "warn",    na.rm = TRUE)
+        n_missing <- sum(result$status == "missing", na.rm = TRUE)
+        n_ok      <- sum(result$status == "ok",      na.rm = TRUE)
+
+        if (n_warn > 0L) {
+          cli::cli_warn(c(
+            "!" = paste0(
+              "dv_pairwise_alignment_matrix: ", n_warn, " pair{?s} flagged, ",
+              n_ok, " ok, ", n_missing, " skipped (not cached)."
+            ),
+            "i" = "Run {.code targets::tar_read(dv_pairwise_alignment_matrix)} to inspect."
+          ))
+        } else {
+          cli::cli_inform(c(
+            "v" = paste0(
+              "dv_pairwise_alignment_matrix: all ", n_ok, " probed pairs ok. ",
+              n_missing, " skipped (not cached)."
+            )
+          ))
+        }
+
+        result
+      },
+      cue = targets::tar_cue(mode = "always")
+    )
+
+  )
+}

--- a/R/utils_validation.R
+++ b/R/utils_validation.R
@@ -271,10 +271,9 @@ check_frequency_alignment <- function(
 #' `cli::cli_warn()` on mismatch but does NOT abort — this is a canary
 #' (informational), not a gate.
 #'
-#' Currently checks Dimension 1 (date_class). Future PRs will extend to
-#' Dimension 2 (freq metadata) and beyond. The function is designed for
-#' future extension: additional `dimension` rows can be appended to the
-#' returned tibble.
+#' Currently checks Dimension 1 (date class) and Dimension 2 (frequency).
+#' The function is designed for future extension: additional `dimension` rows
+#' can be appended to the returned tibble.
 #'
 #' @param registry Two-row tibble (or slice from `dataset_registry()`).
 #'   Must have at least columns `target_name` and `freq`.
@@ -376,7 +375,7 @@ probe_pairwise_alignment <- function(
     ))
     return(tibble::tibble(
       pair      = pair_label,
-      dimension = "date_class",
+      dimension = "freq",
       status    = "warn",
       evidence  = paste0("freq mismatch: ", evidence)
     ))

--- a/R/utils_validation.R
+++ b/R/utils_validation.R
@@ -263,6 +263,137 @@ check_frequency_alignment <- function(
   result
 }
 
+#' Probe pairwise alignment between two registered datasets
+#'
+#' Given a two-row registry slice (one row per dataset in the pair), reads each
+#' target from the cache and checks the `date_class` alignment dimension.
+#' Returns a one-row tibble summarising compatibility. Emits
+#' `cli::cli_warn()` on mismatch but does NOT abort — this is a canary
+#' (informational), not a gate.
+#'
+#' Currently checks Dimension 1 (date_class). Future PRs will extend to
+#' Dimension 2 (freq metadata) and beyond. The function is designed for
+#' future extension: additional `dimension` rows can be appended to the
+#' returned tibble.
+#'
+#' @param registry Two-row tibble (or slice from `dataset_registry()`).
+#'   Must have at least columns `target_name` and `freq`.
+#' @param read_fn Function `read_fn(name)` returning the target object.
+#'   Default reads RDS objects directly from `store`. Pass a fake in tests.
+#' @param store Path to the targets store directory. Defaults to `"_targets"`.
+#' @return One-row tibble: `pair` (chr), `dimension` ("date_class"),
+#'   `status` ("ok", "warn", "missing"), `evidence` (chr detail).
+#' @export
+probe_pairwise_alignment <- function(
+    registry,
+    read_fn = NULL,
+    store   = "_targets") {
+
+  stopifnot(nrow(registry) == 2L)
+
+  if (is.null(read_fn)) {
+    read_fn <- .make_store_reader(store)
+  }
+
+  nm_a <- registry$target_name[[1L]]
+  nm_b <- registry$target_name[[2L]]
+  pair_label <- paste0(nm_a, " vs ", nm_b)
+
+  # Read both targets; catch cache misses gracefully
+  obj_a <- tryCatch(
+    read_fn(nm_a),
+    error = function(e) {
+      cli::cli_inform(c("i" = "Skipping {nm_a}: not in cache ({conditionMessage(e)})"))
+      NULL
+    }
+  )
+  obj_b <- tryCatch(
+    read_fn(nm_b),
+    error = function(e) {
+      cli::cli_inform(c("i" = "Skipping {nm_b}: not in cache ({conditionMessage(e)})"))
+      NULL
+    }
+  )
+
+  # If either is missing, return a "missing" row — not an error
+  if (is.null(obj_a) || is.null(obj_b)) {
+    return(tibble::tibble(
+      pair      = pair_label,
+      dimension = "date_class",
+      status    = "missing",
+      evidence  = paste0(
+        if (is.null(obj_a)) nm_a else "",
+        if (is.null(obj_a) && is.null(obj_b)) " and " else "",
+        if (is.null(obj_b)) nm_b else "",
+        " not in cache"
+      )
+    ))
+  }
+
+  # Extract date column classes
+  cls_a <- if ("date" %in% names(obj_a)) {
+    paste(class(obj_a$date), collapse = "/")
+  } else {
+    NA_character_
+  }
+  cls_b <- if ("date" %in% names(obj_b)) {
+    paste(class(obj_b$date), collapse = "/")
+  } else {
+    NA_character_
+  }
+
+  # Dimension: date_class
+  if (!is.na(cls_a) && !is.na(cls_b) && cls_a != cls_b) {
+    evidence <- paste0(nm_a, ": ", cls_a, "; ", nm_b, ": ", cls_b)
+    cli::cli_warn(c(
+      "!" = "Date-class mismatch detected for pair {.val {pair_label}}.",
+      "i" = "{evidence}",
+      "i" = paste0(
+        "A Date/POSIXct join produces 0 matching rows silently. ",
+        "Coerce both to {.code as.Date()} at the producing target."
+      )
+    ))
+    return(tibble::tibble(
+      pair      = pair_label,
+      dimension = "date_class",
+      status    = "warn",
+      evidence  = evidence
+    ))
+  }
+
+  # Dimension: freq mismatch (from registry metadata — no live data inspection)
+  freq_a <- registry$freq[[1L]]
+  freq_b <- registry$freq[[2L]]
+  if (!is.na(freq_a) && !is.na(freq_b) && freq_a != freq_b) {
+    evidence <- paste0(nm_a, ": ", freq_a, "; ", nm_b, ": ", freq_b)
+    cli::cli_warn(c(
+      "!" = "Frequency mismatch detected for pair {.val {pair_label}}.",
+      "i" = "{evidence}",
+      "i" = paste0(
+        "Joining daily and monthly series produces a sparse result. ",
+        "Use align_period() (#148) before joining."
+      )
+    ))
+    return(tibble::tibble(
+      pair      = pair_label,
+      dimension = "date_class",
+      status    = "warn",
+      evidence  = paste0("freq mismatch: ", evidence)
+    ))
+  }
+
+  # All checked dimensions pass
+  tibble::tibble(
+    pair      = pair_label,
+    dimension = "date_class",
+    status    = "ok",
+    evidence  = paste0("both ", cls_a %||% "unknown", "; freq both ", freq_a %||% "unknown")
+  )
+}
+
+# Null-coalescing operator (base R doesn't have one; rlang's %||% used here)
+`%||%` <- function(x, y) if (is.null(x) || length(x) == 0L) y else x
+
 #' Check month-end-bizday date convention for a set of targets
 #'
 #' For each named target, reads its cached RDS object and verifies that every

--- a/tests/testthat/_snaps/pairwise-alignment.md
+++ b/tests/testthat/_snaps/pairwise-alignment.md
@@ -1,0 +1,31 @@
+# Date vs POSIXct mismatch snapshot — user-facing warning text
+
+    Code
+      withCallingHandlers(probe_pairwise_alignment(reg, read_fn = reader), warning = function(
+        w) {
+        cat("WARNING:", conditionMessage(w), "\n")
+        invokeRestart("muffleWarning")
+      })
+    Output
+      WARNING: ! Date-class mismatch detected for pair "snap_date vs snap_posix".
+      i snap_date: Date; snap_posix: POSIXct/POSIXt
+      i A Date/POSIXct join produces 0 matching rows silently. Coerce both to `as.Date()` at the producing target. 
+      # A tibble: 1 x 4
+        pair                    dimension  status evidence                            
+        <chr>                   <chr>      <chr>  <chr>                               
+      1 snap_date vs snap_posix date_class warn   snap_date: Date; snap_posix: POSIXc~
+
+# probe_pairwise_alignment result snapshot — column names and single-row structure
+
+    Code
+      names(result)
+    Output
+      [1] "pair"      "dimension" "status"    "evidence" 
+
+---
+
+    Code
+      result$status
+    Output
+      [1] "ok"
+

--- a/tests/testthat/_snaps/utils_validation.md
+++ b/tests/testthat/_snaps/utils_validation.md
@@ -8,3 +8,17 @@
       i d_date: Date; d_posix: POSIXct/POSIXt
       i Coerce to a common type (`as.Date()`) at the producing target.
 
+# check_monthly_convention snapshot — ok tibble structure
+
+    Code
+      names(result)
+    Output
+      [1] "target"    "status"    "n"         "pct_match"
+
+---
+
+    Code
+      result$status
+    Output
+      [1] "ok"
+

--- a/tests/testthat/test-pairwise-alignment.R
+++ b/tests/testthat/test-pairwise-alignment.R
@@ -160,12 +160,9 @@ test_that("daily vs monthly registered series flags freq mismatch with status=wa
   )
 
   expect_equal(nrow(result), 1L)
-  expect_equal(result$dimension, "date_class")
-  # When date classes match but freq mismatch — look at freq field
-  # Both are Date class so date_class=ok, but registry freq mismatch is detectable
-  # The function should still return "ok" for date_class and the warn is from freq
-  # (checking registry metadata, not live data)
-  expect_true(result$status %in% c("ok", "warn"))
+  expect_equal(result$dimension, "freq")
+  # Freq mismatch is detected from registry metadata; status must be "warn"
+  expect_equal(result$status, "warn")
 })
 
 test_that("same-freq pair does not produce a warning", {

--- a/tests/testthat/test-pairwise-alignment.R
+++ b/tests/testthat/test-pairwise-alignment.R
@@ -1,0 +1,224 @@
+testthat::local_edition(3)
+source(here::here("R/dataset_registry.R"))
+source(here::here("R/utils_dates.R"))
+source(here::here("R/utils_validation.R"))
+
+# ── Helper factories ──────────────────────────────────────────────────────────
+
+# Synthetic daily Date series
+daily_date_df <- function(n = 30) {
+  tibble::tibble(
+    date  = seq(as.Date("2025-01-01"), by = "day", length.out = n),
+    value = rnorm(n)
+  )
+}
+
+# Synthetic monthly Date series (first of month)
+monthly_date_df <- function(n = 12) {
+  tibble::tibble(
+    date  = seq(as.Date("2025-01-01"), by = "month", length.out = n),
+    value = rnorm(n)
+  )
+}
+
+# Synthetic POSIXct series (same dates, different class — the #146 bug)
+posixct_date_df <- function(n = 30) {
+  tibble::tibble(
+    date  = as.POSIXct(
+      seq(as.Date("2025-01-01"), by = "day", length.out = n)
+    ),
+    value = rnorm(n)
+  )
+}
+
+# Build a minimal two-row registry
+make_pair_registry <- function(name_a = "a", freq_a = "daily",
+                                name_b = "b", freq_b = "daily") {
+  tibble::tibble(
+    target_name  = c(name_a, name_b),
+    kind         = "returns",
+    freq         = c(freq_a, freq_b),
+    date_anchor  = "end_bizday",
+    currency     = "USD",
+    units        = "decimal",
+    identity_col = NA_character_,
+    notes        = NA_character_
+  )
+}
+
+# Build a fake read_fn — same pattern used in test-utils_validation.R
+make_reader <- function(...) {
+  store <- list(...)
+  function(nm) {
+    if (!nm %in% names(store)) stop(paste0("target not found: ", nm))
+    store[[nm]]
+  }
+}
+
+# ── Test 1: Registry parses cleanly ──────────────────────────────────────────
+
+test_that("dataset_registry returns a tibble with required columns including currency, units, identity_col", {
+  reg <- dataset_registry()
+  expect_s3_class(reg, "tbl_df")
+  required <- c("target_name", "kind", "freq", "date_anchor",
+                "currency", "units", "identity_col", "notes")
+  missing_cols <- setdiff(required, names(reg))
+  expect_equal(missing_cols, character(0),
+               info = paste("Missing columns:", paste(missing_cols, collapse = ", ")))
+})
+
+test_that("dataset_registry target_name values are unique", {
+  reg <- dataset_registry()
+  expect_equal(length(unique(reg$target_name)), nrow(reg))
+})
+
+test_that("dataset_registry has at least 10 entries", {
+  reg <- dataset_registry()
+  expect_gte(nrow(reg), 10L)
+})
+
+# ── Test 2: Two same-type Date tibbles align ──────────────────────────────────
+
+test_that("two Date daily series are compatible — all dimensions ok", {
+  reg    <- make_pair_registry("da", "daily", "db", "daily")
+  reader <- make_reader(da = daily_date_df(30), db = daily_date_df(30))
+
+  result <- probe_pairwise_alignment(reg, read_fn = reader)
+
+  expect_s3_class(result, "tbl_df")
+  # Should produce exactly one pair row
+  expect_equal(nrow(result), 1L)
+  expect_true("status" %in% names(result))
+  expect_equal(result$status, "ok")
+  expect_true("dimension" %in% names(result))
+  expect_equal(result$dimension, "date_class")
+})
+
+test_that("probe_pairwise_alignment returns tibble with required columns", {
+  reg    <- make_pair_registry()
+  reader <- make_reader(a = daily_date_df(10), b = daily_date_df(10))
+
+  result <- probe_pairwise_alignment(reg, read_fn = reader)
+
+  required_cols <- c("pair", "dimension", "status", "evidence")
+  missing_cols  <- setdiff(required_cols, names(result))
+  expect_equal(missing_cols, character(0),
+               info = paste("Missing columns:", paste(missing_cols, collapse = ", ")))
+})
+
+# ── Test 3: Date vs POSIXct triggers mismatch warn (the #146 bug) ─────────────
+
+test_that("Date vs POSIXct series flags date_class mismatch with status=warn", {
+  reg    <- make_pair_registry("d_date", "daily", "d_posix", "daily")
+  reader <- make_reader(
+    d_date  = daily_date_df(30),
+    d_posix = posixct_date_df(30)
+  )
+
+  expect_warning(
+    result <- probe_pairwise_alignment(reg, read_fn = reader),
+    regexp = NULL  # any warning acceptable
+  )
+
+  expect_equal(nrow(result), 1L)
+  expect_equal(result$dimension, "date_class")
+  expect_equal(result$status, "warn")
+  # evidence should mention the two class types
+  expect_match(result$evidence, "Date|POSIXct", ignore.case = FALSE)
+})
+
+test_that("Date vs POSIXct mismatch snapshot — user-facing warning text", {
+  reg    <- make_pair_registry("snap_date", "daily", "snap_posix", "daily")
+  reader <- make_reader(
+    snap_date  = daily_date_df(5),
+    snap_posix = posixct_date_df(5)
+  )
+
+  expect_snapshot(
+    withCallingHandlers(
+      probe_pairwise_alignment(reg, read_fn = reader),
+      warning = function(w) {
+        cat("WARNING:", conditionMessage(w), "\n")
+        invokeRestart("muffleWarning")
+      }
+    )
+  )
+})
+
+# ── Test 4: Daily vs monthly freq mismatch ───────────────────────────────────
+
+test_that("daily vs monthly registered series flags freq mismatch with status=warn", {
+  reg    <- make_pair_registry("daily_s", "daily", "monthly_s", "monthly")
+  reader <- make_reader(
+    daily_s   = daily_date_df(30),
+    monthly_s = monthly_date_df(12)
+  )
+
+  expect_warning(
+    result <- probe_pairwise_alignment(reg, read_fn = reader),
+    regexp = NULL
+  )
+
+  expect_equal(nrow(result), 1L)
+  expect_equal(result$dimension, "date_class")
+  # When date classes match but freq mismatch — look at freq field
+  # Both are Date class so date_class=ok, but registry freq mismatch is detectable
+  # The function should still return "ok" for date_class and the warn is from freq
+  # (checking registry metadata, not live data)
+  expect_true(result$status %in% c("ok", "warn"))
+})
+
+test_that("same-freq pair does not produce a warning", {
+  reg    <- make_pair_registry("d1", "daily", "d2", "daily")
+  reader <- make_reader(d1 = daily_date_df(20), d2 = daily_date_df(20))
+
+  # No warning expected — same class, same freq
+  expect_no_warning(
+    result <- probe_pairwise_alignment(reg, read_fn = reader)
+  )
+  expect_equal(result$status, "ok")
+})
+
+# ── Test 5: Missing target handled gracefully ─────────────────────────────────
+
+test_that("missing target in pair returns status=missing not an error", {
+  reg    <- make_pair_registry("present", "daily", "absent", "daily")
+  reader <- make_reader(present = daily_date_df(10))
+  # "absent" not in store — simulates unbuilt target
+
+  result <- probe_pairwise_alignment(reg, read_fn = reader)
+
+  expect_s3_class(result, "tbl_df")
+  expect_equal(nrow(result), 1L)
+  expect_equal(result$status, "missing")
+})
+
+# ── Test 6: plan_data_validation function structure ──────────────────────────
+
+test_that("plan_data_validation() exists and returns a list", {
+  source(here::here("R/plan_data_validation.R"))
+  result <- plan_data_validation()
+  expect_type(result, "list")
+  expect_gte(length(result), 1L)
+})
+
+test_that("plan_data_validation() list contains a target named dv_pairwise_alignment_matrix", {
+  source(here::here("R/plan_data_validation.R"))
+  result <- plan_data_validation()
+  target_names <- vapply(result, function(x) {
+    if (inherits(x, "tar_target")) x$settings$name else NA_character_
+  }, character(1))
+  expect_true("dv_pairwise_alignment_matrix" %in% target_names,
+              info = paste("Found targets:", paste(target_names, collapse = ", ")))
+})
+
+# ── Test 7: probe_pairwise_alignment snapshot — ok tibble structure ──────────
+
+test_that("probe_pairwise_alignment result snapshot — column names and single-row structure", {
+  reg    <- make_pair_registry("snap_a", "daily", "snap_b", "daily")
+  reader <- make_reader(snap_a = daily_date_df(5), snap_b = daily_date_df(5))
+
+  result <- probe_pairwise_alignment(reg, read_fn = reader)
+  expect_snapshot(names(result))
+  expect_snapshot(result$status)
+})

--- a/tests/testthat/test-utils_validation.R
+++ b/tests/testthat/test-utils_validation.R
@@ -275,9 +275,11 @@ test_that("dataset_registry date_anchor values are in the allowed set", {
 
 test_that("dataset_registry has expected column names", {
   reg <- dataset_registry()
+  # Phase 2 (#149): added currency, units, identity_col between date_anchor and notes
   expect_equal(
     names(reg),
-    c("target_name", "kind", "freq", "date_anchor", "notes")
+    c("target_name", "kind", "freq", "date_anchor",
+      "currency", "units", "identity_col", "notes")
   )
 })
 


### PR DESCRIPTION
## Summary

- **Phase 1 only** — registry has 33 entries (not all 42; excludes panel-data targets without a `date` join key)
- **Not wired into `docs/_targets.R`** — `plan_data_validation()` exists but is not sourced/called; manual integration step after reviewing the registry
- Catches: Date/POSIXct class mismatch, registry freq mismatch between pairs (Dimension 1 of the issue spec)
- Does NOT yet catch: currency mismatch, units mismatch, period semantics (Dimension 3-4 from the issue; future PR)

## Changes

### `R/dataset_registry.R`
- Extended schema: added `currency` (ISO-4217 or NA), `units` (decimal/percent/price/count/index/NA), `identity_col` (ticker/factor_name/keyword or NA for aggregate series)
- 33 registered targets; previously had 5 columns, now 8

### `R/utils_validation.R`
- New exported helper `probe_pairwise_alignment(registry, read_fn, store)`: probes one pair on date_class dimension; emits `cli_warn()` on mismatch, returns status tibble with columns `pair`, `dimension`, `status`, `evidence`
- Same `read_fn` injection pattern as existing helpers (testable without live targets store)
- `%||%` null-coalescing operator added (internal)

### `R/plan_data_validation.R` (new)
- `plan_data_validation()` returns a list with one target: `dv_pairwise_alignment_matrix`
- Probes all `combn(n, 2)` pairs from the registry via `probe_pairwise_alignment()`
- `cue = targets::tar_cue(mode = "always")` — re-runs every `tar_make()`
- Emits `cli_warn()` summary if any pair flagged, `cli_inform()` otherwise

### `tests/testthat/test-pairwise-alignment.R` (new, 31 tests)
- Registry schema validation (columns, uniqueness, row count)
- Two same-type Date series → status="ok"
- Date vs POSIXct → status="warn" with evidence (the #146 bug class)
- Daily vs monthly freq mismatch → status="warn"
- Same-freq pair → no warning
- Missing target in pair → status="missing"
- `plan_data_validation()` structure: returns list, contains named target
- Snapshot tests for warning text and column names

## Test plan

- [ ] `parse("_targets.R")` — verified pass
- [ ] `parse("docs/_targets.R")` — verified pass
- [ ] `testthat::test_file("tests/testthat/test-pairwise-alignment.R")` — 31 PASS, 0 FAIL
- [ ] `testthat::test_file("tests/testthat/test-utils_validation.R")` — 54 PASS, 0 FAIL (regression check)
- [ ] After merge: add `source(here::here("R/plan_data_validation.R"))` and `plan_data_validation()` to `docs/_targets.R`

🤖 Generated with [Claude Code](https://claude.com/claude-code)