### PR TITLE
fix: surface errors from 3 silent tryCatch blocks (PR B of roborev sweep)

### DIFF
--- a/R/plan_drif.R
+++ b/R/plan_drif.R
@@ -155,7 +155,10 @@ plan_drif <- function() {
           glmnet::cv.glmnet(X_train, y_train,
                             alpha = drif_params$alpha,
                             nfolds = 5, type.measure = "mse")
-        }, error = function(e) NULL)
+        }, error = function(e) {
+          cli::cli_warn("cv.glmnet failed for month {.val {m}}: {conditionMessage(e)}")
+          NULL
+        })
 
         if (is.null(fit)) return(NULL)
         pred <- as.numeric(predict(fit, X_test, s = "lambda.min"))

--- a/R/plan_stock_backtest.R
+++ b/R/plan_stock_backtest.R
@@ -842,7 +842,10 @@ plan_stock_backtest <- function() {
         fit <- tryCatch({
           glmnet::cv.glmnet(X_train, y_train, alpha = 0.5,
                             nfolds = 5, type.measure = "mse")
-        }, error = function(e) NULL)
+        }, error = function(e) {
+          cli::cli_warn("cv.glmnet failed for month {.val {m}}: {conditionMessage(e)}")
+          NULL
+        })
 
         if (is.null(fit)) return(NULL)
         pred <- as.numeric(predict(fit, X_test, s = "lambda.min"))

--- a/packages/historicaldata/R/connect.R
+++ b/packages/historicaldata/R/connect.R
@@ -13,7 +13,13 @@ hd_connect <- function() {
   # Load httpfs as fallback for non-HF HTTPS URLs (e.g. local servers)
   tryCatch(
     invisible(DBI::dbExecute(con, "INSTALL httpfs; LOAD httpfs;")),
-    error = function(e) NULL
+    error = function(e) {
+      cli::cli_warn(c(
+        "!" = "httpfs extension not loaded: {conditionMessage(e)}",
+        "i" = "Non-HF HTTPS sources (local servers, custom Parquet URLs) will fail. hf:// still works."
+      ))
+      NULL
+    }
   )
   con
 }


### PR DESCRIPTION
## Summary

PR B of the 4-PR roborev sweep. Closes 3 open high-severity roborev findings flagged for the `suppress-warnings-antipattern` rule. Behaviour unchanged on the happy path; on failure, errors are surfaced via `cli::cli_warn` so they show up in `tar_make` logs.

## Fixes

| File | Lines | Failure mode being silenced |
|---|---|---|
| `packages/historicaldata/R/connect.R` | 14–21 | DuckDB `INSTALL httpfs; LOAD httpfs;` — disk full / permission / corrupt cache. Silently left all non-hf:// URL queries broken. |
| `R/plan_drif.R` | 154–161 | `glmnet::cv.glmnet` per-month failure (singular matrix, convergence). Silent month-skip across hundreds of months. |
| `R/plan_stock_backtest.R` | 842–849 | Same `cv.glmnet` pattern in the stock-level DRIF backtest. |

Each `error = function(e) NULL` replaced with `error = function(e) { cli::cli_warn("..."); NULL }`. Downstream `is.null(fit)` checks unchanged.

## Out-of-scope follow-up

`R/plan_stock_backtest.R:181-183` has the same antipattern in HRP weight computation (caught in audit, not roborev-flagged). Worth a small separate PR to keep this commit narrow to the roborev-flagged sites.

## Test plan

- [x] `parse()` succeeds on all 3 files
- [x] `cli` already in `DESCRIPTION` Imports — no new dep
- [ ] `devtools::check()` — deferred to merge gate (no API change)
- [ ] First `tar_make` after merge — surface any pre-existing latent failures these `cli_warn`s now expose

Refs roborev jobs #649, #724, #754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)