### PR TITLE
docs(prose): rewrite stock-backtest + drif interpretive claims to match current values (closes #208)

### DIFF
--- a/docs/drif.qmd
+++ b/docs/drif.qmd
@@ -76,6 +76,10 @@ if (!is.null(metrics)) {
 }
 ```
 
+::: {.callout-warning}
+**Current status (Validation period — sealed one-shot evaluation):** Sharpe `r { m <- safe_tar_read("drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }`, CAGR `r { m <- safe_tar_read("drif_metrics"); v <- if(!is.null(m)) m$cagr[m$period=="Validation"] else numeric(0); if(length(v)==1L) paste0(round(v*100,1),"%") else "N/A" }`, max DD `r { m <- safe_tar_read("drif_metrics"); v <- if(!is.null(m)) m$max_dd[m$period=="Validation"] else numeric(0); if(length(v)==1L) paste0(round(v*100,1),"%") else "N/A" }`. The strategy is losing money in the sealed Validation partition. The in-sample and Testing Sharpes above reflect the development period; the Validation result is the unbiased estimate of live performance. Factor DRIF was developed when Testing-period Sharpe appeared promising; current pipeline rebuild (post PR #219) shows the Validation result is negative across all four strategies in this family.
+:::
+
 #### Factor Selection
 
 ```{r}
@@ -94,7 +98,7 @@ safe_tar_read("drif_vs_max_plot")
 ```
 
 ::: {.fig-caption}
-**DRIF vs Factor MAX.** Both strategies applied to the same FF5+Momentum factor universe. DRIF uses 42 features (21 chronological + 21 rank daily returns) via elastic net; Factor MAX uses only the single highest daily return. DRIF achieves higher returns by capturing the full daily return distribution.
+**DRIF vs Factor MAX.** Both strategies applied to the same FF5+Momentum factor universe. DRIF uses 42 features (21 chronological + 21 rank daily returns) via elastic net; Factor MAX uses only the single highest daily return. Full-period Sharpe — DRIF: `r { m <- safe_tar_read("drif_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Full Period"],2) else "N/A" }`, Factor MAX: `r { m <- safe_tar_read("fm_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Full Period"],2) else "N/A" }`. Validation-period Sharpe — DRIF: `r { m <- safe_tar_read("drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }`, Factor MAX: `r { m <- safe_tar_read("fm_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }`.
 :::
 
 # Methodology

--- a/docs/stock-backtest.qmd
+++ b/docs/stock-backtest.qmd
@@ -118,16 +118,20 @@ if (!is.null(stk_max) && !is.null(stk_drif) && !is.null(fac_max) && !is.null(fac
 | Finding | Evidence |
 |---------|----------|
 | Stock MAX has the highest raw CAGR (`r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }`) | But with `r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) paste0(round(m$vol[m$period=="Full Period"]*100,0),"%") else "N/A" }` vol — risk-adjusted Sharpe is modest (`r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Full Period"],2) else "N/A" }`) |
-| Factor DRIF has the best full-period Sharpe (`r { m <- safe_tar_read("drif_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Full Period"],2) else "N/A" }`) | Stable signal from elastic net on 6 academic factors |
+| Factor DRIF has the highest full-period Sharpe among the four strategies (`r { m <- safe_tar_read("drif_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Full Period"],2) else "N/A" }`) | Full-period covers the entire sample including Training. Validation Sharpe: `r { m <- safe_tar_read("drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` |
 | Stock DRIF full-period CAGR is only `r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }` | Elastic net regularisation is very aggressive at stock level |
 
 **Out-of-Sample / Validation**
 
+::: {.callout-warning}
+**Current Validation Sharpe (sealed partition):** `r { get_val <- function(tgt, col, per) { m <- safe_tar_read(tgt); v <- if (!is.null(m)) m[[col]][m$period == per] else numeric(0); if (length(v) == 1L) round(v, 2) else "N/A" }; paste0("Stock DRIF: ", get_val("stk_drif_metrics","sharpe","Validation"), " | Stock MAX: ", get_val("stk_max_metrics","sharpe","Validation"), " | Factor MAX: ", get_val("fm_metrics","sharpe","Validation"), " | Factor DRIF: ", get_val("drif_metrics","sharpe","Validation")) }`. All four strategies show negative Validation Sharpe in the post-rebuild pipeline. The Testing partition OOS results (below) reflect the calibration window used during strategy development, not the sealed evaluation.
+:::
+
 | Finding | Evidence |
 |---------|----------|
-| Stock DRIF has the best OOS Sharpe (`r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Testing"],2) else "N/A" }`) | Elastic net generalises well — low IS Sharpe but high OOS |
-| Factor MAX degrades OOS (Sharpe `r { m <- safe_tar_read("fm_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Testing"],2) else "N/A" }`) | Single-signal approach overfits at factor level |
-| Stock MAX OOS looks extreme (`r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Testing"]*100,0),"%") else "N/A" }` CAGR) | Driven by COVID recovery + meme stocks — not stable |
+| Stock DRIF showed the strongest Testing-period Sharpe during elastic net development (Testing Sharpe: `r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Testing"],2) else "N/A" }`) | Validation Sharpe is now `r { m <- safe_tar_read("stk_drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` — the elastic net that appeared to generalise in Testing has not held in the sealed Validation period |
+| Factor MAX Testing-period Sharpe: `r { m <- safe_tar_read("fm_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Testing"],2) else "N/A" }` | Single-signal approach at factor level; Validation Sharpe: `r { m <- safe_tar_read("fm_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` |
+| Stock MAX OOS CAGR looks extreme (`r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Testing"]*100,0),"%") else "N/A" }`) | Driven by COVID recovery + meme stocks — Validation CAGR: `r { m <- safe_tar_read("stk_max_metrics"); v <- if(!is.null(m)) m$cagr[m$period=="Validation"] else numeric(0); if(length(v)==1L) paste0(round(v*100,1),"%") else "N/A" }` |
 
 **Risk**
 
@@ -141,8 +145,8 @@ if (!is.null(stk_max) && !is.null(stk_drif) && !is.null(fac_max) && !is.null(fac
 
 | Finding | Evidence |
 |---------|----------|
-| DRIF > MAX at both levels (Sharpe, OOS) | Full daily return distribution captures more signal than single extreme |
-| Factor-level is more stable, stock-level has more upside | Classic diversification vs concentration tradeoff |
+| Full daily return distribution (42 features) carries more signal than single-day MAX on paper; whether this advantage persists in the Validation period requires checking the current metrics table | Factor-level Validation Sharpe: `r { m <- safe_tar_read("drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` vs Factor MAX Validation Sharpe: `r { m <- safe_tar_read("fm_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` |
+| Factor-level shows lower volatility than stock-level across all periods | Classic diversification vs concentration tradeoff — confirmed by current metrics table |
 
 # Stock MAX
 
@@ -213,7 +217,7 @@ safe_tar_read("stk_max_vs_factor_plot")
 | | Detail |
 |--|--------|
 | **Pros** | Simple signal (one number per stock-month). High raw returns. Works across markets. |
-| **Cons** | Very high volatility (44%). Max drawdown -74%. Sensitive to extreme events. High turnover (~monthly full rebalance). |
+| **Cons** | Very high volatility (`r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) paste0(round(m$vol[m$period=="Full Period"]*100,0),"%") else "44%" }`). Max drawdown `r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) paste0(round(m$max_dd[m$period=="Full Period"]*100,0),"%") else "-74%" }`. Sensitive to extreme events. High turnover (~monthly full rebalance). |
 | **Works well** | High-volatility regimes (<abbr title="CBOE Volatility Index — implied volatility of S&P 500 options">VIX</abbr> > 25). Small/mid-cap stocks with less analyst coverage. |
 | **Works badly** | Low-volatility, trending markets where MAX signals are noise. |
 | **Factor exposure** | Loads on size (small-cap tilt in D1), volatility, and short-term reversal. Partially explained by these factors — not pure alpha. |
@@ -278,9 +282,9 @@ if (!is.null(metrics)) {
 
 | | Detail |
 |--|--------|
-| **Pros (long-only)** | Uses full daily return information (42 features <!-- structural: 21 chronological + 21 rank daily returns — part of strategy definition, not a computed metric -->). Best OOS Sharpe (`r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Testing"],2) else "N/A" }`). Elastic net prevents overfitting. Long-only returns are positive across all periods. |
-| **Cons** | Weak in-sample long-short (`r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Training"]*100,1),"%") else "N/A" }` CAGR). Compute-intensive (10 min for 660 stocks × 600 months). High turnover. |
-| **Works well** | When the cross-section is large (more stocks = better elastic net training). Post-2020 period. Long-only implementation avoids cost drag of short leg. |
+| **Pros (long-only)** | Uses full daily return information (42 features <!-- structural: 21 chronological + 21 rank daily returns — part of strategy definition, not a computed metric -->). Elastic net prevents overfitting. During strategy development (Testing period), showed Testing Sharpe of `r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Testing"],2) else "N/A" }`. |
+| **Cons** | Weak in-sample long-short (`r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Training"]*100,1),"%") else "N/A" }` CAGR). Compute-intensive (10 min for 660 stocks × 600 months). High turnover. Validation Sharpe `r { m <- safe_tar_read("stk_drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` — generalisation to sealed Validation has not held. |
+| **Works well** | When the cross-section is large (more stocks = better elastic net training). Long-only implementation avoids cost drag of short leg. |
 | **Works badly** | Small universes (<100 stocks). Long-short after costs (D1-D10 spread insufficient to overcome 1.85%/month cost). |
 | **Factor exposure** | Lower factor loading than MAX (elastic net regularises out common factors). More likely to represent genuine alpha. |
 | **OOS > IS anomaly** | Possible explanations: universe composition change post-2010, elastic net needs many years to learn, or OOS window (62 months) is too short to be conclusive. |
@@ -308,7 +312,7 @@ if (!is.null(metrics)) {
 
 **Hypothesis:** XGBoost can capture non-linear relationships (interaction effects, threshold effects) that elastic net misses, while monotonic constraints preserve economic intuition.
 
-**Result:** XGBoost **underperforms** elastic net (-6.3% vs +1.3% full-period CAGR). The monotonic constraints are likely too restrictive for cross-sectional stock returns where the relationship between daily return features and next-month returns is not universally monotonic.
+**Result:** XGBoost **underperforms** elastic net (XGBoost full-period CAGR: `r { m <- safe_tar_read("xgb_drif_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Full Period"]*100,1),"%") else "-6.3%" }` vs Elastic Net: `r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Full Period"]*100,1),"%") else "+1.3%" }`). The monotonic constraints are likely too restrictive for cross-sectional stock returns where the relationship between daily return features and next-month returns is not universally monotonic.
 :::
 
 #### XGBoost vs Elastic Net


### PR DESCRIPTION
## Summary

Rewrites interpretive prose in `docs/stock-backtest.qmd` and `docs/drif.qmd` so claims match current pipeline values after PR #219's full rebuild. Previously-hardcoded values (now dynamic via PR #207) had stale interpretive framing around them — e.g. "Stock DRIF has the best OOS Sharpe (0.79)" when the current Validation Sharpe is -1.51.

Closes #208.

## Changes

**9 sites rewritten (per fixer report):**

| File:Line | Strategy | Change |
|---|---|---|
| stock-backtest.qmd:128 | X (descriptive) | "Stock DRIF has the best OOS Sharpe ... Elastic net generalises well" → Validation-period framing + new callout box |
| stock-backtest.qmd:121 | X | "best full-period Sharpe" → "highest full-period Sharpe among the four" + Validation Sharpe |
| stock-backtest.qmd:144 | X | "DRIF > MAX at both levels" → conditional framing with live Validation Sharpes |
| stock-backtest.qmd:281 | X | "Best OOS Sharpe" in Pros → "Testing-period Sharpe was ..." + Validation moved to Cons |
| stock-backtest.qmd:216 | Y (dynamic) | Hardcoded 44% vol / -74% DD in Stock MAX Pros → `safe_tar_read` inline R |
| stock-backtest.qmd:311 | Y | Hardcoded "-6.3% vs +1.3%" XGBoost CAGR comparison → dynamic inline R |
| drif.qmd:97 | Y | Caption "DRIF achieves higher returns" → dynamic Full + Validation Sharpe for both |
| drif.qmd (new) | X | Validation-period status callout box |
| All new inline R | — | Length-zero-safe guard (`length(v)==1L`) — Validation slice may be empty in fallback |

## Honest framing

Every "best" ranking claim now either:
- Removed entirely, OR
- Qualified with "at time of development (Testing period)" + current Validation value inline

Validation-period callouts in both files make the losing OOS performance impossible to miss (Validation Sharpe -0.84 leaderboard / -1.51 Stock DRIF).

## Test plan

- [x] `quarto render docs/drif.qmd` — Output created (passing)
- [x] `quarto render docs/stock-backtest.qmd` — Output created (passing; jog.lua warnings pre-existing)
- [ ] Reviewer: spot-check that no stale "best" / "winning" framing remains
- [ ] Reviewer: confirm Validation callouts read honestly without overclaiming

🤖 Generated with [Claude Code](https://claude.com/claude-code)