### PR TITLE
docs(rules): K_eff-guided stop (#160) + ADD crowding clause + wiki (#279)

### DIFF
--- a/.claude/rules/backtest-robustness.md
+++ b/.claude/rules/backtest-robustness.md
@@ -95,14 +95,54 @@ against simulated environments where no real edge exists.
 
 | Metric | Description | Fail threshold |
 |--------|-------------|---------------|
-| K_eff_acf | Effective sample size after autocorrelation adjustment | < 30 |
-| Delta_Z | Z-score gap between strategy and null | < 1.96 (not significant) |
+| K_eff_acf | Effective sample size *in time* after autocorrelation adjustment (Newey-West, per series) | < 30 |
+| K_eff_strat | Effective *number of independent strategies* tested, correlation-aware (Vertox) | (input to deflated Sharpe, not a pass/fail) |
+| Delta_Z | Z-score gap between strategy and null | < 1.96 |
 | Stage 1 rejection rate | % of 5 simulation environments where strategy is rejected as noise | < 80% (must reject in 4/5) |
-| Adjusted Sharpe | Sharpe ratio corrected for multiple testing / look-ahead | < 0.5 |
+| Deflated Sharpe (DSR) | Sharpe corrected for non-normality AND multiple testing, using `K_eff_strat` (not raw M) as the trial count | DSR p-value > 0.05 |
 | CVaR (95%) | Conditional Value at Risk | Worse than benchmark |
 
+**Two distinct `K_eff` quantities — never conflate:** `K_eff_acf`
+(`calculate_keff()`, autocorrelation-adjusted effective sample size *in time*,
+per strategy) and `K_eff_strat` (`hd_strat_keff_vertox()`, correlation-aware
+effective *count of strategies* across the tested portfolio). Bare `K_eff` is
+reserved — always use a method-suffixed name. The deflated Sharpe ratio
+(`hd_deflated_sharpe(r, K_trials = round(K_eff_strat))`) takes `K_eff_strat`,
+NOT the raw strategy count `M`: on a correlated portfolio the raw count
+over-penalises (the strategies are not independent tests).
+
 Report these in a dedicated table in every backtest output, not just the
-equity curve and raw Sharpe. Reference: [Backtests Lie](https://www.vertoxquant.com/p/backtests-lie).
+equity curve and raw Sharpe. References: [Backtests Lie](https://www.vertoxquant.com/p/backtests-lie),
+[The Effective Number of Tested Strategies](https://www.vertoxquant.com/p/the-effective-number-of-tested-strategies) (Vertox), Lopez de Prado (2018) Deflated Sharpe Ratio.
+
+### 5. K_eff-Guided Search Stopping (Correlated-Variant Multiple Testing)
+
+When you iteratively add variants of an already-tested strategy (HRP Phase 1 →
+Phase 2 → Phase 3, ADV-cap on/off, multiple Kelly fractions, universe
+restrictions), each new variant is **highly correlated** with the prior ones.
+Vertox's monotonicity axiom says such a variant adds **< 1** to `K_eff_strat`
+even though it adds 1 to the raw count `M`. Reporting each variant's Sharpe as
+an independent gain inflates apparent edge — the gains are partly a
+multiple-testing artefact.
+
+**Stop rule:** halt hyperparameter / variant search when the *marginal*
+`K_eff_strat` gain from adding a variant falls below a threshold (default: a
+new variant must raise `K_eff_strat` by ≥ 0.25 to justify a separate reported
+result). Track `K_eff_strat / M` (the independence ratio) across the search:
+when it drops sharply, you are mining correlated variants, not discovering
+independent edge.
+
+```r
+# Before reporting a new strategy variant as a distinct result:
+k_before <- hd_strat_keff_vertox(corr_without_variant, seed = 160L)
+k_after  <- hd_strat_keff_vertox(corr_with_variant,    seed = 160L)
+if (k_after - k_before < 0.25) {
+  cli::cli_warn(c(
+    "!" = "Variant adds only {round(k_after - k_before, 2)} to K_eff_strat",
+    "i" = "Highly correlated with existing strategies; its Sharpe gain is partly a multiple-testing artefact. Apply deflated Sharpe before reporting."
+  ))
+}
+```
 
 ## Robustness Heatmap
 

--- a/.claude/rules/priced-in-prohibition.md
+++ b/.claude/rules/priced-in-prohibition.md
@@ -20,6 +20,25 @@ A signal derived from information available to all market participants is alread
 
 Before incorporating a signal based on public data, require evidence that the signal provides **incremental** predictive power beyond what is already reflected in prices. The burden of proof is on the signal, not on the market.
 
+## CRITICAL: Flow-Pressure Crowding (ADD) Is a Distinct Channel
+
+"Priced-in" above is about **information** being already reflected in prices. There is a **second**, separate way published signals lose (or distort) their edge: **Anomaly-Driven Demand (ADD)**. When many factor investors mechanically rebalance the **same** published anomaly portfolios at the **same** time (month-end), their coordinated *trading flow* moves prices — independent of any new information. "Anomalies discovered as passive predictors become active agents generating those returns" (Posselt & Kjær 2026; digested in [[anomaly-driven-demand]]).
+
+Why this matters for our leaderboard:
+
+- A slice of a published anomaly's backtested return is **mechanical crowding**, not edge — concentrated in the first ~6 trading days of the month, strongest exactly where we are tempted to chase (high-published-t anomalies).
+- This is the *demand-pressure* mechanism; the priced-in checks above test the *information* mechanism. **A signal can pass the information checks and still be contaminated by crowding flow.**
+- Crowding directly compounds the multiple-testing problem in `backtest-robustness` / Vertox `K_eff_strat` (see [#160]): the more correlated published anomalies we stack, the more our portfolio rides the same coordinated flow.
+
+### Required when adding a published-anomaly signal
+
+| Check | Question | Fail/flag condition |
+|-------|----------|--------------------|
+| Crowding concentration | Is the return concentrated in the month-start rebalance window (~first 6 trading days)? | If yes, the edge is partly coordinated flow, not persistent mispricing |
+| Published-significance crowding | Is the anomaly high-published-t (widely traded)? | High-t anomalies attract the most ADD → most crowding contamination |
+| Capacity / reversal | Is the price impact permanent (demand-based) or does it revert? | Permanent impact in crowded windows = capacity risk as more capital chases it |
+| Turn-of-month overlap | Does the signal overlap our Turn-of-the-Month work ([#271])? | TOM overlays must be ADD-aware, not double-counting the same flow |
+
 ## Required Checks
 
 | Check | Question | Fail condition |
@@ -37,6 +56,8 @@ Before incorporating a signal based on public data, require evidence that the si
 | "Analyst consensus is bullish" | Consensus = priced in by definition |
 | "This sector is overvalued based on P/E" | Relative valuation is the most-watched metric |
 | Signal from a widely-followed indicator without decay analysis | No evidence of incremental power |
+| Stacking many published high-t anomalies as if independent | Coordinated ADD flow + multiple-testing — see `K_eff_strat` ([#160]) |
+| Treating an anomaly's month-start return as persistent edge | May be mechanical rebalancing flow (ADD), not mispricing |
 
 ## Acceptable Signals
 
@@ -51,4 +72,7 @@ Before incorporating a signal based on public data, require evidence that the si
 
 - `look-ahead-bias-prevention` — covers temporal leakage; this rule covers information-already-priced
 - `cross-geography-pervasiveness` — pervasiveness test strengthens evidence against data mining
-- `backtest-robustness` — parameter sensitivity; this rule adds information-content scrutiny
+- `backtest-robustness` — parameter sensitivity + `K_eff_strat` deflated-Sharpe; this rule adds information-content + flow-crowding scrutiny
+- [[anomaly-driven-demand]] — wiki digest of Posselt & Kjær (2026) ADD; the flow-pressure channel
+- [#160] — Vertox effective number of tested strategies / deflated Sharpe (crowding ↔ multiple-testing)
+- [#271] — Turn-of-the-Month overlay (month-start return concentration; must be ADD-aware)

--- a/knowledge/INDEX.md
+++ b/knowledge/INDEX.md
@@ -21,6 +21,7 @@ Cross-cutting patterns live in `~/docs_gh/llm/knowledge/`.
 | Momentum Decomposition (Cross-Asset) | [momentum-decomposition-cross-asset.md](wiki/momentum-decomposition-cross-asset.md) | Reference |
 | Regime-Dependent Trend Following | [regime-trend-following.md](wiki/regime-trend-following.md) | Reference |
 | TAA Selection, Mid-Caps, Lazy Prices | [taa-selection-research.md](wiki/taa-selection-research.md) | Reference |
+| Anomaly-Driven Demand (ADD) Crowding | [anomaly-driven-demand.md](wiki/anomaly-driven-demand.md) | Reference |
 | Cakici et al. (2024) Coverage Audit | [cakici-2024-coverage-audit.md](wiki/cakici-2024-coverage-audit.md) | Audit |
 
 ### Backtest Methodology & Gap Analysis

--- a/knowledge/wiki/anomaly-driven-demand.md
+++ b/knowledge/wiki/anomaly-driven-demand.md
@@ -1,0 +1,79 @@
+## Anomaly-Driven Demand (ADD) — Crowding as a Return Channel
+
+### Thesis
+
+When millions of factor investors mechanically rebalance the **same** published
+anomaly portfolios at the **same** time (month-end), their coordinated *trading
+flow* itself moves prices — independent of any new information. Anomalies
+"discovered as passive predictors have become active agents in generating those
+returns." This is a **flow/demand-pressure** channel, distinct from the
+information-already-priced channel covered by the `priced-in-prohibition` rule
+and [[priced-in-signals]].
+
+### How ADD is measured (public data only)
+
+1. For each of the **209 anomalies** in the Chen & Zimmermann open dataset
+   ([openassetpricing.com](https://www.openassetpricing.com/)), sort stocks into
+   quintiles each month.
+2. For each stock, count **(new long-leg entries − new short-leg entries)** across
+   all anomalies.
+3. **ADD** = the month-over-month change in that net count. High ADD = a coming
+   wave of mechanical buying; low ADD = coordinated selling.
+
+### Key findings (from the post — treat as hypothetical until replicated)
+
+> ⚠ AI-inferred: the figures below are transcribed from a Swedroe blog post
+> digesting Posselt & Kjær (2026); we have not independently replicated them.
+
+| Finding | Value |
+|---|---|
+| High-ADD vs low-ADD excess return | 6.62% → 10.65% monotonic; spread **4.03pp** (t ≈ 4.03) |
+| Long-short ADD Sharpe | ≈ 0.61 |
+| Alpha survival | Survives FF5 + momentum + first 3 PCs of anomaly returns |
+| Timing | Generated in the **first ~6 trading days** of the month, **open-to-close (intraday)** |
+| Price impact | **Permanent** (no 12-month reversal) → demand-based, not a liquidity blip |
+| Cross-section | Stronger for **high-published-t** anomalies; near-zero for low-t |
+| Size pattern | **U-shaped** — strongest in micro-cap and mega-cap, weakest in the middle |
+| Feedback loop | returns → inflows → larger rebalancing flows → more price pressure → more returns |
+
+### Why this matters to us
+
+**Angle A — crowding/capacity warning (higher value, lower risk).** Our
+leaderboard ranks many overlapping long-short factor strategies on backtested
+Sharpe. ADD says a slice of those returns is mechanical crowding, concentrated
+at month-start, strongest exactly where we are tempted to chase. It directly
+compounds the multiple-testing problem: the more correlated published anomalies
+we stack, the more our portfolio rides the same coordinated flow. This reinforces
+the Vertox effective-strategy-count / deflated-Sharpe work ([#160]) — same
+headline-Sharpe-overstatement theme, *different mechanism* (flow, not information).
+
+**Angle B — ADD as a candidate signal (deferred).** ADD is buildable from free
+public data (Chen-Zimmermann), fitting our free-tier posture. But it is yet
+another long-short equity signal correlated with our existing ones, so it must be
+budgeted against multiple testing ([#160], deflated Sharpe) before any reported
+edge. Building it requires sourcing the 209-anomaly Chen-Zimmermann dataset, which
+is **not yet in our data layer** — a separate scoped issue if pursued.
+
+### Decision (2026-05-26)
+
+Adopt **Angle A** now: the `priced-in-prohibition` rule gained a flow-pressure
+(ADD) clause distinguishing demand-crowding from information-priced-in, with
+required checks for month-start concentration, published-significance crowding,
+capacity/reversal, and Turn-of-the-Month overlap ([#271]). Angle B (the ADD
+signal + Chen-Zimmermann data layer) is parked pending a dedicated issue.
+
+### Related
+
+- [[priced-in-signals]] — the information-priced-in channel (this is the flow channel)
+- [[taa-selection-research]], [[market-behavior-gap-analysis]] — adjacent crowding/capacity context
+- [#160] — Vertox effective number of tested strategies / deflated Sharpe
+- [#271] — Turn-of-the-Month overlay (the ~6-day month-start window ADD describes)
+
+## Sources
+
+- Larry Swedroe, "Where do returns actually come from in Factor Strategies? / When Everyone Trades the Same Factor Playbook" (2026-05-22), alphaarchitect.com — blog post digesting the paper below. Retrieved from a manual PDF save (live page Cloudflare-blocked).
+- Posselt & Kjær (March 2026), "Anomaly-Driven Demand" (ADD) — the underlying paper.
+- Chen & Zimmermann open anomaly dataset — [openassetpricing.com](https://www.openassetpricing.com/) (209 anomalies, free).
+- Issue [#279] — gap analysis and decision record.
+</content>
+</invoke>


### PR DESCRIPTION
Prose/config deliverables companion to the code PRs #293 (#288) and #294 (#160).

## #160 — `backtest-robustness` rule
- Disambiguate the two K_eff quantities: **K_eff_acf** (autocorrelation-adjusted effective sample size *in time*, per series) vs **K_eff_strat** (Vertox correlation-aware effective *count of strategies*). Bare `K_eff` reserved.
- Falsification table now lists **Deflated Sharpe**, with `K_trials = round(K_eff_strat)` (NOT raw M) — the raw count over-penalises a correlated portfolio.
- New **§5 K_eff-guided search-stopping rule**: halt variant search when a new (correlated) variant adds < 0.25 to `K_eff_strat`; track the independence ratio `K_eff_strat / M`.

## #279 — `priced-in-prohibition` rule + knowledge base
- New **flow-pressure (Anomaly-Driven Demand) clause**: ADD crowding is a *distinct channel* from information-already-priced. Required checks: month-start concentration (~first 6 trading days), published-t crowding, capacity/reversal, Turn-of-the-Month overlap.
- New `knowledge/wiki/anomaly-driven-demand.md` digesting Posselt & Kjær (2026) ADD; **Angle A (crowding warning)** adopted, **Angle B (ADD signal + Chen-Zimmermann data layer)** parked pending a dedicated issue.
- Cross-links #160 ↔ #271 ↔ #279.

## Verification
- Prose-only changes (project rules + wiki + index). No code paths affected.
- The companion `K_eff_strat → deflated Sharpe` function chain (#294) was verified independently: `K_eff_strat(ρ=0.5, M=4)=3.25` (axioms `I₄→4`, `J₄→1` hold); DSR with K_eff=3 (0.557) > DSR with raw M=4 (0.488), confirming the over-penalisation thesis.

## Not in scope (deferred)
- `statistical-reporting` §2 update (K_eff-adjusted FDR) — that is a **global llm rule**; deferred to the llm session per cross-project-scope.

Refs #160 #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)