### PR TITLE
fix(ranked): deterministic LAST() in vol GROUP BY (PR-G)

### DIFF
--- a/packages/historicaldata/R/ranked.R
+++ b/packages/historicaldata/R/ranked.R
@@ -71,8 +71,8 @@ hd_most_volatile <- function(dataset = "equity_daily", n = 5, window_days = 21) 
     ),
     latest_vol AS (
       SELECT ticker,
-        LAST(vol) AS vol_21d,
-        LAST(date) AS as_of
+        LAST(vol ORDER BY date) AS vol_21d,
+        MAX(date) AS as_of
       FROM vol
       GROUP BY ticker
     )


### PR DESCRIPTION
## Summary

In `packages/historicaldata/R/ranked.R` `hd_most_volatile()`:

```diff
  latest_vol AS (
    SELECT ticker,
-     LAST(vol) AS vol_21d,
-     LAST(date) AS as_of
+     LAST(vol ORDER BY date) AS vol_21d,
+     MAX(date) AS as_of
    FROM vol
    GROUP BY ticker
  )
```

DuckDB's `LAST()` aggregate without an explicit `ORDER BY` uses arbitrary input order — the row picked per ticker varies across runs (and across DuckDB versions). Adding `ORDER BY date` makes the choice deterministic: the `vol` value at the most recent date is what `hd_most_volatile()` promises to return.

`MAX(date)` for `as_of` is equivalent to `LAST(date ORDER BY date)` and more idiomatic.

`WHERE vol_21d IS NOT NULL` outside the CTE still drops tickers whose most recent stddev window has no data — prior behaviour preserved.

Found by roborev #640.

## Test plan

- [x] `parse("packages/historicaldata/R/ranked.R")` succeeds
- [ ] Next `tar_make()` shows `hd_most_volatile()` returns stable ranking across consecutive runs

PR-H (look-ahead re-verification of `momentum_decomposition.R:352-357` / `:313-315` / `:390-395`) was verified STALE — already fixed by #181's `monthly_ret_lead` change. No code needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)