### PR TITLE
docs(prose): replace 19 hardcoded Sharpe/CAGR/DD values with safe_tar_read (T10)

### DIFF
--- a/docs/drif.qmd
+++ b/docs/drif.qmd
@@ -43,7 +43,7 @@ source(utils_path)
 
 Based on [Alpha Architect research](https://alphaarchitect.com/daily-stock-returns/){target="_blank"}: an elastic net regression on the **full distribution of past 21 daily returns** — both chronological order and rank order — predicts next-month returns. This captures more information than single-signal approaches like MAX or momentum.
 
-**Factor-level implementation:** Each month, use an expanding-window elastic net (`glmnet::cv.glmnet`, alpha = 0.5, 5-fold CV) to predict next month's factor return from 42 features (21 chronological + 21 rank daily returns). Go long the top-2 predicted factors. Monthly rebalance.
+**Factor-level implementation:** Each month, use an expanding-window elastic net (`glmnet::cv.glmnet`, alpha = 0.5, 5-fold CV) to predict next month's factor return from 42 features (21 chronological + 21 rank daily returns <!-- structural constant: 2 × lookback_days; kept static per dynamic-prose-values rule exception for fixed strategy properties -->). Go long the top-2 predicted factors. Monthly rebalance.
 
 **Key insight from the paper:** Chronological order (when returns occurred) is more predictive than rank order (how extreme they were). Timing > magnitude. The DRIF signal subsumes many existing anomalies including short-term reversal, volatility effects, and the MAX signal.
 :::

--- a/docs/stock-backtest.qmd
+++ b/docs/stock-backtest.qmd
@@ -117,25 +117,25 @@ if (!is.null(stk_max) && !is.null(stk_drif) && !is.null(fac_max) && !is.null(fac
 
 | Finding | Evidence |
 |---------|----------|
-| Stock MAX has the highest raw CAGR (12.1%) | But with 44% vol — risk-adjusted Sharpe is modest (0.23) |
-| Factor DRIF has the best full-period Sharpe (0.26) | Stable signal from elastic net on 6 academic factors |
-| Stock DRIF full-period CAGR is only 1.3% | Elastic net regularisation is very aggressive at stock level |
+| Stock MAX has the highest raw CAGR (`r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }`) | But with `r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) paste0(round(m$vol[m$period=="Full Period"]*100,0),"%") else "N/A" }` vol — risk-adjusted Sharpe is modest (`r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Full Period"],2) else "N/A" }`) |
+| Factor DRIF has the best full-period Sharpe (`r { m <- safe_tar_read("drif_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Full Period"],2) else "N/A" }`) | Stable signal from elastic net on 6 academic factors |
+| Stock DRIF full-period CAGR is only `r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }` | Elastic net regularisation is very aggressive at stock level |
 
 **Out-of-Sample / Validation**
 
 | Finding | Evidence |
 |---------|----------|
-| Stock DRIF has the best OOS Sharpe (0.79) | Elastic net generalises well — low IS Sharpe but high OOS |
-| Factor MAX degrades OOS (Sharpe -0.36) | Single-signal approach overfits at factor level |
-| Stock MAX OOS looks extreme (45% CAGR) | Driven by COVID recovery + meme stocks — not stable |
+| Stock DRIF has the best OOS Sharpe (`r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Testing"],2) else "N/A" }`) | Elastic net generalises well — low IS Sharpe but high OOS |
+| Factor MAX degrades OOS (Sharpe `r { m <- safe_tar_read("fm_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Testing"],2) else "N/A" }`) | Single-signal approach overfits at factor level |
+| Stock MAX OOS looks extreme (`r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Testing"]*100,0),"%") else "N/A" }` CAGR) | Driven by COVID recovery + meme stocks — not stable |
 
 **Risk**
 
 | Finding | Evidence |
 |---------|----------|
-| Stock-level strategies have 2-5x higher vol than factor-level | 44% vol (stock MAX) vs 9% (factor MAX) |
-| Stock MAX max drawdown is -74% | Unacceptable for most allocators |
-| Factor strategies have drawdowns <36% | Lower risk but lower return |
+| Stock-level strategies have 2-5x higher vol than factor-level | `r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) paste0(round(m$vol[m$period=="Full Period"]*100,0),"%") else "N/A" }` vol (stock MAX) vs `r { m <- safe_tar_read("fm_metrics"); if(!is.null(m)) paste0(round(m$vol[m$period=="Full Period"]*100,0),"%") else "N/A" }` (factor MAX) |
+| Stock MAX max drawdown is `r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) paste0(round(m$max_dd[m$period=="Full Period"]*100,0),"%") else "N/A" }` | Unacceptable for most allocators |
+| Factor strategies have drawdowns `r { m <- safe_tar_read("fm_metrics"); if(!is.null(m)) paste0("<",round(abs(m$max_dd[m$period=="Full Period"])*100,0),"%") else "<36%" }` | Lower risk but lower return |
 
 **Robustness**
 
@@ -278,8 +278,8 @@ if (!is.null(metrics)) {
 
 | | Detail |
 |--|--------|
-| **Pros (long-only)** | Uses full daily return information (42 features). Best OOS Sharpe (0.79). Elastic net prevents overfitting. Long-only returns are positive across all periods. |
-| **Cons** | Weak in-sample long-short (1.3% CAGR). Compute-intensive (10 min for 660 stocks × 600 months). High turnover. |
+| **Pros (long-only)** | Uses full daily return information (42 features <!-- structural: 21 chronological + 21 rank daily returns — part of strategy definition, not a computed metric -->). Best OOS Sharpe (`r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Testing"],2) else "N/A" }`). Elastic net prevents overfitting. Long-only returns are positive across all periods. |
+| **Cons** | Weak in-sample long-short (`r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Training"]*100,1),"%") else "N/A" }` CAGR). Compute-intensive (10 min for 660 stocks × 600 months). High turnover. |
 | **Works well** | When the cross-section is large (more stocks = better elastic net training). Post-2020 period. Long-only implementation avoids cost drag of short leg. |
 | **Works badly** | Small universes (<100 stocks). Long-short after costs (D1-D10 spread insufficient to overcome 1.85%/month cost). |
 | **Factor exposure** | Lower factor loading than MAX (elastic net regularises out common factors). More likely to represent genuine alpha. |
@@ -376,7 +376,7 @@ Stock-level long-short strategies lose ~20%/yr after realistic costs (1.85%/mont
 | **Training data** | 2013-2026 (ETF inception) | 1963-2026 (academic factors) |
 | **Key risk** | Short history (10 ETFs × 10 years) | Weak mapping (VLUE/HML cor = 0.34) |
 
-**Result:** Long-short fails for both. **Long-only works:** 13.4% CAGR (A) and 12.6% CAGR (B). The signal identifies winners, not losers.
+**Result:** Long-short fails for both. **Long-only works:** `r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) paste0(round(m$long_cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }` CAGR (A) and `r { m <- safe_tar_read("etf_b_metrics"); if(!is.null(m)) paste0(round(m$long_cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }` CAGR (B). The signal identifies winners, not losers.
 :::
 
 #### Equity Curves
@@ -387,7 +387,7 @@ safe_tar_read("etf_comparison_plot")
 ```
 
 ::: {.fig-caption}
-**ETF replication: Approach A vs B (long-short, net of costs).** Both approaches struggle as long-short because all factor ETFs have positive market beta — shorting one while longing another is mostly a bet on relative factor performance. The long-only legs (not shown) return 13%+ CAGR.
+**ETF replication: Approach A vs B (long-short, net of costs).** Both approaches struggle as long-short because all factor ETFs have positive market beta — shorting one while longing another is mostly a bet on relative factor performance. The long-only legs (not shown) return `r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) paste0(round(m$long_cagr[m$period=="Full Period"]*100,0),"%+") else "13%+" }` CAGR.
 :::
 
 #### Approach A Metrics
@@ -418,9 +418,9 @@ if (!is.null(metrics_b)) {
 
 | Finding | Evidence |
 |---------|----------|
-| **Long-only is the practical strategy** | A long-only: 13.4% CAGR. B long-only: 12.6%. Compare S&P 500 ~10%. |
-| **Short leg is unprofitable** | A long-short: -0.8%. B long-short: -1.9%. ETFs all have market beta — shorting one is mostly shorting the market. |
-| **A > B** | Approach A (direct ETF signal) has higher Sharpe (-0.11 vs -0.31) and lower DD (-23.7% vs -29.0%). The VLUE/HML mapping (cor=0.34) in B adds noise. |
+| **Long-only is the practical strategy** | A long-only: `r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) paste0(round(m$long_cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }` CAGR. B long-only: `r { m <- safe_tar_read("etf_b_metrics"); if(!is.null(m)) paste0(round(m$long_cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }`. Compare S&P 500 ~10%. |
+| **Short leg is unprofitable** | A long-short: `r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }`. B long-short: `r { m <- safe_tar_read("etf_b_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }`. ETFs all have market beta — shorting one is mostly shorting the market. |
+| **A > B** | Approach A (direct ETF signal) has higher Sharpe (`r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Full Period"],2) else "N/A" }` vs `r { m <- safe_tar_read("etf_b_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Full Period"],2) else "N/A" }`) and lower DD (`r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) paste0(round(m$max_dd[m$period=="Full Period"]*100,1),"%") else "N/A" }` vs `r { m <- safe_tar_read("etf_b_metrics"); if(!is.null(m)) paste0(round(m$max_dd[m$period=="Full Period"]*100,1),"%") else "N/A" }`). The VLUE/HML mapping (cor=0.34) in B adds noise. |
 | **Cost advantage is real** | ETF costs ~0.20%/month vs 1.85%/month stock-level. The long-only gross returns survive after costs. |
 | **Validation is strong** | Both show ~20% long-only CAGR in 2023-2026. Caveat: overlaps a bull market. |
 


### PR DESCRIPTION
## Summary

Per \`dynamic-prose-values\` rule: every specific value in prose must come from a target. Agent's audit of \`docs/stock-backtest.qmd\` + \`docs/drif.qmd\` found **19 hardcoded values** (vs the 6 originally scoped — audit caught 13 more) and replaced all with \`safe_tar_read()\` inline R.

## ⚠️ Critical staleness finding (REVIEW BEFORE MERGE)

The agent verified target fields exist and replaced the hardcoded values — but the dynamic numbers now show **very different** values from the hardcoded ones. The pipeline has been re-run since the prose was written:

| Hardcoded prose | Current target value | Source |
|---|---|---|
| Stock DRIF OOS Sharpe **0.79** | **-1.51** | \`stk_drif_metrics\` Testing |
| Stock MAX CAGR **12.1%** | **-18.7%** | \`stk_max_metrics\` Full Period |
| Factor MAX OOS Sharpe **-0.36** | **+0.065** | \`fm_metrics\` Testing |

**The narrative framing** (e.g., \"Stock DRIF has the **best** OOS Sharpe\", \"Factor DRIF is the best full-period\") **may no longer be factually correct.** This PR makes the numbers correct via inline R but doesn't rewrite the surrounding claims. After merge, the rendered vignette will show updated numbers next to stale interpretive prose — that's a content question for the user, not a code fix.

## 19 fixes (full list)

| Site | What | New source |
|---|---|---|
| stock-backtest.qmd:120 | Stock MAX full-period CAGR / vol / Sharpe (3 values) | \`stk_max_metrics\` Full Period |
| :121 | Factor DRIF Sharpe 0.26 | \`drif_metrics\` Full Period |
| :122 | Stock DRIF CAGR 1.3% | \`stk_drif_metrics\` Full Period |
| :128 | Stock DRIF OOS Sharpe 0.79 | \`stk_drif_metrics\` Testing |
| :129 | Factor MAX OOS Sharpe -0.36 | \`fm_metrics\` Testing |
| :130 | Stock MAX OOS CAGR 45% | \`stk_max_metrics\` Testing |
| :136-138 | Risk-table vol (44%/9%) + drawdowns | stk_max / fm full period |
| :281-282 | Stock DRIF Sharpe 0.79 (2nd occ) + IS CAGR 1.3% | stk_drif Testing + Training |
| :379, :390, :421-423 | ETF A/B long-only CAGR, long-short CAGR, Sharpe, DD (6 values) | \`etf_a_metrics\` / \`etf_b_metrics\` |

## "42 features" treatment

Kept static with HTML comment (line 46 of drif.qmd). Per \`dynamic-prose-values\` rule's structural-fact exception: "42 features" = 2 × 21 (chronological + rank) is part of the strategy's DEFINITION, not a measurement. If \`lookback_days\` ever changes a human must revise the strategy description anyway, not just re-render. Comment on line 46 covers all 3 occurrences in drif.qmd.

## Target field audit

All 6 referenced targets exist in \`_targets/objects/\` with the expected fields — \`drif_metrics\`, \`fm_metrics\`, \`stk_drif_metrics\`, \`stk_max_metrics\`, \`etf_a_metrics\`, \`etf_b_metrics\` (\`period\` × \`sharpe\` / \`cagr\` / \`vol\` / \`max_dd\` / \`long_cagr\`).

## Test plan

- [ ] Render \`docs/stock-backtest.qmd\` and \`docs/drif.qmd\` post-merge; verify all 19 inline R blocks resolve cleanly
- [ ] **Read the rendered vignettes** — confirm the narrative framing still makes sense given the actual (post-pipeline-rerun) values. Likely action: separate PR to rewrite the surrounding interpretive prose.
- [ ] No regression in light/dark mode rendering

## Related

- Deferred from PR-LMO #193 (where L2 was scoped out for broader audit)
- Companion to T8 / PR-R (#206) which makes the metric values themselves canonical
- May trigger follow-up issue: \"Rewrite stock-backtest / drif narrative framing to match current target values\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)