### PR TITLE
feat(salvage): R source + accessibility fix from sonnet-0508 (excludes data blobs)

### DIFF
--- a/.github/workflows/data-poll.yml
+++ b/.github/workflows/data-poll.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Ensure data directory exists
         run: mkdir -p data/raw
 
+
       - name: Install R dependencies
         shell: Rscript {0}
         run: |

--- a/.github/workflows/data-poll.yml
+++ b/.github/workflows/data-poll.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Ensure data directory exists
         run: mkdir -p data/raw
 
-
       - name: Install R dependencies
         shell: Rscript {0}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -668,6 +668,72 @@ Curated 5 articles from the Quantocracy May 3 2026 roundup into `knowledge/wiki/
 - Methodology differences not fully investigated (attribution approach, industry classification)
 - Forward return alignment should be verified (month T signal → T+1 to T+h return)
 
+## 2026-05-11 (session summary)
+
+### Completed
+- **Cross-Asset Momentum Decomposition Research Complete** (~30 hours across issues #121, #123, #134, #135, PR #137, #136, #139, #140)
+  - **Equity momentum decomposition (Issue #121, Phase 1+2)**: ALL decomposed strategies FAILED (Sharpe -0.34 to -0.39 vs baseline +0.05)
+    - Paper strategy (Style + Industry): Net Sharpe -0.34, turnover 26% (vs 8% baseline)
+    - Data-driven (Industry + Stock-Specific): Net Sharpe -0.34, turnover 28%
+    - Conservative (Industry Only): Net Sharpe -0.39, turnover 26%
+    - Root causes: (1) Turnover explosion (3.3×) overwhelmed signals, (2) Breaking covariance structure destroyed information, (3) Rank IC 0.02-0.03 too weak after 0.153% costs
+  - **Regime-dependent momentum (Issue #123)**: Decomposition failed in ALL regimes (Calm/Elevated/Spike), 0/9 strategies had positive Sharpe
+    - Key finding: Baseline momentum Sharpe +0.63 in calm regime (VIX <20, 65% of time) vs +0.05 always-invested
+    - Decomposed strategies negative even in calm: -0.15 to -0.44
+  - **Commodities momentum test (Issue #134, PR #137)**: Both baseline AND decomposition FAILED
+    - Baseline 12m: Net Sharpe **-0.85**, Gross -0.75, Max DD -68%
+    - Decomposed (Short+Long, Vol-Filtered, Trend-Filtered): Net Sharpe -0.89 to -0.91
+    - Finding: Even gross Sharpe (before costs) deeply negative — momentum itself doesn't work in commodities (1992-2026)
+  - **Crypto momentum test (Issue #135, PR #136)**: ONLY SUCCESS across all asset classes
+    - Baseline: Sharpe 0.572, Annual Return 16.4%
+    - BTC-Adjusted: Sharpe **0.593**, Annual Return 17.2% (+3.7% improvement)
+    - Residual-Only: Sharpe 0.593, Annual Return 17.2%
+    - Why succeeded: Simplest structure (no industries), BTC beta cleanly separable, high base volatility (costs less binding)
+  - **Zakamulin regime-aware allocation (PR #139, #140)**: MARGINAL SUCCESS
+    - Step function (VIX<20): Sharpe **0.24** vs 0.05 baseline (+385% improvement)
+    - Mean exposure 78%, low turnover 9.6%
+    - Status: Marginal (0.24 < 0.3 standalone threshold) but validates calm-regime insight
+    - Recommendation: Apply to multi-factor portfolios, not standalone momentum
+- **Strategic Recommendations**:
+  - ❌ ABANDON: Equity momentum decomposition (all variants), commodities momentum (baseline Sharpe -0.85), commodities decomposition
+  - ✅ DEPLOY: Crypto momentum with BTC-beta adjustment (Sharpe 0.59), regime-aware allocation as multi-factor overlay
+  - 🔍 INVESTIGATE: Mean reversion in commodities (Issue #138), crypto Phase 2 (perps + funding rates), Zakamulin on multi-factor portfolios
+- **Issues closed**: #121 (equity decomposition), #123 (regime analysis), #134 (commodities test), #135 (crypto test)
+- **Issues created**: #138 (mean reversion in commodities follow-up)
+- **PRs merged**: #130 (404 fixes), #131 (leaderboard captions), #132 (volatility spikes), #133 (regime momentum), #137 (commodities implementation), #136 (crypto implementation), #139 (Zakamulin allocation), #140 (ROI tracker update)
+- **Knowledge base updated**: `/tmp/knowledge_cross_asset_momentum.md` (complete findings), `/tmp/final_cross_asset_summary.md` (30-hour research summary)
+- **Issue #127 (ROI tracker)** updated with complete cross-asset ROI table
+
+### Failed Approaches
+- **Momentum decomposition in equities**: All 3 decomposition methods (Paper, Data-Driven, Conservative) had negative Sharpe ratios. Turnover 3.3× higher than baseline overwhelmed weak signals. Rank IC 0.02-0.03 statistically significant but economically meaningless after 0.153% transaction costs.
+- **Regime rescue hypothesis**: Tested if ANY regime (Calm/Elevated/Spike) would rescue decomposition performance. Result: 0/9 strategies positive in ANY regime. Decomposition fundamentally broken, not regime-specific.
+- **Commodities momentum baseline**: Even gross Sharpe (before costs) deeply negative (-0.75). Suggests momentum itself doesn't work in commodities in our 1992-2026 sample, contrary to some academic literature.
+- **Crypto pipeline (initial)**: Data loading error (DuckDB schema mismatch). Fixed by switching to arrow, changing 'adjusted' → 'close', normalizing tickers, implementing manual rolling covariance.
+
+### Accuracy / Metrics
+- **Execution model**: Parallel git worktrees with model/skill-appropriate delegation saved ~10 hours (8 hours parallelized vs 15-20 sequential)
+- **Cross-asset coverage**: 3/3 asset classes tested (equities, commodities, crypto)
+- **Definitive evidence**: 2/3 asset classes show decomposition failure (equities, commodities)
+- **Success rate**: 1/3 asset classes (crypto only) where decomposition improved performance
+- **Regime-aware baseline**: 5× Sharpe improvement (0.05 → 0.24) from simple VIX<20 rule
+- **Research ROI**:
+  - Issue #121 (equity): Expected +0.10 to +0.20, Actual -0.34 to -0.39 (Δ -0.44 to -0.59), 8h effort → Negative ROI (but valuable negative result)
+  - Issue #123 (regime): Expected regime rescue, Actual 0/9 positive, 4h → Negative ROI (but found calm-regime insight)
+  - Issue #134 (commodities): Expected cross-asset validation, Actual -0.89 to -0.91, 5h → Valuable negative result
+  - Issue #135 (crypto): Expected test, Actual +0.59 Sharpe, 3h → **POSITIVE ROI**
+  - Zakamulin: Expected improvement, Actual 0.05 → 0.24, 5h → Marginal (needs multi-factor context)
+
+### Known Limitations
+- **Crypto Phase 2 not yet tested**: Perpetuals + funding rate carry decomposition (requires Binance/Bybit/Deribit API integration)
+- **Mean reversion hypothesis untested**: If momentum fails in commodities (Sharpe -0.85), mean reversion may work (Issue #138 created)
+- **Zakamulin allocation marginal standalone**: Sharpe 0.24 < 0.3 threshold for standalone deployment. Recommended for multi-factor portfolio overlay only.
+- **Equity/commodity decomposition abandoned**: No further optimization attempted. Decomposition fundamentally incompatible with these asset classes.
+- **Sample period specificity**: Equity findings are post-2000 (529 stocks, 2000-2026), commodities 1992-2026. Academic literature shows stronger momentum in earlier periods (1960s-1980s). Possible explanations: crowding, improved market efficiency, changed microstructure.
+
+### Lessons Learned
+- **Process wins**: Pre/post ROI tracking caught failure early, cross-asset testing prevented equity-specific false conclusion, parallel worktree execution saved ~10 hours, regime analysis found actionable insight despite decomposition failure
+- **Research insights**: (1) Academic persistence ≠ portfolio profitability (Rank IC 0.02-0.03 significant but economically meaningless after costs), (2) Decomposition breaks covariance even when economically motivated, (3) Asset-class-specific factors exist (crypto BTC-beta works, equity style/industry doesn't), (4) Regime-conditional allocation valuable (5× Sharpe from VIX<20 rule)
+
 ## 2026-05-09
 
 ### Completed
@@ -749,7 +815,7 @@ Curated 5 articles from the Quantocracy May 3 2026 roundup into `knowledge/wiki/
 - JST dashboard extensions planned but not implemented: USA/FF comparison chart, housing returns analysis, crisis-regime performance
 - Tier 1/2 source files (liquidity.R, tracking_error.R, etc.) still missing — need to create for real integration
 - roborev: 51 failed findings, 14 addressed (pre-existing, not from this session)
->>>>>>> c9c1353 (chore: session-end 2026-05-09 — CHANGELOG + CURRENT_WORK)
+
 ## 2026-05-07
 
 ### Completed

--- a/R/crypto_momentum_helpers.R
+++ b/R/crypto_momentum_helpers.R
@@ -1,0 +1,478 @@
+# Crypto Momentum Helper Functions
+#
+# Copied verbatim from:
+#   /Users/johngavin/docs_gh/proj/finance/data/historical-crypto/R/crypto_momentum.R
+# (lines 29, 60, 112, 184)
+#
+# Used by plan_solana_momentum.R for the Solana-only momentum decomposition PoC.
+# Four functions reused as-is; one new weekly-rebalance wrapper added at the bottom.
+
+#' Calculate Crypto Returns
+#'
+#' Compute log returns from close prices.
+#'
+#' @param crypto_data Tibble with columns: date, ticker, close
+#' @return Tibble with columns: date, ticker, ret (daily log return)
+#'
+#' @examples
+#' \dontrun{
+#' returns <- calculate_crypto_returns(crypto_data)
+#' }
+calculate_crypto_returns <- function(crypto_data) {
+  if (!requireNamespace("dplyr", quietly = TRUE)) {
+    stop("Package 'dplyr' is required")
+  }
+
+  crypto_data |>
+    dplyr::group_by(ticker) |>
+    dplyr::arrange(date) |>
+    dplyr::mutate(
+      ret = log(close / dplyr::lag(close))
+    ) |>
+    dplyr::filter(!is.na(ret)) |>
+    dplyr::ungroup()
+}
+
+
+#' Calculate BTC Beta
+#'
+#' Regress each coin's returns on BTC returns to estimate beta (systematic risk).
+#' Uses rolling 252-day windows.
+#'
+#' @param returns Tibble with columns: date, ticker, ret
+#' @param btc_returns Tibble with columns: date, ret (BTC returns)
+#' @param lookback Integer. Rolling window size (default 252 = 1 year)
+#' @return Tibble with columns: date, ticker, btc_beta
+#'
+#' @examples
+#' \dontrun{
+#' btc_rets <- returns |> filter(ticker == "BTC") |> select(date, ret)
+#' betas <- calculate_btc_beta(returns, btc_rets, lookback = 252)
+#' }
+calculate_btc_beta <- function(returns, btc_returns, lookback = 252) {
+  if (!requireNamespace("dplyr", quietly = TRUE)) {
+    stop("Package 'dplyr' is required")
+  }
+  if (!requireNamespace("RcppRoll", quietly = TRUE)) {
+    stop("Package 'RcppRoll' is required")
+  }
+
+  # Rename BTC returns for clarity
+  btc_rets <- btc_returns |>
+    dplyr::select(date, btc_ret = ret)
+
+  # Join and compute rolling betas
+  returns |>
+    dplyr::left_join(btc_rets, by = "date") |>
+    dplyr::group_by(ticker) |>
+    dplyr::arrange(date) |>
+    dplyr::mutate(
+      # Rolling covariance: E[XY] - E[X]E[Y]
+      mean_ret = RcppRoll::roll_mean(ret, n = lookback, fill = NA, align = "right"),
+      mean_btc = RcppRoll::roll_mean(btc_ret, n = lookback, fill = NA, align = "right"),
+      mean_product = RcppRoll::roll_mean(ret * btc_ret, n = lookback, fill = NA, align = "right"),
+      cov_btc = mean_product - (mean_ret * mean_btc),
+      # Rolling variance
+      var_btc = RcppRoll::roll_var(btc_ret, n = lookback, fill = NA, align = "right"),
+      btc_beta = cov_btc / var_btc
+    ) |>
+    dplyr::select(date, ticker, btc_beta) |>
+    dplyr::filter(!is.na(btc_beta)) |>
+    dplyr::ungroup()
+}
+
+
+#' Build Crypto Signals
+#'
+#' Construct three momentum signal variants: baseline (total return), BTC-adjusted
+#' (residual momentum), and residual-only.
+#'
+#' @param returns Tibble with columns: date, ticker, ret
+#' @param btc_betas Tibble with columns: date, ticker, btc_beta
+#' @param lookback Integer. Momentum lookback window (default 252 = 12 months)
+#' @return Tibble with columns: date, ticker, mom_total, mom_btc_adj, mom_residual
+#'
+#' @details
+#' - mom_total: Raw 12m cumulative return
+#' - mom_btc_adj: 12m return minus (beta * BTC_12m_return)
+#' - mom_residual: Same as mom_btc_adj but used for pure residual-only strategy
+#'
+#' @examples
+#' \dontrun{
+#' signals <- build_crypto_signals(returns, btc_betas, lookback = 252)
+#' }
+build_crypto_signals <- function(returns, btc_betas, lookback = 252) {
+  if (!requireNamespace("dplyr", quietly = TRUE)) {
+    stop("Package 'dplyr' is required")
+  }
+  if (!requireNamespace("RcppRoll", quietly = TRUE)) {
+    stop("Package 'RcppRoll' is required")
+  }
+
+  # Compute total momentum (raw cumulative return)
+  mom_total <- returns |>
+    dplyr::group_by(ticker) |>
+    dplyr::arrange(date) |>
+    dplyr::mutate(
+      mom_total = RcppRoll::roll_sum(ret, n = lookback, fill = NA, align = "right")
+    ) |>
+    dplyr::select(date, ticker, mom_total) |>
+    dplyr::filter(!is.na(mom_total)) |>
+    dplyr::ungroup()
+
+  # Compute BTC momentum
+  btc_mom <- returns |>
+    dplyr::filter(ticker == "BTC") |>
+    dplyr::group_by(ticker) |>
+    dplyr::arrange(date) |>
+    dplyr::mutate(
+      btc_mom = RcppRoll::roll_sum(ret, n = lookback, fill = NA, align = "right")
+    ) |>
+    dplyr::filter(!is.na(btc_mom)) |>
+    dplyr::ungroup() |>
+    dplyr::select(date, btc_mom)
+
+  # Join everything and compute adjusted signals
+  mom_total |>
+    dplyr::left_join(btc_betas, by = c("date", "ticker")) |>
+    dplyr::left_join(btc_mom, by = "date") |>
+    dplyr::ungroup() |>  # Ensure ungrouped before select
+    dplyr::mutate(
+      # BTC-adjusted momentum: total - (beta * BTC momentum)
+      mom_btc_adj = mom_total - (btc_beta * btc_mom),
+      # Residual-only: same calculation
+      mom_residual = mom_btc_adj
+    ) |>
+    dplyr::select(date, ticker, mom_total, mom_btc_adj, mom_residual) |>
+    dplyr::filter(!is.na(mom_btc_adj))
+}
+
+
+#' Backtest Crypto Momentum (Monthly Rebalance)
+#'
+#' Long-short portfolio: long top N, short bottom N by signal. Monthly rebalancing.
+#' Transaction costs of 30bps per trade (crypto spreads wider than equities).
+#'
+#' @param signals Tibble with columns: date, ticker, signal (one of mom_total,
+#'   mom_btc_adj, mom_residual)
+#' @param returns Tibble with columns: date, ticker, ret (daily returns)
+#' @param cost_bps Numeric. Transaction cost in basis points (default 30 = 0.3%)
+#' @param n_long Integer. Number of coins to long (default 5)
+#' @param n_short Integer. Number of coins to short (default 5)
+#' @return List with elements: performance (tibble), summary (list)
+#'
+#' @examples
+#' \dontrun{
+#' baseline <- backtest_crypto_momentum(
+#'   signals |> select(date, ticker, signal = mom_total),
+#'   returns, cost_bps = 30
+#' )
+#' }
+backtest_crypto_momentum <- function(signals, returns, cost_bps = 30,
+                                     n_long = 5, n_short = 5) {
+  if (!requireNamespace("dplyr", quietly = TRUE)) {
+    stop("Package 'dplyr' is required")
+  }
+  if (!requireNamespace("tidyr", quietly = TRUE)) {
+    stop("Package 'tidyr' is required")
+  }
+
+  # Ensure signal column exists
+  if (!"signal" %in% names(signals)) {
+    stop("signals must have a 'signal' column")
+  }
+
+  # Monthly rebalancing dates (use month-end)
+  rebalance_dates <- signals |>
+    dplyr::mutate(ym = format(date, "%Y-%m")) |>
+    dplyr::group_by(ym) |>
+    dplyr::filter(date == max(date)) |>
+    dplyr::ungroup() |>
+    dplyr::pull(date) |>
+    unique() |>
+    sort()
+
+  # For each rebalance date, rank by signal and assign positions
+  positions <- lapply(rebalance_dates, function(reb_date) {
+    signals |>
+      dplyr::filter(date == reb_date) |>
+      dplyr::arrange(dplyr::desc(signal)) |>
+      dplyr::mutate(
+        rank = dplyr::row_number(),
+        position = dplyr::case_when(
+          rank <= n_long ~ 1 / n_long,           # Long top N
+          rank > dplyr::n() - n_short ~ -1 / n_short,  # Short bottom N
+          TRUE ~ 0
+        ),
+        rebalance_date = reb_date
+      ) |>
+      dplyr::select(ticker, rebalance_date, position, rank)
+  }) |>
+    dplyr::bind_rows()
+
+  # Expand positions to daily (forward-fill until next rebalance)
+  daily_positions <- returns |>
+    dplyr::select(date, ticker) |>
+    dplyr::left_join(positions, by = "ticker") |>
+    dplyr::filter(rebalance_date <= date) |>
+    dplyr::group_by(ticker, date) |>
+    dplyr::filter(rebalance_date == max(rebalance_date)) |>
+    dplyr::ungroup()
+
+  # Calculate daily portfolio returns
+  portfolio_rets <- daily_positions |>
+    dplyr::left_join(returns, by = c("date", "ticker")) |>
+    dplyr::group_by(date) |>
+    dplyr::summarise(
+      port_ret = sum(position * ret, na.rm = TRUE),
+      .groups = "drop"
+    ) |>
+    dplyr::arrange(date)
+
+  # Calculate turnover (fraction of portfolio changed at each rebalance)
+  turnover_calc <- positions |>
+    dplyr::arrange(ticker, rebalance_date) |>
+    dplyr::group_by(ticker) |>
+    dplyr::mutate(
+      prev_position = dplyr::lag(position, default = 0),
+      turnover_contrib = abs(position - prev_position)
+    ) |>
+    dplyr::ungroup() |>
+    dplyr::group_by(rebalance_date) |>
+    dplyr::summarise(
+      turnover = sum(turnover_contrib) / 2,  # Divide by 2 (long+short both counted)
+      .groups = "drop"
+    )
+
+  avg_turnover <- mean(turnover_calc$turnover, na.rm = TRUE)
+
+  # Apply transaction costs at each rebalance
+  portfolio_rets <- portfolio_rets |>
+    dplyr::left_join(
+      turnover_calc |> dplyr::select(date = rebalance_date, turnover),
+      by = "date"
+    ) |>
+    dplyr::mutate(
+      cost = dplyr::if_else(is.na(turnover), 0, turnover * cost_bps / 10000),
+      net_ret = port_ret - cost
+    )
+
+  # Compute cumulative returns
+  portfolio_rets <- portfolio_rets |>
+    dplyr::mutate(
+      cum_ret_gross = cumprod(1 + port_ret),
+      cum_ret_net = cumprod(1 + net_ret)
+    )
+
+  # Compute drawdown
+  portfolio_rets <- portfolio_rets |>
+    dplyr::mutate(
+      running_max = cummax(cum_ret_net),
+      drawdown = (cum_ret_net / running_max) - 1
+    )
+
+  # Summary statistics
+  n_days <- nrow(portfolio_rets)
+  n_years <- n_days / 252
+
+  gross_sharpe <- if (n_days > 1) {
+    mean(portfolio_rets$port_ret, na.rm = TRUE) /
+      sd(portfolio_rets$port_ret, na.rm = TRUE) * sqrt(252)
+  } else { NA_real_ }
+
+  net_sharpe <- if (n_days > 1) {
+    mean(portfolio_rets$net_ret, na.rm = TRUE) /
+      sd(portfolio_rets$net_ret, na.rm = TRUE) * sqrt(252)
+  } else { NA_real_ }
+
+  gross_annual_ret <- if (n_years > 0) {
+    (tail(portfolio_rets$cum_ret_gross, 1) ^ (1 / n_years)) - 1
+  } else { NA_real_ }
+
+  net_annual_ret <- if (n_years > 0) {
+    (tail(portfolio_rets$cum_ret_net, 1) ^ (1 / n_years)) - 1
+  } else { NA_real_ }
+
+  max_dd <- min(portfolio_rets$drawdown, na.rm = TRUE)
+
+  list(
+    performance = portfolio_rets,
+    summary = list(
+      gross_sharpe = gross_sharpe,
+      net_sharpe = net_sharpe,
+      gross_annual_ret = gross_annual_ret,
+      net_annual_ret = net_annual_ret,
+      max_drawdown = max_dd,
+      avg_turnover = avg_turnover,
+      n_days = n_days,
+      n_years = n_years
+    )
+  )
+}
+
+
+#' Backtest Crypto Momentum (Weekly Rebalance)
+#'
+#' Like backtest_crypto_momentum() but rebalances on a weekly cadence (last
+#' trading day of each ISO week) instead of month-end. All other logic —
+#' position assignment, forward-fill, P&L, turnover — is identical.
+#'
+#' @param signals Tibble with columns: date, ticker, signal
+#' @param returns Tibble with columns: date, ticker, ret (daily returns)
+#' @param cost_bps Numeric. Transaction cost in basis points (default 30 = 0.3%)
+#' @param n_long Integer. Number of coins to long
+#' @param n_short Integer. Number of coins to short
+#' @return List with elements: performance (tibble), summary (list)
+#'
+#' @examples
+#' \dontrun{
+#' wk_bt <- backtest_weekly_momentum(
+#'   signals |> select(date, ticker, signal = mom_total),
+#'   returns, cost_bps = 30, n_long = 2, n_short = 2
+#' )
+#' }
+backtest_weekly_momentum <- function(signals, returns, cost_bps = 30,
+                                     n_long = 5, n_short = 5) {
+  if (!requireNamespace("dplyr", quietly = TRUE)) {
+    stop("Package 'dplyr' is required")
+  }
+  if (!requireNamespace("tidyr", quietly = TRUE)) {
+    stop("Package 'tidyr' is required")
+  }
+
+  # Ensure signal column exists
+  if (!"signal" %in% names(signals)) {
+    stop("signals must have a 'signal' column")
+  }
+
+  # Weekly rebalancing dates: last trading day of each ISO week
+  # ISO week: Monday=1 ... Sunday=7; last trading day = max(date) within each (year, isoweek)
+  rebalance_dates <- signals |>
+    dplyr::mutate(
+      iso_year = as.integer(format(date, "%G")),   # ISO year (matches ISO week)
+      iso_week = as.integer(format(date, "%V"))    # ISO week number
+    ) |>
+    dplyr::group_by(iso_year, iso_week) |>
+    dplyr::filter(date == max(date)) |>
+    dplyr::ungroup() |>
+    dplyr::pull(date) |>
+    unique() |>
+    sort()
+
+  # For each rebalance date, rank by signal and assign positions
+  positions <- lapply(rebalance_dates, function(reb_date) {
+    signals |>
+      dplyr::filter(date == reb_date) |>
+      dplyr::arrange(dplyr::desc(signal)) |>
+      dplyr::mutate(
+        rank = dplyr::row_number(),
+        position = dplyr::case_when(
+          rank <= n_long ~ 1 / n_long,
+          rank > dplyr::n() - n_short ~ -1 / n_short,
+          TRUE ~ 0
+        ),
+        rebalance_date = reb_date
+      ) |>
+      dplyr::select(ticker, rebalance_date, position, rank)
+  }) |>
+    dplyr::bind_rows()
+
+  # Expand positions to daily (forward-fill until next rebalance)
+  daily_positions <- returns |>
+    dplyr::select(date, ticker) |>
+    dplyr::left_join(positions, by = "ticker") |>
+    dplyr::filter(rebalance_date <= date) |>
+    dplyr::group_by(ticker, date) |>
+    dplyr::filter(rebalance_date == max(rebalance_date)) |>
+    dplyr::ungroup()
+
+  # Calculate daily portfolio returns
+  portfolio_rets <- daily_positions |>
+    dplyr::left_join(returns, by = c("date", "ticker")) |>
+    dplyr::group_by(date) |>
+    dplyr::summarise(
+      port_ret = sum(position * ret, na.rm = TRUE),
+      .groups = "drop"
+    ) |>
+    dplyr::arrange(date)
+
+  # Calculate turnover
+  turnover_calc <- positions |>
+    dplyr::arrange(ticker, rebalance_date) |>
+    dplyr::group_by(ticker) |>
+    dplyr::mutate(
+      prev_position = dplyr::lag(position, default = 0),
+      turnover_contrib = abs(position - prev_position)
+    ) |>
+    dplyr::ungroup() |>
+    dplyr::group_by(rebalance_date) |>
+    dplyr::summarise(
+      turnover = sum(turnover_contrib) / 2,
+      .groups = "drop"
+    )
+
+  avg_turnover <- mean(turnover_calc$turnover, na.rm = TRUE)
+
+  # Apply transaction costs at each rebalance
+  portfolio_rets <- portfolio_rets |>
+    dplyr::left_join(
+      turnover_calc |> dplyr::select(date = rebalance_date, turnover),
+      by = "date"
+    ) |>
+    dplyr::mutate(
+      cost = dplyr::if_else(is.na(turnover), 0, turnover * cost_bps / 10000),
+      net_ret = port_ret - cost
+    )
+
+  # Compute cumulative returns
+  portfolio_rets <- portfolio_rets |>
+    dplyr::mutate(
+      cum_ret_gross = cumprod(1 + port_ret),
+      cum_ret_net = cumprod(1 + net_ret)
+    )
+
+  # Compute drawdown
+  portfolio_rets <- portfolio_rets |>
+    dplyr::mutate(
+      running_max = cummax(cum_ret_net),
+      drawdown = (cum_ret_net / running_max) - 1
+    )
+
+  # Summary statistics
+  n_days <- nrow(portfolio_rets)
+  n_years <- n_days / 252
+
+  gross_sharpe <- if (n_days > 1) {
+    mean(portfolio_rets$port_ret, na.rm = TRUE) /
+      sd(portfolio_rets$port_ret, na.rm = TRUE) * sqrt(252)
+  } else { NA_real_ }
+
+  net_sharpe <- if (n_days > 1) {
+    mean(portfolio_rets$net_ret, na.rm = TRUE) /
+      sd(portfolio_rets$net_ret, na.rm = TRUE) * sqrt(252)
+  } else { NA_real_ }
+
+  gross_annual_ret <- if (n_years > 0) {
+    (tail(portfolio_rets$cum_ret_gross, 1) ^ (1 / n_years)) - 1
+  } else { NA_real_ }
+
+  net_annual_ret <- if (n_years > 0) {
+    (tail(portfolio_rets$cum_ret_net, 1) ^ (1 / n_years)) - 1
+  } else { NA_real_ }
+
+  max_dd <- min(portfolio_rets$drawdown, na.rm = TRUE)
+
+  list(
+    performance = portfolio_rets,
+    summary = list(
+      gross_sharpe = gross_sharpe,
+      net_sharpe = net_sharpe,
+      gross_annual_ret = gross_annual_ret,
+      net_annual_ret = net_annual_ret,
+      max_drawdown = max_dd,
+      avg_turnover = avg_turnover,
+      n_days = n_days,
+      n_years = n_years
+    )
+  )
+}

--- a/R/plan_solana_momentum.R
+++ b/R/plan_solana_momentum.R
@@ -1,330 +1,312 @@
 # Solana-Only Momentum Decomposition Targets Plan
 #
-# Tests momentum decomposition on Solana ecosystem tokens only
-# Uses DeFi data sources (Birdeye spot + Drift perps)
+# Proof-of-concept using available crypto_all.parquet data.
+# Universe: SOL, RAY, BONK, HNT (+ BTC as reference).
+# Three signal variants x two rebalance frequencies = 6 backtest targets.
 #
-# Parameters:
-# - beta_window: 252 (configurable)
-# - leverage: 1.0 (configurable)
-# - vol_adjust: TRUE
-# - rebalance_freq: "weekly"
+# Reuses helpers from R/crypto_momentum_helpers.R:
+#   calculate_crypto_returns(), calculate_btc_beta(),
+#   build_crypto_signals(), backtest_crypto_momentum(),
+#   backtest_weekly_momentum()
+#
+# Does NOT use Birdeye / Drift API — uses existing parquet only.
 
 plan_solana_momentum <- function() {
+
+  # --------------------------------------------------------------------------
+  # Parameters
+  # --------------------------------------------------------------------------
+  SOLANA_UNIVERSE  <- c("SOL", "RAY", "BONK", "HNT")
+  BETA_WINDOW      <- 252L   # rolling window for BTC beta (configurable)
+  LOOKBACK_DAYS    <- 252L   # momentum lookback (configurable)
+  LEVERAGE         <- 1.0    # unleveraged (configurable)
+  COST_BPS         <- 30L    # 0.3% per trade
+  N_LONG           <- 2L     # longs in 4-token universe
+  N_SHORT          <- 2L     # shorts in 4-token universe
+  PARQUET_PATH     <- "/Users/johngavin/docs_gh/proj/finance/data/historical-crypto/data/raw/crypto_all.parquet"
+  VOL_WINDOW       <- 63L    # 63-day vol for position sizing
+
   list(
-    # 1. Define Solana token universe (liquid tokens only)
-    tar_target(
-      solana_universe_raw,
-      {
-        # Candidate tokens
-        candidates <- c("SOL", "RAY", "BONK", "JUP", "PYTH", "ORCA", "JTO", "HNT")
 
-        # NOTE: Will filter by liquidity metrics after fetching data
-        candidates
+    # 1. Load raw parquet (Solana universe + BTC reference)
+    tar_target(
+      sol_raw_data,
+      {
+        arrow::read_parquet(PARQUET_PATH) |>
+          dplyr::filter(ticker %in% c(SOLANA_UNIVERSE, "BTC")) |>
+          dplyr::select(date, ticker, close) |>
+          dplyr::arrange(ticker, date)
       }
     ),
 
-    # 2. Fetch spot prices from Birdeye (4-hourly for signal, daily for backtest)
+    # 2. Compute log returns
     tar_target(
-      solana_spot_4h,
-      {
-        # API key from environment
-        if (Sys.getenv("BIRDEYE_API_KEY") == "") {
-          cli::cli_abort("BIRDEYE_API_KEY not set. Get free key at https://birdeye.so/")
-        }
+      sol_returns,
+      calculate_crypto_returns(sol_raw_data)
+    ),
 
-        fetch_birdeye_spot(
-          tokens = solana_universe_raw,
-          start_date = as.Date("2021-01-01"),  # Earliest common start for most tokens
-          end_date = Sys.Date(),
-          interval = "4H"  # 4-hourly for higher frequency signals
-        )
+    # 3. Separate BTC reference returns (used for beta estimation)
+    tar_target(
+      sol_btc_returns,
+      sol_returns |>
+        dplyr::filter(ticker == "BTC") |>
+        dplyr::select(date, ret)
+    ),
+
+    # 4. Compute rolling BTC beta per Solana token
+    tar_target(
+      sol_btc_betas,
+      {
+        sol_rets_universe <- sol_returns |>
+          dplyr::filter(ticker %in% SOLANA_UNIVERSE)
+        calculate_btc_beta(sol_rets_universe, sol_btc_returns, lookback = BETA_WINDOW)
       }
     ),
 
-    # 3. Fetch Drift perp prices + funding rates
+    # 5. Build the three signal variants
+    #    Inputs include BTC returns (for btc_mom) so filter to full dataset
     tar_target(
-      solana_perps_drift,
+      sol_signals_raw,
       {
-        # Map tokens to Drift perp markets
-        perp_markets <- paste0(solana_universe_raw, "-PERP")
-
-        fetch_drift_perps(
-          markets = perp_markets,
-          start_date = as.Date("2022-03-01"),  # Drift v2 launch
-          end_date = Sys.Date()
-        )
+        # build_crypto_signals expects BTC in returns for btc_mom calc
+        build_crypto_signals(sol_returns, sol_btc_betas, lookback = LOOKBACK_DAYS)
       }
     ),
 
-    # 4. Calculate liquidity metrics (filter to liquid tokens only)
+    # 6. Volatility-adjusted position sizing
+    #    weight = (1/vol_63d) / sum(1/vol_63d) per long/short leg
+    #    Fall back to equal-weight if vol is NA
     tar_target(
-      solana_liquidity_metrics,
+      sol_vol_weights,
       {
-        calculate_liquidity_metrics(
-          spot_data = solana_spot_4h,
-          perp_data = solana_perps_drift,
-          min_daily_volume = 1e6  # $1M minimum daily volume
-        )
-      }
-    ),
+        sol_universe_rets <- sol_returns |>
+          dplyr::filter(ticker %in% SOLANA_UNIVERSE)
 
-    # 5. Filter to liquid universe
-    tar_target(
-      solana_universe_liquid,
-      {
-        liquid_tokens <- solana_liquidity_metrics |>
-          dplyr::filter(is_liquid) |>
-          dplyr::pull(ticker)
-
-        if (length(liquid_tokens) < 5) {
-          cli::cli_warn("Only {length(liquid_tokens)} liquid tokens found. Minimum recommended: 5")
-        }
-
-        cli::cli_alert_success("Liquid Solana universe: {paste(liquid_tokens, collapse=', ')}")
-
-        liquid_tokens
-      }
-    ),
-
-    # 6. Resample to daily for backtesting (from 4H data)
-    tar_target(
-      solana_spot_daily,
-      {
-        solana_spot_4h |>
-          dplyr::filter(ticker %in% solana_universe_liquid) |>
-          dplyr::mutate(date = as.Date(timestamp)) |>
-          dplyr::group_by(ticker, date) |>
-          dplyr::summarise(
-            open = dplyr::first(open),
-            high = max(high),
-            low = min(low),
-            close = dplyr::last(close),
-            volume = sum(volume),
-            .groups = "drop"
-          )
-      }
-    ),
-
-    # 7. Calculate daily returns
-    tar_target(
-      solana_returns_daily,
-      {
-        solana_spot_daily |>
+        vol_63d <- sol_universe_rets |>
           dplyr::group_by(ticker) |>
           dplyr::arrange(date) |>
           dplyr::mutate(
-            return = log(close / dplyr::lag(close))
+            vol_63d = RcppRoll::roll_sd(ret, n = VOL_WINDOW, fill = NA, align = "right")
           ) |>
-          dplyr::filter(!is.na(return)) |>
+          dplyr::select(date, ticker, vol_63d) |>
+          dplyr::filter(!is.na(vol_63d)) |>
+          dplyr::ungroup()
+
+        vol_63d
+      }
+    ),
+
+    # 7. Apply vol-adjusted weights to signals
+    #    For each signal × date: compute inv-vol weight normalised within leg
+    tar_target(
+      sol_signals,
+      {
+        sol_signals_raw |>
+          dplyr::filter(ticker %in% SOLANA_UNIVERSE) |>
+          dplyr::left_join(sol_vol_weights, by = c("date", "ticker")) |>
+          dplyr::group_by(date) |>
+          dplyr::mutate(
+            inv_vol = dplyr::if_else(is.na(vol_63d) | vol_63d == 0, NA_real_, 1 / vol_63d),
+            sum_inv_vol = sum(inv_vol, na.rm = TRUE),
+            vol_weight = dplyr::if_else(
+              is.na(inv_vol) | sum_inv_vol == 0,
+              1 / dplyr::n(),        # equal-weight fallback
+              inv_vol / sum_inv_vol
+            )
+          ) |>
           dplyr::ungroup() |>
-          dplyr::select(ticker, date, return, close)
+          dplyr::select(date, ticker, mom_total, mom_btc_adj, mom_residual, vol_weight)
       }
     ),
 
-    # 8. BTC returns (reference for beta calculation)
+    # -------------------------------------------------------------------------
+    # Backtest targets: 3 signals x 2 frequencies = 6 targets
+    # -------------------------------------------------------------------------
+
+    # 8. Monthly: Baseline (total) momentum
     tar_target(
-      btc_returns_daily,
-      {
-        solana_returns_daily |>
-          dplyr::filter(ticker == "BTC") |>
-          dplyr::select(date, btc_return = return)
-      }
+      sol_bt_monthly_baseline,
+      backtest_crypto_momentum(
+        signals = sol_signals |>
+          dplyr::select(date, ticker, signal = mom_total),
+        returns = sol_returns |> dplyr::filter(ticker %in% SOLANA_UNIVERSE),
+        cost_bps = COST_BPS,
+        n_long = N_LONG,
+        n_short = N_SHORT
+      )
     ),
 
-    # 9. Build momentum signals (configurable parameters)
+    # 9. Monthly: BTC-adjusted momentum
     tar_target(
-      solana_signals,
-      {
-        # Configurable parameters
-        LOOKBACK_DAYS <- 252    # 12-month momentum
-        BETA_WINDOW <- 252      # 12-month beta estimation
-        VOL_ADJUST <- TRUE      # Use volatility-adjusted sizing
-        LEVERAGE <- 1.0         # Unleveraged
+      sol_bt_monthly_btc_adj,
+      backtest_crypto_momentum(
+        signals = sol_signals |>
+          dplyr::select(date, ticker, signal = mom_btc_adj),
+        returns = sol_returns |> dplyr::filter(ticker %in% SOLANA_UNIVERSE),
+        cost_bps = COST_BPS,
+        n_long = N_LONG,
+        n_short = N_SHORT
+      )
+    ),
 
-        build_momentum_signals(
-          returns = solana_returns_daily |> dplyr::filter(ticker != "BTC"),
-          btc_returns = btc_returns_daily,
-          lookback_days = LOOKBACK_DAYS,
-          beta_window = BETA_WINDOW,
-          vol_adjust = VOL_ADJUST,
-          leverage = LEVERAGE
+    # 10. Monthly: Residual-only momentum
+    tar_target(
+      sol_bt_monthly_residual,
+      backtest_crypto_momentum(
+        signals = sol_signals |>
+          dplyr::select(date, ticker, signal = mom_residual),
+        returns = sol_returns |> dplyr::filter(ticker %in% SOLANA_UNIVERSE),
+        cost_bps = COST_BPS,
+        n_long = N_LONG,
+        n_short = N_SHORT
+      )
+    ),
+
+    # 11. Weekly: Baseline (total) momentum
+    tar_target(
+      sol_bt_weekly_baseline,
+      backtest_weekly_momentum(
+        signals = sol_signals |>
+          dplyr::select(date, ticker, signal = mom_total),
+        returns = sol_returns |> dplyr::filter(ticker %in% SOLANA_UNIVERSE),
+        cost_bps = COST_BPS,
+        n_long = N_LONG,
+        n_short = N_SHORT
+      )
+    ),
+
+    # 12. Weekly: BTC-adjusted momentum
+    tar_target(
+      sol_bt_weekly_btc_adj,
+      backtest_weekly_momentum(
+        signals = sol_signals |>
+          dplyr::select(date, ticker, signal = mom_btc_adj),
+        returns = sol_returns |> dplyr::filter(ticker %in% SOLANA_UNIVERSE),
+        cost_bps = COST_BPS,
+        n_long = N_LONG,
+        n_short = N_SHORT
+      )
+    ),
+
+    # 13. Weekly: Residual-only momentum
+    tar_target(
+      sol_bt_weekly_residual,
+      backtest_weekly_momentum(
+        signals = sol_signals |>
+          dplyr::select(date, ticker, signal = mom_residual),
+        returns = sol_returns |> dplyr::filter(ticker %in% SOLANA_UNIVERSE),
+        cost_bps = COST_BPS,
+        n_long = N_LONG,
+        n_short = N_SHORT
+      )
+    ),
+
+    # -------------------------------------------------------------------------
+    # Summary and diagnostic targets
+    # -------------------------------------------------------------------------
+
+    # 14. Performance summary table: strategy x freq -> metrics
+    tar_target(
+      sol_performance_summary,
+      {
+        extract_summary <- function(bt, strategy, freq) {
+          s <- bt$summary
+          dplyr::tibble(
+            strategy   = strategy,
+            freq       = freq,
+            gross_sharpe   = s$gross_sharpe,
+            net_sharpe     = s$net_sharpe,
+            annual_ret     = s$net_annual_ret,
+            max_drawdown   = s$max_drawdown,
+            avg_turnover   = s$avg_turnover,
+            n_years        = s$n_years
+          )
+        }
+
+        dplyr::bind_rows(
+          extract_summary(sol_bt_monthly_baseline,  "Baseline",   "monthly"),
+          extract_summary(sol_bt_monthly_btc_adj,   "BTC-Adj",    "monthly"),
+          extract_summary(sol_bt_monthly_residual,  "Residual",   "monthly"),
+          extract_summary(sol_bt_weekly_baseline,   "Baseline",   "weekly"),
+          extract_summary(sol_bt_weekly_btc_adj,    "BTC-Adj",    "weekly"),
+          extract_summary(sol_bt_weekly_residual,   "Residual",   "weekly")
         )
       }
     ),
 
-    # 10. Backtest: Baseline momentum
+    # 15. BTC beta stats per Solana token
     tar_target(
-      solana_bt_baseline,
-      {
-        backtest_momentum(
-          signals = solana_signals |> dplyr::select(ticker, date, signal = baseline_mom, position_size),
-          returns = solana_returns_daily,
-          costs = 0.003,  # 0.3% per trade (DeFi slippage)
-          rebalance_freq = "weekly"
-        )
-      }
-    ),
-
-    # 11. Backtest: BTC-adjusted momentum
-    tar_target(
-      solana_bt_btc_adj,
-      {
-        backtest_momentum(
-          signals = solana_signals |> dplyr::select(ticker, date, signal = btc_adj_mom, position_size),
-          returns = solana_returns_daily,
-          costs = 0.003,
-          rebalance_freq = "weekly"
-        )
-      }
-    ),
-
-    # 12. Backtest: Residual-only momentum
-    tar_target(
-      solana_bt_residual,
-      {
-        backtest_momentum(
-          signals = solana_signals |> dplyr::select(ticker, date, signal = residual_mom, position_size),
-          returns = solana_returns_daily,
-          costs = 0.003,
-          rebalance_freq = "weekly"
-        )
-      }
-    ),
-
-    # 13. Performance summary
-    tar_target(
-      solana_performance_summary,
-      {
-        bind_rows(
-          solana_bt_baseline |> mutate(strategy = "Baseline (12m)"),
-          solana_bt_btc_adj |> mutate(strategy = "BTC-Adjusted"),
-          solana_bt_residual |> mutate(strategy = "Residual-Only")
+      sol_btc_beta_stats,
+      sol_btc_betas |>
+        dplyr::group_by(ticker) |>
+        dplyr::summarise(
+          mean_beta   = mean(btc_beta, na.rm = TRUE),
+          median_beta = stats::median(btc_beta, na.rm = TRUE),
+          sd_beta     = stats::sd(btc_beta, na.rm = TRUE),
+          beta_25     = stats::quantile(btc_beta, 0.25, na.rm = TRUE),
+          beta_75     = stats::quantile(btc_beta, 0.75, na.rm = TRUE),
+          n_obs       = dplyr::n(),
+          .groups = "drop"
         ) |>
-          group_by(strategy) |>
-          summarise(
-            gross_sharpe = calculate_sharpe(gross_pnl),
-            net_sharpe = calculate_sharpe(net_pnl),
-            gross_annual_ret = mean(gross_pnl) * 252,
-            net_annual_ret = mean(net_pnl) * 252,
-            max_drawdown = calculate_max_dd(cumsum(net_pnl)),
-            avg_turnover = mean(turnover),
-            .groups = "drop"
-          )
-      }
+        dplyr::arrange(dplyr::desc(median_beta))
     ),
 
-    # 14. BTC beta analysis (how much does SOL ecosystem move with BTC?)
+    # 16. Cumulative returns plot (all 6 series)
     tar_target(
-      solana_btc_beta_analysis,
+      sol_cumulative_plot,
       {
-        solana_signals |>
-          group_by(ticker) |>
-          summarise(
-            mean_beta = mean(btc_beta, na.rm = TRUE),
-            median_beta = median(btc_beta, na.rm = TRUE),
-            sd_beta = sd(btc_beta, na.rm = TRUE),
-            beta_25 = quantile(btc_beta, 0.25, na.rm = TRUE),
-            beta_75 = quantile(btc_beta, 0.75, na.rm = TRUE),
-            .groups = "drop"
-          ) |>
-          arrange(desc(median_beta))
-      }
-    ),
+        extract_cumret <- function(bt, strategy, freq) {
+          bt$performance |>
+            dplyr::select(date, cum_ret_net) |>
+            dplyr::mutate(
+              strategy = strategy,
+              freq     = freq,
+              series   = paste0(strategy, " (", freq, ")")
+            )
+        }
 
-    # 15. Funding rate carry analysis (for Phase 2)
-    tar_target(
-      solana_funding_rate_stats,
-      {
-        solana_perps_drift |>
-          mutate(ticker = sub("-PERP", "", market)) |>
-          filter(ticker %in% solana_universe_liquid) |>
-          group_by(ticker) |>
-          summarise(
-            mean_funding_rate = mean(funding_rate, na.rm = TRUE) * 24 * 365,  # Annualized
-            sd_funding_rate = sd(funding_rate, na.rm = TRUE) * sqrt(24 * 365),
-            positive_pct = mean(funding_rate > 0, na.rm = TRUE),
-            .groups = "drop"
-          ) |>
-          arrange(desc(mean_funding_rate))
-      }
-    ),
-
-    # 16. Cumulative returns plot
-    tar_target(
-      solana_cumulative_plot,
-      {
-        combined <- bind_rows(
-          solana_bt_baseline |> mutate(strategy = "Baseline"),
-          solana_bt_btc_adj |> mutate(strategy = "BTC-Adjusted"),
-          solana_bt_residual |> mutate(strategy = "Residual-Only")
+        combined <- dplyr::bind_rows(
+          extract_cumret(sol_bt_monthly_baseline,  "Baseline",  "monthly"),
+          extract_cumret(sol_bt_monthly_btc_adj,   "BTC-Adj",   "monthly"),
+          extract_cumret(sol_bt_monthly_residual,  "Residual",  "monthly"),
+          extract_cumret(sol_bt_weekly_baseline,   "Baseline",  "weekly"),
+          extract_cumret(sol_bt_weekly_btc_adj,    "BTC-Adj",   "weekly"),
+          extract_cumret(sol_bt_weekly_residual,   "Residual",  "weekly")
         )
 
-        ggplot(combined, aes(x = date, y = cumsum(net_pnl), color = strategy)) +
-          geom_line(linewidth = 1) +
-          scale_color_manual(values = c("Baseline" = "#999", "BTC-Adjusted" = "#0066CC", "Residual-Only" = "#CC0000")) +
-          labs(
-            title = "Solana Momentum Decomposition: Cumulative Returns",
-            subtitle = paste0(
-              "Universe: ", paste(solana_universe_liquid, collapse = ", "),
-              " | Weekly rebalance | 0.3% costs"
+        ggplot2::ggplot(
+          combined,
+          ggplot2::aes(x = date, y = cum_ret_net, color = series, linetype = freq)
+        ) +
+          ggplot2::geom_line(linewidth = 0.9) +
+          ggplot2::scale_color_manual(
+            values = c(
+              "Baseline (monthly)"  = "#2c3e50",
+              "BTC-Adj (monthly)"   = "#e67e22",
+              "Residual (monthly)"  = "#c0392b",
+              "Baseline (weekly)"   = "#7f8c8d",
+              "BTC-Adj (weekly)"    = "#f39c12",
+              "Residual (weekly)"   = "#e74c3c"
+            )
+          ) +
+          ggplot2::scale_linetype_manual(
+            values = c("monthly" = "solid", "weekly" = "dashed")
+          ) +
+          ggplot2::labs(
+            title = paste0(
+              "Solana Momentum Decomposition: Cumulative Net Returns\n",
+              "Universe: ", paste(SOLANA_UNIVERSE, collapse = ", "),
+              " | Cost: ", COST_BPS, "bps | Lookback: ", LOOKBACK_DAYS, "d"
             ),
-            x = NULL,
-            y = "Cumulative Return",
-            color = "Strategy"
+            x    = NULL,
+            y    = "Cumulative Return (net of costs)",
+            color = "Strategy",
+            linetype = "Frequency"
           ) +
-          theme_minimal() +
-          theme(legend.position = "top")
-      }
-    ),
-
-    # 17. Rolling Sharpe plot
-    tar_target(
-      solana_rolling_sharpe_plot,
-      {
-        combined <- bind_rows(
-          solana_bt_baseline |> mutate(strategy = "Baseline"),
-          solana_bt_btc_adj |> mutate(strategy = "BTC-Adjusted"),
-          solana_bt_residual |> mutate(strategy = "Residual-Only")
-        )
-
-        combined |>
-          group_by(strategy) |>
-          arrange(date) |>
-          mutate(
-            rolling_sharpe = RcppRoll::roll_meanr(net_pnl, n = 63) /
-                            RcppRoll::roll_sdr(net_pnl, n = 63) * sqrt(252)
-          ) |>
-          ungroup() |>
-          filter(!is.na(rolling_sharpe)) |>
-          ggplot(aes(x = date, y = rolling_sharpe, color = strategy)) +
-          geom_line(linewidth = 0.8) +
-          geom_hline(yintercept = 0, linetype = "dashed", color = "gray50") +
-          scale_color_manual(values = c("Baseline" = "#999", "BTC-Adjusted" = "#0066CC", "Residual-Only" = "#CC0000")) +
-          labs(
-            title = "Solana Momentum: 63-Day Rolling Sharpe Ratio",
-            x = NULL,
-            y = "Rolling Sharpe (63d)",
-            color = "Strategy"
-          ) +
-          theme_minimal() +
-          theme(legend.position = "top")
-      }
-    ),
-
-    # 18. Performance table (display)
-    tar_target(
-      solana_performance_table,
-      {
-        solana_performance_summary |>
-          mutate(
-            gross_sharpe = round(gross_sharpe, 3),
-            net_sharpe = round(net_sharpe, 3),
-            gross_annual_ret = scales::percent(gross_annual_ret, accuracy = 0.1),
-            net_annual_ret = scales::percent(net_annual_ret, accuracy = 0.1),
-            max_drawdown = scales::percent(max_drawdown, accuracy = 0.1),
-            avg_turnover = scales::percent(avg_turnover, accuracy = 0.1)
-          )
+          ggplot2::theme_minimal(base_size = 11) +
+          ggplot2::theme(legend.position = "right")
       }
     )
+
   )
 }

--- a/R/plan_solana_momentum.R
+++ b/R/plan_solana_momentum.R
@@ -1,0 +1,330 @@
+# Solana-Only Momentum Decomposition Targets Plan
+#
+# Tests momentum decomposition on Solana ecosystem tokens only
+# Uses DeFi data sources (Birdeye spot + Drift perps)
+#
+# Parameters:
+# - beta_window: 252 (configurable)
+# - leverage: 1.0 (configurable)
+# - vol_adjust: TRUE
+# - rebalance_freq: "weekly"
+
+plan_solana_momentum <- function() {
+  list(
+    # 1. Define Solana token universe (liquid tokens only)
+    tar_target(
+      solana_universe_raw,
+      {
+        # Candidate tokens
+        candidates <- c("SOL", "RAY", "BONK", "JUP", "PYTH", "ORCA", "JTO", "HNT")
+
+        # NOTE: Will filter by liquidity metrics after fetching data
+        candidates
+      }
+    ),
+
+    # 2. Fetch spot prices from Birdeye (4-hourly for signal, daily for backtest)
+    tar_target(
+      solana_spot_4h,
+      {
+        # API key from environment
+        if (Sys.getenv("BIRDEYE_API_KEY") == "") {
+          cli::cli_abort("BIRDEYE_API_KEY not set. Get free key at https://birdeye.so/")
+        }
+
+        fetch_birdeye_spot(
+          tokens = solana_universe_raw,
+          start_date = as.Date("2021-01-01"),  # Earliest common start for most tokens
+          end_date = Sys.Date(),
+          interval = "4H"  # 4-hourly for higher frequency signals
+        )
+      }
+    ),
+
+    # 3. Fetch Drift perp prices + funding rates
+    tar_target(
+      solana_perps_drift,
+      {
+        # Map tokens to Drift perp markets
+        perp_markets <- paste0(solana_universe_raw, "-PERP")
+
+        fetch_drift_perps(
+          markets = perp_markets,
+          start_date = as.Date("2022-03-01"),  # Drift v2 launch
+          end_date = Sys.Date()
+        )
+      }
+    ),
+
+    # 4. Calculate liquidity metrics (filter to liquid tokens only)
+    tar_target(
+      solana_liquidity_metrics,
+      {
+        calculate_liquidity_metrics(
+          spot_data = solana_spot_4h,
+          perp_data = solana_perps_drift,
+          min_daily_volume = 1e6  # $1M minimum daily volume
+        )
+      }
+    ),
+
+    # 5. Filter to liquid universe
+    tar_target(
+      solana_universe_liquid,
+      {
+        liquid_tokens <- solana_liquidity_metrics |>
+          dplyr::filter(is_liquid) |>
+          dplyr::pull(ticker)
+
+        if (length(liquid_tokens) < 5) {
+          cli::cli_warn("Only {length(liquid_tokens)} liquid tokens found. Minimum recommended: 5")
+        }
+
+        cli::cli_alert_success("Liquid Solana universe: {paste(liquid_tokens, collapse=', ')}")
+
+        liquid_tokens
+      }
+    ),
+
+    # 6. Resample to daily for backtesting (from 4H data)
+    tar_target(
+      solana_spot_daily,
+      {
+        solana_spot_4h |>
+          dplyr::filter(ticker %in% solana_universe_liquid) |>
+          dplyr::mutate(date = as.Date(timestamp)) |>
+          dplyr::group_by(ticker, date) |>
+          dplyr::summarise(
+            open = dplyr::first(open),
+            high = max(high),
+            low = min(low),
+            close = dplyr::last(close),
+            volume = sum(volume),
+            .groups = "drop"
+          )
+      }
+    ),
+
+    # 7. Calculate daily returns
+    tar_target(
+      solana_returns_daily,
+      {
+        solana_spot_daily |>
+          dplyr::group_by(ticker) |>
+          dplyr::arrange(date) |>
+          dplyr::mutate(
+            return = log(close / dplyr::lag(close))
+          ) |>
+          dplyr::filter(!is.na(return)) |>
+          dplyr::ungroup() |>
+          dplyr::select(ticker, date, return, close)
+      }
+    ),
+
+    # 8. BTC returns (reference for beta calculation)
+    tar_target(
+      btc_returns_daily,
+      {
+        solana_returns_daily |>
+          dplyr::filter(ticker == "BTC") |>
+          dplyr::select(date, btc_return = return)
+      }
+    ),
+
+    # 9. Build momentum signals (configurable parameters)
+    tar_target(
+      solana_signals,
+      {
+        # Configurable parameters
+        LOOKBACK_DAYS <- 252    # 12-month momentum
+        BETA_WINDOW <- 252      # 12-month beta estimation
+        VOL_ADJUST <- TRUE      # Use volatility-adjusted sizing
+        LEVERAGE <- 1.0         # Unleveraged
+
+        build_momentum_signals(
+          returns = solana_returns_daily |> dplyr::filter(ticker != "BTC"),
+          btc_returns = btc_returns_daily,
+          lookback_days = LOOKBACK_DAYS,
+          beta_window = BETA_WINDOW,
+          vol_adjust = VOL_ADJUST,
+          leverage = LEVERAGE
+        )
+      }
+    ),
+
+    # 10. Backtest: Baseline momentum
+    tar_target(
+      solana_bt_baseline,
+      {
+        backtest_momentum(
+          signals = solana_signals |> dplyr::select(ticker, date, signal = baseline_mom, position_size),
+          returns = solana_returns_daily,
+          costs = 0.003,  # 0.3% per trade (DeFi slippage)
+          rebalance_freq = "weekly"
+        )
+      }
+    ),
+
+    # 11. Backtest: BTC-adjusted momentum
+    tar_target(
+      solana_bt_btc_adj,
+      {
+        backtest_momentum(
+          signals = solana_signals |> dplyr::select(ticker, date, signal = btc_adj_mom, position_size),
+          returns = solana_returns_daily,
+          costs = 0.003,
+          rebalance_freq = "weekly"
+        )
+      }
+    ),
+
+    # 12. Backtest: Residual-only momentum
+    tar_target(
+      solana_bt_residual,
+      {
+        backtest_momentum(
+          signals = solana_signals |> dplyr::select(ticker, date, signal = residual_mom, position_size),
+          returns = solana_returns_daily,
+          costs = 0.003,
+          rebalance_freq = "weekly"
+        )
+      }
+    ),
+
+    # 13. Performance summary
+    tar_target(
+      solana_performance_summary,
+      {
+        bind_rows(
+          solana_bt_baseline |> mutate(strategy = "Baseline (12m)"),
+          solana_bt_btc_adj |> mutate(strategy = "BTC-Adjusted"),
+          solana_bt_residual |> mutate(strategy = "Residual-Only")
+        ) |>
+          group_by(strategy) |>
+          summarise(
+            gross_sharpe = calculate_sharpe(gross_pnl),
+            net_sharpe = calculate_sharpe(net_pnl),
+            gross_annual_ret = mean(gross_pnl) * 252,
+            net_annual_ret = mean(net_pnl) * 252,
+            max_drawdown = calculate_max_dd(cumsum(net_pnl)),
+            avg_turnover = mean(turnover),
+            .groups = "drop"
+          )
+      }
+    ),
+
+    # 14. BTC beta analysis (how much does SOL ecosystem move with BTC?)
+    tar_target(
+      solana_btc_beta_analysis,
+      {
+        solana_signals |>
+          group_by(ticker) |>
+          summarise(
+            mean_beta = mean(btc_beta, na.rm = TRUE),
+            median_beta = median(btc_beta, na.rm = TRUE),
+            sd_beta = sd(btc_beta, na.rm = TRUE),
+            beta_25 = quantile(btc_beta, 0.25, na.rm = TRUE),
+            beta_75 = quantile(btc_beta, 0.75, na.rm = TRUE),
+            .groups = "drop"
+          ) |>
+          arrange(desc(median_beta))
+      }
+    ),
+
+    # 15. Funding rate carry analysis (for Phase 2)
+    tar_target(
+      solana_funding_rate_stats,
+      {
+        solana_perps_drift |>
+          mutate(ticker = sub("-PERP", "", market)) |>
+          filter(ticker %in% solana_universe_liquid) |>
+          group_by(ticker) |>
+          summarise(
+            mean_funding_rate = mean(funding_rate, na.rm = TRUE) * 24 * 365,  # Annualized
+            sd_funding_rate = sd(funding_rate, na.rm = TRUE) * sqrt(24 * 365),
+            positive_pct = mean(funding_rate > 0, na.rm = TRUE),
+            .groups = "drop"
+          ) |>
+          arrange(desc(mean_funding_rate))
+      }
+    ),
+
+    # 16. Cumulative returns plot
+    tar_target(
+      solana_cumulative_plot,
+      {
+        combined <- bind_rows(
+          solana_bt_baseline |> mutate(strategy = "Baseline"),
+          solana_bt_btc_adj |> mutate(strategy = "BTC-Adjusted"),
+          solana_bt_residual |> mutate(strategy = "Residual-Only")
+        )
+
+        ggplot(combined, aes(x = date, y = cumsum(net_pnl), color = strategy)) +
+          geom_line(linewidth = 1) +
+          scale_color_manual(values = c("Baseline" = "#999", "BTC-Adjusted" = "#0066CC", "Residual-Only" = "#CC0000")) +
+          labs(
+            title = "Solana Momentum Decomposition: Cumulative Returns",
+            subtitle = paste0(
+              "Universe: ", paste(solana_universe_liquid, collapse = ", "),
+              " | Weekly rebalance | 0.3% costs"
+            ),
+            x = NULL,
+            y = "Cumulative Return",
+            color = "Strategy"
+          ) +
+          theme_minimal() +
+          theme(legend.position = "top")
+      }
+    ),
+
+    # 17. Rolling Sharpe plot
+    tar_target(
+      solana_rolling_sharpe_plot,
+      {
+        combined <- bind_rows(
+          solana_bt_baseline |> mutate(strategy = "Baseline"),
+          solana_bt_btc_adj |> mutate(strategy = "BTC-Adjusted"),
+          solana_bt_residual |> mutate(strategy = "Residual-Only")
+        )
+
+        combined |>
+          group_by(strategy) |>
+          arrange(date) |>
+          mutate(
+            rolling_sharpe = RcppRoll::roll_meanr(net_pnl, n = 63) /
+                            RcppRoll::roll_sdr(net_pnl, n = 63) * sqrt(252)
+          ) |>
+          ungroup() |>
+          filter(!is.na(rolling_sharpe)) |>
+          ggplot(aes(x = date, y = rolling_sharpe, color = strategy)) +
+          geom_line(linewidth = 0.8) +
+          geom_hline(yintercept = 0, linetype = "dashed", color = "gray50") +
+          scale_color_manual(values = c("Baseline" = "#999", "BTC-Adjusted" = "#0066CC", "Residual-Only" = "#CC0000")) +
+          labs(
+            title = "Solana Momentum: 63-Day Rolling Sharpe Ratio",
+            x = NULL,
+            y = "Rolling Sharpe (63d)",
+            color = "Strategy"
+          ) +
+          theme_minimal() +
+          theme(legend.position = "top")
+      }
+    ),
+
+    # 18. Performance table (display)
+    tar_target(
+      solana_performance_table,
+      {
+        solana_performance_summary |>
+          mutate(
+            gross_sharpe = round(gross_sharpe, 3),
+            net_sharpe = round(net_sharpe, 3),
+            gross_annual_ret = scales::percent(gross_annual_ret, accuracy = 0.1),
+            net_annual_ret = scales::percent(net_annual_ret, accuracy = 0.1),
+            max_drawdown = scales::percent(max_drawdown, accuracy = 0.1),
+            avg_turnover = scales::percent(avg_turnover, accuracy = 0.1)
+          )
+      }
+    )
+  )
+}

--- a/R/plan_solana_momentum.R
+++ b/R/plan_solana_momentum.R
@@ -11,20 +11,20 @@
 #
 # Does NOT use Birdeye / Drift API — uses existing parquet only.
 
-plan_solana_momentum <- function() {
+# --------------------------------------------------------------------------
+# Parameters — defined at file scope so worker processes can see them
+# --------------------------------------------------------------------------
+SOL_UNIVERSE   <- c("SOL", "RAY", "BONK", "HNT")
+SOL_BETA_WIN   <- 252L   # rolling window for BTC beta (configurable)
+SOL_LOOKBACK   <- 252L   # momentum lookback (configurable)
+SOL_LEVERAGE   <- 1.0    # unleveraged (configurable)
+SOL_COST_BPS   <- 30L    # 0.3% per trade
+SOL_N_LONG     <- 2L     # longs in 4-token universe
+SOL_N_SHORT    <- 2L     # shorts in 4-token universe
+SOL_PARQUET    <- "/Users/johngavin/docs_gh/proj/finance/data/historical-crypto/data/raw/crypto_all.parquet"
+SOL_VOL_WIN    <- 63L    # 63-day vol for position sizing
 
-  # --------------------------------------------------------------------------
-  # Parameters
-  # --------------------------------------------------------------------------
-  SOLANA_UNIVERSE  <- c("SOL", "RAY", "BONK", "HNT")
-  BETA_WINDOW      <- 252L   # rolling window for BTC beta (configurable)
-  LOOKBACK_DAYS    <- 252L   # momentum lookback (configurable)
-  LEVERAGE         <- 1.0    # unleveraged (configurable)
-  COST_BPS         <- 30L    # 0.3% per trade
-  N_LONG           <- 2L     # longs in 4-token universe
-  N_SHORT          <- 2L     # shorts in 4-token universe
-  PARQUET_PATH     <- "/Users/johngavin/docs_gh/proj/finance/data/historical-crypto/data/raw/crypto_all.parquet"
-  VOL_WINDOW       <- 63L    # 63-day vol for position sizing
+plan_solana_momentum <- function() {
 
   list(
 
@@ -32,8 +32,8 @@ plan_solana_momentum <- function() {
     tar_target(
       sol_raw_data,
       {
-        arrow::read_parquet(PARQUET_PATH) |>
-          dplyr::filter(ticker %in% c(SOLANA_UNIVERSE, "BTC")) |>
+        arrow::read_parquet(SOL_PARQUET) |>
+          dplyr::filter(ticker %in% c(SOL_UNIVERSE, "BTC")) |>
           dplyr::select(date, ticker, close) |>
           dplyr::arrange(ticker, date)
       }
@@ -58,8 +58,8 @@ plan_solana_momentum <- function() {
       sol_btc_betas,
       {
         sol_rets_universe <- sol_returns |>
-          dplyr::filter(ticker %in% SOLANA_UNIVERSE)
-        calculate_btc_beta(sol_rets_universe, sol_btc_returns, lookback = BETA_WINDOW)
+          dplyr::filter(ticker %in% SOL_UNIVERSE)
+        calculate_btc_beta(sol_rets_universe, sol_btc_returns, lookback = SOL_BETA_WIN)
       }
     ),
 
@@ -69,7 +69,7 @@ plan_solana_momentum <- function() {
       sol_signals_raw,
       {
         # build_crypto_signals expects BTC in returns for btc_mom calc
-        build_crypto_signals(sol_returns, sol_btc_betas, lookback = LOOKBACK_DAYS)
+        build_crypto_signals(sol_returns, sol_btc_betas, lookback = SOL_LOOKBACK)
       }
     ),
 
@@ -80,13 +80,13 @@ plan_solana_momentum <- function() {
       sol_vol_weights,
       {
         sol_universe_rets <- sol_returns |>
-          dplyr::filter(ticker %in% SOLANA_UNIVERSE)
+          dplyr::filter(ticker %in% SOL_UNIVERSE)
 
         vol_63d <- sol_universe_rets |>
           dplyr::group_by(ticker) |>
           dplyr::arrange(date) |>
           dplyr::mutate(
-            vol_63d = RcppRoll::roll_sd(ret, n = VOL_WINDOW, fill = NA, align = "right")
+            vol_63d = RcppRoll::roll_sd(ret, n = SOL_VOL_WIN, fill = NA, align = "right")
           ) |>
           dplyr::select(date, ticker, vol_63d) |>
           dplyr::filter(!is.na(vol_63d)) |>
@@ -97,12 +97,12 @@ plan_solana_momentum <- function() {
     ),
 
     # 7. Apply vol-adjusted weights to signals
-    #    For each signal × date: compute inv-vol weight normalised within leg
+    #    For each signal x date: compute inv-vol weight normalised within leg
     tar_target(
       sol_signals,
       {
         sol_signals_raw |>
-          dplyr::filter(ticker %in% SOLANA_UNIVERSE) |>
+          dplyr::filter(ticker %in% SOL_UNIVERSE) |>
           dplyr::left_join(sol_vol_weights, by = c("date", "ticker")) |>
           dplyr::group_by(date) |>
           dplyr::mutate(
@@ -129,10 +129,10 @@ plan_solana_momentum <- function() {
       backtest_crypto_momentum(
         signals = sol_signals |>
           dplyr::select(date, ticker, signal = mom_total),
-        returns = sol_returns |> dplyr::filter(ticker %in% SOLANA_UNIVERSE),
-        cost_bps = COST_BPS,
-        n_long = N_LONG,
-        n_short = N_SHORT
+        returns = sol_returns |> dplyr::filter(ticker %in% SOL_UNIVERSE),
+        cost_bps = SOL_COST_BPS,
+        n_long = SOL_N_LONG,
+        n_short = SOL_N_SHORT
       )
     ),
 
@@ -142,10 +142,10 @@ plan_solana_momentum <- function() {
       backtest_crypto_momentum(
         signals = sol_signals |>
           dplyr::select(date, ticker, signal = mom_btc_adj),
-        returns = sol_returns |> dplyr::filter(ticker %in% SOLANA_UNIVERSE),
-        cost_bps = COST_BPS,
-        n_long = N_LONG,
-        n_short = N_SHORT
+        returns = sol_returns |> dplyr::filter(ticker %in% SOL_UNIVERSE),
+        cost_bps = SOL_COST_BPS,
+        n_long = SOL_N_LONG,
+        n_short = SOL_N_SHORT
       )
     ),
 
@@ -155,10 +155,10 @@ plan_solana_momentum <- function() {
       backtest_crypto_momentum(
         signals = sol_signals |>
           dplyr::select(date, ticker, signal = mom_residual),
-        returns = sol_returns |> dplyr::filter(ticker %in% SOLANA_UNIVERSE),
-        cost_bps = COST_BPS,
-        n_long = N_LONG,
-        n_short = N_SHORT
+        returns = sol_returns |> dplyr::filter(ticker %in% SOL_UNIVERSE),
+        cost_bps = SOL_COST_BPS,
+        n_long = SOL_N_LONG,
+        n_short = SOL_N_SHORT
       )
     ),
 
@@ -168,10 +168,10 @@ plan_solana_momentum <- function() {
       backtest_weekly_momentum(
         signals = sol_signals |>
           dplyr::select(date, ticker, signal = mom_total),
-        returns = sol_returns |> dplyr::filter(ticker %in% SOLANA_UNIVERSE),
-        cost_bps = COST_BPS,
-        n_long = N_LONG,
-        n_short = N_SHORT
+        returns = sol_returns |> dplyr::filter(ticker %in% SOL_UNIVERSE),
+        cost_bps = SOL_COST_BPS,
+        n_long = SOL_N_LONG,
+        n_short = SOL_N_SHORT
       )
     ),
 
@@ -181,10 +181,10 @@ plan_solana_momentum <- function() {
       backtest_weekly_momentum(
         signals = sol_signals |>
           dplyr::select(date, ticker, signal = mom_btc_adj),
-        returns = sol_returns |> dplyr::filter(ticker %in% SOLANA_UNIVERSE),
-        cost_bps = COST_BPS,
-        n_long = N_LONG,
-        n_short = N_SHORT
+        returns = sol_returns |> dplyr::filter(ticker %in% SOL_UNIVERSE),
+        cost_bps = SOL_COST_BPS,
+        n_long = SOL_N_LONG,
+        n_short = SOL_N_SHORT
       )
     ),
 
@@ -194,10 +194,10 @@ plan_solana_momentum <- function() {
       backtest_weekly_momentum(
         signals = sol_signals |>
           dplyr::select(date, ticker, signal = mom_residual),
-        returns = sol_returns |> dplyr::filter(ticker %in% SOLANA_UNIVERSE),
-        cost_bps = COST_BPS,
-        n_long = N_LONG,
-        n_short = N_SHORT
+        returns = sol_returns |> dplyr::filter(ticker %in% SOL_UNIVERSE),
+        cost_bps = SOL_COST_BPS,
+        n_long = SOL_N_LONG,
+        n_short = SOL_N_SHORT
       )
     ),
 
@@ -295,8 +295,8 @@ plan_solana_momentum <- function() {
           ggplot2::labs(
             title = paste0(
               "Solana Momentum Decomposition: Cumulative Net Returns\n",
-              "Universe: ", paste(SOLANA_UNIVERSE, collapse = ", "),
-              " | Cost: ", COST_BPS, "bps | Lookback: ", LOOKBACK_DAYS, "d"
+              "Universe: ", paste(SOL_UNIVERSE, collapse = ", "),
+              " | Cost: ", SOL_COST_BPS, "bps | Lookback: ", SOL_LOOKBACK, "d"
             ),
             x    = NULL,
             y    = "Cumulative Return (net of costs)",

--- a/R/plan_solana_momentum.R
+++ b/R/plan_solana_momentum.R
@@ -21,7 +21,7 @@ SOL_LEVERAGE   <- 1.0    # unleveraged (configurable)
 SOL_COST_BPS   <- 30L    # 0.3% per trade
 SOL_N_LONG     <- 2L     # longs in 4-token universe
 SOL_N_SHORT    <- 2L     # shorts in 4-token universe
-SOL_PARQUET    <- "/Users/johngavin/docs_gh/proj/finance/data/historical-crypto/data/raw/crypto_all.parquet"
+SOL_PARQUET    <- here::here("data", "raw", "crypto_all.parquet")
 SOL_VOL_WIN    <- 63L    # 63-day vol for position sizing
 
 plan_solana_momentum <- function() {

--- a/R/solana_defi_data.R
+++ b/R/solana_defi_data.R
@@ -1,0 +1,282 @@
+# Solana DeFi Data Pipeline
+#
+# Fetches spot and perp data from Solana DeFi protocols
+# Target frequency: 4-hourly for signal generation, daily for backtesting
+#
+# Data sources:
+# - Birdeye API: Spot prices (all SPL tokens)
+# - Drift Protocol: Perp prices + funding rates
+# - Pyth Network: Oracle prices (cross-asset reference)
+
+#' Fetch Solana token spot prices from Birdeye
+#'
+#' @param tokens Character vector of token symbols (e.g., "SOL", "RAY", "BONK")
+#' @param start_date Date, start of historical period
+#' @param end_date Date, end of historical period
+#' @param interval Character, "1D" (daily), "4H", "1H", "15m"
+#' @param api_key Character, Birdeye API key (free tier: 100/day, paid: unlimited)
+#'
+#' @return tibble with columns: ticker, timestamp, open, high, low, close, volume
+#'
+#' @details
+#' Birdeye aggregates prices across all Solana DEXs (Orca, Raydium, Jupiter).
+#' Free tier sufficient for daily/4H backtests. Paid tier needed for minute-level.
+#'
+#' Token mint addresses (required for API):
+#' - SOL: So11111111111111111111111111111111111111112
+#' - RAY: 4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R
+#' - BONK: DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263
+#' - JUP: JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN
+#' - PYTH: HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3
+#'
+fetch_birdeye_spot <- function(tokens, start_date, end_date,
+                               interval = c("1D", "4H", "1H", "15m"),
+                               api_key = Sys.getenv("BIRDEYE_API_KEY")) {
+
+  interval <- match.arg(interval)
+
+  # Token mint address mapping (expand as needed)
+  mint_map <- c(
+    "SOL" = "So11111111111111111111111111111111111111112",
+    "RAY" = "4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R",
+    "BONK" = "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+    "JUP" = "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
+    "PYTH" = "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3",
+    "ORCA" = "orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE",
+    "JTO" = "jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL",
+    "HNT" = "hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux"
+  )
+
+  start_unix <- as.numeric(as.POSIXct(start_date))
+  end_unix <- as.numeric(as.POSIXct(end_date))
+
+  results <- purrr::map_dfr(tokens, function(token) {
+    mint <- mint_map[[token]]
+    if (is.null(mint)) {
+      cli::cli_warn("Unknown token {token}, skipping")
+      return(NULL)
+    }
+
+    url <- sprintf(
+      "https://public-api.birdeye.so/defi/ohlcv?address=%s&type=%s&time_from=%d&time_to=%d",
+      mint, interval, start_unix, end_unix
+    )
+
+    resp <- httr2::request(url) |>
+      httr2::req_headers("X-API-KEY" = api_key) |>
+      httr2::req_perform() |>
+      httr2::resp_body_json()
+
+    if (!is.null(resp$data$items)) {
+      tibble::tibble(
+        ticker = token,
+        timestamp = as.POSIXct(purrr::map_dbl(resp$data$items, "unixTime"), origin = "1970-01-01"),
+        open = purrr::map_dbl(resp$data$items, "o"),
+        high = purrr::map_dbl(resp$data$items, "h"),
+        low = purrr::map_dbl(resp$data$items, "l"),
+        close = purrr::map_dbl(resp$data$items, "c"),
+        volume = purrr::map_dbl(resp$data$items, "v")
+      )
+    } else {
+      cli::cli_warn("No data for {token}")
+      NULL
+    }
+  })
+
+  results
+}
+
+#' Fetch Drift Protocol perpetual prices and funding rates
+#'
+#' @param markets Character vector of Drift market symbols (e.g., "SOL-PERP", "BTC-PERP")
+#' @param start_date Date, start of historical period
+#' @param end_date Date, end of historical period
+#'
+#' @return tibble with columns: market, timestamp, mark_price, funding_rate, open_interest
+#'
+#' @details
+#' Drift Protocol S3 bucket: drift-historical-data-v2.s3.eu-west-1.amazonaws.com
+#'
+#' Market IDs (as of 2024):
+#' - 0: SOL-PERP
+#' - 1: BTC-PERP
+#' - 2: ETH-PERP
+#' - 16: BONK-PERP
+#' - 18: JUP-PERP
+#' - 24: PYTH-PERP
+#'
+#' Funding rates: Updated hourly, stored as CSV per month
+#'
+fetch_drift_perps <- function(markets, start_date, end_date) {
+
+  # Market ID mapping (expand from Drift docs)
+  market_ids <- c(
+    "SOL-PERP" = 0,
+    "BTC-PERP" = 1,
+    "ETH-PERP" = 2,
+    "BONK-PERP" = 16,
+    "JUP-PERP" = 18,
+    "PYTH-PERP" = 24,
+    "RAY-PERP" = 20  # Example, verify from Drift
+  )
+
+  # Generate month sequence for data fetch
+  months <- seq(
+    lubridate::floor_date(start_date, "month"),
+    lubridate::floor_date(end_date, "month"),
+    by = "month"
+  )
+
+  results <- purrr::map_dfr(markets, function(market) {
+    market_id <- market_ids[[market]]
+    if (is.null(market_id)) {
+      cli::cli_warn("Unknown Drift market {market}, skipping")
+      return(NULL)
+    }
+
+    purrr::map_dfr(months, function(month) {
+      month_str <- format(month, "%Y-%m")
+
+      # Funding rate CSV
+      url <- sprintf(
+        "https://drift-historical-data-v2.s3.eu-west-1.amazonaws.com/program/dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH/market/%d/fundingRate/fundingRate-%d-%s.csv",
+        market_id, market_id, month_str
+      )
+
+      tryCatch({
+        df <- readr::read_csv(url, show_col_types = FALSE) |>
+          dplyr::mutate(
+            market = market,
+            timestamp = as.POSIXct(ts / 1000, origin = "1970-01-01")  # Drift uses ms
+          ) |>
+          dplyr::select(market, timestamp, funding_rate = fundingRateLong,
+                       mark_price = markPriceBefore, open_interest = baseAssetAmountWithAmm)
+
+        df
+      }, error = function(e) {
+        cli::cli_warn("Failed to fetch {market} for {month_str}: {e$message}")
+        NULL
+      })
+    })
+  })
+
+  results |>
+    dplyr::filter(timestamp >= start_date, timestamp <= end_date)
+}
+
+#' Calculate liquidity metrics for Solana tokens
+#'
+#' @param spot_data tibble from fetch_birdeye_spot()
+#' @param perp_data tibble from fetch_drift_perps()
+#' @param min_daily_volume Numeric, minimum daily volume (USD) for liquidity filter
+#'
+#' @return tibble with columns: ticker, avg_daily_volume_spot, avg_daily_volume_perp,
+#'   liquidity_ratio (perp/spot), is_liquid
+#'
+#' @details
+#' Liquidity criteria:
+#' - Min daily volume: $1M spot, $1M perp
+#' - Liquidity ratio: perp volume should be 50-200% of spot (similar liquidity)
+#' - Max spread: <0.5% (spot-perp basis)
+#'
+calculate_liquidity_metrics <- function(spot_data, perp_data,
+                                       min_daily_volume = 1e6) {
+
+  spot_liquidity <- spot_data |>
+    dplyr::group_by(ticker) |>
+    dplyr::summarise(
+      avg_daily_volume_spot = mean(volume * close, na.rm = TRUE),
+      .groups = "drop"
+    )
+
+  perp_liquidity <- perp_data |>
+    dplyr::mutate(ticker = sub("-PERP", "", market)) |>
+    dplyr::group_by(ticker) |>
+    dplyr::summarise(
+      avg_daily_volume_perp = mean(open_interest * mark_price, na.rm = TRUE),
+      .groups = "drop"
+    )
+
+  spot_liquidity |>
+    dplyr::left_join(perp_liquidity, by = "ticker") |>
+    dplyr::mutate(
+      avg_daily_volume_perp = tidyr::replace_na(avg_daily_volume_perp, 0),
+      liquidity_ratio = avg_daily_volume_perp / avg_daily_volume_spot,
+      is_liquid = avg_daily_volume_spot >= min_daily_volume &
+                  avg_daily_volume_perp >= min_daily_volume &
+                  liquidity_ratio >= 0.5 &
+                  liquidity_ratio <= 2.0
+    )
+}
+
+#' Build momentum signals with configurable parameters
+#'
+#' @param returns tibble with columns: ticker, date, return
+#' @param btc_returns tibble with columns: date, btc_return
+#' @param lookback_days Numeric, momentum lookback period (default 252 = 12 months)
+#' @param beta_window Numeric, rolling window for BTC beta estimation (default 252)
+#' @param vol_adjust Logical, whether to use volatility-adjusted position sizing
+#' @param leverage Numeric, leverage multiplier (default 1.0 = unleveraged)
+#'
+#' @return tibble with columns: ticker, date, baseline_mom, btc_adj_mom, residual_mom,
+#'   btc_beta, position_size
+#'
+build_momentum_signals <- function(returns, btc_returns,
+                                  lookback_days = 252,
+                                  beta_window = 252,
+                                  vol_adjust = TRUE,
+                                  leverage = 1.0) {
+
+  # Join returns with BTC
+  data <- returns |>
+    dplyr::left_join(btc_returns, by = "date")
+
+  # Calculate rolling moments
+  signals <- data |>
+    dplyr::group_by(ticker) |>
+    dplyr::arrange(date) |>
+    dplyr::mutate(
+      # Baseline momentum (trailing return)
+      baseline_mom = RcppRoll::roll_sum(return, n = lookback_days, fill = NA, align = "right"),
+
+      # BTC momentum
+      btc_mom = RcppRoll::roll_sum(btc_return, n = lookback_days, fill = NA, align = "right"),
+
+      # Rolling BTC beta
+      cov_crypto_btc = RcppRoll::roll_cov(return, btc_return, n = beta_window, fill = NA, align = "right"),
+      var_btc = RcppRoll::roll_var(btc_return, n = beta_window, fill = NA, align = "right"),
+      btc_beta = cov_crypto_btc / var_btc,
+
+      # BTC-adjusted momentum
+      btc_adj_mom = baseline_mom - (btc_beta * btc_mom),
+
+      # Residual-only momentum (regress out BTC)
+      residual = return - (btc_beta * btc_return),
+      residual_mom = RcppRoll::roll_sum(residual, n = lookback_days, fill = NA, align = "right"),
+
+      # Volatility (for position sizing)
+      vol_252 = RcppRoll::roll_sd(return, n = 252, fill = NA, align = "right")
+    ) |>
+    dplyr::ungroup()
+
+  # Position sizing
+  if (vol_adjust) {
+    signals <- signals |>
+      dplyr::group_by(date) |>
+      dplyr::mutate(
+        # Inverse volatility weighting
+        inv_vol = 1 / vol_252,
+        inv_vol_sum = sum(inv_vol, na.rm = TRUE),
+        position_size = (inv_vol / inv_vol_sum) * leverage
+      ) |>
+      dplyr::ungroup() |>
+      dplyr::select(-inv_vol, -inv_vol_sum)
+  } else {
+    signals <- signals |>
+      dplyr::mutate(position_size = leverage / dplyr::n_distinct(ticker))
+  }
+
+  signals |>
+    dplyr::select(ticker, date, baseline_mom, btc_adj_mom, residual_mom,
+                 btc_beta, vol_252, position_size)
+}

--- a/docs/_targets.R
+++ b/docs/_targets.R
@@ -31,6 +31,7 @@ pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 # source(here::here("R/regime_correlations.R"))
 # source(here::here("R/tail_keff.R"))
 source(here::here("R/vvix_analysis.R"))
+source(here::here("R/crypto_momentum_helpers.R"))
 
 # Source canonical backtest annualisation helper (annualise_returns()) — used by plan_kelly_variants + plan_etf_replication
 source(here::here("R/utils_metrics.R"))
@@ -119,6 +120,7 @@ source(here::here("R/plan_regime_momentum.R"))
 source(here::here("R/plan_zakamulin_allocation.R"))
 source(here::here("R/plan_commodities_momentum.R"))
 source(here::here("R/plan_crypto_momentum.R"))
+source(here::here("R/plan_solana_momentum.R"))
 
 # Combine: strategy_names FIRST, then partitions, strategies, portfolio, ETF replication, leaderboard, QA
 c(plan_strategy_names(),
@@ -159,6 +161,7 @@ c(plan_strategy_names(),
   plan_zakamulin_allocation(),
   plan_commodities_momentum(),
   plan_crypto_momentum(),
+  plan_solana_momentum(),
 
   # Phase 1 of #149: date-type consistency across all registered datasets.
   # tar_target_raw + explicit deps so targets schedules dv_join_key_types

--- a/docs/vignette-shared.css
+++ b/docs/vignette-shared.css
@@ -56,10 +56,17 @@ table caption, .dataTables_wrapper caption { caption-side: top !important; }
   word-wrap: break-word; overflow-wrap: break-word;
   max-width: 100%;
 }
-table caption, .dataTables_wrapper caption {
+table caption, .dataTables_wrapper caption, .dt-caption {
   word-wrap: break-word; overflow-wrap: break-word;
   white-space: normal !important; max-width: 100%;
   color: #ffffff !important;
+}
+[data-bs-theme="light"] table caption,
+[data-bs-theme="light"] .dataTables_wrapper caption {
+  color: #1a1a1a !important;
+}
+@media (prefers-color-scheme: light) {
+  table caption, .dataTables_wrapper caption { color: #1a1a1a !important; }
 }
 
 /* Click-to-zoom overlay */

--- a/docs/vignette-shared.css
+++ b/docs/vignette-shared.css
@@ -51,7 +51,7 @@ table caption, .dataTables_wrapper caption { caption-side: top !important; }
 
 /* Captions: wrap text to window width */
 .fig-caption {
-  display: block; font-size: 0.85em; color: #888;
+  display: block; font-size: 0.85em; color: #ffffff;
   margin-top: 0.4em; text-align: left; line-height: 1.5;
   word-wrap: break-word; overflow-wrap: break-word;
   max-width: 100%;
@@ -59,6 +59,7 @@ table caption, .dataTables_wrapper caption { caption-side: top !important; }
 table caption, .dataTables_wrapper caption {
   word-wrap: break-word; overflow-wrap: break-word;
   white-space: normal !important; max-width: 100%;
+  color: #ffffff !important;
 }
 
 /* Click-to-zoom overlay */

--- a/docs/vignette_utils.R
+++ b/docs/vignette_utils.R
@@ -141,7 +141,7 @@ hd_dt <- function(df, caption_text) {
   DT::datatable(
     df,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #888;",
+      style = "caption-side: top; text-align: left; font-weight: bold; color: #ffffff;",
       caption_text
     ),
     rownames = FALSE,

--- a/docs/vignette_utils.R
+++ b/docs/vignette_utils.R
@@ -141,7 +141,8 @@ hd_dt <- function(df, caption_text) {
   DT::datatable(
     df,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #ffffff;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
+      class = "dt-caption",
       caption_text
     ),
     rownames = FALSE,

--- a/knowledge/INDEX.md
+++ b/knowledge/INDEX.md
@@ -5,6 +5,17 @@ Cross-cutting patterns live in `~/docs_gh/llm/knowledge/`.
 
 ## Wiki Pages
 
+### Research Findings
+
+- [Momentum Decomposition (Cross-Asset)](wiki/momentum-decomposition-cross-asset.md) — 30-hour research: FAILED in equities/commodities, SUCCESS in crypto, regime-aware baseline shows promise
+- [JST-DMS Comparison](wiki/jst-dms-comparison.md) — Free alternative to DMS, survivorship bias correction, multi-decade underperformance norms
+- [TAA Selection Research](wiki/taa-selection-research.md) — Tactical asset allocation strategy selection
+- [Regime Trend Following](wiki/regime-trend-following.md) — Regime-dependent trend following analysis
+- [Macrosynergy Research](wiki/macrosynergy-research.md) — Macrosynergy macro signal research
+- [Market Behavior Gap Analysis](wiki/market-behavior-gap-analysis.md) — Market behavior coverage gaps
+
+### Data Sources & Signals
+
 - [ECB Data](wiki/ecb-data.md) — 29 series, API quirks, frequency mismatches, CISS sub-indices
 - [Guardian NLP](wiki/guardian-nlp.md) — Keyword counts and sentimentr body text: no predictive signal
 - [CISS Stress Analysis](wiki/ciss-stress.md) — Sub-market decomposition, VIX correlations, regime proxy

--- a/knowledge/INDEX.md
+++ b/knowledge/INDEX.md
@@ -7,7 +7,7 @@ Cross-cutting patterns live in `~/docs_gh/llm/knowledge/`.
 
 ### Research Findings
 
-- [Momentum Decomposition (Cross-Asset)](wiki/momentum-decomposition-cross-asset.md) — 30-hour research: FAILED in equities/commodities, SUCCESS in crypto, regime-aware baseline shows promise
+- [Momentum Decomposition (Cross-Asset)](wiki/momentum-decomposition-cross-asset.md) — 20-hour research: FAILED in equities/commodities, pipeline complete in crypto, regime-aware baseline shows promise
 - [JST-DMS Comparison](wiki/jst-dms-comparison.md) — Free alternative to DMS, survivorship bias correction, multi-decade underperformance norms
 - [TAA Selection Research](wiki/taa-selection-research.md) — Tactical asset allocation strategy selection
 - [Regime Trend Following](wiki/regime-trend-following.md) — Regime-dependent trend following analysis

--- a/knowledge/wiki/momentum-decomposition-cross-asset.md
+++ b/knowledge/wiki/momentum-decomposition-cross-asset.md
@@ -1,0 +1,159 @@
+# Cross-Asset Momentum Decomposition Findings
+
+**Date:** 2026-05-11
+**Context:** Issues #121, #123, #134, #135
+**Conclusion:** GLOBAL ABANDON
+
+## Summary
+
+Tested momentum decomposition across three asset classes. Found universal failure:
+- Equities: Decomposition destroyed value
+- Commodities: Both baseline AND decomposition failed
+- Crypto: Pipeline error (incomplete)
+
+## Evidence
+
+### US Equities (Issue #121, #123)
+- Sample: 529 stocks, 2000-2026, monthly
+- Baseline (Total 12m): Net Sharpe +0.05, Gross +0.07, Turnover 8%
+- Decomposed strategies (Paper, Data-Driven, Conservative):
+  - Net Sharpe: **-0.34 to -0.39** (ALL NEGATIVE)
+  - Gross Sharpe: -0.23 to -0.28
+  - Turnover: 26-27% (3.3× higher)
+- Regime test (Issue #123): Decomposition failed in ALL regimes (Calm/Elevated/Spike)
+- Root causes:
+  1. Turnover explosion (3.3×) overwhelmed weak signals
+  2. Signal dilution: Breaking covariance structure destroyed information
+  3. Baseline too weak (Sharpe 0.05) to optimize
+
+### Commodities (Issue #134, PR #137)
+- Sample: 37 series, 1992-2026, monthly
+- Baseline (12m): Net Sharpe **-0.85**, Gross -0.75
+- Decomposed (Short+Long, Vol-Filtered, Trend-Filtered):
+  - Net Sharpe: **-0.89 to -0.91** (WORSE than baseline)
+  - Gross Sharpe: -0.79 to -0.80
+  - Turnover: 10.7-10.9% (no explosion like equities)
+- **Critical finding:** Baseline momentum itself doesn't work in commodities
+  - Even gross Sharpe (before costs) is deeply negative
+  - Simpler structure (no industries) didn't help
+  - Economic carry decomposition (roll yield) unavailable in dataset
+
+### Crypto (Issue #135, PR #136)
+- Sample: 14 tickers, 2014-2026 (attempted)
+- Result: Data loading error (DuckDB schema issue)
+- Status: Implementation complete, debugging required for completeness
+- Expected outcome: Likely negative given pattern in equities and commodities
+
+## Implications
+
+### 1. Momentum Decomposition is Fundamentally Broken
+- Failed in equities (complex structure)
+- Failed in commodities (simple structure)
+- No asset class evidence supports decomposition
+
+### 2. Momentum Itself May Be Weak Cross-Asset
+- Equities: Barely positive (Sharpe 0.05)
+- Commodities: Deeply negative (Sharpe -0.85)
+- Crypto: Unknown (pipeline error)
+- Contrast with academic literature showing robust momentum in equities
+
+### 3. Regime-Conditional Baseline Shows Promise
+- From Issue #123: Baseline momentum in VIX calm regime (VIX <20, 65% of time)
+  - Sharpe: +0.63 (vs 0.05 always-invested)
+  - This is the actionable finding from momentum research
+
+## Recommendations
+
+### Immediate
+1. **ABANDON momentum decomposition** globally - no supporting evidence
+2. **Close Issue #121** (equity decomposition) - complete, failed
+3. **Close Issue #123** (regime analysis) - complete, no regime rescues decomposition
+4. **Close Issue #134** (commodities test) - complete, failed
+5. **Close Issue #135** (crypto test) - incomplete but conclusion clear
+
+### Strategic
+1. **Focus on proven cross-asset factors:**
+   - Value (robust across equities, credit, FX)
+   - Carry (robust in FX, rates, commodities)
+   - Quality (robust in equities)
+2. **If momentum required:** Use total return ONLY, never decompose
+3. **Pursue regime-aware baseline momentum:**
+   - Zakamulin continuous allocation by VIX regime
+   - Exploit calm-regime Sharpe 0.63 (vs 0.05 always-invested)
+4. **Investigate mean reversion in commodities:**
+   - If momentum fails (Sharpe -0.85), test mean reversion
+   - Commodities have backwardation/contango cycles
+   - May exhibit mean reversion instead of momentum
+
+## Related Research
+
+### Papers Referenced
+- De Boer, Gao, Montminy (2025) "Momentum Decomposition" SSRN 5716502
+  - Showed decomposition methodology for equities
+  - We replicated and extended to cross-asset
+  - Found no supporting evidence in any asset class
+
+### Academic Momentum Literature
+- Jegadeesh & Titman (1993): Original momentum premium (~1% monthly, 1965-1989)
+- Our finding: Sharpe 0.05 (2000-2026)
+- Possible explanations:
+  1. Sample period difference (post-2000 vs 1960s-1980s)
+  2. Momentum crowding (more capital chasing same signals)
+  3. Transaction costs evolved (spreads tighter but HFT competition)
+  4. Market efficiency improved (information faster)
+
+## ROI Tracking
+
+| Issue | Expected Sharpe | Actual Sharpe | Delta | Effort | ROI |
+|-------|----------------|---------------|-------|--------|-----|
+| #121 | +0.10 to +0.20 | **-0.34 to -0.39** | -0.45 to -0.59 | 8h | NEGATIVE |
+| #123 | Rescue via regime | **No rescue (0/9 positive)** | Confirmed failure | 4h | NEGATIVE |
+| #134 | Test commodities | **-0.89 to -0.91** | Worse than equities | 5h | NEGATIVE (valuable) |
+| #135 | Test crypto | Pipeline error | Incomplete | 3h | INCOMPLETE |
+
+**Total effort:** 20 hours
+**Value:** Definitive negative result - prevents future wasted effort on decomposition
+
+## Confidence
+
+- ✅ **High confidence (>95%):** Decomposition doesn't work in equities or commodities
+- ✅ **Medium confidence (70-80%):** Baseline momentum is weak cross-asset in our sample
+- ✅ **High confidence (>90%):** Regime-aware baseline momentum shows promise (Sharpe 0.63 in calm)
+- ⚠️ **Low confidence (<50%):** Mean reversion in commodities (untested hypothesis)
+
+## Status: COMPLETE (2026-05-11)
+
+All research objectives achieved:
+- ✅ Crypto pipeline debugged and completed (PR #136 merged)
+- ✅ Issue #138 created: Test mean reversion in commodities
+- ✅ Zakamulin regime-aware allocation implemented (PR #139, #140 merged)
+- ✅ Issue #127 (ROI tracker) updated with complete cross-asset findings
+- ✅ CHANGELOG.md updated with comprehensive research summary
+
+## Future Work
+
+1. **Crypto Phase 2**: Test perpetuals + funding rate carry decomposition (requires Binance/Bybit API)
+2. **Mean reversion in commodities**: Pursue Issue #138 follow-up
+3. **Multi-factor integration**: Apply Zakamulin regime allocation to value/quality/carry blends
+4. **Academic comparison**: Compare our post-2000 equity findings to Jegadeesh & Titman 1965-1989 results
+
+---
+
+## Sources
+
+- [Issue #121](https://github.com/JohnGavin/historical/issues/121): Equity momentum decomposition (CLOSED - FAILED)
+- [Issue #123](https://github.com/JohnGavin/historical/issues/123): Regime-dependent momentum analysis (CLOSED - no rescue, calm-regime insight)
+- [Issue #134](https://github.com/JohnGavin/historical/issues/134): Commodities momentum test (CLOSED - FAILED)
+- [Issue #135](https://github.com/JohnGavin/historical/issues/135): Crypto momentum test (CLOSED - SUCCESS)
+- [Issue #138](https://github.com/JohnGavin/historical/issues/138): Mean reversion follow-up (OPEN)
+- [PR #137](https://github.com/JohnGavin/historical/pull/137): Commodities implementation (MERGED)
+- [PR #136](https://github.com/JohnGavin/historical/pull/136): Crypto implementation (MERGED - debugging complete)
+- [PR #139](https://github.com/JohnGavin/historical/pull/139): Zakamulin allocation (MERGED)
+- [PR #140](https://github.com/JohnGavin/historical/pull/140): ROI tracker update (MERGED)
+- De Boer, Gao, Montminy (2025) "Momentum Decomposition" SSRN 5716502
+- Jegadeesh & Titman (1993) "Returns to Buying Winners and Selling Losers"
+
+**Confidence markers:**
+- ✅ Confirmed via backtests (2 asset classes, 1992-2026)
+- ⚠️ Sample-specific findings (post-2000 for equities, full sample for commodities)
+- ❌ Contradicts some academic literature (Jegadeesh & Titman momentum premium)

--- a/knowledge/wiki/momentum-decomposition-cross-asset.md
+++ b/knowledge/wiki/momentum-decomposition-cross-asset.md
@@ -9,7 +9,7 @@
 Tested momentum decomposition across three asset classes. Found universal failure:
 - Equities: Decomposition destroyed value
 - Commodities: Both baseline AND decomposition failed
-- Crypto: Pipeline error (incomplete)
+- Crypto: Pipeline debugged and completed (PR #136 merged); result expected negative given cross-asset pattern
 
 ## Evidence
 
@@ -39,10 +39,10 @@ Tested momentum decomposition across three asset classes. Found universal failur
   - Economic carry decomposition (roll yield) unavailable in dataset
 
 ### Crypto (Issue #135, PR #136)
-- Sample: 14 tickers, 2014-2026 (attempted)
-- Result: Data loading error (DuckDB schema issue)
-- Status: Implementation complete, debugging required for completeness
-- Expected outcome: Likely negative given pattern in equities and commodities
+- Sample: 14 tickers, 2014-2026
+- Result: Pipeline debugged (DuckDB schema issue resolved, PR #136 merged); quantitative result not reported separately
+- Status: Complete — closed as SUCCESS (pipeline ran end-to-end)
+- Expected outcome: Likely negative given universal failure pattern in equities and commodities
 
 ## Implications
 
@@ -54,8 +54,10 @@ Tested momentum decomposition across three asset classes. Found universal failur
 ### 2. Momentum Itself May Be Weak Cross-Asset
 - Equities: Barely positive (Sharpe 0.05)
 - Commodities: Deeply negative (Sharpe -0.85)
-- Crypto: Unknown (pipeline error)
+- Crypto: Pipeline completed; quantitative Sharpe not separately reported here
 - Contrast with academic literature showing robust momentum in equities
+
+> ⚠ AI-inferred: The inference that "momentum is weak cross-asset" extrapolates two asset classes to a general claim. Equities (Sharpe 0.05) and commodities (Sharpe -0.85) are confirmed; crypto and other asset classes are not.
 
 ### 3. Regime-Conditional Baseline Shows Promise
 - From Issue #123: Baseline momentum in VIX calm regime (VIX <20, 65% of time)
@@ -69,7 +71,7 @@ Tested momentum decomposition across three asset classes. Found universal failur
 2. **Close Issue #121** (equity decomposition) - complete, failed
 3. **Close Issue #123** (regime analysis) - complete, no regime rescues decomposition
 4. **Close Issue #134** (commodities test) - complete, failed
-5. **Close Issue #135** (crypto test) - incomplete but conclusion clear
+5. **Close Issue #135** (crypto test) - pipeline complete (PR #136 merged, CLOSED - SUCCESS)
 
 ### Strategic
 1. **Focus on proven cross-asset factors:**
@@ -109,7 +111,7 @@ Tested momentum decomposition across three asset classes. Found universal failur
 | #121 | +0.10 to +0.20 | **-0.34 to -0.39** | -0.45 to -0.59 | 8h | NEGATIVE |
 | #123 | Rescue via regime | **No rescue (0/9 positive)** | Confirmed failure | 4h | NEGATIVE |
 | #134 | Test commodities | **-0.89 to -0.91** | Worse than equities | 5h | NEGATIVE (valuable) |
-| #135 | Test crypto | Pipeline error | Incomplete | 3h | INCOMPLETE |
+| #135 | Test crypto | Pipeline debugged, end-to-end run | Complete | 3h | COMPLETE (pipeline) |
 
 **Total effort:** 20 hours
 **Value:** Definitive negative result - prevents future wasted effort on decomposition


### PR DESCRIPTION
## Summary

Salvages R source code, CI workflow fixes, and documentation from the `sonnet-0508` branch, **excluding all `data/raw/*.parquet` binary blobs** (regenerable from sources).

This PR replaces the `sonnet-0508` branch per the historical#238 salvage audit.

---

## Commits Applied (INCLUDE — 8 commits)

| SHA | Original commit | Files |
|-----|----------------|-------|
| `fad12d3` (was `7ca0ab3`) | fix: create data/raw directory before poll | `.github/workflows/data-poll.yml` |
| `d6e1a96` (was `8afc08c`) | fix: add system deps for curl and fs packages | `.github/workflows/data-poll.yml` |
| `5e8c18c` (was `b548e41`) | docs: cross-asset momentum decomposition research complete | `CHANGELOG.md` |
| `2b1700b` (was `15e64d7`) | docs: add momentum decomposition cross-asset wiki page | `knowledge/wiki/momentum-decomposition-cross-asset.md`, `knowledge/INDEX.md` |
| `22311fe` (was `1a5ec02`) | feat: Solana DeFi momentum implementation (DeFi-only) | `R/plan_solana_momentum.R`, `R/solana_defi_data.R` |
| `3052f5b` (was `1eff05a`) | feat: Solana-only momentum PoC (SOL/RAY/BONK/HNT, weekly + monthly backtest) | `R/crypto_momentum_helpers.R`, `R/plan_solana_momentum.R`, `docs/_targets.R` |
| `bd117ef` (was `b071570`) | fix: move Solana plan constants to file scope for targets workers | `R/plan_solana_momentum.R` |
| `15aa081` (was `65ae930`) | **fix: change all caption text from gray to pure white** (dark-mode contrast) | `docs/vignette_utils.R`, `docs/vignette-shared.css` |

---

## Commits Skipped — Already in HEAD (already-applied, 8 commits)

These commits applied as empty (HEAD was already a superset):

- `c434355` — fix: weekly poll missing deps + kalshi safe_num (deps already in HEAD; kalshi fix already in HEAD)
- `3fcc604` — feat: VVIX analysis functions (R/plan_vvix.R, R/vvix_analysis.R already in HEAD)
- `7c77110` — feat: wire VVIX and Tier 1 integrations to docs pipeline (docs/_targets.R already had these)
- `66824ea` — fix: force-add gitignored data/raw + add historicaldata deps (already in HEAD)
- `0aa4e09` — fix: add contents write permission for git push (already in HEAD)
- `35ce5a1` — fix: add git pull --rebase before push (already in HEAD, HEAD uses dynamic `${{ github.ref_name }}`)
- `8ac51ce` — fix: rebase from current branch (already in HEAD)
- `531a58d` — docs: deploy JST Macrohistory dashboard + wiki (already in HEAD)

---

## Commits Skipped — Pure Data Blobs (5 commits, EXCLUDED by design)

- `4b9187f` — data: ecb 2026-05-09 (`data/raw/ecb_series.parquet`, 1.7MB)
- `0b89897` — data: commodities 2026-05-09 (`data/raw/commodities.parquet`, 724KB)
- `8c3390c` — data: kalshi 2026-05-09 (`data/raw/kalshi_fomc.parquet`, 5KB)
- `f44c5ed` — data: cboe_vol 2026-05-09 (`data/raw/cboe_vol.parquet`, 1.3MB)
- `7dc90ab` — data: guardian 2026-05-09 (`data/raw/guardian_monthly.parquet`, 3KB)

Data parquet files were **intentionally excluded** — they are regenerable from sources via the weekly data-poll workflow (`.github/workflows/data-poll.yml`).

---

## Commits Skipped — Session-End Docs (1 commit)

- `fb16a8f` — chore: session-end 2026-05-09 CHANGELOG + CURRENT_WORK: **skipped** (semantic conflict with HEAD's more current 2026-05-20 session content; research notes already captured in `5e8c18c`)

---

## Verification

- `git diff main -- "*.parquet"`: empty (no parquet changes)
- `parse("docs/_targets.R")`: OK (includes `plan_solana_momentum`)
- `parse("R/crypto_momentum_helpers.R")`: OK
- `parse("R/plan_solana_momentum.R")`: OK
- `parse("R/solana_defi_data.R")`: OK
- `pkgload::load_all()`: requires project flake.nix (not testable without `nix develop`)

---

## Key Files

- `R/crypto_momentum_helpers.R` — new: crypto momentum helper functions
- `R/plan_solana_momentum.R` — new: Solana/DeFi momentum targets plan
- `R/solana_defi_data.R` — new: Solana DeFi data fetching
- `docs/vignette_utils.R` — accessibility fix: caption color `#888` → `#ffffff`
- `docs/vignette-shared.css` — accessibility: caption color applied cleanly
- `knowledge/wiki/momentum-decomposition-cross-asset.md` — new wiki page

🤖 Generated with [Claude Code](https://claude.com/claude-code)