### PR TITLE
docs(knowledge): INDEX.md catalogue + LOG.md (closes #97)

### DIFF
--- a/knowledge/INDEX.md
+++ b/knowledge/INDEX.md
@@ -1,30 +1,50 @@
-# Historical Data Project — Knowledge Base
+# historical — Knowledge Base
 
 Project-specific findings, lessons, and cross-references.
 Cross-cutting patterns live in `~/docs_gh/llm/knowledge/`.
 
 ## Wiki Pages
 
-### Workflow & Infrastructure
-
-- [Kinlay Agentic Workflow Audit](wiki/kinlay-agentic-workflow-audit.md) — 5-pillar gap-check vs current stack; research-log DB is MISSING and highest-priority; PIT wrapper PARTIAL; Critic covers 1 of 6 defect classes
-
-### Research Findings
-
-- [Momentum Decomposition (Cross-Asset)](wiki/momentum-decomposition-cross-asset.md) — 20-hour research: FAILED in equities/commodities, pipeline complete in crypto, regime-aware baseline shows promise
-- [JST-DMS Comparison](wiki/jst-dms-comparison.md) — Free alternative to DMS, survivorship bias correction, multi-decade underperformance norms
-- [TAA Selection Research](wiki/taa-selection-research.md) — Tactical asset allocation strategy selection
-- [Regime Trend Following](wiki/regime-trend-following.md) — Regime-dependent trend following analysis
-- [Macrosynergy Research](wiki/macrosynergy-research.md) — Macrosynergy macro signal research
-- [Market Behavior Gap Analysis](wiki/market-behavior-gap-analysis.md) — Market behavior coverage gaps
-
 ### Data Sources & Signals
 
-- [ECB Data](wiki/ecb-data.md) — 29 series, API quirks, frequency mismatches, CISS sub-indices
-- [Guardian NLP](wiki/guardian-nlp.md) — Keyword counts and sentimentr body text: no predictive signal
-- [CISS Stress Analysis](wiki/ciss-stress.md) — Sub-market decomposition, VIX correlations, regime proxy
-- [Priced-In Signals](wiki/priced-in-signals.md) — Why public news has no edge (NYT, Guardian, keyword counts)
-- [Quantocracy May 2026](wiki/quantocracy-may-2026.md) — May 3 2026 roundup: 5 articles, 2 new topics (regime sizing, risk parity audit), 3 already-covered
+| Topic | Page | Status |
+|-------|------|--------|
+| ECB Statistical Data Warehouse | [ecb-data.md](wiki/ecb-data.md) | Reference |
+| Guardian NLP Sentiment | [guardian-nlp.md](wiki/guardian-nlp.md) | Reference |
+| CISS Systemic Stress Analysis | [ciss-stress.md](wiki/ciss-stress.md) | Reference |
+| Priced-In Signals Evidence Log | [priced-in-signals.md](wiki/priced-in-signals.md) | Reference |
+
+### Strategies & Factors
+
+| Topic | Page | Status |
+|-------|------|--------|
+| Momentum Decomposition (Cross-Asset) | [momentum-decomposition-cross-asset.md](wiki/momentum-decomposition-cross-asset.md) | Reference |
+| Regime-Dependent Trend Following | [regime-trend-following.md](wiki/regime-trend-following.md) | Reference |
+| TAA Selection, Mid-Caps, Lazy Prices | [taa-selection-research.md](wiki/taa-selection-research.md) | Reference |
+| Cakici et al. (2024) Coverage Audit | [cakici-2024-coverage-audit.md](wiki/cakici-2024-coverage-audit.md) | Audit |
+
+### Backtest Methodology & Gap Analysis
+
+| Topic | Page | Status |
+|-------|------|--------|
+| Tinsley Backtest Framework Audit | [tinsley-backtest-framework-audit.md](wiki/tinsley-backtest-framework-audit.md) | Audit |
+| Market Behavior Gap Analysis | [market-behavior-gap-analysis.md](wiki/market-behavior-gap-analysis.md) | Audit |
+| Daloopa/investing Gap Analysis | [daloopa-gap-analysis.md](wiki/daloopa-gap-analysis.md) | Audit |
+| JST vs DMS Dataset Comparison | [jst-dms-comparison.md](wiki/jst-dms-comparison.md) | Reference |
+
+### Research Roundups & External Sources
+
+| Topic | Page | Status |
+|-------|------|--------|
+| Quantocracy May 2026 Roundup | [quantocracy-may-2026.md](wiki/quantocracy-may-2026.md) | Reference |
+| Macrosynergy Macro Data Research | [macrosynergy-research.md](wiki/macrosynergy-research.md) | Draft |
+| Research ROI Framework | [research-roi.md](wiki/research-roi.md) | Draft |
+
+### Workflow & Infrastructure
+
+| Topic | Page | Status |
+|-------|------|--------|
+| Kinlay Agentic Workflow Audit | [kinlay-agentic-workflow-audit.md](wiki/kinlay-agentic-workflow-audit.md) | Audit |
 
 ## Log
 

--- a/knowledge/LOG.md
+++ b/knowledge/LOG.md
@@ -2,6 +2,28 @@
 
 Chronological record of findings. Wiki pages synthesise these into structured knowledge.
 
+## 2026-05-23
+
+### Cakici et al. (2024) Coverage Audit (#118)
+- **Source:** GitHub issue #118 (audit spec); Cakici, Fieberg, Metko, Zaremba — SSRN 6005614
+- **Finding:** Grep sweep across `R/` and `packages/historicaldata/R/` shows elastic-net forecasting (DRIF), short-term reversal, and anomaly-sorting already implemented; long-run reversal, option-implied vol, analyst forecast dispersion, and earnings surprises have zero coverage
+- **Action:** Wiki page created at `wiki/cakici-2024-coverage-audit.md`; implementation gaps tracked in #117 and #157
+
+### Tinsley Backtest Framework Audit (#143)
+- **Source:** GitHub issue #143 (audit spec); Martyn Tinsley's seven-pillar backtest quality framework
+- **Finding:** 8-pillar audit: HAVE on simplicity, walk-forward, logic-before-patterns; PARTIAL on data quality (survivorship bias flagged not filtered), parameter sensitivity (only Avoid Worst swept), implementation realism (cost inconsistency 0.50% vs 0.20%), portfolio context (correlation matrix not wired into ranking), risk-as-architecture (loss clustering absent)
+- **Action:** Wiki page created at `wiki/tinsley-backtest-framework-audit.md`; two confirmed gaps (survivorship bias filter, loss clustering) have proposed fixes in the audit page
+
+### Kinlay Agentic Workflow Audit (#192)
+- **Source:** GitHub issue #192 (audit spec); Kinlay (2026-05), "Agentic Workflows for Alpha Research"
+- **Finding:** 5-pillar gap-check: PIT wrapper PARTIAL (vintages module exists, no systematic registry for all targets); critic covers 1 of 6 Kinlay defect classes; research-log DB entirely MISSING (highest-priority gap for issue #200 OLMAR use case)
+- **Action:** Wiki page created at `wiki/kinlay-agentic-workflow-audit.md`; research-log DB tracked in #200
+
+### Knowledge Base INDEX.md and LOG.md (#97)
+- **Source:** GitHub issue #97 (knowledge/ structure spec)
+- **Finding:** 15 wiki pages existed across 4 thematic groups; INDEX.md was partial (missing cakici, tinsley, daloopa pages and the research-roi placeholder); LOG.md had no 2026-05-23 entry
+- **Action:** Complete INDEX.md written with all 15 pages catalogued + research-roi.md placeholder; LOG.md seeded with this entry
+
 ## 2026-05-08
 
 ### Tier 1 Data Integration Test Validation (PR #111)


### PR DESCRIPTION
## Summary

- Complete `knowledge/INDEX.md` cataloguing all 15 wiki pages across 4 thematic groups: Data Sources & Signals, Strategies & Factors, Backtest Methodology & Gap Analysis, Research Roundups & External Sources, and Workflow & Infrastructure
- Added placeholder row for `wiki/research-roi.md` (Status: Draft) for a parallel task
- Seeded `knowledge/LOG.md` with a 2026-05-23 entry documenting the three audit pages added this session (Cakici #118, Tinsley #143, Kinlay #192) and the INDEX/LOG creation (#97)
- Preserved the Workflow & Infrastructure section and all prior LOG.md entries

## Test plan

- [ ] All 15 wiki pages have a row in INDEX.md
- [ ] Each page link resolves to an existing `.md` file (or placeholder row marked Draft)
- [ ] LOG.md 2026-05-23 entry matches what was actually built this session
- [ ] No prior LOG.md content removed

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)