### PR TITLE
fix(nix): closure-rebuild shellHook + slider dep (partial fix for #211)

### DIFF
--- a/default.post.sh
+++ b/default.post.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# default.post.sh — Idempotent patch to re-apply the closure-rebuild shellHook
+# after `t update` regenerates flake.nix.
+#
+# Per nix-nested-shell-isolation rule (defensive workflow):
+# When `t update` regenerates flake.nix, it strips hand-edited shellHook blocks.
+# Run this script immediately after `t update` to re-apply the patch.
+#
+# Overlay being re-applied:
+#   - closure-rebuild: discards inherited R_LIBS_SITE from outer nix shells
+#     (fixes ABI mismatch segfault in slider/dplyr/glmnet/arrow when entering
+#     this project shell from inside another nix-shell). Closes #211.
+#
+# Usage:
+#   t update           # regenerates flake.nix (strips shellHook patch)
+#   bash default.post.sh   # re-applies the patch (idempotent)
+#
+# Idempotency guard: checks for presence of "Closure-rebuild" marker before patching.
+set -euo pipefail
+
+NIX_FILE="$(dirname "$0")/flake.nix"
+
+if [ ! -f "$NIX_FILE" ]; then
+  echo "ERROR: $NIX_FILE not found" >&2
+  exit 1
+fi
+
+MARKER="Closure-rebuild"
+if grep -q "$MARKER" "$NIX_FILE"; then
+  echo "default.post.sh: closure-rebuild shellHook already present in flake.nix — skipping"
+  exit 0
+fi
+
+echo "default.post.sh: applying closure-rebuild shellHook patch to $NIX_FILE..."
+
+python3 - <<'PYEOF'
+import sys
+
+filepath = "flake.nix"
+
+with open(filepath, 'r') as f:
+    content = f.read()
+
+insertion = '''            # ----------------------------------------------------------------
+            # Closure-rebuild: discard any inherited R_LIBS_SITE from outer
+            # nix shells (global nix-nested-shell-isolation rule, 2026-05-18).
+            # When this shell is entered from inside another nix-shell, the
+            # outer R_LIBS_SITE points at libraries compiled against a
+            # DIFFERENT R binary -> segfault on first native call
+            # (slider::slide_dbl, dplyr::mutate, glmnet, arrow, etc.).
+            # Fix: rebuild R_LIBS_SITE from this shell\'s own buildInputs
+            # closure, discarding all inherited paths. Closes #211.
+            # ----------------------------------------------------------------
+            R_LIBS_SITE=""
+            for pkg in $buildInputs; do
+              for dep in $(nix-store -qR "$pkg" 2>/dev/null); do
+                if [ -d "$dep/library" ]; then
+                  case ":$R_LIBS_SITE:" in
+                    *":$dep/library:"*) ;;
+                    *) R_LIBS_SITE="\'\'${R_LIBS_SITE:+$R_LIBS_SITE:}$dep/library" ;;
+                  esac
+                fi
+              done
+            done
+            export R_LIBS_SITE
+            unset R_LIBS_USER
+            unset R_LIBS
+'''
+
+marker = "          shellHook = ''\n"
+pos = content.find(marker)
+if pos == -1:
+    print("ERROR: shellHook marker not found in flake.nix", file=sys.stderr)
+    sys.exit(1)
+
+insert_pos = pos + len(marker)
+new_content = content[:insert_pos] + insertion + content[insert_pos:]
+
+with open(filepath, 'w') as f:
+    f.write(new_content)
+
+print(f"Patch applied: inserted closure-rebuild block ({len(insertion)} chars)")
+PYEOF
+
+echo "default.post.sh: done. Verify with: grep -c 'Closure-rebuild' flake.nix"

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
             usethis
             HierPortfolios
             yfscreen
+            slider
           ];
         };
 
@@ -80,6 +81,30 @@
           ] ++ additionalTools;
 
           shellHook = ''
+            # ----------------------------------------------------------------
+            # Closure-rebuild: discard any inherited R_LIBS_SITE from outer
+            # nix shells (global nix-nested-shell-isolation rule, 2026-05-18).
+            # When this shell is entered from inside another nix-shell, the
+            # outer R_LIBS_SITE points at libraries compiled against a
+            # DIFFERENT R binary -> segfault on first native call
+            # (slider::slide_dbl, dplyr::mutate, glmnet, arrow, etc.).
+            # Fix: rebuild R_LIBS_SITE from this shell's own buildInputs
+            # closure, discarding all inherited paths. Closes #211.
+            # ----------------------------------------------------------------
+            R_LIBS_SITE=""
+            for pkg in $buildInputs; do
+              for dep in $(nix-store -qR "$pkg" 2>/dev/null); do
+                if [ -d "$dep/library" ]; then
+                  case ":$R_LIBS_SITE:" in
+                    *":$dep/library:"*) ;;
+                    *) R_LIBS_SITE="''${R_LIBS_SITE:+$R_LIBS_SITE:}$dep/library" ;;
+                  esac
+                fi
+              done
+            done
+            export R_LIBS_SITE
+            unset R_LIBS_USER
+            unset R_LIBS
             echo "=================================================="
             echo "T Project: historical_data"
             echo "=================================================="

--- a/tproject.toml
+++ b/tproject.toml
@@ -5,7 +5,7 @@ description = "Historical finance database: Python fetches + R validates/cleans 
 [dependencies]
 
 [r-dependencies]
-packages = ["dplyr", "arrow", "curl", "duckdb", "duckplyr", "devtools", "ggplot2", "glmnet", "pkgload", "pointblank", "reviser", "roxygen2", "scales", "targets", "crew", "DT", "fredr", "frenchdata", "httr2", "jsonlite", "knitr", "purrr", "reticulate", "testthat", "tidyr", "xgboost", "cli", "rlang", "usethis", "HierPortfolios", "yfscreen"]
+packages = ["dplyr", "arrow", "curl", "duckdb", "duckplyr", "devtools", "ggplot2", "glmnet", "pkgload", "pointblank", "reviser", "roxygen2", "scales", "targets", "crew", "DT", "fredr", "frenchdata", "httr2", "jsonlite", "knitr", "purrr", "reticulate", "testthat", "tidyr", "xgboost", "cli", "rlang", "usethis", "HierPortfolios", "yfscreen", "slider"]
 
 [py-dependencies]
 version = "python313"


### PR DESCRIPTION
## Summary

Adds the closure-rebuild \`shellHook\` to \`flake.nix\` per the global \`nix-nested-shell-isolation\` rule, plus \`slider\` to deps, plus an idempotent \`default.post.sh\` patch script for surviving \`t update\` regenerations.

## What's fixed

**Outer-shell R_LIBS_SITE contamination** is now resolved. The new shellHook:

\`\`\`bash
R_LIBS_SITE=\"\"
for pkg in \$buildInputs; do
  for dep in \$(nix-store -qR \"\$pkg\" 2>/dev/null); do
    if [ -d \"\$dep/library\" ]; then
      case \":\$R_LIBS_SITE:\" in
        *\":\$dep/library:\"*) ;;
        *) R_LIBS_SITE=\"\${R_LIBS_SITE:+\$R_LIBS_SITE:}\$dep/library\" ;;
      esac
    fi
  done
done
export R_LIBS_SITE
unset R_LIBS_USER
unset R_LIBS
\`\`\`

Smoke test (PASS):
\`\`\`
slider OK: 10 values
dplyr OK: 3 rows
R_LIBS_SITE: 438 /nix/store paths, all from this project's closure
R_LIBS: 0 chars (cleared)
All /nix/store?: TRUE (no outer-shell contamination)
\`\`\`

## What's NOT fixed (next-step blocker)

\`zak_signal_percentile\` rebuild **still fails** with the same segfault. Root cause is downstream of this PR:

**\`docs/_targets.R:14-30\` contains a glob hack** that scans \`/nix/store/*-r-PKG-*/library\` for 5 packages (\`duckplyr\`, \`glmnet\`, \`xgboost\`, \`slider\`, \`RcppRoll\`) and adds their FULL closures to \`.libPaths()\`. The closures include paths built against DIFFERENT R binaries, re-introducing the ABI contamination the shellHook just removed.

This was also flagged by B2 triage agent as roborev #738 \"duplicated nix glob hack\" — same pattern.

The deeper fix (out of scope here) is:
1. Add all 5 packages to flake.nix r-dependencies (this PR added \`slider\`; still need \`duckplyr\`, \`glmnet\`, \`xgboost\`, \`RcppRoll\`)
2. Run \`t update\` to regenerate
3. Run \`bash default.post.sh\` to re-apply the shellHook patch (the script is idempotent + guarded by a \`grep -q\` marker)
4. Remove or tighten the glob hack in \`docs/_targets.R:14-30\` — only fall through if the package truly isn't in \`.libPaths()\` AFTER the dev shell's proper deps load

Tracking as next step in #211.

## Survival of \`t update\`

\`default.post.sh\` is a new idempotent patch script. If \`t update\` regenerates \`flake.nix\` and strips the shellHook, run \`bash default.post.sh\` to re-apply. Script checks for the \`# Closure-rebuild\` marker and skips if already present.

## Diff

| File | Change |
|---|---|
| \`flake.nix\` | +25 lines: 24-line shellHook block + 1 line adding \`slider\` to \`rPackages\` |
| \`tproject.toml\` | +1 line: \`\"slider\"\` in \`[r-dependencies] packages\` |
| \`default.post.sh\` | +85 lines (new): idempotent re-apply script |

## Test plan

- [x] Slider smoke test: PASS
- [x] R_LIBS_SITE rebuild verification: 438 paths, all from project closure
- [ ] \`zak_signal_percentile\` rebuild: **STILL FAILS** — blocked by the glob hack, not this PR
- [ ] After future PR adds \`duckplyr\`/\`glmnet\`/\`xgboost\`/\`RcppRoll\` to deps + removes glob hack, full \`tar_make()\` should reach all 502 targets without segfault

## Related

- #211 (parent issue; this PR closes the shellHook half, leaves the glob hack for next step)
- #210 verdict #738 (duplicated nix glob hack flagged separately by B2 triage)
- Global rule \`nix-nested-shell-isolation\` — reference implementation source

🤖 Generated with [Claude Code](https://claude.com/claude-code)