### PR TITLE
fix(docs): replace hardcoded ranking prose with descriptive text (closes #228)

### DIFF
--- a/docs/stock-backtest.qmd
+++ b/docs/stock-backtest.qmd
@@ -129,7 +129,7 @@ if (!is.null(stk_max) && !is.null(stk_drif) && !is.null(fac_max) && !is.null(fac
 
 | Finding | Evidence |
 |---------|----------|
-| Stock DRIF showed the strongest Testing-period Sharpe during elastic net development (Testing Sharpe: `r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Testing"],2) else "N/A" }`) | Validation Sharpe is now `r { m <- safe_tar_read("stk_drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` — the elastic net that appeared to generalise in Testing has not held in the sealed Validation period |
+| Stock DRIF Testing-period Sharpe during elastic net development: `r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Testing"],2) else "N/A" }` | Validation Sharpe is now `r { m <- safe_tar_read("stk_drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` — the elastic net that appeared to generalise in Testing has not held in the sealed Validation period |
 | Factor MAX Testing-period Sharpe: `r { m <- safe_tar_read("fm_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Testing"],2) else "N/A" }` | Single-signal approach at factor level; Validation Sharpe: `r { m <- safe_tar_read("fm_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` |
 | Stock MAX OOS CAGR looks extreme (`r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Testing"]*100,0),"%") else "N/A" }`) | Driven by COVID recovery + meme stocks — Validation CAGR: `r { m <- safe_tar_read("stk_max_metrics"); v <- if(!is.null(m)) m$cagr[m$period=="Validation"] else numeric(0); if(length(v)==1L) paste0(round(v*100,1),"%") else "N/A" }` |
 
@@ -146,7 +146,7 @@ if (!is.null(stk_max) && !is.null(stk_drif) && !is.null(fac_max) && !is.null(fac
 | Finding | Evidence |
 |---------|----------|
 | Full daily return distribution (42 features) carries more signal than single-day MAX on paper; whether this advantage persists in the Validation period requires checking the current metrics table | Factor-level Validation Sharpe: `r { m <- safe_tar_read("drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` vs Factor MAX Validation Sharpe: `r { m <- safe_tar_read("fm_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` |
-| Factor-level shows lower volatility than stock-level across all periods | Classic diversification vs concentration tradeoff — confirmed by current metrics table |
+| Factor-level vs stock-level volatility comparison — see current metrics table | Classic diversification vs concentration tradeoff |
 
 # Stock MAX
 
@@ -424,9 +424,9 @@ if (!is.null(metrics_b)) {
 |---------|----------|
 | **Long-only is the practical strategy** | A long-only: `r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) paste0(round(m$long_cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }` CAGR. B long-only: `r { m <- safe_tar_read("etf_b_metrics"); if(!is.null(m)) paste0(round(m$long_cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }`. Compare S&P 500 ~10%. |
 | **Short leg is unprofitable** | A long-short: `r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }`. B long-short: `r { m <- safe_tar_read("etf_b_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }`. ETFs all have market beta — shorting one is mostly shorting the market. |
-| **A > B** | Approach A (direct ETF signal) has higher Sharpe (`r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Full Period"],2) else "N/A" }` vs `r { m <- safe_tar_read("etf_b_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Full Period"],2) else "N/A" }`) and lower DD (`r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) paste0(round(m$max_dd[m$period=="Full Period"]*100,1),"%") else "N/A" }` vs `r { m <- safe_tar_read("etf_b_metrics"); if(!is.null(m)) paste0(round(m$max_dd[m$period=="Full Period"]*100,1),"%") else "N/A" }`). The VLUE/HML mapping (cor=0.34) in B adds noise. |
+| **Approach A vs B** | A full-period Sharpe: `r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Full Period"],2) else "N/A" }`. B full-period Sharpe: `r { m <- safe_tar_read("etf_b_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Full Period"],2) else "N/A" }`. A max DD: `r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) paste0(round(m$max_dd[m$period=="Full Period"]*100,1),"%") else "N/A" }`. The VLUE/HML mapping (cor=0.34) in B adds noise. |
 | **Cost advantage is real** | ETF costs ~0.20%/month vs 1.85%/month stock-level. The long-only gross returns survive after costs. |
-| **Validation is strong** | Both show ~20% long-only CAGR in 2023-2026. Caveat: overlaps a bull market. |
+| **Validation** | A long-only CAGR (Validation): `r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) paste0(round(m$long_cagr[m$period=="Validation"]*100,1),"%") else "N/A" }`. B long-only CAGR (Validation): `r { m <- safe_tar_read("etf_b_metrics"); if(!is.null(m)) paste0(round(m$long_cagr[m$period=="Validation"]*100,1),"%") else "N/A" }`. Caveat: overlaps a bull market. |
 
 # Details
 


### PR DESCRIPTION
## Summary

- Removes 4 hardcoded ranking/sign assertions from `docs/stock-backtest.qmd` that would drift on pipeline rebuild
- Affects lines 132, 149, 427, 429
- All replaced with either neutral descriptive text or dynamic `safe_tar_read()` inline R expressions

| Line | Old (hardcoded) | New (neutral/dynamic) |
|------|-----------------|----------------------|
| 132 | "showed the **strongest** Testing-period Sharpe" | "Testing-period Sharpe: \`r ...\`" |
| 149 | "shows **lower volatility** than stock-level across all periods" | "Factor-level vs stock-level volatility comparison — see current metrics table" |
| 427 | "**A > B**" (ranking label) + "has **higher** Sharpe" | "Approach A vs B" with both Sharpes already dynamic |
| 429 | "Both show **~20%** long-only CAGR in 2023-2026" | Dynamic `safe_tar_read("etf_a_metrics")` + `etf_b_metrics` Validation long_cagr |

YAML front matter verified to parse cleanly after edits.

Note: `docs/stock-backtest.html` is a stale rendered artifact (last rendered in commit `c87d59f`). It contains previously-fixed hardcoded values that were corrected in the QMD source across commits 05f2ede–27b958b. A re-render after `tar_make()` will bring the HTML in sync.

## Test plan

- [x] `rmarkdown::yaml_front_matter()` parses without error
- [ ] Re-render `docs/stock-backtest.qmd` after `tar_make()` to verify inline R resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)