### PR TITLE
feat(leaderboard): Vertox K_eff_strat → deflated Sharpe (#160)

### DIFF
--- a/.claude/rules/backtest-robustness.md
+++ b/.claude/rules/backtest-robustness.md
@@ -95,14 +95,54 @@ against simulated environments where no real edge exists.
 
 | Metric | Description | Fail threshold |
 |--------|-------------|---------------|
-| K_eff_acf | Effective sample size after autocorrelation adjustment | < 30 |
-| Delta_Z | Z-score gap between strategy and null | < 1.96 (not significant) |
+| K_eff_acf | Effective sample size *in time* after autocorrelation adjustment (Newey-West, per series) | < 30 |
+| K_eff_strat | Effective *number of independent strategies* tested, correlation-aware (Vertox) | (input to deflated Sharpe, not a pass/fail) |
+| Delta_Z | Z-score gap between strategy and null | < 1.96 |
 | Stage 1 rejection rate | % of 5 simulation environments where strategy is rejected as noise | < 80% (must reject in 4/5) |
-| Adjusted Sharpe | Sharpe ratio corrected for multiple testing / look-ahead | < 0.5 |
+| Deflated Sharpe (DSR) | Sharpe corrected for non-normality AND multiple testing, using `K_eff_strat` (not raw M) as the trial count | DSR p-value > 0.05 |
 | CVaR (95%) | Conditional Value at Risk | Worse than benchmark |
 
+**Two distinct `K_eff` quantities — never conflate:** `K_eff_acf`
+(`calculate_keff()`, autocorrelation-adjusted effective sample size *in time*,
+per strategy) and `K_eff_strat` (`hd_strat_keff_vertox()`, correlation-aware
+effective *count of strategies* across the tested portfolio). Bare `K_eff` is
+reserved — always use a method-suffixed name. The deflated Sharpe ratio
+(`hd_deflated_sharpe(r, K_trials = round(K_eff_strat))`) takes `K_eff_strat`,
+NOT the raw strategy count `M`: on a correlated portfolio the raw count
+over-penalises (the strategies are not independent tests).
+
 Report these in a dedicated table in every backtest output, not just the
-equity curve and raw Sharpe. Reference: [Backtests Lie](https://www.vertoxquant.com/p/backtests-lie).
+equity curve and raw Sharpe. References: [Backtests Lie](https://www.vertoxquant.com/p/backtests-lie),
+[The Effective Number of Tested Strategies](https://www.vertoxquant.com/p/the-effective-number-of-tested-strategies) (Vertox), Lopez de Prado (2018) Deflated Sharpe Ratio.
+
+### 5. K_eff-Guided Search Stopping (Correlated-Variant Multiple Testing)
+
+When you iteratively add variants of an already-tested strategy (HRP Phase 1 →
+Phase 2 → Phase 3, ADV-cap on/off, multiple Kelly fractions, universe
+restrictions), each new variant is **highly correlated** with the prior ones.
+Vertox's monotonicity axiom says such a variant adds **< 1** to `K_eff_strat`
+even though it adds 1 to the raw count `M`. Reporting each variant's Sharpe as
+an independent gain inflates apparent edge — the gains are partly a
+multiple-testing artefact.
+
+**Stop rule:** halt hyperparameter / variant search when the *marginal*
+`K_eff_strat` gain from adding a variant falls below a threshold (default: a
+new variant must raise `K_eff_strat` by ≥ 0.25 to justify a separate reported
+result). Track `K_eff_strat / M` (the independence ratio) across the search:
+when it drops sharply, you are mining correlated variants, not discovering
+independent edge.
+
+```r
+# Before reporting a new strategy variant as a distinct result:
+k_before <- hd_strat_keff_vertox(corr_without_variant, seed = 160L)
+k_after  <- hd_strat_keff_vertox(corr_with_variant,    seed = 160L)
+if (k_after - k_before < 0.25) {
+  cli::cli_warn(c(
+    "!" = "Variant adds only {round(k_after - k_before, 2)} to K_eff_strat",
+    "i" = "Highly correlated with existing strategies; its Sharpe gain is partly a multiple-testing artefact. Apply deflated Sharpe before reporting."
+  ))
+}
+```
 
 ## Robustness Heatmap
 

--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -204,7 +204,7 @@ plan_leaderboard <- function() {
           dsr_pvalue      = d$dsr_pvalue,
           dsr_haircut_pct = d$haircut_pct,
           k_eff_strat     = strat_keff_vertox,
-          k_raw           = length(col_map)
+          k_raw           = nrow(strat_corr_matrix)
         )
       }))
     })

--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -143,6 +143,18 @@ plan_leaderboard <- function() {
           )
       }
 
+      # ── Deflated Sharpe (full-sample; K_trials = Vertox K_eff_strat, not raw M) — #160 ──
+      # DSR is a full-sample statistic, so it broadcasts to all period rows; the
+      # vignette surfaces it only in the Full-Period view.
+      if (!is.null(strat_deflated_sharpe) && nrow(strat_deflated_sharpe) > 0) {
+        all_metrics <- all_metrics |>
+          left_join(
+            strat_deflated_sharpe |>
+              select(strategy, deflated_sharpe, dsr_pvalue, k_eff_strat),
+            by = "strategy"
+          )
+      }
+
       all_metrics
     }),
 
@@ -162,6 +174,39 @@ plan_leaderboard <- function() {
       as.data.frame(cor_mat) |>
         tibble::rownames_to_column("strategy") |>
         as_tibble()
+    }),
+
+    # ── Vertox K_eff_strat: correlation-aware effective strategy count ────────
+    # Uses strat_corr_matrix from plan_strategy_correlation (available as dep).
+    # seed = 160 for reproducibility (issue #160).
+    targets::tar_target(strat_keff_vertox, {
+      historicaldata::hd_strat_keff_vertox(strat_corr_matrix, n_sim = 20000L, seed = 160L)
+    }),
+
+    # ── Deflated Sharpe per strategy (#160) ───────────────────────────────────
+    # K_trials = K_eff_strat (Vertox correlation-aware count, rounded to integer),
+    # NOT raw M=4: correlated strategies → raw count over-penalises.
+    # ann_factor = 12 (monthly returns in port_returns).
+    # col_map keys match port_returns column names; values match leaderboard labels.
+    targets::tar_target(strat_deflated_sharpe, {
+      library(dplyr)
+      k_eff <- max(1L, round(strat_keff_vertox))
+      col_map <- c(stk_max = "Stock MAX", stk_drif = "Stock DRIF",
+                   fac_max = "Factor MAX", fac_drif = "Factor DRIF")
+      bind_rows(lapply(names(col_map), function(col) {
+        r <- port_returns[[col]]
+        r <- r[!is.na(r)]
+        d <- historicaldata::hd_deflated_sharpe(r, K_trials = k_eff, ann_factor = 12L)
+        tibble::tibble(
+          strategy        = unname(col_map[[col]]),
+          naive_sharpe    = d$naive_sharpe,
+          deflated_sharpe = d$dsr,
+          dsr_pvalue      = d$dsr_pvalue,
+          dsr_haircut_pct = d$haircut_pct,
+          k_eff_strat     = strat_keff_vertox,
+          k_raw           = length(col_map)
+        )
+      }))
     })
   )
 }

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -330,6 +330,35 @@ if (!is.null(boot_ci)) {
 }
 ```
 
+#### Deflated Sharpe
+
+The Deflated Sharpe Ratio (<abbr title="Deflated Sharpe Ratio: Sharpe adjusted for non-normality (skewness, kurtosis) and multiple testing across K trials — Lopez de Prado 2018">DSR</abbr>) adjusts the naive Sharpe for both non-normality of returns (skewness and kurtosis) and multiple testing, answering the question: given that we tested K strategies, is this Sharpe ratio statistically significant? The multiple-testing penalty uses the Vertox correlation-aware effective count K_eff_strat (not the raw count M = 4), because the 4 strategies are correlated — using the raw count would over-penalise and reject strategies that carry genuine independent signal. See [Lopez de Prado (2018)](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2460551) for the DSR derivation and [Vertox — The Effective Number of Tested Strategies](https://www.vertoxquant.com/p/the-effective-number-of-tested-strategies) for the K_eff_strat methodology.
+
+```{r}
+#| label: deflated-sharpe
+x <- safe_tar_read("strat_deflated_sharpe")
+if (!is.null(x)) {
+  keff <- round(x$k_eff_strat[1], 2)
+  kraw <- x$k_raw[1]
+  cap <- paste0(
+    "Deflated Sharpe (Lopez de Prado 2018). ",
+    "Multiple-testing penalty uses Vertox K_eff_strat = ", keff,
+    " effective strategies vs ", kraw,
+    " raw — the 4 strategies are correlated, so the raw count over-penalises. ",
+    "DSR adjusts for skewness, kurtosis, and the effective number of trials."
+  )
+  display <- x |>
+    transmute(
+      Strategy        = strategy,
+      `Naive Sharpe`  = round(naive_sharpe, 2),
+      `Deflated Sharpe` = round(deflated_sharpe, 2),
+      `Haircut %`     = paste0(round(dsr_haircut_pct, 1), "%"),
+      `DSR p-value`   = round(dsr_pvalue, 3)
+    )
+  hd_dt(display, cap)
+}
+```
+
 #### Alpha Decay
 
 ```{r}


### PR DESCRIPTION
## Summary

- Adds `strat_keff_vertox` and `strat_deflated_sharpe` targets to `R/plan_leaderboard.R`. Note: `strat_corr_matrix` was NOT duplicated — it already exists in `plan_strategy_correlation.R` and is consumed as a cross-plan dependency.
- Both new targets coexist cleanly with the `strat_corr_augment` join from #268 (disjoint columns: `deflated_sharpe`, `dsr_pvalue`, `k_eff_strat` vs `correlation_max`, `redundant`, `incremental_sharpe`).
- The `K_trials` argument to `hd_deflated_sharpe()` is `round(K_eff_strat)` (Vertox correlation-aware count, not raw M=4): correlated strategies share information, so the raw count over-penalises and would reject genuine signal.
- `docs/leaderboard.qmd`: new **Deflated Sharpe** tab inserted after Bootstrap CI under the Robustness section. Dynamic caption (keff and kraw read from the target at render time — no hardcoded numbers). Prose cites Lopez de Prado (2018) and Vertox.
- `.claude/rules/backtest-robustness.md`: disambiguation of `K_eff_acf` vs `K_eff_strat` (never bare `K_eff`), DSR row added to the falsification table, new §5 K_eff-guided search stopping rule (marginal threshold ≥ 0.25 per new variant).

## Note on #279 / current main

The `hd_strat_keff_vertox()` and `hd_deflated_sharpe()` package functions are already exported on current main (added by #279 or earlier). This PR wires them into the pipeline and vignette — no function re-implementation.

## Note on global statistical-reporting rule

The `statistical-reporting` §2 K_eff-FDR update is deferred to the `llm` session per the `cross-project-scope` rule (that rule lives in the global llm project, not this project's tree).

## Test plan

- [x] `PARSE OK` — `parse("docs/_targets.R")` and `parse("R/plan_leaderboard.R")` both succeed
- [x] `git diff --stat origin/main` shows exactly 3 files changed
- [ ] Live pipeline numbers: verify on next `tar_make()` deploy (DSR values and K_eff_strat render correctly in the Deflated Sharpe tab)

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)