### PR TITLE
refactor(metrics): canonical calc_backtest_metrics() — compound annualisation (PR-R)

### DIFF
--- a/R/plan_etf_replication.R
+++ b/R/plan_etf_replication.R
@@ -217,12 +217,14 @@ plan_etf_replication <- function() {
       p <- etf_a_portfolio
       calc_m <- function(df, label) {
         n <- nrow(df); if (n < 6) return(NULL)
+        m      <- calc_backtest_metrics(df$port_ret)
+        m_long <- calc_backtest_metrics(df$long_only_ret)
         tibble(period = label, months = n,
-               cagr = prod(1 + df$port_ret)^(12/n) - 1,
-               long_cagr = prod(1 + df$long_only_ret)^(12/n) - 1,
-               vol = sd(df$port_ret) * sqrt(12),
-               sharpe = (prod(1 + df$port_ret)^(12/n) - 1) / (sd(df$port_ret) * sqrt(12)),
-               max_dd = min(cumprod(1 + df$port_ret) / cummax(cumprod(1 + df$port_ret)) - 1))
+               cagr = m$cagr,
+               long_cagr = m_long$cagr,
+               vol = m$vol,
+               sharpe = m$sharpe,
+               max_dd = m$max_dd)
       }
       bind_rows(
         calc_m(p |> filter(date <= etf_params$is_end), "Training"),
@@ -301,12 +303,14 @@ plan_etf_replication <- function() {
       p <- etf_b_portfolio
       calc_m <- function(df, label) {
         n <- nrow(df); if (n < 6) return(NULL)
+        m      <- calc_backtest_metrics(df$port_ret)
+        m_long <- calc_backtest_metrics(df$long_only_ret)
         tibble(period = label, months = n,
-               cagr = prod(1 + df$port_ret)^(12/n) - 1,
-               long_cagr = prod(1 + df$long_only_ret)^(12/n) - 1,
-               vol = sd(df$port_ret) * sqrt(12),
-               sharpe = (prod(1 + df$port_ret)^(12/n) - 1) / (sd(df$port_ret) * sqrt(12)),
-               max_dd = min(cumprod(1 + df$port_ret) / cummax(cumprod(1 + df$port_ret)) - 1))
+               cagr = m$cagr,
+               long_cagr = m_long$cagr,
+               vol = m$vol,
+               sharpe = m$sharpe,
+               max_dd = m$max_dd)
       }
       bind_rows(
         calc_m(p |> filter(date <= etf_params$is_end), "Training"),

--- a/R/plan_kelly_variants.R
+++ b/R/plan_kelly_variants.R
@@ -34,19 +34,16 @@ plan_kelly_variants <- function() {
           f <- mean(ret) / var(ret) * frac
           f <- max(0, min(1, f))
           strat_ret <- ret * f
-          n <- length(strat_ret)
+          m <- calc_backtest_metrics(strat_ret)
           tibble(
             strategy   = strat,
             method     = paste0("Fractional (", frac * 100, "%)"),
             fraction   = frac,
             f_star     = round(f, 4),
-            cagr_pct   = round((prod(1 + strat_ret)^(12 / n) - 1) * 100, 1),
-            vol_pct    = round(sd(strat_ret) * sqrt(12) * 100, 1),
-            sharpe     = round(mean(strat_ret) / sd(strat_ret) * sqrt(12), 2),
-            max_dd_pct = round(
-              min((cumprod(1 + strat_ret) -
-                     cummax(cumprod(1 + strat_ret))) /
-                    cummax(cumprod(1 + strat_ret))) * 100, 1),
+            cagr_pct   = round(m$cagr * 100, 1),
+            vol_pct    = round(m$vol * 100, 1),
+            sharpe     = round(m$sharpe, 2),
+            max_dd_pct = round(m$max_dd * 100, 1),
             bankrupt   = any(cumprod(1 + strat_ret) < 0.01)
           )
         })
@@ -68,19 +65,16 @@ plan_kelly_variants <- function() {
         bk  <- hd_kelly_bayesian(ret)
         f   <- max(0, min(1, bk$f_star))
         strat_ret <- ret * f
-        n <- length(strat_ret)
+        m <- calc_backtest_metrics(strat_ret)
         tibble(
           strategy   = strat,
           method     = "Bayesian",
           fraction   = NA_real_,
           f_star     = round(f, 4),
-          cagr_pct   = round((prod(1 + strat_ret)^(12 / n) - 1) * 100, 1),
-          vol_pct    = round(sd(strat_ret) * sqrt(12) * 100, 1),
-          sharpe     = round(mean(strat_ret) / sd(strat_ret) * sqrt(12), 2),
-          max_dd_pct = round(
-            min((cumprod(1 + strat_ret) -
-                   cummax(cumprod(1 + strat_ret))) /
-                  cummax(cumprod(1 + strat_ret))) * 100, 1),
+          cagr_pct   = round(m$cagr * 100, 1),
+          vol_pct    = round(m$vol * 100, 1),
+          sharpe     = round(m$sharpe, 2),
+          max_dd_pct = round(m$max_dd * 100, 1),
           bankrupt   = any(cumprod(1 + strat_ret) < 0.01)
         )
       })
@@ -101,19 +95,16 @@ plan_kelly_variants <- function() {
         bk  <- hd_kelly_bounded(ret, fraction = 0.25)
         f   <- max(0, min(1, bk$f_star))
         strat_ret <- ret * f
-        n <- length(strat_ret)
+        m <- calc_backtest_metrics(strat_ret)
         tibble(
           strategy   = strat,
           method     = "Bounded",
           fraction   = 0.25,
           f_star     = round(f, 4),
-          cagr_pct   = round((prod(1 + strat_ret)^(12 / n) - 1) * 100, 1),
-          vol_pct    = round(sd(strat_ret) * sqrt(12) * 100, 1),
-          sharpe     = round(mean(strat_ret) / sd(strat_ret) * sqrt(12), 2),
-          max_dd_pct = round(
-            min((cumprod(1 + strat_ret) -
-                   cummax(cumprod(1 + strat_ret))) /
-                  cummax(cumprod(1 + strat_ret))) * 100, 1),
+          cagr_pct   = round(m$cagr * 100, 1),
+          vol_pct    = round(m$vol * 100, 1),
+          sharpe     = round(m$sharpe, 2),
+          max_dd_pct = round(m$max_dd * 100, 1),
           bankrupt   = any(cumprod(1 + strat_ret) < 0.01)
         )
       })

--- a/R/utils_metrics.R
+++ b/R/utils_metrics.R
@@ -1,0 +1,83 @@
+# Canonical backtest annualisation metrics
+#
+# Single source of truth for leaderboard metrics so all plans produce
+# comparable Sharpe, CAGR, vol, max drawdown, and Calmar values.
+# Uses compound (geometric) annualisation — what investors actually earn.
+#
+# Formula:
+#   CAGR   = cumprod(1 + r)[n] ^ (periods_per_year / n) - 1
+#   vol    = sd(r) * sqrt(periods_per_year)
+#   Sharpe = CAGR / vol
+
+#' Canonical backtest annualisation metrics
+#'
+#' Annualises a vector of periodic returns (monthly assumed by default).
+#' Returns include CAGR (geometric), annual vol, Sharpe (CAGR / vol),
+#' max drawdown, and Calmar.
+#'
+#' Uses compound (geometric) annualisation throughout so results from
+#' different plans are directly comparable on the leaderboard.
+#'
+#' @param ret Numeric vector of periodic returns (e.g., monthly).
+#' @param periods_per_year Integer. Default 12L (monthly). Use 252L for
+#'   daily or 4L for quarterly returns.
+#' @param na.rm Logical. If \code{TRUE} (default), NA values are dropped
+#'   before computation.
+#'
+#' @return A named list with elements:
+#'   \describe{
+#'     \item{cagr}{Compound annual growth rate (decimal, not percent).}
+#'     \item{vol}{Annualised volatility (sd * sqrt(periods_per_year)).}
+#'     \item{sharpe}{Sharpe ratio (CAGR / vol); NA when vol is zero.}
+#'     \item{max_dd}{Maximum drawdown (negative number, e.g. -0.12 = -12\%).}
+#'     \item{calmar}{Calmar ratio (CAGR / abs(max_dd)); NA when max_dd is zero.}
+#'     \item{n}{Number of non-NA observations used.}
+#'   }
+#'
+#' @family backtest
+#' @export
+calc_backtest_metrics <- function(ret, periods_per_year = 12L, na.rm = TRUE) {
+  if (!is.numeric(ret)) {
+    cli::cli_abort(c(
+      "x" = "{.arg ret} must be a numeric vector.",
+      "i" = "Got {.cls {class(ret)}}."
+    ))
+  }
+  if (!is.numeric(periods_per_year) || length(periods_per_year) != 1L ||
+      periods_per_year <= 0) {
+    cli::cli_abort(c(
+      "x" = "{.arg periods_per_year} must be a single positive number.",
+      "i" = "Got {periods_per_year}."
+    ))
+  }
+
+  if (isTRUE(na.rm)) ret <- ret[!is.na(ret)]
+
+  n <- length(ret)
+  if (n < 2L) {
+    return(list(
+      cagr   = NA_real_,
+      vol    = NA_real_,
+      sharpe = NA_real_,
+      max_dd = NA_real_,
+      calmar = NA_real_,
+      n      = n
+    ))
+  }
+
+  equity <- cumprod(1 + ret)
+  cagr   <- equity[n]^(periods_per_year / n) - 1
+  vol    <- stats::sd(ret) * sqrt(periods_per_year)
+  sharpe <- if (vol > 0) cagr / vol else NA_real_
+  max_dd <- min(equity / cummax(equity) - 1)
+  calmar <- if (max_dd < 0) cagr / abs(max_dd) else NA_real_
+
+  list(
+    cagr   = cagr,
+    vol    = vol,
+    sharpe = sharpe,
+    max_dd = max_dd,
+    calmar = calmar,
+    n      = n
+  )
+}

--- a/tests/testthat/test-utils-metrics.R
+++ b/tests/testthat/test-utils-metrics.R
@@ -1,0 +1,94 @@
+test_that("calc_backtest_metrics: all-zero returns produce CAGR 0, vol 0, sharpe NA, max_dd 0", {
+  ret <- rep(0, 24)
+  m <- calc_backtest_metrics(ret)
+  expect_equal(m$cagr,   0, tolerance = 1e-10)
+  expect_equal(m$vol,    0, tolerance = 1e-10)
+  expect_true(is.na(m$sharpe))
+  expect_equal(m$max_dd, 0, tolerance = 1e-10)
+  expect_equal(m$n, 24L)
+})
+
+test_that("calc_backtest_metrics: 1% monthly for 12 months gives CAGR ~12.68%", {
+  ret <- rep(0.01, 12)
+  m <- calc_backtest_metrics(ret, periods_per_year = 12L)
+  expected_cagr <- 1.01^12 - 1   # 0.126825...
+  expect_equal(m$cagr, expected_cagr, tolerance = 1e-8)
+  expect_equal(m$n, 12L)
+})
+
+test_that("calc_backtest_metrics: known toy series gives expected Sharpe to 2 dp", {
+  # Alternating +5%, -3% monthly for 24 months
+  # Mean = 0.01, var ≈ 0.0016, so we can work out expected values analytically
+  ret <- rep(c(0.05, -0.03), 12)   # 24 months
+  m <- calc_backtest_metrics(ret, periods_per_year = 12L)
+
+  # CAGR: prod(1+ret)^(12/24) - 1 = (1.05 * 0.97)^12 / 24... let's just verify sign
+  # Each pair: 1.05 * 0.97 = 1.0185, so equity grows slowly
+  expect_true(m$cagr > 0)
+  expect_true(m$sharpe > 0)   # positive Sharpe since CAGR > 0
+  expect_true(m$max_dd < 0)   # must have some drawdown
+  expect_equal(m$n, 24L)
+
+  # Spot-check Sharpe to 2 decimal places
+  equity <- cumprod(1 + ret)
+  n <- 24
+  cagr_expected <- equity[n]^(12 / n) - 1
+  vol_expected  <- stats::sd(ret) * sqrt(12)
+  sharpe_expected <- cagr_expected / vol_expected
+  expect_equal(m$sharpe, sharpe_expected, tolerance = 1e-10)
+})
+
+test_that("calc_backtest_metrics: second toy series — constant positive returns", {
+  # 36 months of exactly 0.5% (low vol, positive CAGR)
+  ret <- rep(0.005, 36)
+  m <- calc_backtest_metrics(ret, periods_per_year = 12L)
+
+  expected_cagr <- 1.005^12 - 1
+  expect_equal(m$cagr, expected_cagr, tolerance = 1e-8)
+  # vol should be 0 (constant), so sharpe NA
+  expect_equal(m$vol, 0, tolerance = 1e-10)
+  expect_true(is.na(m$sharpe))
+  # No drawdown on constant positive returns
+  expect_equal(m$max_dd, 0, tolerance = 1e-10)
+  expect_true(is.na(m$calmar))  # max_dd = 0, calmar undefined
+})
+
+test_that("calc_backtest_metrics: fewer than 2 observations returns all NA", {
+  expect_equal(calc_backtest_metrics(numeric(0))$n, 0L)
+  expect_true(is.na(calc_backtest_metrics(numeric(0))$cagr))
+  expect_equal(calc_backtest_metrics(0.1)$n, 1L)
+  expect_true(is.na(calc_backtest_metrics(0.1)$sharpe))
+})
+
+test_that("calc_backtest_metrics: NA values are dropped by default", {
+  ret_with_na <- c(0.01, NA, 0.02, NA, 0.03)
+  ret_clean   <- c(0.01, 0.02, 0.03)
+  m_na    <- calc_backtest_metrics(ret_with_na)
+  m_clean <- calc_backtest_metrics(ret_clean)
+  expect_equal(m_na$cagr,   m_clean$cagr,   tolerance = 1e-10)
+  expect_equal(m_na$sharpe, m_clean$sharpe, tolerance = 1e-10)
+  expect_equal(m_na$n, 3L)
+})
+
+test_that("calc_backtest_metrics: daily periods_per_year = 252 changes output", {
+  set.seed(42L)
+  ret <- rnorm(252, mean = 0.0003, sd = 0.01)
+  m_d <- calc_backtest_metrics(ret, periods_per_year = 252L)
+  m_m <- calc_backtest_metrics(ret, periods_per_year = 12L)
+  # Annual vol with daily scaling should be larger than with monthly scaling
+  expect_true(m_d$vol > m_m$vol)
+})
+
+test_that("calc_backtest_metrics: non-numeric ret aborts with cli_abort", {
+  expect_error(
+    calc_backtest_metrics(c("a", "b", "c")),
+    class = "rlang_error"
+  )
+})
+
+test_that("calc_backtest_metrics: invalid periods_per_year aborts", {
+  expect_error(
+    calc_backtest_metrics(c(0.01, 0.02), periods_per_year = -1),
+    class = "rlang_error"
+  )
+})


### PR DESCRIPTION
## Summary

Extracts canonical annualisation formula to \`R/utils_metrics.R\` and refactors 5 inline metric sites across \`plan_kelly_variants.R\` (3 sites) and \`plan_etf_replication.R\` (2 sites). Makes leaderboard Sharpe / CAGR / vol values comparable across strategies.

### Before / after

**plan_kelly_variants.R** had SIMPLE annualisation:
\`\`\`r
vol_pct = round(sd(strat_ret) * sqrt(12) * 100, 1),
sharpe  = round(mean(strat_ret) / sd(strat_ret) * sqrt(12), 2),
\`\`\`

**plan_etf_replication.R** had COMPOUND annualisation:
\`\`\`r
vol    = sd(df\$port_ret) * sqrt(12),
sharpe = (prod(1 + df\$port_ret)^(12/n) - 1) / (sd(df\$port_ret) * sqrt(12)),
\`\`\`

Now both use \`calc_backtest_metrics()\` with the COMPOUND formula:
\`\`\`
CAGR    = cumprod(1+r)[n]^(periods_per_year/n) - 1
vol     = sd(r) * sqrt(periods_per_year)
Sharpe  = CAGR / vol
\`\`\`

(Compound is what investors actually earn; arithmetic mean × 12 overstates for mean-positive series.)

### Sharpe shift expected

- **kv_*** targets (kelly_variants): Sharpe values will shift DOWN slightly from prior runs (compound CAGR < arithmetic mean × 12 for positive-mean series)
- **etf_*** targets: unchanged (refactor only — they already used compound)

No old \`_targets/objects/\` cache existed for direct comparison; document the shift in CHANGELOG when leaderboard re-runs.

### New helper API

\`\`\`r
calc_backtest_metrics(ret, periods_per_year = 12L, na.rm = TRUE)
#  → list(cagr, vol, sharpe, max_dd, calmar, n)
\`\`\`

Supports any frequency: daily (\`periods_per_year = 252L\`), monthly (default \`12L\`), quarterly (\`4L\`).

### Tests

\`tests/testthat/test-utils-metrics.R\` — 9 test cases, 27 assertions, all PASS:
- All-zero returns → CAGR 0, vol 0, sharpe NA, max_dd 0
- 1% monthly × 12 → CAGR ≈ (1.01^12 - 1) = 12.68%
- Toy series → Sharpe to 2-decimal expected
- NA handling
- Daily scaling
- Input validation

## Verification

- \`parse()\` on all 3 modified files: OK
- \`targets::tar_validate()\`: PASS
- \`testthat::test_file()\`: \`[ FAIL 0 | WARN 0 | SKIP 0 | PASS 27 ]\`

## Test plan

- [x] tar_validate passes
- [x] Unit tests pass (27/27)
- [ ] Post-merge: run \`tar_make()\` on kv_* and etf_* targets; document Sharpe shift in CHANGELOG
- [ ] Leaderboard target rebuilds without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)