### PR TITLE
fix(ci): CI-portable R test suite + restore r-tests.yml (#288)

### DIFF
--- a/.github/workflows/r-tests.yml
+++ b/.github/workflows/r-tests.yml
@@ -1,0 +1,36 @@
+name: R Package Tests
+
+on:
+  push:
+    paths:
+      - 'packages/historicaldata/**'
+      - '.github/workflows/r-tests.yml'
+  pull_request:
+    paths:
+      - 'packages/historicaldata/**'
+      - '.github/workflows/r-tests.yml'
+  workflow_dispatch:
+
+jobs:
+  r-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Supply the rstats-on-nix Cachix substituter via the installer's
+          # TRUSTED system config (/etc/nix/nix.conf), and add the runner to
+          # trusted-users so the flake's own nixConfig.extra-substituters is
+          # honoured too. Supplying substituters post-hoc in
+          # ~/.config/nix/nix.conf is UNtrusted and was ignored
+          # ("ignoring untrusted ... extra-substituters"), forcing a slow
+          # from-source rebuild of R (issue #288).
+          extra-conf: |
+            trusted-users = root runner
+            extra-substituters = https://rstats-on-nix.cachix.org
+            extra-trusted-public-keys = rstats-on-nix.cachix.org-1:vdiiVgocg6WeJrODIqdprZRUrhi1JzhBnXv7aWI6+F0=
+
+      - name: Run R package tests (unit only; integration tests skip on CI)
+        run: |
+          nix develop --command bash -c 'cd packages/historicaldata && Rscript -e "devtools::test(stop_on_failure = TRUE)"'

--- a/packages/historicaldata/tests/testthat/helper-skip.R
+++ b/packages/historicaldata/tests/testthat/helper-skip.R
@@ -1,0 +1,17 @@
+# Test helpers separating CI-portable unit tests from network/integration tests.
+#
+# Issue #288: duckdb's `httpfs` extension cannot autoload on an offline CI
+# runner, so integration tests that read remote `hf://` parquet (and other
+# live-data tests) must be skipped on CI. These are integration tests, not
+# offline-safe unit tests. testthat auto-loads `helper-*.R` before tests.
+
+#' Skip a test that requires live remote data access.
+#'
+#' Skips on CRAN, on CI (where duckdb httpfs cannot autoload offline), and
+#' when offline. Use in place of the `skip_on_cran(); skip_if_offline()` pair
+#' for any test that hits the network (hf:// parquet, FRED, Ken French, etc.).
+skip_if_no_remote_data <- function() {
+  testthat::skip_on_cran()
+  testthat::skip_on_ci()
+  testthat::skip_if_offline()
+}

--- a/packages/historicaldata/tests/testthat/test-query.R
+++ b/packages/historicaldata/tests/testthat/test-query.R
@@ -1,6 +1,5 @@
 test_that("hd_ohlcv returns tibble for AAPL", {
-  skip_on_cran()
-  skip_if_offline()
+  skip_if_no_remote_data()
 
   result <- hd_ohlcv("AAPL", from = "2026-04-01", to = "2026-04-10")
   expect_s3_class(result, "tbl_df")
@@ -12,8 +11,7 @@ test_that("hd_ohlcv returns tibble for AAPL", {
 test_that("hd_ohlcv auto-detects crypto dataset", {
   expect_equal(historicaldata:::detect_dataset("BONK"), "crypto_daily")
 
-  skip_on_cran()
-  skip_if_offline()
+  skip_if_no_remote_data()
 
   result <- hd_ohlcv("BTC", from = "2026-04-01", to = "2026-04-10")
   expect_s3_class(result, "tbl_df")
@@ -22,8 +20,7 @@ test_that("hd_ohlcv auto-detects crypto dataset", {
 })
 
 test_that("hd_macro returns data for SP500", {
-  skip_on_cran()
-  skip_if_offline()
+  skip_if_no_remote_data()
 
   result <- hd_macro("SP500", from = "2026-04-01")
   expect_s3_class(result, "tbl_df")
@@ -33,8 +30,7 @@ test_that("hd_macro returns data for SP500", {
 })
 
 test_that("hd_factors returns FF3 daily data", {
-  skip_on_cran()
-  skip_if_offline()
+  skip_if_no_remote_data()
 
   result <- hd_factors("FF3", "daily", from = "2026-01-01")
   expect_s3_class(result, "tbl_df")
@@ -44,8 +40,7 @@ test_that("hd_factors returns FF3 daily data", {
 })
 
 test_that("hd_tickers returns character vector", {
-  skip_on_cran()
-  skip_if_offline()
+  skip_if_no_remote_data()
 
   tickers <- hd_tickers("equity_daily")
   expect_type(tickers, "character")
@@ -54,8 +49,7 @@ test_that("hd_tickers returns character vector", {
 })
 
 test_that("hd_macro_series returns series IDs", {
-  skip_on_cran()
-  skip_if_offline()
+  skip_if_no_remote_data()
 
   series <- hd_macro_series()
   expect_type(series, "character")
@@ -64,8 +58,7 @@ test_that("hd_macro_series returns series IDs", {
 })
 
 test_that("hd_ohlcv snapshot of AAPL structure", {
-  skip_on_cran()
-  skip_if_offline()
+  skip_if_no_remote_data()
 
   result <- hd_ohlcv("AAPL", from = "2026-04-07", to = "2026-04-10")
   expect_snapshot(str(result))
@@ -90,8 +83,7 @@ test_that("hd_connect_local handles quoted parquet paths", {
 })
 
 test_that("hd_ohlcv split-and-bind: mixed equity + crypto batch", {
-  skip_on_cran()
-  skip_if_offline()
+  skip_if_no_remote_data()
 
   result <- hd_ohlcv(c("AAPL", "BTC"), from = "2026-04-01", to = "2026-04-10")
   expect_s3_class(result, "tbl_df")
@@ -107,8 +99,7 @@ test_that("hd_ohlcv split-and-bind: mixed equity + crypto batch", {
 })
 
 test_that("hd_ohlcv split-and-bind: collect=FALSE informs user", {
-  skip_on_cran()
-  skip_if_offline()
+  skip_if_no_remote_data()
 
   expect_snapshot(
     result <- hd_ohlcv(c("AAPL", "BTC"), from = "2026-04-01",
@@ -118,8 +109,7 @@ test_that("hd_ohlcv split-and-bind: collect=FALSE informs user", {
 })
 
 test_that("hd_ohlcv split-and-bind: single-dataset batch keeps fast path", {
-  skip_on_cran()
-  skip_if_offline()
+  skip_if_no_remote_data()
 
   # Two equity tickers — no inform message, no split, normal collect respected
   result <- hd_ohlcv(c("AAPL", "MSFT"), from = "2026-04-01", to = "2026-04-05")

--- a/packages/historicaldata/tests/testthat/test-registry.R
+++ b/packages/historicaldata/tests/testthat/test-registry.R
@@ -32,8 +32,7 @@ test_that("hd_datasets snapshot", {
 })
 
 test_that("registry schema matches actual parquet columns for all datasets", {
-  skip_on_cran()
-  skip_if_offline()
+  skip_if_no_remote_data()
 
   ds_list <- hd_datasets()
   for (nm in names(ds_list)) {


### PR DESCRIPTION
## Summary

- **`helper-skip.R`**: adds `skip_if_no_remote_data()` — a single call that combines `skip_on_cran()` + `skip_on_ci()` + `skip_if_offline()`, so duckdb `httpfs`-dependent integration tests are automatically skipped on offline CI runners
- **`test-query.R` / `test-registry.R`**: replaces all 11 two-line `skip_on_cran(); skip_if_offline()` guard pairs (10 in test-query.R, 1 in test-registry.R) with the new `skip_if_no_remote_data()` helper; network-free tests are untouched
- **`.github/workflows/r-tests.yml`**: restores the removed CI workflow; drops the sunset `magic-nix-cache` action and instead supplies the `rstats-on-nix` Cachix substituter via the DeterminateSystems installer's trusted `extra-conf` (fixes "ignoring untrusted extra-substituters" + the resulting from-source R rebuild)

## Acceptance criteria

- [ ] `helper-skip.R` exists at `packages/historicaldata/tests/testthat/helper-skip.R`
- [ ] `grep -rn "skip_if_offline\|skip_on_cran" test-query.R test-registry.R` returns zero matches
- [ ] Network-free tests (`hd_datasets snapshot`, `hd_connect_local`, `hd_ohlcv: empty ticker vector errors`, `detect_dataset…`, `hd_av_registry…`) retain their existing guards and continue to run in CI
- [ ] `.github/workflows/r-tests.yml` is present and triggers on `packages/historicaldata/**` changes
- [ ] CI job passes: network tests report SKIP, unit tests report PASS, 0 failures

## Test plan

- [ ] Verify CI run on this PR passes without failures
- [ ] Confirm test-query.R network tests show SKIP in CI log
- [ ] Confirm pure-numeric tests (test-olmar.R, test-hd_strat_keff_vertox.R, etc.) still pass

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)