### PR TITLE
feat(leaderboard): Vertox K_eff_strat → deflated Sharpe (#160)

### DIFF
--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -122,6 +122,16 @@ plan_leaderboard <- function() {
           left_join(boot_join, by = "strategy")
       }
 
+      # Deflated Sharpe (full-sample; K_trials = Vertox K_eff_strat, not raw M) — #160
+      if (!is.null(strat_deflated_sharpe)) {
+        all_metrics <- all_metrics |>
+          left_join(
+            strat_deflated_sharpe |>
+              select(strategy, deflated_sharpe, dsr_pvalue, k_eff_strat),
+            by = "strategy"
+          )
+      }
+
       all_metrics
     }),
 
@@ -141,6 +151,44 @@ plan_leaderboard <- function() {
       as.data.frame(cor_mat) |>
         tibble::rownames_to_column("strategy") |>
         as_tibble()
+    }),
+
+    # ── Vertox K_eff_strat → Deflated Sharpe chain — #160 ─────────────
+
+    # Numeric matrix form of strategy_correlation (feeds hd_strat_keff_vertox)
+    targets::tar_target(strat_corr_matrix, {
+      cm <- as.matrix(strategy_correlation[, setdiff(names(strategy_correlation), "strategy")])
+      rownames(cm) <- strategy_correlation$strategy
+      cm
+    }),
+
+    # Correlation-aware effective count of strategies (fixed seed for reproducible MC)
+    targets::tar_target(strat_keff_vertox, {
+      historicaldata::hd_strat_keff_vertox(strat_corr_matrix, n_sim = 20000L, seed = 160L)
+    }),
+
+    # Per-strategy Deflated Sharpe using K_eff_strat as K_trials (not raw M=4)
+    targets::tar_target(strat_deflated_sharpe, {
+      library(dplyr)
+      k_eff <- max(1L, round(strat_keff_vertox))
+      col_map <- c(stk_max = "Stock MAX", stk_drif = "Stock DRIF",
+                   fac_max = "Factor MAX", fac_drif = "Factor DRIF")
+      bind_rows(lapply(seq_along(col_map), function(i) {
+        col   <- names(col_map)[i]
+        label <- col_map[i]
+        r <- port_returns[[col]]
+        r <- r[!is.na(r)]
+        d <- historicaldata::hd_deflated_sharpe(r, K_trials = k_eff, ann_factor = 12L)
+        tibble::tibble(
+          strategy        = label,
+          naive_sharpe    = d$naive_sharpe,
+          deflated_sharpe = d$dsr,
+          dsr_pvalue      = d$dsr_pvalue,
+          dsr_haircut_pct = d$haircut_pct,
+          k_eff_strat     = strat_keff_vertox,
+          k_raw           = length(col_map)
+        )
+      }))
     })
   )
 }

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -330,6 +330,38 @@ if (!is.null(boot_ci)) {
 }
 ```
 
+#### Deflated Sharpe
+
+The Deflated Sharpe Ratio (DSR; Lopez de Prado 2018) adjusts the naive Sharpe for non-normality (skewness and excess kurtosis in the return distribution) and for the multiple-testing problem that arises when several strategies are evaluated on the same data. The multiple-testing penalty here uses the Vertox correlation-aware effective count `K_eff_strat` rather than the raw strategy count M = 4, because the four strategies share factor exposures and are positively correlated — using the raw count would over-penalise and produce an artificially conservative DSR.
+
+```{r}
+#| label: deflated-sharpe
+keff_raw <- safe_tar_read("strat_keff_vertox")
+dsr_tbl  <- safe_tar_read("strat_deflated_sharpe")
+if (!is.null(dsr_tbl) && !is.null(keff_raw)) {
+  keff  <- keff_raw
+  k_raw <- dsr_tbl$k_raw[1]
+  display <- dsr_tbl |>
+    transmute(
+      Strategy         = strategy,
+      `Naive Sharpe`   = round(naive_sharpe, 2),
+      `Deflated Sharpe` = round(deflated_sharpe, 2),
+      `Haircut %`      = round(dsr_haircut_pct, 1),
+      `DSR p-value`    = round(dsr_pvalue, 3)
+    )
+  cap <- paste0(
+    "Deflated Sharpe (Lopez de Prado 2018). ",
+    "Multiple-testing penalty uses Vertox K_eff_strat = ",
+    round(keff, 2),
+    " effective strategies vs ",
+    k_raw,
+    " raw — the 4 strategies are correlated, so the raw count would over-penalise. ",
+    "DSR adjusts for skewness, kurtosis, and the effective number of trials."
+  )
+  hd_dt(display, cap)
+}
+```
+
 #### Alpha Decay
 
 ```{r}


### PR DESCRIPTION
## Summary

- Wires the Vertox `K_eff_strat → Deflated Sharpe` chain into the leaderboard pipeline
- Adds 3 new targets: `strat_corr_matrix`, `strat_keff_vertox`, `strat_deflated_sharpe`
- The leaderboard target left-joins `deflated_sharpe`, `dsr_pvalue`, and `k_eff_strat` columns; the join is guarded by `!is.null(strat_deflated_sharpe)` matching the existing `boot_ci_summary` optional-join convention
- Adds a new **Deflated Sharpe** tab to the Robustness section of `docs/leaderboard.qmd`, showing Naive Sharpe vs Deflated Sharpe, Haircut %, and DSR p-value for the 4 strategies; caption is fully dynamic

## Acceptance criteria covered by this PR (#160)

- [x] `strat_corr_matrix` target — numeric matrix form of `strategy_correlation`
- [x] `strat_keff_vertox` target — correlation-aware effective count (seed=160L, n_sim=20000L)
- [x] `strat_deflated_sharpe` target — per-strategy DSR using `K_eff_strat` as `K_trials`, `ann_factor = 12L`
- [x] `leaderboard` target — left-join adds `deflated_sharpe`, `dsr_pvalue`, `k_eff_strat` columns
- [x] `leaderboard.qmd` — Deflated Sharpe tab with prose, dynamic caption citing K_eff_strat vs raw M=4

## Deferred (out of scope for this PR)

- `statistical-reporting` global-rule update — deferred to llm session
- `backtest-robustness` project-rule update — handled separately by orchestrator

## Verification

- Parse gate: `PARSE OK` (both `docs/_targets.R` and `R/plan_leaderboard.R` parse cleanly)
- Isolated logic test: nix develop was still pulling packages (cold cache) when this PR was opened; live pipeline numbers will be verified on the next `tar_make` deploy

## Notes on implementation

The leaderboard `strat_deflated_sharpe` join uses `if (!is.null(strat_deflated_sharpe))` to match the existing optional-join convention already used for `boot_ci_summary`. The targets dependency is resolved by bare-name reference (`strat_deflated_sharpe`) inside the target body, consistent with how all other upstream targets are referenced in this file. `purrr::imap_dfr` was replaced with `bind_rows(lapply(...))` to avoid an explicit `library(purrr)` call, keeping the target self-contained.

Refs #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)