### PR TITLE
fix(vignette): NA hygiene in 3 vig_pair code targets (PR-E)

### DIFF
--- a/R/plan_vignette.R
+++ b/R/plan_vignette.R
@@ -110,7 +110,7 @@ vol <- hd_ohlcv(vol_tickers, from = "2023-06-01") |>
   mutate(
     log_ret = log(adjusted / lag(adjusted)),
     cum_sq = cumsum(if_else(is.na(log_ret), 0, log_ret^2)),
-    vol_21d = sqrt(pmax((cum_sq - lag(cum_sq, 21, default = 0)) / 21, 0)) * sqrt(252)
+    vol_21d = sqrt(pmax((cum_sq - lag(cum_sq, 21, default = NA_real_)) / 21, 0)) * sqrt(252)
   ) |>
   filter(!is.na(vol_21d), date >= as.Date("2024-01-01")) |>
   ungroup()
@@ -176,10 +176,9 @@ wide <- hd_ohlcv(corr_tickers, from = "2023-01-01") |>
   mutate(ret = log(close / lag(close))) |>
   filter(!is.na(ret)) |> ungroup() |>
   select(date, ticker, ret) |>
-  pivot_wider(names_from = ticker, values_from = ret) |>
-  filter(if_all(everything(), ~ !is.na(.)))
+  pivot_wider(names_from = ticker, values_from = ret)
 
-cor_mat <- cor(wide |> select(-date))
+cor_mat <- cor(wide |> select(-date), use = "pairwise.complete.obs")
 cor_long <- cor_mat |> as.data.frame() |>
   mutate(row = rownames(cor_mat)) |>
   pivot_longer(-row, names_to = "col", values_to = "cor")
@@ -249,8 +248,10 @@ p
 # Batch query: 2 credit spread series in one request
 spreads <- hd_macro(c("BAMLH0A0HYM2", "BAMLC0A4CBBB"), from = "2020-01-01") |>
   filter(!is.na(value)) |>
-  mutate(series_id = recode(series_id,
-    BAMLH0A0HYM2 = "HY Spread", BAMLC0A4CBBB = "BBB Spread"))
+  mutate(series_id = case_match(series_id,
+    "BAMLH0A0HYM2" ~ "HY Spread",
+    "BAMLC0A4CBBB" ~ "BBB Spread",
+    .default = series_id))
 
 ggplot(spreads, aes(date, value, colour = series_id)) +
   geom_line(linewidth = 0.5) +


### PR DESCRIPTION
## Summary

Three small fixes inside `vig_pair()` code-as-string bodies in `R/plan_vignette.R`. All three flagged repeatedly across the roborev backlog and verified LIVE before fixing.

- **`vig_eq_vol` line 113** — rolling vol lag default `0` → `NA_real_`. With `default = 0`, the first 20 days produced artificially low realised volatility. Line 115 already filters `!is.na(vol_21d)`, so NA values are now correctly dropped from the warmup window.
- **`vig_cr_corr` line 180** — drop `filter(if_all(everything(), ~ !is.na(.)))` survivorship filter; switch `cor()` to `use = "pairwise.complete.obs"`. Old filter dropped every date where any token had any NA, biasing the correlation matrix toward dates with full coverage.
- **`vig_ma_spreads` line 252** — swap `dplyr::recode()` for `case_match()`. `recode()` superseded since dplyr 1.1.0; `case_match()` avoids NSE confusion. `.default = series_id` preserves unmatched values.

The yield-curve `min(inv$date)` guard at lines 228-230 was flagged in the same backlog but is **STALE** — already guarded at line 236 (`if (nrow(inv) > 0)`). No change needed.

Companion to the 2026-05-16 sweep (#179 SQL injection, #180 silent tryCatch, #181 look-ahead bias, #182 HTML-in-git policy).

## Test plan

- [x] `parse("R/plan_vignette.R")` succeeds (4 expressions)
- [x] `grep -nE 'default = 0\b|if_all\(everything\(\)|[^_]recode\('` returns no matches in file
- [ ] CI: vignette render (HTML output) at next `tar_make()`
- [ ] Visual check: `vig_eq_vol` first 20 days of plot should now be absent (NA filtered), not flat-low; `vig_cr_corr` correlation matrix unchanged or slightly more cells filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)