### PR TITLE
fix(docs): dark-mode gating + bslib overrides + XSS innerHTML + DRY (cluster D)

### DIFF
--- a/docs/_includes/build-info-footer.qmd
+++ b/docs/_includes/build-info-footer.qmd
@@ -1,0 +1,6 @@
+```{r}
+#| label: build-info
+#| echo: false
+#| results: asis
+build_info()
+```

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -1,0 +1,4 @@
+project:
+  type: default
+  post-render:
+    - /Users/johngavin/docs_gh/llm/.claude/scripts/quarto_post_render_contrast.sh

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -87,7 +87,10 @@ format:
             // Clone just the img into a temporary overlay div
             var div = document.createElement('div');
             div.className = 'fullscreen-overlay';
-            div.innerHTML = '<img src="' + img.src + '">';
+            var overlayImg = document.createElement('img');
+            overlayImg.src = img.src;
+            overlayImg.alt = img.alt || '';
+            div.appendChild(overlayImg);
             div.addEventListener('click', function() { div.remove(); });
             document.body.appendChild(div);
           });

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -19,14 +19,13 @@ format:
           /* Plot height: constrain to reasonable aspect ratio */
           .cell-output-display img { min-height: auto; max-height: 500px; object-fit: contain; }
           /* Kill dashboard fill layout — content flows like a normal page */
+          /* Exclude .bslib-grid and .bslib-grid-item to preserve grid layout */
           .bslib-page-fill, .html-fill-container, .html-fill-item,
-          .bslib-card, .card, .tab-pane, .tab-content, .card-body,
-          .bslib-grid, .bslib-grid-item {
+          .bslib-card, .card, .tab-pane, .tab-content, .card-body {
             height: auto !important;
             min-height: 0 !important;
             max-height: none !important;
             overflow: visible !important;
-            flex: none !important;
           }
           /* Each cell output: block layout, no overlap */
           .cell-output-display { display: block !important; position: relative !important;
@@ -36,7 +35,7 @@ format:
           /* Fig captions: below the plot, not overlaid */
           .fig-caption { display: block; position: relative; clear: both;
             margin-top: 0.5em; margin-bottom: 1em; }
-          /* Tables: block, no overlap, horizontal scroll via wrapper */
+          /* Tables: block, horizontal scroll (not overflow:visible which breaks DT scroll) */
           .datatables, .dataTables_wrapper { display: block !important;
             position: relative !important; overflow-x: auto !important;
             margin-top: 0.5em; margin-bottom: 1em; }

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -697,9 +697,4 @@ Then start R and run the Setup tab code above.
 
 ## Row
 
-```{r}
-#| label: build-info
-#| echo: false
-#| results: asis
-build_info()
-```
+{{< include _includes/build-info-footer.qmd >}}

--- a/docs/macro-defense-rotation.qmd
+++ b/docs/macro-defense-rotation.qmd
@@ -38,12 +38,11 @@ format:
           /* Allow navbar tabs to wrap to second line */
           .navbar-nav { flex-wrap: wrap !important; }
           .navbar .nav-link { font-size: 0.9em; padding: 0.3em 0.6em !important; }
+          /* Exclude .bslib-grid and .bslib-grid-item to preserve grid layout */
           .bslib-page-fill, .html-fill-container, .html-fill-item,
-          .bslib-card, .card, .tab-pane, .tab-content, .card-body,
-          .bslib-grid, .bslib-grid-item {
+          .bslib-card, .card, .tab-pane, .tab-content, .card-body {
             height: auto !important; min-height: 0 !important;
             max-height: none !important; overflow: visible !important;
-            flex: none !important;
           }
           .cell-output-display { display: block !important; position: relative !important;
             overflow: visible !important; margin-bottom: 1em; }

--- a/docs/macro-defense-rotation.qmd
+++ b/docs/macro-defense-rotation.qmd
@@ -77,7 +77,10 @@ format:
             if (!img) return;
             var div = document.createElement('div');
             div.className = 'fullscreen-overlay';
-            div.innerHTML = '<img src="' + img.src + '">';
+            var overlayImg = document.createElement('img');
+            overlayImg.src = img.src;
+            overlayImg.alt = img.alt || '';
+            div.appendChild(overlayImg);
             div.addEventListener('click', function() { div.remove(); });
             document.body.appendChild(div);
           });

--- a/docs/macro-defense-rotation.qmd
+++ b/docs/macro-defense-rotation.qmd
@@ -695,9 +695,4 @@ ggplot(both, aes(date, cum, colour = method)) +
 
 #### Build Info
 
-```{r}
-#| label: build-info
-#| echo: false
-#| results: asis
-build_info()
-```
+{{< include _includes/build-info-footer.qmd >}}

--- a/docs/vignette-shared.css
+++ b/docs/vignette-shared.css
@@ -22,12 +22,11 @@ body { font-size: 1.1em; }
 [data-bs-theme="light"] .fig-caption { color: #555 !important; }
 
 /* Kill dashboard fill layout — content flows like a normal page */
+/* Exclude .bslib-grid and .bslib-grid-item to preserve grid layout */
 .bslib-page-fill, .html-fill-container, .html-fill-item,
-.bslib-card, .card, .tab-pane, .tab-content, .card-body,
-.bslib-grid, .bslib-grid-item {
+.bslib-card, .card, .tab-pane, .tab-content, .card-body {
   height: auto !important; min-height: 0 !important;
   max-height: none !important; overflow: visible !important;
-  flex: none !important;
 }
 
 /* Cell outputs: block layout, no overlap */

--- a/docs/vignette_utils.R
+++ b/docs/vignette_utils.R
@@ -120,14 +120,17 @@ hd_dt <- function(df, caption_text) {
       ),
       initComplete = DT::JS(
         "function(settings, json) {",
-        "  $(this.api().table().container()).css({'color': '#ddd', 'background-color': '#1a1a1a'});",
-        "  $(this.api().table().header()).css({'color': '#ddd', 'background-color': '#222'});",
-        "  $('input', this.api().table().container()).css({'color': '#ddd', 'background-color': '#333', 'border-color': '#555'});",
+        "  var isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark'",
+        "    || document.body.classList.contains('dark-mode');",
+        "  if (isDark) {",
+        "    $(this.api().table().container()).css({'color': '#ddd', 'background-color': '#1a1a1a'});",
+        "    $(this.api().table().header()).css({'color': '#ddd', 'background-color': '#222'});",
+        "    $('input', this.api().table().container()).css({'color': '#ddd', 'background-color': '#333', 'border-color': '#555'});",
+        "  }",
         "}"
       )
     )
-  ) |>
-    DT::formatStyle(columns = names(df), color = "#ddd", backgroundColor = "#1a1a1a")
+  )
 }
 
 #' DT table transposed: few rows + many columns → columns become rows


### PR DESCRIPTION
## Summary

Roborev cluster D: six LIVE high-severity fixes across \`docs/vignette_utils.R\`, \`docs/examples.qmd\`, \`docs/backtest.qmd\`, \`docs/macro-defense-rotation.qmd\` (plus new \`_quarto.yml\` post-render contrast hook and \`_includes/build-info-footer.qmd\` shared partial). Five commits, agent hit org limit before pushing or running final contrast check.

### Commits

- \`bc91c8f\` — \`_quarto.yml\` post-render contrast script registration (prerequisite)
- \`424ac46\` — F1 dark-mode DT colours gated behind isDark check (light users readable)
- \`058931c\` — F2/F3/F4 bslib-grid \`flex:none\`, datatables \`overflow:visible\`, fill-container \`height:auto\` removed/scoped
- \`047215d\` — F5 XSS-prone \`innerHTML\` + \`img.src\` string concat replaced with \`createElement\` (auto-escaped)
- \`c4df067\` — F6 build-info block extracted to shared partial; both call sites updated

## Worker limit caveat

Agent did NOT run \`check_dark_contrast.sh\` or \`quarto render\` smoke test before budget cutoff. **Manual verification needed:**

\`\`\`bash
~/docs_gh/llm/.claude/scripts/check_dark_contrast.sh   # must exit 0
nix develop --command quarto render docs/examples.qmd --to html    # smoke
\`\`\`

If either fails, the PR needs a follow-up before merge.

## Test plan

- [ ] Visual inspect each docs page in BOTH light and dark mode (no unreadable tables, grid layouts intact, DT tables scroll horizontally)
- [ ] \`check_dark_contrast.sh\` exits 0
- [ ] \`quarto render docs/examples.qmd\` succeeds
- [ ] Confirm \`_includes/build-info-footer.qmd\` renders correctly via both \`{{< include >}}\` call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)