### PR TITLE
fix(security): SQL injection in metadata.R + audit of stale findings (PR A of roborev sweep)

### DIFF
--- a/packages/historicaldata/R/metadata.R
+++ b/packages/historicaldata/R/metadata.R
@@ -24,13 +24,16 @@ hd_search <- function(pattern, dataset = NULL, collect = TRUE) {
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
 
   ds <- hd_datasets()[["metadata"]]
-  escaped_pattern <- gsub("'", "''", pattern)
+  # SQL-quote user inputs via DBI to defeat injection (`'; DROP TABLE x;--` etc.)
+  # Manual gsub("'", "''", x) is insufficient — fails on backslash, NUL, encoding edges.
+  qpattern <- DBI::dbQuoteString(con, pattern)
   where <- sprintf(
-    "regexp_matches(ticker, '%s') OR regexp_matches(LOWER(long_name), LOWER('%s'))",
-    escaped_pattern, escaped_pattern
+    "regexp_matches(ticker, %s) OR regexp_matches(LOWER(long_name), LOWER(%s))",
+    qpattern, qpattern
   )
   if (!is.null(dataset)) {
-    where <- paste0("(", where, ") AND dataset = '", gsub("'", "''", dataset), "'")
+    qdataset <- DBI::dbQuoteString(con, dataset)
+    where <- paste0("(", where, ") AND dataset = ", qdataset)
   }
 
   sql <- sprintf(
@@ -96,7 +99,12 @@ hd_exchanges <- function(dataset = NULL) {
   con <- hd_connect()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
 
-  where <- if (!is.null(dataset)) sprintf("WHERE dataset = '%s'", dataset) else ""
+  # SQL-quote dataset via DBI to defeat injection (was sprintf with raw '%s').
+  where <- if (!is.null(dataset)) {
+    sprintf("WHERE dataset = %s", DBI::dbQuoteString(con, dataset))
+  } else {
+    ""
+  }
   DBI::dbGetQuery(con, sprintf(
     "SELECT exchange, full_exchange, COUNT(*) as n_tickers,
             STRING_AGG(DISTINCT dataset, ', ') as datasets


### PR DESCRIPTION
## Summary

PR A of the 4-PR roborev sweep agreed on the user's "go ahead with first PR, second PR, third PR and HTML-in-git" direction. Fixes the 2 REAL SQL injection findings in `metadata.R` and audits the 7 other SQL-tagged roborev findings as stale.

## Fixes (2 real findings)

| File | Function | Issue | Fix |
|---|---|---|---|
| `metadata.R:27-31` | `hd_search` | `gsub("'", "''", pattern)` manual escape — insufficient against backslash + encoding-edge inputs | `DBI::dbQuoteString(con, pattern)` |
| `metadata.R:33` | `hd_search` (dataset path) | Same manual escape on `dataset` | `DBI::dbQuoteString(con, dataset)` |
| `metadata.R:99` | `hd_exchanges` | `sprintf("WHERE dataset = '%s'", dataset)` — no escape at all | `sprintf("WHERE dataset = %s", DBI::dbQuoteString(con, dataset))` |

`?` parameter binding cannot be used here — both queries compose SQL alongside `hd_read_parquet_sql()` and pass the value into `regexp_matches()`/`WHERE` clauses where DuckDB needs an SQL string literal, not a bind value. `DBI::dbQuoteString()` returns a fully escaped, properly-quoted literal that DuckDB parses safely.

## Audit of 7 other SQL findings — all STALE

Verified each by reading the current code on main:

| Job | Site | Current state |
|---|---|---|
| #608 | `query.R:53-57` | `duckplyr::read_parquet_duckdb()` + dplyr verbs (no SQL) |
| #608 | `connect.R:34-37` | `DBI::dbQuoteIdentifier()` + `DBI::dbQuoteString()` already applied |
| #661 | `amendments.R:28` | `duckplyr::read_parquet_duckdb()` + `filter(ticker == !!ticker)` |
| #666 | `amendments.R:58-59` | Same — duckplyr-based |
| #762 | `vintages.R:46-49` | `duckplyr::read_parquet_duckdb()` |
| #682 | `docs/backtest.qmd:48` | File no longer exists |
| #718 | `plan_qa_vignette.R:33-37` | `duckplyr::read_parquet_duckdb()` + `distinct()` + `collect()` |

**Recommendation**: close all 7 in the roborev DB after this PR merges. They're resolved by historical refactors but the post-commit hook never re-checked. Per the `roborev-resolution` rule, this is the documented "remote-merged PRs don't fire post-commit" coverage gap.

## Test plan

- [x] `parse(metadata.R)` succeeds
- [x] Audit of 5 other R files + 1 qmd + 1 plan confirms stale findings (reads above)
- [ ] `devtools::check()` deferred to merge gate
- [ ] Functional test (`hd_search("AAPL")`, `hd_exchanges("equity_daily")`) — quick smoke test after merge; helper tests if any aren't currently in the test suite

## What's next (per user's roborev sweep direction)

- **PR B** — Silent tryCatch sweep (still need to verify count; ~5 sites located in `connect.R:14-17`, `plan_drif.R:160`, `plan_stock_backtest.R:182,845`)
- **PR C** — Look-ahead bias fixes + `qa_look_ahead_bias` target per `look-ahead-bias-prevention` rule
- **PR D** — `.gitignore` decision on docs/*.html (reviewers flagged "Nth consecutive commit" 10 times; need policy call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)