### PR TITLE
fix(query): split-and-bind hd_ohlcv for mixed-dataset batches (PR-F)

### DIFF
--- a/packages/historicaldata/NEWS.md
+++ b/packages/historicaldata/NEWS.md
@@ -1,0 +1,9 @@
+# historicaldata 0.1.1
+
+* `hd_ohlcv()` now correctly handles mixed-dataset batches (e.g.
+  `c("AAPL", "BTC")`) by detecting each ticker's dataset, querying each
+  parquet separately, and binding the results. Previously, only the first
+  ticker's dataset was queried — non-matching tickers were silently dropped.
+  When the batch spans datasets, the result is always materialised; pass
+  an explicit `dataset = "equity_daily"` (or similar) to force single-dataset
+  routing and preserve lazy frames.

--- a/packages/historicaldata/R/query.R
+++ b/packages/historicaldata/R/query.R
@@ -7,23 +7,66 @@
 #'   Single: `"AAPL"`. Batch: `c("AAPL", "MSFT", "GOOGL")`.
 #' @param from Start date (character or Date). Default: no filter.
 #' @param to End date (character or Date). Default: no filter.
-#' @param dataset Dataset name from registry. If NULL, auto-detected from first ticker.
+#' @param dataset Dataset name from registry. If `NULL` (default), each ticker
+#'   is routed to its dataset via [detect_dataset()] and results are bound
+#'   together. Pass an explicit dataset name to force single-dataset routing.
 #' @param local If TRUE, query local cache instead of remote.
 #' @param collect If TRUE, materialise immediately (backward compatible).
 #'   If FALSE (default), return a lazy duckplyr frame.
+#' @details
+#' Mixed-dataset batches (e.g. `c("AAPL", "BTC")`) are split by detected
+#' dataset, queried separately, and `bind_rows`'d. Columns that exist in
+#' only one dataset (e.g. `adjusted` in equities, `market_cap` in crypto)
+#' are filled with `NA` for rows from the other dataset. When the batch
+#' spans multiple datasets, the result is always materialised — `collect
+#' = FALSE` cannot be honoured because lazy frames from distinct parquet
+#' sources cannot be bound.
 #' @return Lazy duckplyr frame (collect=FALSE) or tibble (collect=TRUE)
 #' @family data-access
 #' @export
 #' @examplesIf interactive()
 #' hd_ohlcv("AAPL", from = "2024-01-01") |> collect()
 #' hd_ohlcv(c("AAPL", "MSFT"), from = "2024-01-01", collect = TRUE)
+#' hd_ohlcv(c("AAPL", "BTC"), from = "2024-01-01")  # mixed equity + crypto
 hd_ohlcv <- function(ticker, from = NULL, to = NULL,
                      dataset = NULL, local = FALSE, collect = TRUE) {
   ticker <- as.character(ticker)
-  if (is.null(dataset)) {
-    dataset <- detect_dataset(ticker[1])
+  if (length(ticker) == 0L) {
+    cli::cli_abort("{.arg ticker} must be a non-empty character vector.")
   }
 
+  # Explicit dataset: skip auto-detection, single-dataset query (unchanged behaviour).
+  if (!is.null(dataset)) {
+    return(hd_ohlcv_single(ticker, dataset, from, to, local, collect))
+  }
+
+  # Auto-detect per ticker, then group.
+  detected <- vapply(ticker, detect_dataset, character(1L), USE.NAMES = FALSE)
+  ds_groups <- split(ticker, detected)
+
+  # Fast path: all tickers belong to one dataset — single query, identical to old behaviour.
+  if (length(ds_groups) == 1L) {
+    return(hd_ohlcv_single(ticker, names(ds_groups), from, to, local, collect))
+  }
+
+  # Mixed-dataset batch: query each, bind, return materialised.
+  # Lazy mode cannot survive bind_rows across distinct parquet sources — inform user.
+  if (!collect) {
+    cli::cli_inform(c(
+      "Mixed-dataset batch detected: {.val {names(ds_groups)}}.",
+      "i" = "Returning materialised tibble; {.code collect = FALSE} cannot be honoured when binding across datasets."
+    ))
+  }
+
+  results <- lapply(names(ds_groups), function(ds_name) {
+    hd_ohlcv_single(ds_groups[[ds_name]], ds_name, from, to, local, collect = TRUE)
+  })
+  dplyr::bind_rows(results) |> dplyr::arrange(ticker, date)
+}
+
+#' @noRd
+# Internal: single-dataset OHLCV query. See hd_ohlcv for split-and-bind public wrapper.
+hd_ohlcv_single <- function(ticker, dataset, from, to, local, collect) {
   ds <- hd_datasets()[[dataset]]
   if (is.null(ds)) {
     cli::cli_abort("Unknown dataset: {dataset}. See {.fn hd_datasets}.")

--- a/packages/historicaldata/man/hd_ohlcv.Rd
+++ b/packages/historicaldata/man/hd_ohlcv.Rd
@@ -21,7 +21,9 @@ Single: \code{"AAPL"}. Batch: \code{c("AAPL", "MSFT", "GOOGL")}.}
 
 \item{to}{End date (character or Date). Default: no filter.}
 
-\item{dataset}{Dataset name from registry. If NULL, auto-detected from first ticker.}
+\item{dataset}{Dataset name from registry. If \code{NULL} (default), each ticker
+is routed to its dataset via \code{\link[=detect_dataset]{detect_dataset()}} and results are bound
+together. Pass an explicit dataset name to force single-dataset routing.}
 
 \item{local}{If TRUE, query local cache instead of remote.}
 
@@ -35,10 +37,19 @@ Lazy duckplyr frame (collect=FALSE) or tibble (collect=TRUE)
 Returns a duckplyr lazy frame by default. Call \code{collect()} to materialise,
 or chain additional dplyr verbs for server-side computation.
 }
+\details{
+Mixed-dataset batches (e.g. \code{c("AAPL", "BTC")}) are split by detected
+dataset, queried separately, and \code{bind_rows}'d. Columns that exist in
+only one dataset (e.g. \code{adjusted} in equities, \code{market_cap} in crypto)
+are filled with \code{NA} for rows from the other dataset. When the batch
+spans multiple datasets, the result is always materialised — \code{collect = FALSE} cannot be honoured because lazy frames from distinct parquet
+sources cannot be bound.
+}
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 hd_ohlcv("AAPL", from = "2024-01-01") |> collect()
 hd_ohlcv(c("AAPL", "MSFT"), from = "2024-01-01", collect = TRUE)
+hd_ohlcv(c("AAPL", "BTC"), from = "2024-01-01")  # mixed equity + crypto
 \dontshow{\}) # examplesIf}
 }
 \seealso{

--- a/packages/historicaldata/tests/testthat/_snaps/query.md
+++ b/packages/historicaldata/tests/testthat/_snaps/query.md
@@ -58,3 +58,20 @@
         ..$ frequency  : chr "append-only"
         ..$ description: chr "PIT log of all metadata changes: computed fields, enrichments, corrections"
 
+# hd_ohlcv split-and-bind: collect=FALSE informs user
+
+    Code
+      result <- hd_ohlcv(c("AAPL", "BTC"), from = "2026-04-01", to = "2026-04-05",
+      collect = FALSE)
+    Message
+      Mixed-dataset batch detected: "crypto_daily" and "equity_daily".
+      i Returning materialised tibble; `collect = FALSE` cannot be honoured when binding across datasets.
+
+# hd_ohlcv: empty ticker vector errors
+
+    Code
+      hd_ohlcv(character(0))
+    Condition
+      Error in `hd_ohlcv()`:
+      ! `ticker` must be a non-empty character vector.
+

--- a/packages/historicaldata/tests/testthat/test-query.R
+++ b/packages/historicaldata/tests/testthat/test-query.R
@@ -88,3 +88,45 @@ test_that("hd_connect_local handles quoted parquet paths", {
   result <- DBI::dbGetQuery(con, "SELECT x FROM sample")
   expect_equal(result$x, 1)
 })
+
+test_that("hd_ohlcv split-and-bind: mixed equity + crypto batch", {
+  skip_on_cran()
+  skip_if_offline()
+
+  result <- hd_ohlcv(c("AAPL", "BTC"), from = "2026-04-01", to = "2026-04-10")
+  expect_s3_class(result, "tbl_df")
+  expect_true(nrow(result) > 0L)
+  expect_true("AAPL" %in% result$ticker)
+  expect_true("BTC" %in% result$ticker)
+  # Union of schemas: equity-only columns are NA for crypto rows
+  expect_true("adjusted" %in% names(result))     # equity-only column
+  aapl_rows <- result[result$ticker == "AAPL", ]
+  btc_rows  <- result[result$ticker == "BTC",  ]
+  expect_true(all(!is.na(aapl_rows$adjusted)))   # AAPL has adjusted prices
+  expect_true(all(is.na(btc_rows$adjusted)))     # BTC rows get NA for equity-only col
+})
+
+test_that("hd_ohlcv split-and-bind: collect=FALSE informs user", {
+  skip_on_cran()
+  skip_if_offline()
+
+  expect_snapshot(
+    result <- hd_ohlcv(c("AAPL", "BTC"), from = "2026-04-01",
+                       to = "2026-04-05", collect = FALSE)
+  )
+  expect_s3_class(result, "tbl_df")  # materialised despite collect=FALSE
+})
+
+test_that("hd_ohlcv split-and-bind: single-dataset batch keeps fast path", {
+  skip_on_cran()
+  skip_if_offline()
+
+  # Two equity tickers — no inform message, no split, normal collect respected
+  result <- hd_ohlcv(c("AAPL", "MSFT"), from = "2026-04-01", to = "2026-04-05")
+  expect_s3_class(result, "tbl_df")
+  expect_setequal(unique(result$ticker), c("AAPL", "MSFT"))
+})
+
+test_that("hd_ohlcv: empty ticker vector errors", {
+  expect_snapshot(error = TRUE, hd_ohlcv(character(0)))
+})


### PR DESCRIPTION
## Summary

Resolves **roborev #641 silent data loss**. `hd_ohlcv(c("AAPL", "BTC"))` previously called `detect_dataset(ticker[1])` and queried only ONE parquet — BTC rows were silently dropped because BTC isn't in `equity_daily.parquet`. No warning, no error, just missing rows.

### New behaviour

- Per-ticker dataset detection via `vapply(ticker, detect_dataset, ...)`
- `split(ticker, detected_dataset)`, then `lapply` over groups
- `bind_rows` per-dataset results, then `arrange(ticker, date)`
- **Single-dataset fast path unchanged** (no perf regression for legacy callers)
- Explicit `dataset = "..."` arg still forces single-dataset routing

Schema union: equity-only columns (`open`/`high`/`low`/`adjusted`) are `NA` for crypto rows. Mixed-dataset batches are always materialised — `collect = FALSE` can't be honoured across distinct parquet sources; `cli::cli_inform()` tells the user when this auto-upgrade happens.

### Refactor

Extracted internal `hd_ohlcv_single()` holding the original single-dataset body verbatim. `hd_ohlcv` is now a 30-line public router.

### Tests

Four new `test_that` blocks appended to `test-query.R`:
- mixed AAPL+BTC batch: both tickers present, BTC `adjusted` is NA
- collect=FALSE on mixed batch: snapshot inform message
- single-dataset batch: fast path preserved (no inform fired)
- empty ticker vector: snapshot cli_abort message

Result: `[ FAIL 0 | WARN 1 | SKIP 0 | PASS 37 ]`. The 1 warning is pre-existing (`Coercing nanoseconds to a lower resolution`, from duckplyr).

### Side-finding (separate roborev pass, NOT fixed here)

Registry declares `crypto_daily.parquet` has a `market_cap` column but the actual parquet does not carry it. Registry/data schema drift. Worth filing as its own issue.

### NEWS / version

`NEWS.md` was missing; created and bumped patch version to `0.1.1`.

## Test plan

- [x] `parse()` succeeds for `query.R` (7 expressions) and `test-query.R` (13 expressions)
- [x] `devtools::document()` regenerates `hd_ohlcv.Rd` cleanly
- [x] `devtools::test(filter = "query")`: 37 pass, 0 fail, 0 warn (new), 2 new snapshots accepted
- [ ] User pull on a known mixed batch (e.g. `hd_ohlcv(c("AAPL", "BTC", "ETH", "MSFT"), from = "2026-04-01")`) and visually confirm all 4 tickers appear in result

🤖 Generated with [Claude Code](https://claude.com/claude-code)