### PR TITLE
docs/chore: stale prose cleanup post-#219 (PR-U5)

### DIFF
--- a/R/plan_backtest.R
+++ b/R/plan_backtest.R
@@ -3,8 +3,8 @@
 # Expanding window backtest with out-of-sample holdout.
 # All parameters in bt_params — change once, tar_make() rebuilds all.
 #
-# Usage:
-#   targets::tar_make(store = "docs/_targets_backtest")
+# Usage (from docs/ directory):
+#   targets::tar_make()
 
 plan_backtest <- function() {
   list(

--- a/docs/drif.qmd
+++ b/docs/drif.qmd
@@ -60,7 +60,7 @@ safe_tar_read("drif_cumret_plot")
 ```
 
 ::: {.fig-caption}
-**DRIF vs Market.** Y: growth of $1 (log scale). Blue = DRIF (top-2 factors by elastic net prediction, equal weight). Red = Market factor (Mkt-RF). Dashed line = OOS start (2020). Uses PCA-OLS fallback (glmnet not in current Nix shell). Source: Fama-French FF5 + Momentum via `hd_factors()`.
+**DRIF vs Market.** Y: growth of $1 (log scale). Blue = DRIF (top-2 factors by elastic net prediction, equal weight). Red = Market factor (Mkt-RF). Dashed line = OOS start (2020). Source: Fama-French FF5 + Momentum via `hd_factors()`.
 :::
 
 #### Metrics
@@ -161,7 +161,7 @@ Our factor-level implementation applies the same logic: the sequence of daily fa
 1. **Research:** [A Unified Framework for Anomalies based on Daily Returns](https://alphaarchitect.com/daily-stock-returns/){target="_blank" rel="noopener noreferrer"} — Alpha Architect (2026)
 2. **Comparison:** [Factor MAX](factor-max.html) — simpler signal using only max daily return
 3. **Data:** FF5 + Momentum via [Ken French Data Library](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html){target="_blank" rel="noopener noreferrer"}
-4. **Methodology:** Expanding window, PCA-OLS (glmnet unavailable in current Nix shell)
+4. **Methodology:** Expanding window, elastic net (glmnet) factor selection, equal-weight top-2
 
 #### Build Info
 

--- a/docs/european-overlay.qmd
+++ b/docs/european-overlay.qmd
@@ -300,7 +300,7 @@ if (!is.null(ecb_raw)) {
       style = "caption-side: top; text-align: left;",
       htmltools::HTML(paste0(
         "Country-level CISS: systemic stress per country (daily, 2000-2026). ",
-        "Italy and France peaked during the eurozone debt crisis (2011-2012). All countries peaked during GFC (2008). ",
+        "Peak dates per country are shown in the Max date column. ",
         "The ECB also computes a <strong>US CISS</strong> for cross-Atlantic comparison — a potential overlay signal for US equities too. ",
         "Source: <a href='https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/ecb.R' target='_blank'>hd_ecb_registry()</a>. ",
         "Reference: <a href='https://www.ecb.europa.eu/stats/macroprudential_indicators/systemic_risk/html/index.en.html' target='_blank'>ECB CISS dashboard</a>."


### PR DESCRIPTION
## Summary

5 LIVE stale-prose findings from #210 Tier E. 5 roborev verdicts closed. All low-severity but obsolete/wrong content.

### #739 + #740 — \`docs/drif.qmd\` stale glmnet warnings (commit \`324f3d8\`)

PR #219 added glmnet to the dev shell. Two sites in drif.qmd still warned readers about "glmnet not in Nix shell — PCA-OLS fallback":

- line 63 fig-caption: removed obsolete fallback note
- line 164 References: updated from "PCA-OLS (glmnet unavailable)" to accurate "elastic net (glmnet) factor selection, equal-weight top-2"

### #853 + #852 — european-overlay caption date mismatch (commit \`755f317\`)

Caption at line 303 claimed "Italy and France peaked 2011-2012" + "All countries peaked during GFC 2008" — contradictory and stale. Table already has a dynamic \`Max date\` column. Replaced both claims with "Peak dates per country are shown in the Max date column." → caption now ALWAYS matches the rendered data.

### #705 — \`R/plan_backtest.R\` stale Usage comment (commit \`04cfe9a\`)

File header said \`tar_make(store = \"docs/_targets_backtest\")\` — a separate store that hasn't existed since the unified pipeline migration. Replaced with accurate \`tar_make()\` from the unified store.

## Verification

- \`parse(\"R/plan_backtest.R\")\`: PASS
- 5 roborev verdicts closed via \`roborev close 739 740 853 852 705\`

## Related

- PR #219 (made the glmnet prose obsolete)
- #210 (parent; this PR closes Tier E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)