### PR TITLE
feat(jst): add JST Macrohistory registry entry + tests (closes #98)

### DIFF
--- a/packages/historicaldata/R/registry.R
+++ b/packages/historicaldata/R/registry.R
@@ -57,6 +57,21 @@ hd_datasets <- function() {
                  "source", "method", "amended_at", "amended_by", "reversible"),
       frequency = "append-only",
       description = "PIT log of all metadata changes: computed fields, enrichments, corrections"
+    ),
+    jst_macrohistory = list(
+      url = "https://www.macrohistory.net/app/download/9834512469/JSTdatasetR6.dta",
+      schema = c("iso", "year", "eq_tr", "bond_tr", "housing_tr", "bill_rate",
+                 "eq_capgain", "eq_dp", "housing_capgain", "housing_rent_yd",
+                 "capital_tr", "risky_tr", "safe_tr", "cpi", "gdp", "rgdpmad",
+                 "pop", "unemp", "stir", "ltrate", "xrusd", "debtgdp",
+                 "tloans", "tmort", "crisisJST", "money", "narrowm"),
+      frequency = "annual",
+      description = paste0(
+        "Jorda-Schularick-Taylor Macrohistory Database (Release 6): ",
+        "18 countries, 1870-2020, annual returns for equity, bonds, housing, ",
+        "bills; plus macro, credit, FX, and financial crisis indicators. ",
+        "Free download from macrohistory.net. Use hd_jst() to fetch."
+      )
     )
   )
 }

--- a/packages/historicaldata/tests/testthat/test-jst.R
+++ b/packages/historicaldata/tests/testthat/test-jst.R
@@ -1,0 +1,68 @@
+test_that("hd_jst_variables returns expected structure", {
+  vars <- hd_jst_variables()
+  expect_s3_class(vars, "tbl_df")
+  expect_named(vars, c("variable", "category", "description", "coverage"))
+  expect_true(nrow(vars) >= 10)
+  # Key return variables must be present
+  expect_true("eq_tr" %in% vars$variable)
+  expect_true("bond_tr" %in% vars$variable)
+  expect_true("housing_tr" %in% vars$variable)
+  expect_true("crisisJST" %in% vars$variable)
+})
+
+test_that("hd_jst_variables categories are non-empty strings", {
+  vars <- hd_jst_variables()
+  expect_true(all(nzchar(vars$variable)))
+  expect_true(all(nzchar(vars$category)))
+  expect_true(all(nzchar(vars$description)))
+})
+
+test_that("jst_macrohistory entry is in hd_datasets registry", {
+  ds <- hd_datasets()
+  expect_true("jst_macrohistory" %in% names(ds))
+  entry <- ds[["jst_macrohistory"]]
+  expect_true(all(c("url", "schema", "frequency", "description") %in% names(entry)))
+  expect_equal(entry$frequency, "annual")
+  expect_true(grepl("macrohistory", entry$url, fixed = TRUE))
+  # Schema covers required columns from issue #98
+  expect_true("iso" %in% entry$schema)
+  expect_true("year" %in% entry$schema)
+  expect_true("eq_tr" %in% entry$schema)
+  expect_true("bond_tr" %in% entry$schema)
+  expect_true("housing_tr" %in% entry$schema)
+})
+
+test_that("hd_jst returns cached data when cache file exists", {
+  cache_file <- file.path(hd_cache_path(), "jst_macrohistory.rds")
+  skip_if(!file.exists(cache_file), "JST cache file not present — run hd_jst() once to populate")
+
+  result <- hd_jst(cache = TRUE)
+  expect_s3_class(result, "tbl_df")
+  expect_true("iso" %in% names(result))
+  expect_true("year" %in% names(result))
+  expect_true("eq_tr" %in% names(result))
+  expect_true(nrow(result) > 0)
+  # 18 countries expected in Release 6
+  expect_true(length(unique(result$iso)) >= 10)
+  # Coverage 1870-2020
+  expect_true(min(result$year) <= 1900)
+  expect_true(max(result$year) >= 2000)
+})
+
+test_that("hd_jst aborts when cache missing and haven not installed", {
+  cache_file <- file.path(hd_cache_path(), "jst_macrohistory.rds")
+  skip_if(file.exists(cache_file), "Cache exists — skip abort test")
+
+  # Simulate missing haven by pointing cache to an empty tempdir
+  # and checking the error path via requireNamespace
+  withr::with_envvar(c(HD_CACHE_DIR = tempdir()), {
+    tmp_cache <- file.path(tempdir(), "jst_macrohistory.rds")
+    if (file.exists(tmp_cache)) file.remove(tmp_cache)
+
+    skip_if(requireNamespace("haven", quietly = TRUE) &&
+              requireNamespace("httr2", quietly = TRUE),
+            "Both haven and httr2 available — network call would occur")
+
+    expect_error(hd_jst(cache = FALSE), "required")
+  })
+})


### PR DESCRIPTION
## Summary

- Registers `jst_macrohistory` in `hd_datasets()` with URL, schema (27 columns), frequency, and description
- Adds `tests/testthat/test-jst.R`: 5 tests covering variable catalogue structure, registry entry shape, and cache-gated data integrity (skips cleanly when no local cache)
- The `hd_jst()` fetch wrapper and `hd_jst_variables()` catalogue were already present in `jst.R`; `haven` and `httr2` are already in Suggests

No new runtime dependencies. DESCRIPTION unchanged.

## Acceptance checklist

- [x] Registry entry (`jst_macrohistory` in `hd_datasets()`)
- [x] Fetch wrapper (`hd_jst()` in `jst.R`, pre-existing)
- [x] Skip-if-no-cache test (`skip_if(!file.exists(cache_file), ...)`)
- [x] Branch pushed + PR open

## Test results

```
[ FAIL 0 | WARN 0 | SKIP 1 | PASS 27 ]
```

Skip: abort-path test correctly skips when local cache is present.

## Test plan

- [ ] Confirm CI passes (all 27 tests, 1 skip expected)
- [ ] Optionally run `hd_jst()` interactively to populate cache and verify full 18-country dataset loads

Closes #98

Generated with [Claude Code](https://claude.com/claude-code)