### PR TITLE
fix: look-ahead bias — calendar-shift + lead before forward window (PR C of roborev sweep)

### DIFF
--- a/R/momentum_decomposition.R
+++ b/R/momentum_decomposition.R
@@ -381,20 +381,26 @@ compute_persistence <- function(decomposed_momentum,
     h <- results$horizon[i]
     h_months <- horizon_months[h]
 
-    # Join signal with forward returns
-    # Compute forward returns using slider (forward-looking window)
+    # Join signal with forward returns. The signal at month T must predict
+    # returns over T+1 through T+h. Lead the return series by one period
+    # first, then take a forward window of length h. Without the lead, the
+    # window T:T+h-1 includes month T's own return — i.e., the signal is
+    # "predicting" the month it was computed in (roborev #941, look-ahead
+    # bias).
     forward <- stock_returns |>
       dplyr::group_by(ticker) |>
       dplyr::arrange(date) |>
       dplyr::mutate(
+        monthly_ret_lead = dplyr::lead(monthly_ret, n = 1L),
         forward_ret = slider::slide_dbl(
-          monthly_ret,
+          monthly_ret_lead,
           ~prod(1 + .x, na.rm = FALSE) - 1,
           .before = 0,
           .after = h_months - 1,
           .complete = TRUE
         )
       ) |>
+      dplyr::select(-monthly_ret_lead) |>
       dplyr::ungroup() |>
       dplyr::select(ticker, date, forward_ret)
 

--- a/R/plan_stock_backtest.R
+++ b/R/plan_stock_backtest.R
@@ -9,6 +9,28 @@
 
 # ── Helpers (not targets) ─────────────────────────────────────────
 
+#' Shift a "YYYY-MM" string by one calendar month
+#'
+#' Replaces the look-ahead-prone `dplyr::lead(ym)` row-based shift, which
+#' silently pairs a month-T signal with a non-T+1 return when a ticker has
+#' gaps in its monthly panel. Calendar-based shift means the signal_ym -> ym
+#' pairing is fixed at the calendar level — missing months become explicit
+#' NA after the downstream join rather than silently shifting to the wrong
+#' return. Vectorised; base R only (no lubridate dep).
+#'
+#' Fixes roborev #752 (R/plan_stock_backtest.R look-ahead).
+#'
+#' @noRd
+next_ym <- function(ym) {
+  vapply(ym, function(x) {
+    if (is.na(x) || !nzchar(x)) return(NA_character_)
+    d <- as.Date(paste0(x, "-01"))
+    if (is.na(d)) return(NA_character_)
+    d_next <- seq.Date(d, by = "1 month", length.out = 2L)[2L]
+    format(d_next, "%Y-%m")
+  }, character(1L), USE.NAMES = FALSE)
+}
+
 #' Assign decile ranks within each month
 #' @param df Data frame with ym and signal columns
 #' @param signal_col Name of signal column (unquoted)
@@ -454,7 +476,7 @@ plan_stock_backtest <- function() {
       signal <- stk_max_signal |>
         group_by(ticker) |>
         arrange(ym) |>
-        mutate(signal_ym = ym, ym = dplyr::lead(ym)) |>
+        mutate(signal_ym = ym, ym = next_ym(ym)) |>
         filter(!is.na(ym)) |>
         ungroup()
 
@@ -499,7 +521,7 @@ plan_stock_backtest <- function() {
       signal <- stk_max_signal |>
         group_by(ticker) |>
         arrange(ym) |>
-        mutate(signal_ym = ym, ym = dplyr::lead(ym)) |>
+        mutate(signal_ym = ym, ym = next_ym(ym)) |>
         filter(!is.na(ym)) |>
         ungroup()
 
@@ -544,7 +566,7 @@ plan_stock_backtest <- function() {
       signal <- stk_max_signal |>
         group_by(ticker) |>
         arrange(ym) |>
-        mutate(signal_ym = ym, ym = dplyr::lead(ym)) |>
+        mutate(signal_ym = ym, ym = next_ym(ym)) |>
         filter(!is.na(ym)) |>
         ungroup()
 


### PR DESCRIPTION
## Summary

PR C of the 4-PR roborev sweep. Closes 2 high-severity findings flagged against the global `look-ahead-bias-prevention` rule. **Both fixes CHANGE BACKTEST RESULTS** — please review delta carefully before merge.

## Fixes

### Fix 1 — `R/plan_stock_backtest.R` (3 sites; roborev #752)

`dplyr::lead(ym)` after `group_by(ticker) |> arrange(ym)` is a **row-based** shift, not calendar. For a ticker missing Feb, the Jan signal silently pairs with March returns. Both look-ahead AND wrong-period.

New helper:

```r
next_ym <- function(ym) {
  vapply(ym, function(x) {
    if (is.na(x) || !nzchar(x)) return(NA_character_)
    d <- as.Date(paste0(x, "-01"))
    if (is.na(d)) return(NA_character_)
    d_next <- seq.Date(d, by = "1 month", length.out = 2L)[2L]
    format(d_next, "%Y-%m")
  }, character(1L), USE.NAMES = FALSE)
}
```

Three `mutate(signal_ym = ym, ym = dplyr::lead(ym))` sites replaced with `mutate(signal_ym = ym, ym = next_ym(ym))`. Missing months now produce explicit NA after the downstream join instead of silently shifting to the wrong return.

Base R only — no new dependency.

### Fix 2 — `R/momentum_decomposition.R` (roborev #941)

`slider::slide_dbl(monthly_ret, .before = 0, .after = h_months - 1)` includes month T's OWN return in the "forward" window. Horizon "1m" was "predicting" the month the signal was computed in.

Fixed by leading the input series first:

```r
monthly_ret_lead = dplyr::lead(monthly_ret, n = 1L),
forward_ret = slider::slide_dbl(monthly_ret_lead, ...)
```

Window `T:T+h-1` on the leaded series equals `T+1:T+h` on the original — the intended forward window.

## Expected directional impact on metrics

- **`stk_max_*` / `stk_drif_*` / `fals_rsc_*` etc.**: fewer signal→return pairs (calendar shift drops misaligned ones). Net Sharpe / CAGR effect unpredictable per-strategy.
- **`momentum_decomposition::compute_persistence`**: IC / t-stat values WILL move. Any persistence metric inflated by look-ahead will drop.

The CHANGELOG entry under "Accuracy fixes" should document both deltas once `tar_make` is re-run.

## Mandatory follow-up (NOT in this PR)

The `look-ahead-bias-prevention` rule says "Every project with a backtest MUST include a `qa_look_ahead_bias` target". Template lives in `model-evaluation-calibration` skill (~50 LOC, 4 sub-checks). **Strongly recommend filing a follow-up issue / PR for this QA target so the violations don't recur** — otherwise the next backtest addition silently reintroduces the same bug.

## Test plan

- [x] `parse()` succeeds on both files
- [x] `next_ym()` is correct on year/leap-year boundaries by construction (uses `seq.Date` which knows the calendar)
- [x] No new dependencies (slider already in deps)
- [ ] Re-run `tar_make()` after merge to surface the result deltas
- [ ] CHANGELOG entry documenting before/after numbers per affected strategy
- [ ] `devtools::check()` — deferred to merge gate

Refs roborev jobs #752, #941.

🤖 Generated with [Claude Code](https://claude.com/claude-code)