### PR TITLE
fix(scripts): Python fetch correctness — dead rename + 'or' on 0.0 yield (PR-U4)

### DIFF
--- a/scripts/fetch_crypto.py
+++ b/scripts/fetch_crypto.py
@@ -80,14 +80,18 @@ def main():
     combined = pd.concat(frames, ignore_index=True)
 
     # Standardise columns
-    col_map = {"adj_close": "adjusted"}
-    combined = combined.rename(columns=col_map)
+    # Note: crypto data has no adjusted-close column (CoinGecko/Yahoo crypto never
+    # had one); the adj_close → adjusted rename was dead code and is removed.
+    # keep list below selects only columns that actually exist in crypto OHLCV.
 
     if hasattr(combined["date"].dtype, "tz") and combined["date"].dt.tz is not None:
         combined["date"] = combined["date"].dt.tz_localize(None)
 
     keep = ["date", "open", "high", "low", "close", "volume",
             "ticker", "source", "asset_class"]
+    required = {"date", "close", "ticker"}
+    missing = required - set(combined.columns)
+    assert not missing, f"Missing required columns after reshape: {missing}"
     combined = combined[[c for c in keep if c in combined.columns]]
     combined = combined.sort_values(["ticker", "date"]).reset_index(drop=True)
 

--- a/scripts/fetch_metadata.py
+++ b/scripts/fetch_metadata.py
@@ -74,6 +74,15 @@ def yahoo_ticker(ticker: str, dataset: str) -> str:
     return ticker
 
 
+def first_present(d: dict, *keys):
+    """Return the first value that is not None, ignoring falsy-but-valid 0.0."""
+    for k in keys:
+        v = d.get(k)
+        if v is not None:
+            return v
+    return None
+
+
 def fetch_yahoo_info(yahoo_sym: str) -> dict:
     """Fetch metadata from yfinance .info dict."""
     try:
@@ -97,9 +106,10 @@ def fetch_yahoo_info(yahoo_sym: str) -> dict:
             "fifty_two_week_low": info.get("fiftyTwoWeekLow"),
             # ETF-specific
             "expense_ratio": info.get("annualReportExpenseRatio"),
-            # Yield: use trailingAnnualDividendYield if available, else yield
-            # Flag yields > 20% as "synthetic" (likely options premium, not dividends)
-            "yield_pct": info.get("trailingAnnualDividendYield") or info.get("yield"),
+            # Yield: use trailingAnnualDividendYield if available, else yield.
+            # Use first_present (not `or`) so 0.0 (no dividend) is not treated as
+            # missing and does not fall through to the next key (#646 #667).
+            "yield_pct": first_present(info, "trailingAnnualDividendYield", "yield"),
             "yield_type": (
                 "synthetic" if (info.get("yield") or 0) > 0.20 else
                 "trailing" if info.get("trailingAnnualDividendYield") else


### PR DESCRIPTION
## Summary

3 LIVE Python fetch bugs from #210 Tier D. 3 roborev verdicts closed.

### #660 — \`scripts/fetch_crypto.py:83\` dead rename (commit \`41b0452\`)

Removed dead \`col_map = {\"adj_close\": \"adjusted\"}\` rename block. Crypto data (Yahoo Finance OHLCV) never had an \`adj_close\` column, and \`adjusted\` was not in the \`keep\` list anyway — the rename was silently discarded every run. Added defensive \`assert\` that \`{date, close, ticker}\` are present after reshape.

### #646 + #667 — \`scripts/fetch_metadata.py:102\` Python \`or\` on numeric yields (commit \`39cfafe\`)

Added \`first_present(d, *keys)\` helper that returns the first value that is **not None** (unlike Python's \`or\` which treats \`0.0\` as falsy).

\`\`\`python
# BEFORE
yield_pct = info.get(\"trailingAnnualDividendYield\") or info.get(\"yield\")
# 0.0 is falsy → falls through to wrong source

# AFTER
def first_present(d, *keys):
    for k in keys:
        v = d.get(k)
        if v is not None:
            return v
    return None

yield_pct = first_present(info, \"trailingAnnualDividendYield\", \"yield\")
\`\`\`

## Verification

- \`python3 -c 'import ast; ast.parse(open(...).read())'\` for both files: PASS
- 3 roborev verdicts closed via \`roborev close 660 646 667\`

## Related

- #210 (parent; this PR closes Tier D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)