### PR TITLE
docs(knowledge): Quantocracy May-3 2026 roundup (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 Added `knowledge/wiki/daloopa-gap-analysis.md`: gap analysis of daloopa/investing (institutional fundamental data MCP) vs our current data setup. Conclusion: 1 adopt (REST API design lessons for #2), 2 defer (MCP integration + `hd_fundamentals()` wrapper pending paid account), 4 reject as out-of-scope (15 analyst-workflow skills and standalone earnings/SEC features). Full analysis at `knowledge/wiki/daloopa-gap-analysis.md`.
 
+### Quantocracy May-3 2026 roundup curated (#126)
+
+Curated 5 articles from the Quantocracy May 3 2026 roundup into `knowledge/wiki/quantocracy-may-2026.md`. Cross-referenced against open issues: StratProof covered by #125, Macrosynergy by #124. Two new topics surfaced: optimal regime-dependent exposure sizing (Alpha Architect, actionable for plan_regime.R) and risk parity 58-year tail audit (Beyond Passive, context for #114).
+
 ## 2026-05-15
 
 ### #150 Option C — top-100 market-cap restriction on stk_universe


### PR DESCRIPTION
## Summary

- Curated the [Quantocracy May 3 2026 roundup](https://quantocracy.com/recent-quant-links-from-quantocracy-as-of-05032026/) into `knowledge/wiki/quantocracy-may-2026.md` (local-only, not committed per wiki-storage-policy)
- CHANGELOG updated with 2026-05-16 entry

## Articles Surveyed (5)

| # | Title | Source | Project status |
|---|-------|--------|---------------|
| 1 | I paper-traded 22 popular crypto strategies on real fees for 10 days | Strat Proof | Covered by #125 |
| 2 | Where Risk Parity Hurts: A 58-Year Audit of Tails and Drawdowns | Beyond Passive | New → #163 |
| 3 | Almost Explicit Implied Volatility | Chase the Devil | Informational (no issue) |
| 4 | Rethinking Trend Following: Optimal Regime-Dependent Allocation | Alpha Architect | New → #162 |
| 5 | Curve trades with macroeconomic signals | Macrosynergy | Covered by #124 |

## Cross-References Found

- **#125** — StratProof 22 crypto strategies (already covered)
- **#124** — Macrosynergy yield curve macro signals (already covered)
- **#114** — HRP risk parity implementation (empirical context from #163)
- **#119, #141** — regime classification/momentum (related to #162 on exposure sizing)

## New Issues Filed

- **#162** — `research: Optimal regime-dependent exposure sizing for trend following (Alpha Architect 2026)` — directly actionable upgrade to heuristic scaling in plan_regime.R / plan_risk_state.R. Difficulty: M.
- **#163** — `research: Risk parity 58-year tail/drawdown audit — empirical context for HRP (#114)` — fills empirical evidence gap for #114. Difficulty: S.

## Fetch Notes

Individual article pages were not fetchable (WebFetch permission denied in agent session). All article content sourced from Quantocracy's own blurbs (verbatim from HTML `qo-description` divs). AI-inferred synthesis marked with `> ⚠ AI-inferred:` per confidence-markers rule.

## Test plan

- [ ] Verify CHANGELOG entry is correct and under 2026-05-16
- [ ] Confirm knowledge/wiki/ files are NOT included in this PR (local-only)
- [ ] Check #162 and #163 are correctly cross-referenced in issue tracker

🤖 Generated with [Claude Code](https://claude.com/claude-code)