### PR TITLE
feat(query): point-in-time hard-error guard (#281 Step 2)

### DIFF
--- a/packages/historicaldata/R/query.R
+++ b/packages/historicaldata/R/query.R
@@ -1,3 +1,36 @@
+# ── Point-in-time hard-error guard ────────────────────────────────────────────
+
+#' Abort if a requested end-date is in the future
+#'
+#' Raises a classed error (`"hd_future_date"`) when `to` is strictly after
+#' `Sys.Date()`. This prevents accidental look-ahead in backtesting and
+#' strategy research: requesting data "to" a future date implies knowledge
+#' of prices that do not yet exist, silently corrupting any analysis that
+#' depends on point-in-time correctness.
+#'
+#' @param to Date or character. The upper bound passed to a data-access
+#'   function. `NULL` is silently allowed (no upper filter).
+#' @param arg_name Character scalar used in the error message.
+#' @return Invisibly `NULL` when `to <= Sys.Date()` or `to` is `NULL`.
+#' @noRd
+.hd_check_pit <- function(to, arg_name = "to") {
+  if (is.null(to)) return(invisible(NULL))
+  to_date <- tryCatch(as.Date(to), error = function(e) NULL)
+  if (is.null(to_date) || is.na(to_date)) return(invisible(NULL))
+  if (to_date > Sys.Date()) {
+    cli::cli_abort(
+      c(
+        "Future-dated request: {.arg {arg_name}} = {.val {as.character(to_date)}} is after today ({.val {as.character(Sys.Date())}}).",
+        "x" = "Requesting data beyond today is a look-ahead risk: prices for {.val {as.character(to_date)}} do not exist yet.",
+        "i" = "Use {.code to = Sys.Date()} or an earlier date."
+      ),
+      class = "hd_future_date",
+      call = rlang::caller_env()
+    )
+  }
+  invisible(NULL)
+}
+
 # ── Survivorship-bias guard ───────────────────────────────────────────────────
 
 #' Warn when a dataset is known to be survivorship-biased
@@ -66,6 +99,10 @@ hd_check_survivorship_bias <- function(dataset) {
 #' = FALSE` cannot be honoured because lazy frames from distinct parquet
 #' sources cannot be bound.
 #' @return Lazy duckplyr frame (collect=FALSE) or tibble (collect=TRUE)
+#' @section Point-in-time guard:
+#'   Passing `to > Sys.Date()` raises a classed error (`"hd_future_date"`).
+#'   Future-dated requests imply look-ahead knowledge and are forbidden to
+#'   prevent silent backtest contamination.
 #' @family data-access
 #' @export
 #' @examplesIf interactive()
@@ -74,6 +111,7 @@ hd_check_survivorship_bias <- function(dataset) {
 #' hd_ohlcv(c("AAPL", "BTC"), from = "2024-01-01")  # mixed equity + crypto
 hd_ohlcv <- function(ticker, from = NULL, to = NULL,
                      dataset = NULL, local = FALSE, collect = TRUE) {
+  .hd_check_pit(to)
   ticker <- as.character(ticker)
   if (length(ticker) == 0L) {
     cli::cli_abort("{.arg ticker} must be a non-empty character vector.")
@@ -181,12 +219,17 @@ hd_lazy <- function(dataset = "equity_daily", local = FALSE) {
 #' @param local If TRUE, query local cache instead of remote.
 #' @param collect If TRUE (default), materialise. If FALSE, return lazy frame.
 #' @return Lazy duckplyr frame or tibble
+#' @section Point-in-time guard:
+#'   Passing `to > Sys.Date()` raises a classed error (`"hd_future_date"`).
+#'   Future-dated requests imply look-ahead knowledge and are forbidden to
+#'   prevent silent backtest contamination.
 #' @family data-access
 #' @export
 #' @examplesIf interactive()
 #' hd_macro("SP500", from = "2024-01-01") |> head()
 hd_macro <- function(series_id, from = NULL, to = NULL,
                      local = FALSE, collect = TRUE) {
+  .hd_check_pit(to)
   series_id <- as.character(series_id)
   ds <- hd_datasets()[["macro_daily"]]
 

--- a/packages/historicaldata/man/hd_macro.Rd
+++ b/packages/historicaldata/man/hd_macro.Rd
@@ -23,6 +23,13 @@ Lazy duckplyr frame or tibble
 \description{
 Query FRED macro series
 }
+\section{Point-in-time guard}{
+
+Passing \code{to > Sys.Date()} raises a classed error (\code{"hd_future_date"}).
+Future-dated requests imply look-ahead knowledge and are forbidden to
+prevent silent backtest contamination.
+}
+
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 hd_macro("SP500", from = "2024-01-01") |> head()

--- a/packages/historicaldata/man/hd_ohlcv.Rd
+++ b/packages/historicaldata/man/hd_ohlcv.Rd
@@ -45,6 +45,13 @@ are filled with \code{NA} for rows from the other dataset. When the batch
 spans multiple datasets, the result is always materialised — \code{collect = FALSE} cannot be honoured because lazy frames from distinct parquet
 sources cannot be bound.
 }
+\section{Point-in-time guard}{
+
+Passing \code{to > Sys.Date()} raises a classed error (\code{"hd_future_date"}).
+Future-dated requests imply look-ahead knowledge and are forbidden to
+prevent silent backtest contamination.
+}
+
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 hd_ohlcv("AAPL", from = "2024-01-01") |> collect()

--- a/packages/historicaldata/tests/testthat/test-pit-guard.R
+++ b/packages/historicaldata/tests/testthat/test-pit-guard.R
@@ -1,0 +1,115 @@
+
+# Tests for point-in-time hard-error guard (issue #281, Step 2)
+#
+# RED phase: these tests will fail until the guard is added to the functions.
+
+test_that("hd_ohlcv aborts when to > Sys.Date()", {
+  future_date <- Sys.Date() + 30L
+  expect_error(
+    hd_ohlcv("AAPL", to = future_date),
+    class = "hd_future_date"
+  )
+})
+
+test_that("hd_ohlcv error message mentions the requested date", {
+  future_date <- Sys.Date() + 30L
+  expect_error(
+    hd_ohlcv("AAPL", to = future_date),
+    regexp = as.character(future_date)
+  )
+})
+
+test_that("hd_ohlcv error mentions look-ahead", {
+  future_date <- Sys.Date() + 30L
+  expect_error(
+    hd_ohlcv("AAPL", to = future_date),
+    regexp = "look-ahead"
+  )
+})
+
+test_that("hd_ohlcv accepts to = Sys.Date() without error", {
+  # today is valid — should NOT trigger the guard
+  # (network call: skip if offline; guard fires before any network I/O so no skip needed)
+  today <- Sys.Date()
+  expect_no_error(
+    tryCatch(
+      hd_ohlcv("AAPL", to = today),
+      # Suppress network errors — we only care the guard doesn't fire
+      error = function(e) {
+        if (inherits(e, "hd_future_date")) stop(e)
+        invisible(NULL)
+      }
+    )
+  )
+})
+
+test_that("hd_ohlcv accepts to = Sys.Date() - 1 without error", {
+  yesterday <- Sys.Date() - 1L
+  expect_no_error(
+    tryCatch(
+      hd_ohlcv("AAPL", to = yesterday),
+      error = function(e) {
+        if (inherits(e, "hd_future_date")) stop(e)
+        invisible(NULL)
+      }
+    )
+  )
+})
+
+test_that("hd_ohlcv aborts on character future date string", {
+  future_str <- as.character(Sys.Date() + 30L)
+  expect_error(
+    hd_ohlcv("AAPL", to = future_str),
+    class = "hd_future_date"
+  )
+})
+
+test_that("hd_macro aborts when to > Sys.Date()", {
+  future_date <- Sys.Date() + 30L
+  expect_error(
+    hd_macro("SP500", to = future_date),
+    class = "hd_future_date"
+  )
+})
+
+test_that("hd_macro error message mentions the requested date", {
+  future_date <- Sys.Date() + 30L
+  expect_error(
+    hd_macro("SP500", to = future_date),
+    regexp = as.character(future_date)
+  )
+})
+
+test_that("hd_macro error mentions look-ahead", {
+  future_date <- Sys.Date() + 30L
+  expect_error(
+    hd_macro("SP500", to = future_date),
+    regexp = "look-ahead"
+  )
+})
+
+test_that("hd_macro accepts to = Sys.Date() without error", {
+  today <- Sys.Date()
+  expect_no_error(
+    tryCatch(
+      hd_macro("SP500", to = today),
+      error = function(e) {
+        if (inherits(e, "hd_future_date")) stop(e)
+        invisible(NULL)
+      }
+    )
+  )
+})
+
+test_that("hd_macro accepts to = NULL without error (no filter)", {
+  # NULL to means no upper-date filter — guard must not fire
+  expect_no_error(
+    tryCatch(
+      hd_macro("SP500", to = NULL),
+      error = function(e) {
+        if (inherits(e, "hd_future_date")) stop(e)
+        invisible(NULL)
+      }
+    )
+  )
+})


### PR DESCRIPTION
## Summary

- Adds `.hd_check_pit()` internal helper that raises a classed `hd_future_date` error when `to > Sys.Date()`, preventing look-ahead contamination in backtests
- Guard called at the top of `hd_ohlcv()` and `hd_macro()` before any network I/O
- 11 new testthat tests in `tests/testthat/test-pit-guard.R` covering: abort on future date, error message content, acceptance of today/yesterday/NULL

## Test plan

- [x] RED confirmed: 7 tests failed before guard was added (functions not found / no guard present)
- [x] GREEN confirmed: all 11 new tests pass after guard added
- [x] Full suite: 351 PASS, 5 pre-existing FAIL (registry snapshot drift + network tests — unrelated to this change), 5 SKIP
- [x] `devtools::document()` run — `hd_ohlcv.Rd` and `hd_macro.Rd` regenerated with `@section Point-in-time guard:`
- [x] `cli` confirmed already in DESCRIPTION Imports (no change needed)

Implements Kinlay-audit Step 2 only. Does not implement Steps 3, 4, or 5.

Part of #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)