### PR TITLE
fix(registry): reconcile crypto_daily schema with actual parquet (closes #186)

### DIFF
--- a/packages/historicaldata/R/registry.R
+++ b/packages/historicaldata/R/registry.R
@@ -17,10 +17,10 @@ hd_datasets <- function() {
     ),
     crypto_daily = list(
       url = hd_base_url("crypto_daily.parquet"),
-      schema = c("date", "close", "volume", "market_cap",
+      schema = c("date", "open", "high", "low", "close", "volume",
                  "ticker", "source", "asset_class"),
       frequency = "daily",
-      description = "Cryptocurrency daily prices (CoinGecko)"
+      description = "Cryptocurrency daily OHLCV (Yahoo Finance)"
     ),
     macro_daily = list(
       url = hd_base_url("macro_daily.parquet"),

--- a/packages/historicaldata/tests/testthat/_snaps/registry.md
+++ b/packages/historicaldata/tests/testthat/_snaps/registry.md
@@ -11,9 +11,9 @@
         ..$ description: chr "US equities daily OHLCV (Yahoo Finance)"
        $ crypto_daily       :List of 4
         ..$ url        : chr "hf://datasets/JohnGavin/finance-data/crypto_daily.parquet"
-        ..$ schema     : chr [1:7] "date" "close" "volume" "market_cap" ...
+        ..$ schema     : chr [1:9] "date" "open" "high" "low" ...
         ..$ frequency  : chr "daily"
-        ..$ description: chr "Cryptocurrency daily prices (CoinGecko)"
+        ..$ description: chr "Cryptocurrency daily OHLCV (Yahoo Finance)"
        $ macro_daily        :List of 4
         ..$ url        : chr "hf://datasets/JohnGavin/finance-data/macro_daily.parquet"
         ..$ schema     : chr [1:4] "date" "value" "series_id" "source"

--- a/packages/historicaldata/tests/testthat/test-registry.R
+++ b/packages/historicaldata/tests/testthat/test-registry.R
@@ -30,3 +30,36 @@ test_that("hd_cache_path returns a path", {
 test_that("hd_datasets snapshot", {
   expect_snapshot(str(hd_datasets()))
 })
+
+test_that("registry schema matches actual parquet columns for all datasets", {
+  skip_on_cran()
+  skip_if_offline()
+
+  ds_list <- hd_datasets()
+  for (nm in names(ds_list)) {
+    ds <- ds_list[[nm]]
+    # Read one row to get column names without downloading full parquet
+    actual_cols <- tryCatch(
+      duckplyr::read_parquet_duckdb(ds$url) |>
+        utils::head(1) |>
+        dplyr::collect() |>
+        names(),
+      error = function(e) {
+        testthat::skip(paste("Cannot reach", nm, "parquet:", conditionMessage(e)))
+        character(0)
+      }
+    )
+    if (!length(actual_cols)) next
+    missing_from_parquet <- setdiff(ds$schema, actual_cols)
+    extra_in_parquet     <- setdiff(actual_cols, ds$schema)
+    msg <- paste0(
+      "dataset '", nm, "': ",
+      if (length(missing_from_parquet)) paste("in schema not in parquet:", paste(missing_from_parquet, collapse=", ")),
+      if (length(extra_in_parquet))     paste("in parquet not in schema:", paste(extra_in_parquet, collapse=", "))
+    )
+    expect_true(
+      setequal(actual_cols, ds$schema),
+      label = msg
+    )
+  }
+})


### PR DESCRIPTION
The `crypto_daily` registry entry declared a `market_cap` column that the actual parquet does not carry — any code reading `market_cap` silently got NA. Schema updated to match actual columns (`date, open, high, low, close, volume, ...`). Adds a snapshot test "registry schema matches actual parquet columns for all datasets" that fails if any dataset's declared schema diverges from the parquet head. Refetching market_cap from a source is a separate follow-up. Closes #186.