### PR TITLE
ci(pytest): wire Python test suite into CI (closes #239)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,31 @@
+name: Python Tests
+
+on:
+  push:
+    paths:
+      - 'scripts/**.py'
+      - 'tests/test_**.py'
+      - '.github/workflows/pytest.yml'
+  pull_request:
+    paths:
+      - 'scripts/**.py'
+      - 'tests/test_**.py'
+      - '.github/workflows/pytest.yml'
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run pytest
+        run: pytest tests/test_fetch_metadata.py -v


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pytest.yml` — a dedicated GitHub Actions job that runs `tests/test_fetch_metadata.py` on every push/PR touching Python files
- Uses Python 3.12 (pinned for reproducibility), installs `pytest` only (no extra deps — `metadata_helpers` uses stdlib)
- Triggers on changes to `scripts/**py`, `tests/test_**.py`, or the workflow file itself
- Required gate (no `continue-on-error`), closes the regression gap flagged by roborev 3561

## Test plan

- [ ] Verify the `pytest` job appears in the Actions tab after this PR is opened
- [ ] Confirm all 8 existing tests pass (green check)
- [ ] Confirm the workflow does NOT trigger on R-only changes (e.g. `.R` file edits)

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)