### PR TITLE
fix(qa): wire qa_summary to validate sub-targets + dedup nix comment (#210 Tier B)

### DIFF
--- a/R/plan_qa_vignette.R
+++ b/R/plan_qa_vignette.R
@@ -70,6 +70,33 @@ plan_qa_vignette <- function() {
         stk_max_metrics,
         xgb_drif_metrics
       ))
+
+      # Validate QA sub-targets.  Each returns a list with at minimum an
+      # $n_issues or $issues field.  Collect any failures and abort once so
+      # the developer sees all problems in one run.
+      qa_failures <- character(0)
+
+      if (isTRUE(qa_metadata_sync$issues > 0)) {
+        qa_failures <- c(qa_failures,
+          sprintf("qa_metadata_sync: %d dataset issue(s)", qa_metadata_sync$issues))
+      }
+      if (isTRUE(qa_volume_sanity$flagged > 0)) {
+        qa_failures <- c(qa_failures,
+          sprintf("qa_volume_sanity: %d ticker(s) with suspicious volume", qa_volume_sanity$flagged))
+      }
+      if (isTRUE(qa_html_quality$n_issues > 0)) {
+        qa_failures <- c(qa_failures,
+          sprintf("qa_html_quality: %d HTML issue(s) across %d file(s)",
+                  qa_html_quality$n_issues, qa_html_quality$n_files))
+      }
+
+      if (length(qa_failures) > 0L) {
+        cli::cli_abort(c(
+          "x" = "QA summary: {length(qa_failures)} QA target(s) reported failures:",
+          setNames(qa_failures, rep("i", length(qa_failures)))
+        ))
+      }
+
       cli::cli_inform(c("v" = "QA: all metric targets succeeded ({format(Sys.time(), '%H:%M:%S')})"))
       invisible(NULL)
     }, cue = targets::tar_cue(mode = "always")),
@@ -130,9 +157,6 @@ plan_qa_vignette <- function() {
       library(dplyr)
 
       ds <- hd_datasets()[["equity_daily"]]
-      # Note: duckplyr/glmnet/xgboost/slider/RcppRoll are provided by the dev shell.
-      # Earlier versions of this file globbed /nix/store as a fallback — removed in PR #219
-      # since it re-introduced ABI-incompatible /nix/store paths (issue #211).
 
       # Per-ticker dollar volume
       ticker_stats <- duckplyr::read_parquet_duckdb(ds$url) |>


### PR DESCRIPTION
## Summary

- `qa_summary` now explicitly depends on `qa_metadata_sync`, `qa_volume_sanity`, and `qa_html_quality` and calls `cli::cli_abort()` if any sub-target reports failures — closes the silent-pass hole where QA checks could find issues while `qa_summary` still emitted \"QA: all metric targets succeeded\"
- Removed a verbatim duplicate of the nix-glob-removal comment from `qa_volume_sanity` (identical comment already present in `qa_metadata_sync`)

## What was wrong

`qa_summary` contained `invisible(list(...all metrics...))` to wire upstream dependencies, but the body discarded all returned values. If `qa_metadata_sync` found missing tickers, `qa_volume_sanity` flagged outliers, or `qa_html_quality` detected leaked code — none of those failures propagated to `qa_summary`. It always emitted the success message.

## Fix approach

Added a failure-collection block after the `invisible(list(...))` that checks the `$issues`, `$flagged`, and `$n_issues` fields from each QA sub-target. Uses `isTRUE(x > 0)` to be safe against `NULL` (e.g. when no HTML files exist). Calls `cli_abort()` with all failures concatenated so a developer sees every problem in one run.

## Note on existing behaviour

If `qa_metadata_sync` or `qa_volume_sanity` currently has non-zero issues, `qa_summary` will now **FAIL** on the next `tar_make()`. This is the intended behaviour — these were always silent failures before this PR.

## Test plan

- [x] `parse(\"R/plan_qa_vignette.R\")` passes cleanly
- [x] `tests/testthat/test-qa-summary-deps.R` — all 5 tests pass (verified locally)
- [ ] Confirm `tar_make()` runs cleanly in CI (qa_summary depends on 3 new upstream targets; all were already in the pipeline)

Closes #210 (Tier B)