### PR TITLE
fix(qa): VIGNETTE_STRICT=1 silent-disable + safe_tar_read NULL masquerade (closes #231, #232)

### DIFF
--- a/docs/vignette_utils.R
+++ b/docs/vignette_utils.R
@@ -30,23 +30,38 @@ show_code <- function(target_name) {
 
 #' Read a vig_* target with RDS fallback
 #'
-#' In strict mode (set VIGNETTE_STRICT=true env var), fails with error instead
-#' of returning NULL. Use strict mode in CI/production renders to catch missing
-#' targets early.
+#' In strict mode (set VIGNETTE_STRICT=true or VIGNETTE_STRICT=1 env var),
+#' fails with error instead of returning a stale-marker value. Use strict mode
+#' in CI/production renders to catch missing targets early.
 #'
-#' Accepted values for VIGNETTE_STRICT use R's as.logical() semantics:
-#'   Accepts the logical literals "TRUE"/"T" and "FALSE"/"F" (case-insensitive,
-#'   so "true", "True", "t", "false", "False", "f" all parse). Any other string
-#'   (including "1", "0", "yes", "no") yields NA, which isTRUE() treats as FALSE.
-#'   Use VIGNETTE_STRICT=true to enable strict mode; anything else disables it.
+#' When a target is missing in non-strict mode, returns a stale-marker object:
+#' NA_real_ with class "stale_marker". Downstream prose and tables should check
+#' for this with is_stale_marker() and display "MISSING" rather than a number.
+#'
+#' VIGNETTE_STRICT parsing: accepts "true"/"false"/"TRUE"/"FALSE" (logical
+#' literals via as.logical()), AND "1"/"0" (numeric strings). Setting
+#' VIGNETTE_STRICT=1 or VIGNETTE_STRICT=true both enable strict mode.
+#' Any other value (e.g. unset, empty string) disables strict mode.
+#' Semantic: env var SET to a truthy value = strict mode ON.
 #'
 #' @param name Target name to read
 #' @param strict If TRUE, stop() on missing target. Default: checks VIGNETTE_STRICT env var.
-safe_tar_read <- function(name,
-                          strict = isTRUE(as.logical(Sys.getenv("VIGNETTE_STRICT", "false")))) {
-  result <- tryCatch(
+.parse_vignette_strict <- function() {
+  raw <- Sys.getenv("VIGNETTE_STRICT", "")
+  if (nzchar(raw) && raw %in% c("1", "yes", "on")) return(TRUE)
+  isTRUE(as.logical(raw))
+}
 
-targets::tar_read_raw(name),
+#' @rdname safe_tar_read
+#' @export
+is_stale_marker <- function(x) {
+  inherits(x, "stale_marker")
+}
+
+safe_tar_read <- function(name,
+                          strict = .parse_vignette_strict()) {
+  result <- tryCatch(
+    targets::tar_read_raw(name),
     error = function(e) {
       rds_dirs <- c("../inst/extdata/vignettes", "inst/extdata/vignettes")
       for (d in rds_dirs) {
@@ -57,9 +72,17 @@ targets::tar_read_raw(name),
     }
   )
 
-  if (is.null(result) && strict) {
-    stop("VIGNETTE_STRICT: Target '", name, "' not found. Run tar_make() first.",
-         call. = FALSE)
+  if (is.null(result)) {
+    if (strict) {
+      stop("VIGNETTE_STRICT: Target '", name, "' not found. Run tar_make() first.",
+           call. = FALSE)
+    }
+    # Return a typed marker instead of NULL so downstream code cannot silently
+    # treat it as a real number. Check with is_stale_marker(); display "MISSING".
+    marker <- NA_real_
+    class(marker) <- "stale_marker"
+    attr(marker, "target") <- name
+    return(marker)
   }
 
   result

--- a/tests/testthat/test-vignette-utils.R
+++ b/tests/testthat/test-vignette-utils.R
@@ -1,0 +1,101 @@
+testthat::local_edition(3)
+source(here::here("docs/vignette_utils.R"))
+
+# ---------------------------------------------------------------------------
+# .parse_vignette_strict — issue #232
+# VIGNETTE_STRICT=1 must ENABLE strict mode (not disable it silently via NA)
+# ---------------------------------------------------------------------------
+
+test_that(".parse_vignette_strict: unset env var returns FALSE (strict mode OFF)", {
+  withr::with_envvar(list(VIGNETTE_STRICT = ""), {
+    expect_false(.parse_vignette_strict())
+  })
+})
+
+test_that(".parse_vignette_strict: VIGNETTE_STRICT=true returns TRUE (logical string)", {
+  withr::with_envvar(list(VIGNETTE_STRICT = "true"), {
+    expect_true(.parse_vignette_strict())
+  })
+})
+
+test_that(".parse_vignette_strict: VIGNETTE_STRICT=TRUE returns TRUE (case-insensitive)", {
+  withr::with_envvar(list(VIGNETTE_STRICT = "TRUE"), {
+    expect_true(.parse_vignette_strict())
+  })
+})
+
+test_that(".parse_vignette_strict: VIGNETTE_STRICT=1 returns TRUE (numeric string, issue #232)", {
+  # as.logical('1') == NA, so isTRUE(as.logical('1')) == FALSE — this was the bug.
+  # The fix adds '1' to the truthy-string list before calling as.logical().
+  withr::with_envvar(list(VIGNETTE_STRICT = "1"), {
+    expect_true(.parse_vignette_strict())
+  })
+})
+
+test_that(".parse_vignette_strict: VIGNETTE_STRICT=yes returns TRUE (common truthy alias)", {
+  withr::with_envvar(list(VIGNETTE_STRICT = "yes"), {
+    expect_true(.parse_vignette_strict())
+  })
+})
+
+test_that(".parse_vignette_strict: VIGNETTE_STRICT=on returns TRUE (common truthy alias)", {
+  withr::with_envvar(list(VIGNETTE_STRICT = "on"), {
+    expect_true(.parse_vignette_strict())
+  })
+})
+
+test_that(".parse_vignette_strict: VIGNETTE_STRICT=false returns FALSE", {
+  withr::with_envvar(list(VIGNETTE_STRICT = "false"), {
+    expect_false(.parse_vignette_strict())
+  })
+})
+
+test_that(".parse_vignette_strict: VIGNETTE_STRICT=0 returns FALSE", {
+  withr::with_envvar(list(VIGNETTE_STRICT = "0"), {
+    # '0' is not in the truthy list, as.logical('0') == NA, isTRUE(NA) == FALSE
+    expect_false(.parse_vignette_strict())
+  })
+})
+
+# ---------------------------------------------------------------------------
+# safe_tar_read NULL fallback — issue #231
+# Missing targets must return a stale_marker, NOT NULL or a real number
+# ---------------------------------------------------------------------------
+
+test_that("safe_tar_read: returns stale_marker when target and RDS files are absent", {
+  withr::with_envvar(list(VIGNETTE_STRICT = ""), {
+    result <- safe_tar_read("nonexistent_target_xyz_12345")
+    expect_true(is_stale_marker(result))
+    expect_true(is.na(result))
+    expect_equal(attr(result, "target"), "nonexistent_target_xyz_12345")
+  })
+})
+
+test_that("is_stale_marker: returns TRUE for stale markers, FALSE for real values", {
+  marker <- NA_real_
+  class(marker) <- "stale_marker"
+  expect_true(is_stale_marker(marker))
+  expect_false(is_stale_marker(42.0))
+  expect_false(is_stale_marker(NULL))
+  expect_false(is_stale_marker(NA_real_))  # bare NA without class is NOT a marker
+})
+
+test_that("safe_tar_read: stops in strict mode when target is absent", {
+  withr::with_envvar(list(VIGNETTE_STRICT = "true"), {
+    expect_error(
+      safe_tar_read("nonexistent_target_xyz_12345"),
+      regexp = "VIGNETTE_STRICT"
+    )
+  })
+})
+
+test_that("safe_tar_read: VIGNETTE_STRICT=1 triggers strict error (issue #232 + #231 integration)", {
+  # Confirms that the #232 parser fix flows through to safe_tar_read behaviour:
+  # setting =1 must cause strict-mode error, not silent NULL/stale return.
+  withr::with_envvar(list(VIGNETTE_STRICT = "1"), {
+    expect_error(
+      safe_tar_read("nonexistent_target_xyz_12345"),
+      regexp = "VIGNETTE_STRICT"
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Two silent-failure bugs in `docs/vignette_utils.R` that caused false-OK signals in QA:

### #232 — VIGNETTE_STRICT=1 silently disabled strict mode

`isTRUE(as.logical("1"))` evaluates to `FALSE` because `as.logical("1")` returns `NA`. Setting `VIGNETTE_STRICT=1` (the most natural way to enable strict mode from a shell) therefore silently **disabled** strictness — the opposite of the intended semantic.

**Fix:** extracted `.parse_vignette_strict()` helper that checks `"1"`, `"yes"`, `"on"` as truthy strings before calling `as.logical()`. Documented semantic: *env var SET to a truthy value = strict mode ON*.

### #231 — safe_tar_read() returned NULL for missing targets

When a target and all RDS fallbacks were absent, `safe_tar_read()` returned `NULL`. In inline Quarto prose (`` `r safe_tar_read(...)` ``), `NULL` renders as an empty string or inherits a stale cached value — shipping a fake number into rendered output.

**Fix:** returns a typed `stale_marker` object instead of `NULL`:
```r
marker <- NA_real_
class(marker) <- "stale_marker"
attr(marker, "target") <- name
```
Added `is_stale_marker()` predicate for downstream detection. Strict mode still calls `stop()`.

## Test plan

- [x] 17 new `testthat` tests in `tests/testthat/test-vignette-utils.R`
- [x] `.parse_vignette_strict()`: covers `=1`, `=yes`, `=on`, `=true`, `=TRUE`, `=false`, `=0`, unset
- [x] `safe_tar_read()`: absent target → `is_stale_marker()` TRUE, attr preserved
- [x] `is_stale_marker()`: TRUE for marker, FALSE for bare `NA_real_`, `NULL`, numeric
- [x] Integration: `VIGNETTE_STRICT=1` + absent target → `stop()` with "VIGNETTE_STRICT" message
- [x] All 17 tests pass: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 17 ]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)