### PR TITLE
fix(vignette-utils): rate-limit VIGNETTE_STRICT typo warning to once per session

### DIFF
--- a/docs/vignette_utils.R
+++ b/docs/vignette_utils.R
@@ -36,12 +36,18 @@ show_code <- function(target_name) {
   raw <- tolower(trimws(Sys.getenv("VIGNETTE_STRICT", "")))
   if (raw %in% c("1", "yes", "on", "true", "t")) return(TRUE)
   if (raw %in% c("0", "no", "off", "false", "f", "")) return(FALSE)
-  # Unrecognised non-empty value — surface the typo instead of silently defaulting
-  cli::cli_warn(c(
-    "Unrecognised {.envvar VIGNETTE_STRICT} value {.val {raw}} — falling back to FALSE",
-    i = "Accepted truthy: 1, yes, on, true, t (case-insensitive, whitespace-tolerant)",
-    i = "Accepted falsy: 0, no, off, false, f, '' (empty)"
-  ))
+  # Unrecognised non-empty value — surface the typo instead of silently defaulting.
+  # .frequency = "once" + .frequency_id prevents spam when safe_tar_read() is
+  # called N times in a single render with the same typo'd value (roborev #4263).
+  cli::cli_warn(
+    c(
+      "Unrecognised {.envvar VIGNETTE_STRICT} value {.val {raw}} — falling back to FALSE",
+      i = "Accepted truthy: 1, yes, on, true, t (case-insensitive, whitespace-tolerant)",
+      i = "Accepted falsy: 0, no, off, false, f, '' (empty)"
+    ),
+    .frequency = "once",
+    .frequency_id = paste0("vignette_strict_typo_", raw)
+  )
   FALSE
 }
 

--- a/tests/testthat/test-vignette-utils.R
+++ b/tests/testthat/test-vignette-utils.R
@@ -177,7 +177,12 @@ test_that(".parse_vignette_strict: VIGNETTE_STRICT=Off returns FALSE (mixed-case
 test_that(".parse_vignette_strict: VIGNETTE_STRICT=treu returns FALSE AND triggers cli_warn (typo guard, roborev T1)", {
   # 'treu' is not in any alias list; old code did isTRUE(suppressWarnings(as.logical('treu')))
   # which silently returned FALSE. New code surfaces a cli_warn so CI typos are visible.
+  # Reset frequency tracking so this test is hermetic and not suppressed by other tests
+  # that trigger the same warning (roborev 4039).
   withr::with_envvar(list(VIGNETTE_STRICT = "treu"), {
+    rlang::reset_warning_verbosity("vignette_strict_typo_treu")
+    withr::defer(rlang::reset_warning_verbosity("vignette_strict_typo_treu"))
+
     expect_warning(
       result <- .parse_vignette_strict(),
       regexp = "Unrecognised"
@@ -214,5 +219,29 @@ test_that(".parse_vignette_strict: 'n' is unrecognised alias — warns and retur
       regexp = "Unrecognised"
     )
     expect_false(result)
+  })
+})
+
+test_that(".parse_vignette_strict: typo warning fires AT MOST ONCE across N calls (roborev #4263)", {
+  # When safe_tar_read() is called N times during a single vignette render
+  # with a typo'd VIGNETTE_STRICT value, the cli_warn must not spam the console.
+  # .frequency = "once" + .frequency_id in cli_warn() achieves this.
+  withr::with_envvar(list(VIGNETTE_STRICT = "yse"), {
+    # Reset rlang's frequency tracking so this test is hermetic
+    rlang::reset_warning_verbosity("vignette_strict_typo_yse")
+    withr::defer(rlang::reset_warning_verbosity("vignette_strict_typo_yse"))
+
+    warnings_seen <- c()
+    withCallingHandlers(
+      {
+        for (i in seq_len(5)) .parse_vignette_strict()
+      },
+      warning = function(w) {
+        warnings_seen <<- c(warnings_seen, conditionMessage(w))
+        invokeRestart("muffleWarning")
+      }
+    )
+    expect_length(warnings_seen, 1L)
+    expect_match(warnings_seen[[1]], "Unrecognised")
   })
 })


### PR DESCRIPTION
## Summary

Closes roborev review #4263.

### Problem

`safe_tar_read()` calls `.parse_vignette_strict()` as a default-argument expression, so the env-var parse runs on **every call**. A vignette with N `safe_tar_read()` calls and a typo'd `VIGNETTE_STRICT` value (e.g. `VIGNETTE_STRICT=yse`) previously fired `cli::cli_warn()` N times — spamming the console and burying real signal.

### Fix (Approach 1 — simpler)

`cli::cli_warn()` passes `...` to `rlang::warn()`. Added two arguments to the existing `cli_warn` call:

```r
cli::cli_warn(
  c(...),
  .frequency = "once",
  .frequency_id = paste0("vignette_strict_typo_", raw)
)
```

- `.frequency = "once"` — rlang suppresses subsequent identical warnings in the same session.
- `.frequency_id` keyed on the raw value so each distinct typo (`yse`, `truee`, etc.) gets its own bucket.

No state added, no memoiser, no architectural change.

### Test evidence

New test in `test-vignette-utils.R`:

```
test_that(".parse_vignette_strict: typo warning fires AT MOST ONCE across N calls (roborev #4263)")
```

Calls `.parse_vignette_strict()` 5 times with `VIGNETTE_STRICT=yse`, collects warnings via `withCallingHandlers`, asserts `expect_length(warnings_seen, 1L)`. Uses `rlang::reset_warning_verbosity()` for hermeticity.

```
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 31 ]
```

## Test plan

- [x] `tests/testthat/test-vignette-utils.R` — all 31 expectations pass locally
- [x] New test exercises the rate-limit path: 5 calls, 1 warning
- [x] Existing typo test still passes: `expect_warning(..., regexp = "Unrecognised")`
- [x] All pre-existing strict-mode and alias tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)