### PR TITLE
refactor: rename K_eff → K_eff_acf (#160 PR 1 of 4, disambiguation)

### DIFF
--- a/.claude/rules/backtest-robustness.md
+++ b/.claude/rules/backtest-robustness.md
@@ -95,7 +95,7 @@ against simulated environments where no real edge exists.
 
 | Metric | Description | Fail threshold |
 |--------|-------------|---------------|
-| K_eff | Effective sample size after autocorrelation adjustment | < 30 |
+| K_eff_acf | Effective sample size after autocorrelation adjustment | < 30 |
 | Delta_Z | Z-score gap between strategy and null | < 1.96 (not significant) |
 | Stage 1 rejection rate | % of 5 simulation environments where strategy is rejected as noise | < 80% (must reject in 4/5) |
 | Adjusted Sharpe | Sharpe ratio corrected for multiple testing / look-ahead | < 0.5 |

--- a/R/plan_integration.R
+++ b/R/plan_integration.R
@@ -4,7 +4,7 @@
 # - Liquidity analysis → consolidated_equity
 # - Tracking error/IR → strategy returns + SPY benchmark
 # - Regime correlations → multi-asset returns + VIX
-# - Tail K_eff → strategy returns + VIX
+# - Tail K_eff_acf → strategy returns + VIX
 
 plan_integration <- function() {
   list(
@@ -261,11 +261,11 @@ plan_integration <- function() {
       {
         keff_crisis_calm_by_strategy |>
           DT::datatable(
-            caption = "Effective Sample Size (K_eff) by Strategy and Regime",
+            caption = "Effective Sample Size (K_eff_acf) by Strategy and Regime",
             options = list(pageLength = 20),
             rownames = FALSE
           ) |>
-          DT::formatRound(columns = c("K_eff", "acf_sum"), digits = 2) |>
+          DT::formatRound(columns = c("K_eff_acf", "acf_sum"), digits = 2) |>
           DT::formatPercentage(columns = "efficiency", digits = 1) |>
           DT::formatRound(columns = "N", digits = 0)
       }

--- a/R/plan_tail_keff.R
+++ b/R/plan_tail_keff.R
@@ -1,12 +1,12 @@
-# Tail effective sample size (K_eff) targets
-# Addresses gap from #105: tail K_eff mentioned in #55 but not computed
+# Tail effective sample size (K_eff_acf) targets
+# Addresses gap from #105: tail K_eff_acf mentioned in #55 but not computed
 # Measures effective independent observations in crisis vs calm regimes
 
 library(targets)
 library(dplyr)
 
 list(
-  # === K_eff by strategy and regime (crisis vs calm) ===
+  # === K_eff_acf by strategy and regime (crisis vs calm) ===
   tar_target(
     keff_crisis_calm_by_strategy,
     {
@@ -19,7 +19,7 @@ list(
     }
   ),
 
-  # === K_eff visualization ===
+  # === K_eff_acf visualization ===
   tar_target(
     keff_efficiency_plot,
     {
@@ -27,23 +27,23 @@ list(
     }
   ),
 
-  # === K_eff summary table ===
+  # === K_eff_acf summary table ===
   tar_target(
     keff_summary_table,
     {
       keff_crisis_calm_by_strategy |>
         DT::datatable(
-          caption = "Effective Sample Size (K_eff) by Strategy and Regime",
+          caption = "Effective Sample Size (K_eff_acf) by Strategy and Regime",
           options = list(pageLength = 20),
           rownames = FALSE
         ) |>
-        DT::formatRound(columns = c("K_eff", "acf_sum"), digits = 2) |>
+        DT::formatRound(columns = c("K_eff_acf", "acf_sum"), digits = 2) |>
         DT::formatPercentage(columns = "efficiency", digits = 1) |>
         DT::formatRound(columns = "N", digits = 0)
     }
   ),
 
-  # === Tail partition K_eff (5%/90%/5%) ===
+  # === Tail partition K_eff_acf (5%/90%/5%) ===
   # Example for a single strategy
   tar_target(
     keff_tail_partitions_example,
@@ -62,10 +62,10 @@ list(
     keff_crisis_calm_summary,
     {
       keff_crisis_calm_by_strategy |>
-        dplyr::select(strategy, regime, K_eff, efficiency) |>
+        dplyr::select(strategy, regime, K_eff_acf, efficiency) |>
         tidyr::pivot_wider(
           names_from = regime,
-          values_from = c(K_eff, efficiency)
+          values_from = c(K_eff_acf, efficiency)
         ) |>
         dplyr::mutate(
           # Crisis efficiency as % of calm efficiency
@@ -82,8 +82,8 @@ list(
     {
       tibble::tibble(
         metric = c(
-          "K_eff",
-          "Efficiency (K_eff/N)",
+          "K_eff_acf",
+          "Efficiency (K_eff_acf/N)",
           "Crisis penalty",
           "Data multiplier"
         ),

--- a/R/tail_keff.R
+++ b/R/tail_keff.R
@@ -1,26 +1,26 @@
-# Tail effective sample size (K_eff) analysis
-# Gap from #105: tail K_eff mentioned in #55 but not implemented
+# Tail effective sample size (K_eff_acf) analysis
+# Gap from #105: tail K_eff_acf mentioned in #55 but not implemented
 # Measures effective independent observations accounting for autocorrelation
 
-#' Calculate effective sample size (K_eff) using Newey-West approach
+#' Calculate effective sample size (K_eff_acf) using Newey-West approach
 #'
-#' K_eff adjusts sample size for autocorrelation. Higher autocorrelation
+#' K_eff_acf adjusts sample size for autocorrelation. Higher autocorrelation
 #' reduces effective sample size, affecting statistical power.
 #'
-#' Formula: K_eff = N / (1 + 2 * sum(rho_k))
+#' Formula: K_eff_acf = N / (1 + 2 * sum(rho_k))
 #' where rho_k are autocorrelations up to lag L
 #'
 #' @param x Numeric vector of observations
 #' @param max_lag Maximum lag for autocorrelation (default: floor(N^(1/3)))
-#' @return List with K_eff, N, and autocorrelation sum
+#' @return List with K_eff_acf, N, and autocorrelation sum
 #' @export
 calculate_keff <- function(x, max_lag = NULL) {
   x_clean <- x[!is.na(x)]
   N <- length(x_clean)
 
   if (N < 10) {
-    cli::cli_warn("Fewer than 10 observations for K_eff calculation")
-    return(list(K_eff = NA_real_, N = N, acf_sum = NA_real_))
+    cli::cli_warn("Fewer than 10 observations for K_eff_acf calculation")
+    return(list(K_eff_acf = NA_real_, N = N, acf_sum = NA_real_))
   }
 
   if (is.null(max_lag)) {
@@ -37,26 +37,26 @@ calculate_keff <- function(x, max_lag = NULL) {
   acf_sum <- sum(acf_values * nw_weights, na.rm = TRUE)
 
   # Effective sample size
-  K_eff <- N / (1 + 2 * acf_sum)
+  K_eff_acf <- N / (1 + 2 * acf_sum)
 
   list(
-    K_eff = K_eff,
+    K_eff_acf = K_eff_acf,
     N = N,
     acf_sum = acf_sum,
-    efficiency = K_eff / N  # Proportion of "independent" observations
+    efficiency = K_eff_acf / N  # Proportion of "independent" observations
   )
 }
 
-#' Calculate tail K_eff split by crisis regime
+#' Calculate tail K_eff_acf split by crisis regime
 #'
 #' Compares effective sample size in crisis (VIX ≥ 30) vs calm (VIX < 30) periods.
-#' Crisis periods typically have higher autocorrelation → lower K_eff.
+#' Crisis periods typically have higher autocorrelation → lower K_eff_acf.
 #'
 #' @param returns Numeric vector of strategy returns
 #' @param dates Date vector (same length as returns)
 #' @param vix_data Tibble with columns: date, vix
 #' @param crisis_threshold VIX threshold for crisis (default 30)
-#' @return Tibble with K_eff for crisis, calm, and full sample
+#' @return Tibble with K_eff_acf for crisis, calm, and full sample
 #' @export
 tail_keff_crisis_calm <- function(returns, dates, vix_data, crisis_threshold = 30) {
   # Join returns with VIX
@@ -68,7 +68,7 @@ tail_keff_crisis_calm <- function(returns, dates, vix_data, crisis_threshold = 3
   crisis_returns <- data |> dplyr::filter(vix >= crisis_threshold) |> dplyr::pull(return)
   calm_returns <- data |> dplyr::filter(vix < crisis_threshold) |> dplyr::pull(return)
 
-  # Calculate K_eff for each regime
+  # Calculate K_eff_acf for each regime
   keff_crisis <- calculate_keff(crisis_returns)
   keff_calm <- calculate_keff(calm_returns)
   keff_full <- calculate_keff(data$return)
@@ -76,18 +76,18 @@ tail_keff_crisis_calm <- function(returns, dates, vix_data, crisis_threshold = 3
   tibble::tibble(
     regime = c("Full Sample", "Crisis (VIX ≥ 30)", "Calm (VIX < 30)"),
     N = c(keff_full$N, keff_crisis$N, keff_calm$N),
-    K_eff = c(keff_full$K_eff, keff_crisis$K_eff, keff_calm$K_eff),
+    K_eff_acf = c(keff_full$K_eff_acf, keff_crisis$K_eff_acf, keff_calm$K_eff_acf),
     efficiency = c(keff_full$efficiency, keff_crisis$efficiency, keff_calm$efficiency),
     acf_sum = c(keff_full$acf_sum, keff_crisis$acf_sum, keff_calm$acf_sum)
   )
 }
 
-#' Calculate tail K_eff for multiple strategies
+#' Calculate tail K_eff_acf for multiple strategies
 #'
 #' @param returns_df Tibble with columns: date, strategy, return
 #' @param vix_data Tibble with columns: date, vix
 #' @param crisis_threshold VIX threshold for crisis (default 30)
-#' @return Tibble with K_eff by strategy and regime
+#' @return Tibble with K_eff_acf by strategy and regime
 #' @export
 tail_keff_by_strategy <- function(returns_df, vix_data, crisis_threshold = 30) {
   returns_df |>
@@ -106,13 +106,13 @@ tail_keff_by_strategy <- function(returns_df, vix_data, crisis_threshold = 30) {
     tidyr::unnest(keff_results)
 }
 
-#' Calculate K_eff for tail partitions (5%/90%/5%)
+#' Calculate K_eff_acf for tail partitions (5%/90%/5%)
 #'
 #' Splits returns into bottom 5%, middle 90%, top 5% and calculates
-#' K_eff for each partition.
+#' K_eff_acf for each partition.
 #'
 #' @param returns Numeric vector of returns
-#' @return Tibble with K_eff by tail partition
+#' @return Tibble with K_eff_acf by tail partition
 #' @export
 tail_keff_partitions <- function(returns) {
   returns_clean <- returns[!is.na(returns)]
@@ -126,7 +126,7 @@ tail_keff_partitions <- function(returns) {
   middle_90 <- returns_clean[returns_clean > q05 & returns_clean < q95]
   top_5 <- returns_clean[returns_clean >= q95]
 
-  # Calculate K_eff for each partition
+  # Calculate K_eff_acf for each partition
   keff_bottom <- calculate_keff(bottom_5)
   keff_middle <- calculate_keff(middle_90)
   keff_top <- calculate_keff(top_5)
@@ -136,12 +136,12 @@ tail_keff_partitions <- function(returns) {
     threshold_low = c(NA, q05, q95),
     threshold_high = c(q05, q95, NA),
     N = c(keff_bottom$N, keff_middle$N, keff_top$N),
-    K_eff = c(keff_bottom$K_eff, keff_middle$K_eff, keff_top$K_eff),
+    K_eff_acf = c(keff_bottom$K_eff_acf, keff_middle$K_eff_acf, keff_top$K_eff_acf),
     efficiency = c(keff_bottom$efficiency, keff_middle$efficiency, keff_top$efficiency)
   )
 }
 
-#' Plot K_eff efficiency by regime
+#' Plot K_eff_acf efficiency by regime
 #'
 #' @param keff_df Output from tail_keff_crisis_calm() or tail_keff_by_strategy()
 #' @return ggplot bar chart
@@ -157,7 +157,7 @@ plot_keff_efficiency <- function(keff_df) {
       title = "Effective Sample Size Efficiency by Regime",
       subtitle = "Lower efficiency = higher autocorrelation (fewer independent observations)",
       x = NULL,
-      y = "K_eff / N (Efficiency)"
+      y = "K_eff_acf / N (Efficiency)"
     ) +
     ggplot2::theme_minimal() +
     ggplot2::theme(


### PR DESCRIPTION
## Summary

PR 1 of the 4-PR plan posted as the audit response on [#160](https://github.com/JohnGavin/historical/issues/160#issuecomment-4467923628). **Mechanical rename, zero behavior change.**

Frees the bare `K_eff` token so a future PR can introduce `K_eff_strat` (the Vertox cross-strategy effective count) without silent collision against the existing time/ACF quantity.

## Naming decision (audit acceptance criterion #1)

| Quantity | New name | Where defined |
|---|---|---|
| Existing time/ACF K_eff (this PR) | **`K_eff_acf`** | `R/tail_keff.R::calculate_keff()` — Newey-West formula `N / (1 + 2·Σρ_k)` |
| Vertox cross-strategy K_eff (PR 2) | **`K_eff_strat`** | not yet implemented |
| Bare `K_eff` | **reserved / forbidden** | enforce in code review (and potentially a grep-based pre-commit check) |

## Files changed (4)

| File | What |
|---|---|
| `R/tail_keff.R` | list field, tibble columns, local var, all roxygen mentions |
| `R/plan_tail_keff.R` | caption, column refs in `select()`/`pivot_wider()`, comment markers |
| `R/plan_integration.R` | caption + `DT::formatRound()` column ref (line 264, 268) |
| `.claude/rules/backtest-robustness.md` | falsification-summary table row (line 98) |

## What's intentionally NOT renamed

- **Function names** (`calculate_keff`, `tail_keff_crisis_calm`, `tail_keff_by_strategy`, `tail_keff_partitions`, `plot_keff_efficiency`) — they use the lowercase `keff_*` prefix, never the bare `K_eff` token; no disambiguation issue.
- **Local variables** (`keff_crisis`, `keff_calm`, `keff_full`, `keff_bottom`, `keff_middle`, `keff_top`, `keff_results`, `keff_df`) — same reason.
- The `K_EFF` (all-caps) section header in `R/plan_integration.R:258` — distinct token, case-sensitive grep skipped it.

## Test plan

- [x] `grep -E 'K_eff[^_]|K_eff$'` across the 4 files: **0 hits** (no bare `K_eff` left)
- [x] `parse()` succeeds on all 3 R files
- [ ] `devtools::check()` — deferred to merge gate (this PR is a rename; no new code paths to exercise)
- [ ] Downstream pipeline rebuild (`tar_make()`) — the targets `keff_summary_table`, `keff_crisis_calm_summary`, `keff_interpretation` will rebuild because their tibble schemas changed. Worth a sanity rebuild after merge.

## What follows this PR (audit phasing)

| PR | What | Vehicle | Status |
|---|---|---|---|
| **PR 1 (this)** | rename | quick-fix / mechanical | open |
| PR 2 | `strat_keff()` helper port (numerical quadrature + Brent inversion) | sonnet worktree (numerics review) | not started |
| PR 3 | targets + `deflated_sharpe` leaderboard column + vignette | sonnet worktree | not started |
| PR 4 | `statistical-reporting` + `analytical-review-checklist` rule updates | quick-fix / prose | not started |

PR 1 is blocking for the rest because the naming collision is real today.

## Refs

- Refs #160 (PR 1 of 4)
- Audit comment: [#160 issuecomment-4467923628](https://github.com/JohnGavin/historical/issues/160#issuecomment-4467923628)

🤖 Generated with [Claude Code](https://claude.com/claude-code)