### PR TITLE
fix: 4 LIVE roborev bugs across leaderboard / factormax / avoid_worst / vintages (PR-U1)

### DIFF
--- a/R/plan_avoid_worst.R
+++ b/R/plan_avoid_worst.R
@@ -467,14 +467,19 @@ plan_avoid_worst <- function() {
     targets::tar_target(aw_vix_daily, {
       library(dplyr)
 
-      spy <- aw_daily_returns |> filter(ticker == "SPY") |> arrange(date)
+      # Coerce both sides to Date BEFORE joining: hd_macro() may return POSIXct,
+      # and a Date vs POSIXct left_join silently produces zero matches.
+      spy <- aw_daily_returns |>
+        filter(ticker == "SPY") |>
+        dplyr::mutate(date = as.Date(date)) |>
+        arrange(date)
       vix <- hd_macro("VIXCLS") |>
         select(date, vix = value) |>
+        dplyr::mutate(date = as.Date(date)) |>
         arrange(date)
 
       spy |>
-        left_join(vix, by = "date") |>
-        dplyr::mutate(date = as.Date(date, tz = "UTC"))
+        left_join(vix, by = "date")
     }),
 
     targets::tar_target(aw_practical_params, {

--- a/R/plan_factormax.R
+++ b/R/plan_factormax.R
@@ -339,8 +339,14 @@ plan_factormax <- function() {
         mutate(cum = cumprod(1 + ret)) |>
         ungroup()
 
-      # Get dates for x-axis from etf data
-      date_lookup <- etf_m |> distinct(ym, date)
+      # Get dates for x-axis from etf data. Use slice_max to guarantee one row
+      # per ym: different ETFs may have different month-end dates (holiday calendars),
+      # which makes distinct(ym, date) produce > 1 row per ym and fan-out the join.
+      date_lookup <- etf_m |>
+        dplyr::group_by(ym) |>
+        dplyr::slice_max(date, n = 1L, with_ties = FALSE) |>
+        dplyr::ungroup() |>
+        dplyr::select(ym, date)
       combined <- combined |> left_join(date_lookup, by = "ym")
 
       ggplot(combined, aes(date, cum, colour = strategy)) +

--- a/R/plan_portfolio_opt.R
+++ b/R/plan_portfolio_opt.R
@@ -188,6 +188,7 @@ plan_portfolio_opt <- function() {
         tibble(
           period = label, months = n,
           opt_cagr   = prod(1 + df$optimal_ret)^(12/n) - 1,
+          opt_vol    = sd(df$optimal_ret) * sqrt(12),
           opt_sharpe = sharpe(df$optimal_ret),
           opt_maxdd  = maxdd(df$optimal_ret),
           hrp_cagr   = prod(1 + df$hrp_ret)^(12/n) - 1,

--- a/packages/historicaldata/R/vintages.R
+++ b/packages/historicaldata/R/vintages.R
@@ -90,7 +90,13 @@ hd_revision_analysis <- function(series_id, from = "2000-01-01") {
   analysis <- reviser::get_revision_analysis(rev_data)
   first_efficient <- tryCatch(
     reviser::get_first_efficient_release(rev_data),
-    error = function(e) NULL
+    error = function(e) {
+      cli::cli_warn(c(
+        "!" = "vintages: get_first_efficient_release() failed for {.val {series_id}}",
+        "i" = "{conditionMessage(e)}"
+      ))
+      NULL
+    }
   )
 
   list(


### PR DESCRIPTION
## Summary

Four LIVE bugs surfaced by B2 triage agent (issue #210 Tier A). Each was confirmed against current code, fixed minimally, tested where unit-testable, and the roborev verdict closed.

## Per-finding

### #1113 — \`opt_vol\` column missing

**Surface:** \`R/plan_leaderboard.R:35\` references \`opt_vol\` which doesn't exist in the upstream portfolio_opt target output → leaderboard renders NA.

**Root cause:** \`R/plan_portfolio_opt.R\` \`calc_port_metrics()\` tibble was missing the column.

**Fix (\`e63e1a7\`):** added \`opt_vol = sd(df\$optimal_ret) * sqrt(12)\` to the metrics tibble in \`plan_portfolio_opt.R\`.

### #713 — \`distinct(ym, date)\` fan-out

**Surface:** \`R/plan_factormax.R:343\`. The ETF \`date_lookup\` join would multiply rows when different ETFs had different holiday calendars within the same month.

**Fix (\`7e635d0\`):** replaced \`distinct(ym, date)\` with \`group_by(ym) |> slice_max(date, n=1L, with_ties=FALSE) |> ungroup() |> select(ym, date)\` — guarantees one row per \`ym\`.

### #1096 — Date / POSIXct join silent zero-row

**Surface:** \`R/plan_avoid_worst.R:475-477\`. \`spy\` had \`POSIXct\` date; \`vix\` had \`Date\`. \`left_join(by = \"date\")\` silently produced zero matches (the global \`data-validation-timeseries\` rule Section 9 trap).

**Fix (\`a15f661\`):** moved \`as.Date()\` coercion to BEFORE the join on both sides.

### #762 — Silent \`tryCatch\` in vintages

**Surface:** \`packages/historicaldata/R/vintages.R:91-94\`. \`tryCatch(reviser::get_first_efficient_release(...), error = function(e) NULL)\` — pattern that PR #180 swept elsewhere but missed this site.

**Fix (\`6ce4f83\`):** now \`cli::cli_warn(\"vintages: <series_id>: {conditionMessage(e)}\")\` before returning \`NULL\` — matches PR #180's convention.

## Verification

- \`parse()\` on all 4 modified files: PASS
- \`tar_validate(callr_function = NULL)\`: PASS (no errors)
- No unit tests added — \`vintages.R\` is API-driven (\`reviser::get_first_efficient_release\` needs live data); the other 3 are plan-target internals that can't be exercised without full pipeline execution.

## Roborev closures

Agent ran:
\`\`\`
roborev close 1113   # ok
roborev close 713    # ok
roborev close 1096   # ok
roborev close 762    # ok
\`\`\`

## Related

- #210 (parent — 20 LIVE findings; this PR addresses Tier A's 4)
- Yesterday's PR #180 (silent-tryCatch sweep — pattern continued here)
- Global \`data-validation-timeseries\` rule §9 (Date/POSIXct trap — what bit #1096)

🤖 Generated with [Claude Code](https://claude.com/claude-code)