### PR TITLE
feat(quality): add survivorship-bias warning for equity_daily (scoped fix for #150)

### DIFF
--- a/packages/historicaldata/R/query.R
+++ b/packages/historicaldata/R/query.R
@@ -1,3 +1,47 @@
+# ── Survivorship-bias guard ───────────────────────────────────────────────────
+
+#' Warn when a dataset is known to be survivorship-biased
+#'
+#' Emits a `cli::cli_warn()` if `dataset` is flagged with
+#' `survivorship_biased = TRUE` in the registry. Call this before computing
+#' per-stock Sharpe / CAGR / drawdown metrics so that callers are reminded the
+#' numbers overstate achievable performance.
+#'
+#' The `equity_daily` dataset is survivorship-biased: the 672-ticker universe
+#' reflects currently-listed stocks only. Known failed firms (Enron, Lehman
+#' Brothers, Bear Stearns, WorldCom, Washington Mutual) are absent. Across 56
+#' years of history (1970-2026), zero delistings are recorded. Per-stock
+#' performance metrics derived from this dataset overstate returns by an
+#' unquantified but non-trivial amount (literature estimate: +1 to +3 pp/year
+#' CAGR for long-only strategies). See GitHub issue #150 for full analysis and
+#' remediation roadmap.
+#'
+#' @param dataset Dataset name from [hd_datasets()].
+#' @return `dataset` invisibly. Called for its warning side-effect.
+#' @family data-access
+#' @family quality-audit
+#' @export
+#' @examples
+#' hd_check_survivorship_bias("equity_daily")  # emits a warning
+#' hd_check_survivorship_bias("factors")       # silent
+hd_check_survivorship_bias <- function(dataset) {
+  ds <- hd_datasets()[[dataset]]
+  if (is.null(ds)) {
+    cli::cli_abort("Unknown dataset: {.val {dataset}}. See {.fn hd_datasets}.")
+  }
+  if (isTRUE(ds[["survivorship_biased"]])) {
+    n_del <- ds[["known_delistings"]]
+    cli::cli_warn(c(
+      "{.val {dataset}} is survivorship-biased: {n_del} delisting event{?s} recorded across full history.",
+      "i" = "Universe contains only currently-listed tickers.",
+      "i" = "Known failed firms (Enron, Lehman, Bear Stearns, WorldCom, WaMu) are absent.",
+      "x" = "Per-stock Sharpe / CAGR / drawdown metrics OVER-ESTIMATE achievable performance.",
+      ">" = "True fix requires a point-in-time universe with delisting records (CRSP/WRDS/Sharadar). See GitHub issue #150."
+    ))
+  }
+  invisible(dataset)
+}
+
 #' Query OHLCV data for one or more tickers
 #'
 #' Returns a duckplyr lazy frame by default. Call `collect()` to materialise,
@@ -70,6 +114,15 @@ hd_ohlcv_single <- function(ticker, dataset, from, to, local, collect) {
   ds <- hd_datasets()[[dataset]]
   if (is.null(ds)) {
     cli::cli_abort("Unknown dataset: {dataset}. See {.fn hd_datasets}.")
+  }
+
+  # Emit a once-per-session survivorship-bias warning for equity_daily (#150)
+  if (isTRUE(ds[["survivorship_biased"]])) {
+    warn_key <- paste0("hd_survivorship_warned_", dataset)
+    if (!isTRUE(getOption(warn_key))) {
+      hd_check_survivorship_bias(dataset)
+      options(stats::setNames(list(TRUE), warn_key))
+    }
   }
 
   source_path <- if (local) {

--- a/packages/historicaldata/R/registry.R
+++ b/packages/historicaldata/R/registry.R
@@ -13,7 +13,16 @@ hd_datasets <- function() {
       schema = c("date", "open", "high", "low", "close", "adjusted",
                  "volume", "ticker", "source", "asset_class"),
       frequency = "daily",
-      description = "US equities daily OHLCV (Yahoo Finance)"
+      description = paste0(
+        "US equities daily OHLCV (Yahoo Finance). ",
+        "WARNING: survivorship-biased — universe reflects currently-listed ",
+        "tickers only. 0 delistings observed across 56 years (1970-2026). ",
+        "Known failed firms (Enron, Lehman, Bear Stearns, WorldCom, WaMu) ",
+        "are absent. Per-stock Sharpe / CAGR / drawdown metrics overstate ",
+        "achievable performance. See GitHub issue #150."
+      ),
+      survivorship_biased = TRUE,
+      known_delistings    = 0L
     ),
     crypto_daily = list(
       url = hd_base_url("crypto_daily.parquet"),

--- a/packages/historicaldata/tests/testthat/test-survivorship-bias.R
+++ b/packages/historicaldata/tests/testthat/test-survivorship-bias.R
@@ -1,0 +1,64 @@
+
+# Tests for survivorship-bias guard (issue #150)
+#
+# RED phase: these tests will fail until the implementation is added.
+
+test_that("equity_daily registry entry declares survivorship_biased = TRUE", {
+  ds <- hd_datasets()
+  expect_true(
+    isTRUE(ds[["equity_daily"]][["survivorship_biased"]]),
+    label = "equity_daily$survivorship_biased must be TRUE"
+  )
+})
+
+test_that("equity_daily registry entry declares known_delistings = 0L", {
+  ds <- hd_datasets()
+  expect_identical(
+    ds[["equity_daily"]][["known_delistings"]],
+    0L,
+    label = "equity_daily$known_delistings must be 0L (documented in #150)"
+  )
+})
+
+test_that("non-equity datasets do NOT have survivorship_biased flag", {
+  ds <- hd_datasets()
+  # Fama-French factors are point-in-time — no survivorship bias
+  expect_false(
+    isTRUE(ds[["factors"]][["survivorship_biased"]]),
+    label = "factors dataset should not be flagged as survivorship-biased"
+  )
+})
+
+test_that("hd_check_survivorship_bias emits warning for equity_daily", {
+  expect_warning(
+    hd_check_survivorship_bias("equity_daily"),
+    regexp = "survivorship"
+  )
+})
+
+test_that("hd_check_survivorship_bias is silent for factors dataset", {
+  expect_no_warning(
+    hd_check_survivorship_bias("factors")
+  )
+})
+
+test_that("hd_check_survivorship_bias is silent for macro_daily", {
+  expect_no_warning(
+    hd_check_survivorship_bias("macro_daily")
+  )
+})
+
+test_that("hd_check_survivorship_bias errors on unknown dataset", {
+  expect_error(
+    hd_check_survivorship_bias("nonexistent_dataset"),
+    regexp = "Unknown dataset"
+  )
+})
+
+test_that("hd_datasets equity_daily description mentions survivorship bias", {
+  ds <- hd_datasets()
+  expect_true(
+    grepl("survivorship", ds[["equity_daily"]][["description"]], ignore.case = TRUE),
+    label = "equity_daily description should mention survivorship bias"
+  )
+})


### PR DESCRIPTION
Scoped fix for #150 — full fix is delisting-data sourcing (CRSP/WRDS/Sharadar), which is a separate data-engineering effort.

This PR:
- Adds `hd_check_survivorship_bias()` to `packages/historicaldata/R/query.R` — emits a cli::cli_warn with named-bullet structure listing the limitation, citing #150.
- Marks `equity_daily` in the registry with `survivorship_biased = TRUE` and `known_delistings = 0L`.
- `hd_ohlcv("equity_daily")` now emits a once-per-session warning via the new helper.
- New test file `packages/historicaldata/tests/testthat/test-survivorship-bias.R` covers the warning behaviour.

Real fix (point-in-time delisting universe) tracked as follow-up. Closes #150 partially — full closure when delisting data lands.