### PR TITLE
refactor(targets): hoist 135 pkgload::load_all() out of target bodies (PR-T)

### DIFF
--- a/R/plan_alpha_decay.R
+++ b/R/plan_alpha_decay.R
@@ -229,7 +229,6 @@ plan_alpha_decay <- function() {
       library(ggplot2)
       library(dplyr)
       library(scales)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       # Normalise Sharpe to fraction of baseline (delay=1)
       baselines <- decay_metrics |>

--- a/R/plan_avoid_worst.R
+++ b/R/plan_avoid_worst.R
@@ -22,7 +22,6 @@ plan_avoid_worst <- function() {
     # ── Daily returns: index ETFs ───────────────────────────────
     targets::tar_target(aw_daily_returns, {
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       purrr::map_dfr(aw_params$index_tickers, function(tkr) {
         d <- hd_ohlcv(tkr) |>
@@ -41,7 +40,6 @@ plan_avoid_worst <- function() {
     # ── Daily returns: Fama-French Mkt-RF (1926+) ──────────────
     targets::tar_target(aw_daily_ff, {
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       ff <- hd_factors() |>
         filter(factor_name == "Mkt-RF", frequency == "daily") |>
@@ -149,7 +147,6 @@ plan_avoid_worst <- function() {
       library(ggplot2)
       library(dplyr)
       library(scales)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       spy <- aw_daily_returns |> filter(ticker == "SPY") |> arrange(date)
       ret <- spy$ret
@@ -263,7 +260,6 @@ plan_avoid_worst <- function() {
     targets::tar_target(aw_clustering_plot, {
       library(ggplot2)
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       worst <- aw_clustering$worst |> mutate(type = "10 Worst Days")
       best <- aw_clustering$best |> mutate(type = "10 Best Days")
@@ -377,7 +373,6 @@ plan_avoid_worst <- function() {
     targets::tar_target(aw_rolling_plot, {
       library(ggplot2)
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       plot_data <- aw_rolling |>
         select(date, `All Days` = ret_all,
@@ -398,7 +393,6 @@ plan_avoid_worst <- function() {
     targets::tar_target(aw_net_benefit_plot, {
       library(ggplot2)
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       plot_data <- aw_rolling |>
         select(date,
@@ -472,7 +466,6 @@ plan_avoid_worst <- function() {
     # for a cooling-off period until vol subsides
     targets::tar_target(aw_vix_daily, {
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       spy <- aw_daily_returns |> filter(ticker == "SPY") |> arrange(date)
       vix <- hd_macro("VIXCLS") |>
@@ -561,7 +554,6 @@ plan_avoid_worst <- function() {
     targets::tar_target(aw_practical_plot, {
       library(ggplot2)
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       plot_data <- aw_practical_backtest |>
         select(date,
@@ -759,7 +751,6 @@ plan_avoid_worst <- function() {
     targets::tar_target(aw_walkforward_curve, {
       library(dplyr)
       library(ggplot2)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       d <- aw_vix_daily |> filter(!is.na(vix), !is.na(ret))
       wf <- aw_walkforward
@@ -911,7 +902,6 @@ plan_avoid_worst <- function() {
     # ── Cross-market validation (#45) ───────────────────────────
     targets::tar_target(aw_cross_market, {
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       vix <- hd_macro("VIXCLS") |> select(date, vix = value) |> arrange(date)
 

--- a/R/plan_backtest.R
+++ b/R/plan_backtest.R
@@ -29,7 +29,6 @@ plan_backtest <- function() {
 
     # ── Data: monthly prices ──────────────────────────────────────
     targets::tar_target(bt_prices, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       all_tickers <- c(bt_params$tickers, bt_params$benchmark, bt_params$cash_proxy)
       raw <- hd_ohlcv(all_tickers, from = as.character(bt_params$start_date))
 

--- a/R/plan_bootstrap_ci.R
+++ b/R/plan_bootstrap_ci.R
@@ -125,7 +125,6 @@ plan_bootstrap_ci <- function() {
     targets::tar_target(boot_sharpe_plot, {
       library(ggplot2)
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       strategy_labels <- c(
         stk_max = "Stock MAX", stk_drif = "Stock DRIF",

--- a/R/plan_causal_graph.R
+++ b/R/plan_causal_graph.R
@@ -146,7 +146,6 @@ plan_causal_graph <- function() {
 
     # ── Assemble test data for conditional independence tests ───────
     targets::tar_target(cg_test_data, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       # ── Fama-French factors (monthly, %) → proportions ───────────

--- a/R/plan_circuit_breaker.R
+++ b/R/plan_circuit_breaker.R
@@ -55,7 +55,6 @@ plan_circuit_breaker <- function() {
 
     # ── Raw data: fetch all FRED series ──────────────────────────
     targets::tar_target(cb_data, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       results <- purrr::map(cb_params$fed_series, function(sid) {
@@ -241,7 +240,6 @@ plan_circuit_breaker <- function() {
     # Compare to unconditional SPY returns over the same holding windows
     # to see whether activations are a buy or sell signal.
     targets::tar_target(cb_vs_spy, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       # SPY daily returns (close-to-close adjusted)
@@ -320,7 +318,6 @@ plan_circuit_breaker <- function() {
     targets::tar_target(cb_plot, {
       library(ggplot2)
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       # Normalise each series to index = 1 at the start so they fit on
       # one panel despite different units ($B vs $T etc.)

--- a/R/plan_crypto_momentum.R
+++ b/R/plan_crypto_momentum.R
@@ -200,7 +200,6 @@ plan_crypto_momentum <- function() {
       ) |>
         select(date, strategy, cum_ret_net)
 
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       ggplot(combined, aes(date, cum_ret_net, color = strategy)) +
         geom_line(linewidth = 0.7) +
@@ -251,7 +250,6 @@ plan_crypto_momentum <- function() {
       ) |>
         select(date, strategy, roll_sharpe)
 
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       ggplot(combined, aes(date, roll_sharpe, color = strategy)) +
         geom_line(linewidth = 0.7) +

--- a/R/plan_drif.R
+++ b/R/plan_drif.R
@@ -30,7 +30,6 @@ plan_drif <- function() {
 
     # ── Data: full daily factor history in one query ──────────────
     targets::tar_target(drif_daily, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       ff5 <- hd_factors(dataset = "FF5", frequency = "daily",
@@ -281,7 +280,6 @@ plan_drif <- function() {
       library(ggplot2)
       library(dplyr)
       library(scales)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       plot_data <- drif_portfolio |>
         select(date, `DRIF` = port_cum, `Market (Mkt-RF)` = bench_cum) |>
@@ -334,7 +332,6 @@ plan_drif <- function() {
       library(ggplot2)
       library(dplyr)
       library(scales)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       plot_data <- drif_vs_max |>
         select(date, `DRIF` = drif_cum, `Factor MAX` = max_cum) |>

--- a/R/plan_ecb.R
+++ b/R/plan_ecb.R
@@ -38,10 +38,7 @@ plan_ecb <- function() {
 
     # ── Fetch all ECB series ────────────────────────────────────────────
     targets::tar_target(ecb_raw, {
-      reg <- pkgload::load_all(
-        here::here("packages/historicaldata"), quiet = TRUE
-      )$env
-      registry <- reg$hd_ecb_registry()
+      registry <- hd_ecb_registry()
 
       results <- lapply(ecb_params$series, function(nm) {
         info <- registry[[nm]]
@@ -54,7 +51,7 @@ plan_ecb <- function() {
         # but transport errors (connection refused, TCP stall) can still escape
         # as R conditions.  tryCatch here ensures the lapply continues.
         tryCatch({
-          df <- reg$hd_ecb(info$key, start = ecb_params$start_date)
+          df <- hd_ecb(info$key, start = ecb_params$start_date)
           if (!is.null(df)) {
             df$series_name <- nm
             df$description <- info$description

--- a/R/plan_etf_replication.R
+++ b/R/plan_etf_replication.R
@@ -41,7 +41,6 @@ plan_etf_replication <- function() {
 
     # ── ETF daily returns ─────────────────────────────────────────
     targets::tar_target(etf_daily, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       all_tickers <- c(etf_params$etf_tickers, etf_params$benchmark)
@@ -323,7 +322,6 @@ plan_etf_replication <- function() {
       library(ggplot2)
       library(dplyr)
       library(scales)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       a <- etf_a_portfolio |> select(date, `A: DRIF on ETFs` = port_cum)
       b <- etf_b_portfolio |> select(date, `B: Academic → ETFs` = port_cum)

--- a/R/plan_european_overlay.R
+++ b/R/plan_european_overlay.R
@@ -39,7 +39,6 @@ plan_european_overlay <- function() {
 
     # ── Data: fetch European ETF returns + join RSC regime ───────────────
     targets::tar_target(eur_daily, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       # rsc_regime already has: date, regime, exposure, rf_lag, spy_ret etc.
@@ -110,7 +109,6 @@ plan_european_overlay <- function() {
 
     # ── Results: overlay metrics per EU ticker ───────────────────────────
     targets::tar_target(eur_results, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       calc_metrics <- function(ret_vec, label, strategy_name, ticker) {
@@ -162,7 +160,6 @@ plan_european_overlay <- function() {
 
     # ── Fama-French regression: falsification for each EU ticker ─────────
     targets::tar_target(eur_ff_regression, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       # Fetch FF5 + Momentum daily factors (same as plan_falsification.R)
@@ -215,7 +212,6 @@ plan_european_overlay <- function() {
 
     # ── Comparison: US (SPY) vs European overlays ────────────────────────
     targets::tar_target(eur_comparison, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       # SPY overlay OOS metrics from rsc_portfolio (Full period)
@@ -295,7 +291,6 @@ plan_european_overlay <- function() {
 
     # ── CISS overlay results ───────────────────────────────────────────
     targets::tar_target(eur_ciss_results, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       if (is.null(eur_ciss_regime)) return(NULL)

--- a/R/plan_factormax.R
+++ b/R/plan_factormax.R
@@ -27,7 +27,6 @@ plan_factormax <- function() {
 
     # ── Data: daily factor returns ────────────────────────────────
     targets::tar_target(fm_daily, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       # FF5 has HML, SMB, RMW, CMA, Mkt-RF, RF
@@ -193,7 +192,6 @@ plan_factormax <- function() {
       library(ggplot2)
       library(dplyr)
       library(scales)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       plot_data <- fm_portfolio |>
         select(date, `Factor MAX` = port_cum, `Market (Mkt-RF)` = bench_cum) |>
@@ -216,7 +214,6 @@ plan_factormax <- function() {
     targets::tar_target(fm_heatmap, {
       library(ggplot2)
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       # Last 3 years for readability
       recent <- fm_signal |>
@@ -248,7 +245,6 @@ plan_factormax <- function() {
 
     # ── ETF comparison: real-world factor ETFs ────────────────────
     targets::tar_target(fm_etf_data, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       # Factor ETFs mapped to academic factors
@@ -321,7 +317,6 @@ plan_factormax <- function() {
       library(ggplot2)
       library(dplyr)
       library(scales)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       if (is.null(fm_etf_data)) return(NULL)
 
       # Plot VLUE vs HML and MTUM vs Mom (most interesting pair)

--- a/R/plan_falsification.R
+++ b/R/plan_falsification.R
@@ -73,7 +73,6 @@ plan_falsification <- function() {
     # ═══════════════════════════════════════════════════════════════════
 
     targets::tar_target(fals_factors, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       ff5 <- hd_factors(dataset = "FF5", frequency = "daily")
@@ -85,7 +84,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_rf, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       hd_factors(dataset = "FF5", frequency = "daily") |>
@@ -100,12 +98,10 @@ plan_falsification <- function() {
     # ═══════════════════════════════════════════════════════════════════
 
     targets::tar_target(fals_hac_avoid_worst, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       hd_hac_sharpe(fals_avoid_worst_input$strategy_ret)
     }),
 
     targets::tar_target(fals_wn_avoid_worst, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret    <- fals_avoid_worst_input$strategy_ret
       T_obs  <- sum(!is.na(ret))
       nulls  <- hd_null_env_white_noise(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -117,7 +113,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_rv_avoid_worst, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_avoid_worst_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_regime_vol(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -129,7 +124,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_ma1_avoid_worst, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_avoid_worst_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_ma1(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -141,7 +135,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_fn_avoid_worst, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_avoid_worst_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_factor_null(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -153,7 +146,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_garch_avoid_worst, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_avoid_worst_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_garch11(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -165,7 +157,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_gjr_avoid_worst, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_avoid_worst_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_gjr_garch(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -177,7 +168,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_ff_avoid_worst, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       hd_factor_null_test(
         strategy_daily = fals_avoid_worst_input,
         rf_daily       = fals_rf,
@@ -191,12 +181,10 @@ plan_falsification <- function() {
     # ═══════════════════════════════════════════════════════════════════
 
     targets::tar_target(fals_hac_drif, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       hd_hac_sharpe(fals_drif_input$strategy_ret)
     }),
 
     targets::tar_target(fals_wn_drif, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_drif_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_white_noise(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -208,7 +196,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_rv_drif, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_drif_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_regime_vol(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -220,7 +207,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_ma1_drif, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_drif_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_ma1(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -232,7 +218,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_fn_drif, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_drif_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_factor_null(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -244,7 +229,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_garch_drif, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_drif_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_garch11(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -256,7 +240,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_gjr_drif, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_drif_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_gjr_garch(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -268,7 +251,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_ff_drif, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       hd_factor_null_test(
         strategy_daily = fals_drif_input,
         rf_daily       = fals_rf,
@@ -282,12 +264,10 @@ plan_falsification <- function() {
     # ═══════════════════════════════════════════════════════════════════
 
     targets::tar_target(fals_hac_fac_max, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       hd_hac_sharpe(fals_fac_max_input$strategy_ret)
     }),
 
     targets::tar_target(fals_wn_fac_max, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_fac_max_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_white_noise(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -299,7 +279,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_rv_fac_max, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_fac_max_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_regime_vol(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -311,7 +290,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_ma1_fac_max, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_fac_max_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_ma1(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -323,7 +301,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_fn_fac_max, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_fac_max_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_factor_null(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -335,7 +312,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_garch_fac_max, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_fac_max_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_garch11(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -347,7 +323,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_gjr_fac_max, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_fac_max_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_gjr_garch(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -359,7 +334,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_ff_fac_max, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       hd_factor_null_test(
         strategy_daily = fals_fac_max_input,
         rf_daily       = fals_rf,
@@ -373,12 +347,10 @@ plan_falsification <- function() {
     # ═══════════════════════════════════════════════════════════════════
 
     targets::tar_target(fals_hac_rsc, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       hd_hac_sharpe(fals_rsc_input$strategy_ret)
     }),
 
     targets::tar_target(fals_wn_rsc, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret    <- fals_rsc_input$strategy_ret
       T_obs  <- sum(!is.na(ret))
       nulls  <- hd_null_env_white_noise(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -390,7 +362,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_rv_rsc, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_rsc_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_regime_vol(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -402,7 +373,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_ma1_rsc, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_rsc_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_ma1(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -414,7 +384,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_fn_rsc, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_rsc_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_factor_null(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -426,7 +395,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_garch_rsc, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_rsc_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_garch11(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -438,7 +406,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_gjr_rsc, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_rsc_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_gjr_garch(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -450,7 +417,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_ff_rsc, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       hd_factor_null_test(
         strategy_daily = fals_rsc_input,
         rf_daily       = fals_rf,
@@ -464,12 +430,10 @@ plan_falsification <- function() {
     # ═══════════════════════════════════════════════════════════════════
 
     targets::tar_target(fals_hac_ltr, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       hd_hac_sharpe(fals_ltr_input$strategy_ret)
     }),
 
     targets::tar_target(fals_wn_ltr, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_ltr_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_white_noise(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -481,7 +445,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_rv_ltr, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_ltr_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_regime_vol(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -493,7 +456,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_ma1_ltr, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_ltr_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_ma1(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -505,7 +467,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_fn_ltr, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_ltr_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_factor_null(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -517,7 +478,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_garch_ltr, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_ltr_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_garch11(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -529,7 +489,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_gjr_ltr, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       ret   <- fals_ltr_input$strategy_ret
       T_obs <- sum(!is.na(ret))
       nulls <- hd_null_env_gjr_garch(T_obs, M = fals_params$M, seed = fals_params$seed)
@@ -541,7 +500,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_ff_ltr, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       hd_factor_null_test(
         strategy_daily = fals_ltr_input,
         rf_daily       = fals_rf,
@@ -555,7 +513,6 @@ plan_falsification <- function() {
     # ═══════════════════════════════════════════════════════════════════
 
     targets::tar_target(fals_keff, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       all_rets <- Reduce(
@@ -574,7 +531,6 @@ plan_falsification <- function() {
     }),
 
     targets::tar_target(fals_delta_z, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       z_is <- c(
         fals_hac_avoid_worst$hac_tstat,
@@ -600,7 +556,6 @@ plan_falsification <- function() {
     # ═══════════════════════════════════════════════════════════════════
 
     targets::tar_target(fals_tail_independence, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       aligned <- align_period(
         series = list(
@@ -652,23 +607,18 @@ plan_falsification <- function() {
     # ═══════════════════════════════════════════════════════════════════
 
     targets::tar_target(fals_dsr_avoid_worst, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       hd_deflated_sharpe(fals_avoid_worst_input$strategy_ret, K_trials = 5L, ann_factor = 252L)
     }),
     targets::tar_target(fals_dsr_drif, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       hd_deflated_sharpe(fals_drif_input$strategy_ret, K_trials = 5L, ann_factor = 12L)
     }),
     targets::tar_target(fals_dsr_fac_max, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       hd_deflated_sharpe(fals_fac_max_input$strategy_ret, K_trials = 5L, ann_factor = 12L)
     }),
     targets::tar_target(fals_dsr_rsc, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       hd_deflated_sharpe(fals_rsc_input$strategy_ret, K_trials = 5L, ann_factor = 252L)
     }),
     targets::tar_target(fals_dsr_ltr, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       hd_deflated_sharpe(fals_ltr_input$strategy_ret, K_trials = 5L, ann_factor = 12L)
     }),
 
@@ -795,7 +745,6 @@ plan_falsification <- function() {
     # ═══════════════════════════════════════════════════════════════════
 
     targets::tar_target(fals_spy_ret, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       hd_ohlcv("SPY") |>
@@ -811,7 +760,6 @@ plan_falsification <- function() {
     # ═══════════════════════════════════════════════════════════════════
 
     targets::tar_target(fals_results_db, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       # ── Helper: drawdown analysis ──────────────────────────────────

--- a/R/plan_forecast_eval.R
+++ b/R/plan_forecast_eval.R
@@ -42,7 +42,6 @@ plan_forecast_eval <- function() {
     # CRPS_naive uses the full-sample unconditional distribution (all returns
     # except the current one) — a constant reference that ignores timing.
     targets::tar_target(fe_crps, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       set.seed(fe_params$seed)
@@ -113,7 +112,6 @@ plan_forecast_eval <- function() {
     # Forecast probability: rolling win rate over the previous roll_months periods.
     # Naive baseline: unconditional win rate over the full sample.
     targets::tar_target(fe_brier, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       strategy_list <- list(
@@ -187,7 +185,6 @@ plan_forecast_eval <- function() {
     # We measure how well this signal predicts actual forward SPY returns at
     # horizons 1, 2, 3, 5, 10, 21 trading days.
     targets::tar_target(fe_horizon, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       # Daily SPY returns

--- a/R/plan_guardian.R
+++ b/R/plan_guardian.R
@@ -26,13 +26,10 @@ plan_guardian <- function() {
 
     # ── Monthly keyword counts ──────────────────────────────────────────
     targets::tar_target(gdn_monthly_counts, {
-      reg <- pkgload::load_all(
-        here::here("packages/historicaldata"), quiet = TRUE
-      )$env
 
       results <- lapply(gdn_params$keywords, function(kw) {
         cli::cli_inform("Fetching Guardian: {kw}")
-        reg$hd_guardian_monthly(
+        hd_guardian_monthly(
           query   = kw,
           section = gdn_params$section,
           from    = gdn_params$from,
@@ -64,13 +61,10 @@ plan_guardian <- function() {
     targets::tar_target(gdn_vs_spy, {
       if (nrow(gdn_monthly_counts) == 0L) return(NULL)
 
-      reg <- pkgload::load_all(
-        here::here("packages/historicaldata"), quiet = TRUE
-      )$env
 
       # Get SPY monthly returns
       spy <- tryCatch({
-        reg$hd_ohlcv("SPY", from = gdn_params$from, collect = TRUE) |>
+        hd_ohlcv("SPY", from = gdn_params$from, collect = TRUE) |>
           dplyr::mutate(
             year_month = format(as.Date(date), "%Y-%m")
           ) |>

--- a/R/plan_integration.R
+++ b/R/plan_integration.R
@@ -57,7 +57,6 @@ plan_integration <- function() {
     targets::tar_target(
       spy_returns,
       {
-        pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
         hd_ohlcv("SPY") |>
           dplyr::arrange(date) |>
           dplyr::mutate(
@@ -82,7 +81,6 @@ plan_integration <- function() {
           )
 
         # Get benchmark asset returns (SPY, TLT, GLD, DBC)
-        pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
         benchmark_assets <- hd_ohlcv(c("SPY", "TLT", "GLD", "DBC")) |>
           dplyr::select(date, ticker, adjusted) |>
           dplyr::arrange(ticker, date) |>
@@ -111,7 +109,6 @@ plan_integration <- function() {
     targets::tar_target(
       equity_with_adv,
       {
-        pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
         # Get SPY as example - full universe would be hd_universe("equity")
         # but that's 50+ tickers and slow for demo
         equity_data <- hd_ohlcv("SPY") |>

--- a/R/plan_jst.R
+++ b/R/plan_jst.R
@@ -15,10 +15,7 @@ plan_jst <- function() {
 
     # ── Load JST data ─────────────────────────────────────────────────────
     targets::tar_target(jst_raw, {
-      reg <- pkgload::load_all(
-        here::here("packages/historicaldata"), quiet = TRUE
-      )$env
-      reg$hd_jst(cache = TRUE)
+      hd_jst(cache = TRUE)
     }),
 
     # ── Equity premium by country and decade ──────────────────────────────
@@ -72,9 +69,6 @@ plan_jst <- function() {
     # ── Compare JST USA with Fama-French market factor ─────────────────────
     # Overlap period: 1926-2020 (FF starts 1926, JST ends 2020)
     targets::tar_target(jst_ff_comparison, {
-      reg <- pkgload::load_all(
-        here::here("packages/historicaldata"), quiet = TRUE
-      )$env
 
       # JST USA annual equity premium
       jst_usa <- jst_raw |>
@@ -85,7 +79,7 @@ plan_jst <- function() {
         dplyr::select(year, jst_premium)
 
       # FF market premium (annual)
-      ff <- reg$hd_factors(dataset = "FF3", frequency = "annual")
+      ff <- hd_factors(dataset = "FF3", frequency = "annual")
       if (is.null(ff) || nrow(ff) == 0L) {
         cli::cli_warn("FF3 annual data not available")
         return(NULL)

--- a/R/plan_kelly.R
+++ b/R/plan_kelly.R
@@ -119,7 +119,6 @@ plan_kelly <- function() {
     targets::tar_target(kelly_comparison_plot, {
       library(ggplot2)
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       kelly_metrics |>
         ggplot(aes(x = strategy, y = sharpe, fill = sizing)) +

--- a/R/plan_kelly_variants.R
+++ b/R/plan_kelly_variants.R
@@ -18,7 +18,6 @@ plan_kelly_variants <- function() {
     }),
 
     targets::tar_target(kv_sweep, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       strategies <- list(
@@ -55,7 +54,6 @@ plan_kelly_variants <- function() {
     }),
 
     targets::tar_target(kv_bayesian, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       strategies <- list(
@@ -89,7 +87,6 @@ plan_kelly_variants <- function() {
     }),
 
     targets::tar_target(kv_bounded, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       strategies <- list(

--- a/R/plan_ltr_momentum.R
+++ b/R/plan_ltr_momentum.R
@@ -45,7 +45,6 @@ plan_ltr_momentum <- function() {
 
     # ── Universe: US non-ETF equities with sufficient history ─────────────
     targets::tar_target(ltr_universe, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       # Load xgboost path for later targets
@@ -146,7 +145,6 @@ plan_ltr_momentum <- function() {
     # ── Metrics: Training, Testing, Full ──────────────────────────────────
     targets::tar_target(ltr_metrics, {
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       p <- ltr_params
 
@@ -193,7 +191,6 @@ plan_ltr_momentum <- function() {
       library(ggplot2)
       library(dplyr)
       library(scales)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       port <- ltr_portfolio
 
@@ -332,7 +329,6 @@ plan_ltr_momentum <- function() {
     # ── Subperiod Analysis: 3 equal subperiods ───────────────────────────
     targets::tar_target(ltr_subperiod, {
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       port <- ltr_portfolio |> filter(!is.na(port_ret)) |> arrange(date)
 

--- a/R/plan_mean_reversion.R
+++ b/R/plan_mean_reversion.R
@@ -47,7 +47,6 @@ plan_mean_reversion <- function() {
 
     # ── Data: daily returns for universe ────────────────────────
     targets::tar_target(mr_daily, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       purrr::map_dfr(mr_params$tickers, function(tkr) {
@@ -237,7 +236,6 @@ plan_mean_reversion <- function() {
     targets::tar_target(mr_plot, {
       library(ggplot2)
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       # SPY benchmark
       spy <- hd_ohlcv("SPY", from = as.character(mr_params$start_date)) |>

--- a/R/plan_nyt_sentiment.R
+++ b/R/plan_nyt_sentiment.R
@@ -141,7 +141,6 @@ plan_nyt_sentiment <- function() {
       }
 
       # Load SPY daily OHLCV
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       spy_daily <- tryCatch(
         hd_ohlcv("SPY") |>

--- a/R/plan_portfolio_opt.R
+++ b/R/plan_portfolio_opt.R
@@ -212,7 +212,6 @@ plan_portfolio_opt <- function() {
       library(ggplot2)
       library(dplyr)
       library(scales)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       w_pso <- port_optimal_weights
       w_hrp <- port_hrp_weights

--- a/R/plan_qa_vignette.R
+++ b/R/plan_qa_vignette.R
@@ -18,7 +18,6 @@ plan_qa_vignette <- function() {
     # QA 2: Dataset-metadata consistency (#19)
     # Checks that every ticker in OHLCV parquets has a metadata row
     targets::tar_target(qa_metadata_sync, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       duckplyr_path <- Sys.glob("/nix/store/*-r-duckplyr-*/library")
@@ -69,7 +68,6 @@ plan_qa_vignette <- function() {
     # yfinance reports incorrect volume for non-US markets
     # Flag tickers with suspiciously high dollar volume
     targets::tar_target(qa_volume_sanity, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       ds <- hd_datasets()[["equity_daily"]]

--- a/R/plan_quiz.R
+++ b/R/plan_quiz.R
@@ -15,7 +15,6 @@ plan_quiz <- function() {
     }),
 
     targets::tar_target(quiz_rounds, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
       set.seed(quiz_params$seed)
 

--- a/R/plan_rafi.R
+++ b/R/plan_rafi.R
@@ -38,7 +38,6 @@ plan_rafi <- function() {
 
     # ── Data: monthly FF5 + Momentum factors ────────────────────────────────
     targets::tar_target(rafi_data, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       ff5 <- hd_factors(dataset = "FF5", frequency = "monthly") |>
@@ -201,7 +200,6 @@ plan_rafi <- function() {
 
     # ── FF regression: falsification ─────────────────────────────────────────
     targets::tar_target(rafi_ff_regression, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       # Build long-form factors for hd_factor_null_test

--- a/R/plan_regime.R
+++ b/R/plan_regime.R
@@ -214,7 +214,6 @@ plan_regime <- function() {
       library(ggplot2)
       library(dplyr)
       library(scales)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       # Build shading rectangles for high-risk periods
       high_risk_periods <- regime_portfolio |>

--- a/R/plan_risk_state.R
+++ b/R/plan_risk_state.R
@@ -39,7 +39,6 @@ plan_risk_state <- function() {
 
     # ── Data: fetch and join all signals ─────────────────────────
     targets::tar_target(rsc_data, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       # SPY daily returns
@@ -246,7 +245,6 @@ plan_risk_state <- function() {
 
     # ── Metrics: summary per partition for all strategy variants ──
     targets::tar_target(rsc_metrics, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       calc_metrics <- function(ret_vec, label, strategy_name) {
@@ -315,7 +313,6 @@ plan_risk_state <- function() {
 
     # ── Plot: equity curve SPY buy-and-hold vs SPY with overlay ──
     targets::tar_target(rsc_plot, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(ggplot2)
       library(dplyr)
 
@@ -372,7 +369,6 @@ plan_risk_state <- function() {
 
     # ── Plot: three-panel signal chart ───────────────────────────
     targets::tar_target(rsc_plot_signals, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(ggplot2)
       library(dplyr)
 
@@ -422,7 +418,6 @@ plan_risk_state <- function() {
 
     # ── Plot: overlay comparison DRIF and Factor MAX ──────────────
     targets::tar_target(rsc_overlay_comparison, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(ggplot2)
       library(dplyr)
 
@@ -505,7 +500,6 @@ plan_risk_state <- function() {
 
     # ── Alpha decay: delay signals 1-10 days ─────────────────────
     targets::tar_target(rsc_alpha_decay, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       # Re-run SPY overlay with signals delayed by d additional days
@@ -590,7 +584,6 @@ plan_risk_state <- function() {
 
     # ── Subperiod analysis: three sub-periods ────────────────────
     targets::tar_target(rsc_subperiod, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       calc_sp <- function(data, label) {

--- a/R/plan_shadow_trades.R
+++ b/R/plan_shadow_trades.R
@@ -25,7 +25,6 @@ plan_shadow_trades <- function() {
     # and aw_daily_returns$SPY as the underlying daily return series.
     targets::tar_target(shadow_avoid_worst, {
       library(dplyr)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       # SPY daily returns (underlying for the avoid_worst strategy)
       spy <- aw_daily_returns |>

--- a/R/plan_stock_backtest.R
+++ b/R/plan_stock_backtest.R
@@ -391,7 +391,6 @@ plan_stock_backtest <- function() {
 
     # ── Group 1: Top-N tickers by current market cap (#150 Option C) ──
     targets::tar_target(stk_top_tickers, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       duckplyr_path <- Sys.glob("/nix/store/*-r-duckplyr-*/library")
@@ -408,7 +407,6 @@ plan_stock_backtest <- function() {
 
     # ── Group 1: Universe — top-N non-ETF stocks with sufficient history ──
     targets::tar_target(stk_universe, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       duckplyr_path <- Sys.glob("/nix/store/*-r-duckplyr-*/library")
@@ -470,7 +468,6 @@ plan_stock_backtest <- function() {
 
     # ── Group 1: Risk-free rate (monthly) ─────────────────────────
     targets::tar_target(stk_rf, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       hd_factors(dataset = "FF3", frequency = "daily",
@@ -738,7 +735,6 @@ plan_stock_backtest <- function() {
       library(ggplot2)
       library(dplyr)
       library(scales)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       p <- stk_max_portfolio
       plot_data <- p |>
@@ -780,7 +776,6 @@ plan_stock_backtest <- function() {
       library(ggplot2)
       library(dplyr)
       library(scales)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       comp <- stk_max_vs_factor
       plot_data <- comp |>
@@ -970,7 +965,6 @@ plan_stock_backtest <- function() {
       library(ggplot2)
       library(dplyr)
       library(scales)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       p <- stk_drif_portfolio
       plot_data <- p |>
@@ -1017,7 +1011,6 @@ plan_stock_backtest <- function() {
       library(ggplot2)
       library(dplyr)
       library(scales)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       comp <- stk_all_comparison
       plot_data <- comp |>

--- a/R/plan_strategy_decay.R
+++ b/R/plan_strategy_decay.R
@@ -11,7 +11,6 @@ plan_strategy_decay <- function() {
 
     # ── Macro regime classification ─────────────────────────────
     targets::tar_target(decay_regimes, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       # Monthly macro data for regime classification

--- a/R/plan_vignette.R
+++ b/R/plan_vignette.R
@@ -23,7 +23,6 @@ vig_pair <- function(name, code) {
       code_text
     }, list(CODE = code))),
     targets::tar_target_raw(name, substitute({
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
       library(ggplot2)
       library(scales)

--- a/R/plan_vix_macro_overlay.R
+++ b/R/plan_vix_macro_overlay.R
@@ -24,7 +24,6 @@ plan_vix_macro_overlay <- function() {
     }),
 
     targets::tar_target(vmo_daily, {
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
       library(dplyr)
 
       # VIX

--- a/R/plan_volatility_spikes.R
+++ b/R/plan_volatility_spikes.R
@@ -9,7 +9,6 @@ plan_volatility_spikes <- function() {
       vix_daily,
       {
         # VIX comes from FRED via historicaldata package (series VIXCLS)
-        pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
         hd_macro("VIXCLS") |>
           dplyr::select(date, vix = value) |>

--- a/R/plan_xgb_signal.R
+++ b/R/plan_xgb_signal.R
@@ -150,7 +150,6 @@ plan_xgb_signal <- function() {
       library(ggplot2)
       library(dplyr)
       library(scales)
-      pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 
       comp <- xgb_vs_enet
       plot_data <- comp |>

--- a/docs/_targets.R
+++ b/docs/_targets.R
@@ -37,6 +37,13 @@ tar_option_set(
   format = "rds"
 )
 
+# Load local historicaldata package once at pipeline parse time.
+# historicaldata is not installed in the nix env — pkgload::load_all() is
+# the correct mechanism. Running it here (once) replaces 135 per-target
+# pkgload::load_all() calls that were wasteful and side-effectful.
+# See namespace-discipline rule and roborev PR-T.
+pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
+
 # Source Tier 1 & 2 gap functions
 # TODO: create liquidity.R, tracking_error.R, regime_correlations.R, tail_keff.R
 # source(here::here("R/liquidity.R"))


### PR DESCRIPTION
## Summary

Replaces **135 in-target \`pkgload::load_all(here::here(\"packages/historicaldata\"))\` calls** across **35 plan files** with a single top-level call in \`docs/_targets.R\`. Per global \`namespace-discipline\` rule.

### Scope correction

Original deep-sweep finding cited \"11+ sites\" — fixer's grep found **135 calls in 35 plan files** (12× the original estimate).

### Approach (option b — preserve current install model)

\`historicaldata\` is NOT installed in the nix env (\`requireNamespace(\"historicaldata\")\` returns FALSE). The pipeline relies on \`pkgload::load_all()\` to make the local package available. Two viable approaches:

- **(a)** Install via tproject.toml + \`t update\` — riskier, may pull more deps
- **(b)** Keep ONE \`pkgload::load_all()\` at \`docs/_targets.R\` top-level (after \`tar_option_set()\`) — runs once per pipeline parse instead of once per target body

Agent chose **(b)** for safety.

### Pattern variants handled

Most files had the simple pattern:
\`\`\`r
tar_target(x, {
  pkgload::load_all(...)
  hd_function()
})
\`\`\`

Three files (\`plan_jst.R\`, \`plan_guardian.R\`, \`plan_ecb.R\`) used a more elaborate pattern that needed unwinding:
\`\`\`r
reg <- pkgload::load_all(...)\$env
reg\$hd_jst()
\`\`\`
→ replaced with direct \`hd_jst()\` (package available from top-level load).

## Verification

- \`tar_validate()\`: **PASS** (exit 0)
- \`fals_params\` smoke build: **PASS** (\`\$M=100, \$seed=42, \$alpha_level=0.05\`)
- File count: 36 modified (35 plan files + \`docs/_targets.R\`)

## Risk

- **Pipeline parse time:** single \`pkgload::load_all()\` runs once at \`_targets.R\` parse instead of 135× during \`tar_make()\`. Net speedup expected.
- **Test isolation:** if any individual target previously relied on re-loading the package (e.g. to pick up unsaved edits to a single function mid-run), that workflow breaks. \`devtools::load_all()\` from RStudio still works alongside.
- **No new package deps**: this is pure-refactor.

## Test plan

- [x] tar_validate passes
- [x] One target smoke-built (\`fals_params\`)
- [ ] Full \`tar_make()\` rebuild — recommend running after merge to verify no target relies on per-target load_all side-effects
- [ ] Confirm vignette renders still work (no namespace surprises)

## Related

- Roborev deep-sweep Tier 4 #5 (in-target pkgload anti-pattern)
- Global rule \`namespace-discipline\` — section on \`library()\` / \`pkgload::load_all()\` inside function bodies

🤖 Generated with [Claude Code](https://claude.com/claude-code)