### PR TITLE
chore(roborev): document HTML-in-git wontfix policy (PR D, 10 jobs closed)

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -4,3 +4,16 @@
 fix_min_severity = "high"
 refine_min_severity = "high"
 max_prompt_size = 200000
+
+# ── Review-exclusion policy ──────────────────────────────────────────────────
+# Some patterns reviewers will keep flagging are intentional in this project.
+# Document them here so future review prompts can be told not to re-flag.
+#
+# 1. HTML in docs/ (10 jobs closed 2026-05-16, IDs 628 630 631 632 633 635
+#    636 637 638 715). GitHub Pages serves this project's site directly from
+#    `main` `/docs/`, per the global `gh-pages-nojekyll` and
+#    `website-index-update` rules. Removing `docs/*.html` from git breaks
+#    the deployed site. Reviewers should NOT flag committed HTML/CSS/JS in
+#    `docs/` as a code-review concern — it is the deployed artifact.
+#    Internal-only HTML (e.g. examples.html, dashboard.html dev builds) IS
+#    gitignored via docs/.gitignore where appropriate.


### PR DESCRIPTION
## Summary

PR D of the 4-PR roborev sweep. Pure configuration change — closes 10 high-severity roborev findings as wontfix and documents the persistent policy exception in `.roborev.toml`.

## What was done

| Action | Detail |
|---|---|
| **Closed** | 10 roborev jobs (#628 #630 #631 #632 #633 #635 #636 #637 #638 #715), each with an explanatory comment attached via `roborev comment` |
| **Documented** | 12-line policy block added to `.roborev.toml` so future review prompts can be configured not to re-flag this pattern |
| **Code changes** | None |

## Rationale

The 10 jobs all flagged "Generated HTML committed to source control" with recommended fix "git rm --cached + gitignore + CI-render". This **contradicts** the project's deploy model:

- Global rule [`gh-pages-nojekyll`](https://github.com/JohnGavin/llm/blob/main/.claude/rules/gh-pages-nojekyll.md): GitHub Pages serves the historical site from `main` `/docs/` directly. `.nojekyll` already in place.
- Global rule [`website-index-update`](https://github.com/JohnGavin/llm/blob/main/.claude/rules/website-index-update.md): project pages live in `/docs/` and MUST be served from the default branch.

Removing `docs/*.html` from git breaks the deployed site immediately. The reviewer's pattern recognition is correct in general (committed HTML is noisy in PRs) but inapplicable to this project's chosen deploy model.

Internal-only HTML (dev/scratch builds, e.g. `examples.html`) IS gitignored via `docs/.gitignore` where appropriate — selective rather than blanket.

## What's still in roborev (not addressed by this PR D)

After this sweep (PR A + B + C + D), the open roborev backlog drops from **69 high-severity findings** to:

- **40 commit-specific findings** that don't cluster — each tied to a specific commit, needs individual triage. No common pattern to batch-close.
- **1 broken-target finding** (R/plan_factormax.R QA gap) — separate small PR.
- **1 hardcoded-prose value** (`docs/stock-backtest.qmd`) — separate small PR per `dynamic-prose-values` rule.
- **1 misleading docstring** (`R/plan_backtest.R` outdated `tar_make` comment) — trivial fix.
- **1 dark-mode unconditional CSS** in `docs/vignette_utils.R` — needs decision.
- **The pending `qa_look_ahead_bias` target** mentioned as follow-up in PR C.

These are queued but out of scope for the 4-PR sweep agreed today.

## Refs

Closed roborev jobs: #628 #630 #631 #632 #633 #635 #636 #637 #638 #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)