### PR TITLE
fix(scripts): guard metadata_helpers import path — roborev main-backlog cleanup

### DIFF
--- a/scripts/fetch_metadata.py
+++ b/scripts/fetch_metadata.py
@@ -22,6 +22,14 @@ try:
 except ImportError:
     sys.exit("yfinance required: pip install yfinance")
 
+# Ensure metadata_helpers is importable regardless of invocation mode:
+#   python scripts/fetch_metadata.py   → scripts/ not on sys.path by default
+#   python -m scripts.fetch_metadata   → relative import would fail at top-level
+# Inserting the script's own directory supports both modes.
+_scripts_dir = str(Path(__file__).parent)
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
 from metadata_helpers import _yield_fields, first_present  # noqa: E402
 
 # US equity tickers


### PR DESCRIPTION
## Summary

Clears the 7-review roborev main-branch backlog. One code fix; six closes with explanatory comments.

## Code change

- `scripts/fetch_metadata.py`: Add `sys.path` guard before `from metadata_helpers import` so the import works under both `python scripts/fetch_metadata.py` (direct) and `python -m scripts.fetch_metadata` (module) invocation modes. Uses `Path(__file__).parent` with a `not in sys.path` guard for idempotency. Closes roborev #4025.

## Reviews closed (no code change)

| Review | Action |
|--------|--------|
| #4030 | Addressed by open PR #242 (`fix/roborev-4263-warn-once`) — `.frequency = "once"` already implemented |
| #4026 | Same as #4030 — duplicate finding on earlier commit |
| #3854 | Already fixed in merge commit d4fb72b (sys.frame/commandArgs script-path anchor) |
| #3829 | Duplicate of #3854 on an earlier commit |
| #3849 | Already fixed in merge commit 80325fe — `suppressWarnings` replaced with explicit `cli_warn()` |
| #3828 | Confirmed still broken; deferred to #246 (requires NULL guards + full re-render) |

## Test plan

- [ ] `python3 -c "import sys; sys.path.insert(0, 'scripts'); import fetch_metadata"` succeeds in the project nix shell
- [ ] Review all 7 confirmed closed in roborev (`/usr/local/bin/roborev list` shows none open from this batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)