### PR TITLE
fix(stk_universe): coerce POSIXct→Date before threshold filter (closes #203)

### DIFF
--- a/R/plan_stock_backtest.R
+++ b/R/plan_stock_backtest.R
@@ -419,7 +419,8 @@ plan_stock_backtest <- function() {
       all_data <- duckplyr::read_parquet_duckdb(ds$url) |>
         filter(!grepl("\\.L$", ticker), ticker %in% stk_top_tickers) |>
         select(date, ticker, close, adjusted, volume) |>
-        collect()
+        collect() |>
+        mutate(date = as.Date(date, tz = "UTC"))  # coerce POSIXct -> Date before any comparison (#203)
 
       # Filter to tickers with enough history
       ticker_stats <- all_data |>
@@ -432,8 +433,7 @@ plan_stock_backtest <- function() {
       all_data |>
         filter(ticker %in% ticker_stats$ticker,
                date >= stk_params$start_date) |>
-        arrange(ticker, date) |>
-        mutate(date = as.Date(date, tz = "UTC"))   # coerce POSIXct from DuckDB TIMESTAMP
+        arrange(ticker, date)
     }),
 
     # ── Group 1: Monthly returns for all stocks ───────────────────

--- a/tests/testthat/test-stock-backtest.R
+++ b/tests/testthat/test-stock-backtest.R
@@ -86,3 +86,48 @@ test_that("apply_adv_cap: no cap binds when weights are small", {
   expect_false(any(result$hit_cap))
   expect_equal(sum(result$capped_w), 1, tolerance = 1e-9)
 })
+
+# ── F4: stk_universe date coercion — no Ops.POSIXt/Ops.Date warning (#203) ───
+
+test_that("date >= Date threshold emits no Ops.POSIXt/Ops.Date warning", {
+  # Reproduce the stk_universe filter pattern: DuckDB returns POSIXct;
+  # stk_params$start_date is Date (from as.Date() in plan_partitions.R).
+  # Before fix, this produced:
+  #   Warning: Incompatible methods ("Ops.POSIXt", "Ops.Date") for ">="
+  library(dplyr)
+
+  posixct_dates <- as.POSIXct(c("2005-01-03", "2006-06-15", "2020-01-02"), tz = "UTC")
+  df <- tibble::tibble(
+    date   = posixct_dates,
+    ticker = c("AAPL", "MSFT", "GOOG"),
+    close  = c(1.0, 2.0, 3.0)
+  )
+  start_date <- as.Date("2006-01-01")   # Date, as set by bt_partitions$equity$train_start
+
+  # After fix: coerce POSIXct -> Date before comparison
+  df_coerced <- df |> mutate(date = as.Date(date, tz = "UTC"))
+
+  expect_no_warning(
+    df_coerced |> filter(date >= start_date),
+    message = "Incompatible methods"
+  )
+
+  # Confirm the filter actually works correctly: only 2006-06-15 and 2020-01-02 survive
+  result <- df_coerced |> filter(date >= start_date)
+  expect_equal(nrow(result), 2L)
+  expect_equal(class(result$date), "Date")
+})
+
+test_that("raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)", {
+  # Confirm the original bug is detectable — raw POSIXct warns.
+  library(dplyr)
+
+  posixct_dates <- as.POSIXct(c("2005-01-03", "2020-01-02"), tz = "UTC")
+  df <- tibble::tibble(date = posixct_dates, value = 1:2)
+  start_date <- as.Date("2006-01-01")
+
+  expect_warning(
+    df |> filter(date >= start_date),
+    regexp = "Incompatible methods"
+  )
+})


### PR DESCRIPTION
Coerce DuckDB-returned POSIXct timestamps to Date before `date >= stk_params$start_date` comparison, eliminating the Ops.POSIXt vs Ops.Date incompatible-methods warning. Adds 2 tests: one asserts no warning after fix, one is a baseline that confirms the original bug shape (raw POSIXct does warn). Closes #203.