### PR TITLE
fix(momentum): bump lookback_months 12 → 25 (unblock PR #188 cascade)

### DIFF
--- a/R/plan_momentum_decomposition.R
+++ b/R/plan_momentum_decomposition.R
@@ -51,7 +51,7 @@ plan_momentum_decomposition <- function() {
           stock_returns = stock_returns_monthly,
           factor_returns = ff_5factors,
           industry_returns = ff_industries_12,
-          lookback_months = 12,
+          lookback_months = 25,
           min_obs = 6
         )
       }


### PR DESCRIPTION
## Summary

**Single-line urgent fix** — PR #188 raised the F6 overfit guard in \`decompose_momentum()\` (\`cli_abort\` when \`lookback_months < 25\`) but did NOT update the caller at \`R/plan_momentum_decomposition.R:54\`. The momentum_components target errors on every \`tar_make()\` and 5 downstream targets cascade-fail.

Because \`tar_option_set(error = \"continue\")\`, rendered vignettes have been silently reading pre-PR-#188 May-10 cached objects since #188 merged. The F3 baseline change + F4 turnover change + F1 join change in #188 have not propagated to any rendered output.

## Detection

Spot-check agent T6 (targets-runner) ran \`tar_validate()\` and \`tar_make()\` against momentum targets post-#188 merge. Verdict: WARN. Full diagnostic in PR #188's spot-check report:

```
✖ \`lookback_months\` must be >= 25 to avoid overfitting.
ℹ Regression has 18 parameters (5 FF + 12 industry + 1 intercept).
ℹ Received: 12 months (12 obs vs 18 params).
```

## Cascade impact

5 momentum targets that have been silently serving May-10 stale cache:

- \`persistence_metrics\` — last fresh 2026-05-10 18:26
- \`momentum_comparison\` — last fresh 2026-05-10 18:38
- \`momentum_summary_table\` — last fresh 2026-05-10 18:27
- \`persistence_plot\` — last fresh 2026-05-10 18:38
- \`momentum_dispersion\` — last fresh 2026-05-10 18:38

After this PR merges, next \`tar_make()\` will rebuild all 5 with the corrected lookback. Expect metric values to shift (F3 baseline is now actual 12m return, not reconstructed sum).

## Test plan

- [x] One-line edit in \`R/plan_momentum_decomposition.R\` (12 → 25)
- [ ] Post-merge: \`tar_make()\` rebuilds 5 momentum targets without error
- [ ] Vignettes touching momentum show fresh metrics (no May-10 staleness)

## Related

- #188 (cluster B PR that introduced the F6 guard) — this is the missing call-site update from that PR's budget-killed verification
- Separately surfaced: \`stk_universe\` Date/POSIXct \`Incompatible methods\` warning (unrelated to momentum) — filing as separate issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)