### PR TITLE
fix(stock-backtest): NULL guards for plot chunks — closes #246

### DIFF
--- a/docs/stock-backtest.qmd
+++ b/docs/stock-backtest.qmd
@@ -65,7 +65,7 @@ Two signals applied at two levels, producing four strategies:
 
 ```{r}
 #| fig-height: 6
-safe_tar_read("stk_all_comparison_plot")
+{ p <- safe_tar_read("stk_all_comparison_plot"); if (!is.null(p)) p else cat("*Chart not available — run tar_make() to generate.*\n") }
 ```
 
 ::: {.fig-caption}
@@ -181,7 +181,7 @@ if (!is.null(stk_max) && !is.null(stk_drif) && !is.null(fac_max) && !is.null(fac
 
 ```{r}
 #| fig-height: 6
-safe_tar_read("stk_max_plot")
+{ p <- safe_tar_read("stk_max_plot"); if (!is.null(p)) p else cat("*Chart not available — run tar_make() to generate.*\n") }
 ```
 
 ::: {.fig-caption}
@@ -205,7 +205,7 @@ if (!is.null(metrics)) {
 
 ```{r}
 #| fig-height: 6
-safe_tar_read("stk_max_vs_factor_plot")
+{ p <- safe_tar_read("stk_max_vs_factor_plot"); if (!is.null(p)) p else cat("*Chart not available — run tar_make() to generate.*\n") }
 ```
 
 ::: {.fig-caption}
@@ -258,7 +258,7 @@ safe_tar_read("stk_max_vs_factor_plot")
 
 ```{r}
 #| fig-height: 6
-safe_tar_read("stk_drif_plot")
+{ p <- safe_tar_read("stk_drif_plot"); if (!is.null(p)) p else cat("*Chart not available — run tar_make() to generate.*\n") }
 ```
 
 ::: {.fig-caption}
@@ -319,7 +319,7 @@ if (!is.null(metrics)) {
 
 ```{r}
 #| fig-height: 6
-safe_tar_read("xgb_vs_enet_plot")
+{ p <- safe_tar_read("xgb_vs_enet_plot"); if (!is.null(p)) p else cat("*Chart not available — run tar_make() to generate.*\n") }
 ```
 
 ::: {.fig-caption}
@@ -387,7 +387,7 @@ Stock-level long-short strategies lose ~20%/yr after realistic costs (1.85%/mont
 
 ```{r}
 #| fig-height: 6
-safe_tar_read("etf_comparison_plot")
+{ p <- safe_tar_read("etf_comparison_plot"); if (!is.null(p)) p else cat("*Chart not available — run tar_make() to generate.*\n") }
 ```
 
 ::: {.fig-caption}


### PR DESCRIPTION
## Summary

- Added NULL guards to all 6 bare `safe_tar_read()` plot-rendering chunks in `docs/stock-backtest.qmd`
- Affected chunks: `stk_all_comparison_plot`, `stk_max_plot`, `stk_max_vs_factor_plot`, `stk_drif_plot`, `xgb_vs_enet_plot`, `etf_comparison_plot`
- When a target is absent (NULL), chunks now emit `*Chart not available — run tar_make() to generate.*` instead of the raw `NULL` that produced `<pre><code>NULL</code></pre>` in the HTML

## Re-render deferred

The committed `docs/stock-backtest.html` artifact still contains the stale NULL panels from the previous build. A full re-render requires `nix develop` + `tar_make()` with all stock-backtest targets present (multi-hour computation). **Re-render is deferred to the next normal session** once all required targets are confirmed present.

## Test plan

- [ ] Verify `docs/stock-backtest.qmd` — all 6 plot chunks now have `if (!is.null(p)) p else cat(...)` guards
- [ ] After next `tar_make()` completes with all required targets, re-render and confirm no `<pre><code>NULL</code></pre>` in the HTML
- [ ] Confirm empty tabs (lines 1111-1114) resolve after re-render

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)