### PR TITLE
docs(wiki): Walk Forward Correlation digest (Tinsley SSRN 6324079) — #297

### DIFF
--- a/knowledge/INDEX.md
+++ b/knowledge/INDEX.md
@@ -29,6 +29,7 @@ Cross-cutting patterns live in `~/docs_gh/llm/knowledge/`.
 | Topic | Page | Status |
 |-------|------|--------|
 | Tinsley Backtest Framework Audit | [tinsley-backtest-framework-audit.md](wiki/tinsley-backtest-framework-audit.md) | Audit |
+| Walk Forward Correlation (WFC) | [walk-forward-correlation.md](wiki/walk-forward-correlation.md) | Reference |
 | Market Behavior Gap Analysis | [market-behavior-gap-analysis.md](wiki/market-behavior-gap-analysis.md) | Audit |
 | Daloopa/investing Gap Analysis | [daloopa-gap-analysis.md](wiki/daloopa-gap-analysis.md) | Audit |
 | JST vs DMS Dataset Comparison | [jst-dms-comparison.md](wiki/jst-dms-comparison.md) | Reference |

--- a/knowledge/raw/tinsley-walk-forward-correlation-2026.md
+++ b/knowledge/raw/tinsley-walk-forward-correlation-2026.md
@@ -1,0 +1,121 @@
+# Walk Forward Correlation — key excerpts (raw source)
+
+Source paper: Martyn Tinsley, "Walk Forward Correlation: A Diagnostic for Over-Fitting
+and Structural Edge in Trading Strategy Optimisation", Trade Like A Machine Ltd,
+February 2026. SSRN abstract_id=6324079 (8 pp). Local PDF saved at
+`knowledge/raw/Walk Forward Correlation 8pgs 1 Apr 2026 Martyn Tinsley.pdf`
+(binary not committed — convention is markdown transcripts). JEL: G17, C52, C63.
+
+Excerpts below are faithful quotes/paraphrases for provenance; page refs in brackets.
+This is raw source material — APPEND ONLY, do not edit existing lines.
+
+---
+
+## Abstract (p.1)
+
+"This paper introduces Walk Forward Correlation (WFC), a diagnostic technique for
+assessing both over-fitting and the presence of genuine structural edge in trading
+strategy optimisation. Traditional single-stage walk-forward validation and
+multi-stage Walk Forward Analysis (WFA) evaluate only the single parameter set
+selected as most robust or optimal during each in-sample (IS) optimisation window.
+This approach can lead to false confidence when the chosen parameters perform well
+out-of-sample (OOS) purely by chance."
+
+"WFC evaluates the entire optimisation surface by computing performance metrics for
+all parameter combinations across both IS and OOS datasets, and then measuring the
+correlation between IS and OOS performance across the full n-dimensional parameter
+space. A high positive correlation indicates that IS performance is predictive of
+OOS performance, suggesting that over-fitting has been effectively constrained. A
+low or near-zero correlation indicates that IS performance contains little or no
+information about OOS behaviour, implying over-fitting or the absence of structural
+edge."
+
+## Related literature (p.2)
+
+WFC is positioned against: Walk Forward Analysis (WFA, Pardo 2011), Combinatorial
+Purged Cross-Validation (CPCV, Lopez de Prado 2018), the Deflated Sharpe Ratio
+(DSR, Bailey & Lopez de Prado 2014), the Probability of Backtest Overfitting (PBO,
+Bailey et al. 2014), and White's Reality Check (WRC, White 2000).
+
+"Although these methods address selection bias, data leakage, and statistical
+significance, none directly examine the pairwise relationship between IS and OOS
+performance for every parameter combination. WFC fills this gap by analysing the
+optimisation surface as a whole."
+
+## Methodology (p.2-3)
+
+Parameter vector θ = (θ1, θ2, ..., θk); P = full grid of parameter combinations
+evaluated during optimisation. For each θ ∈ P define mappings X, Y : P → R where
+X(θ) = in-sample performance metric and Y(θ) = out-of-sample performance metric,
+yielding the paired dataset {(X(θ), Y(θ)) : θ ∈ P}.
+
+Correlation definition (eq. 5): **WFC = ρ(X, Y)**, where ρ may be chosen as:
+Pearson correlation (default), Spearman rank correlation, Kendall's tau, or
+distance correlation.
+
+Structural edge (p.3): "a positive expected out-of-sample performance arising from
+persistent, non-random relationships in market data, and which remains stable across
+neighbouring regions of the strategy's parameter space. Structural edge requires
+both: positive OOS performance, and predictive consistency between IS and OOS
+performance. Correlation alone cannot establish structural edge; it measures the
+predictive capability of the model, not profitability."
+
+## Parameter-space topology (p.4)
+
+- Smooth topology: small parameter changes lead to small performance changes; IS and
+  OOS surfaces tend to align, producing higher WFC and indicating stable edge.
+- Chaotic topology: small parameter changes lead to large, unpredictable performance
+  changes; IS and OOS surfaces diverge, producing low WFC and indicating noise.
+
+## Interpretation (p.4)
+
+- WFC ≈ 1: IS performance reliably predicts OOS. Structural edge exists ONLY if OOS
+  values are positive. 1.0 is a theoretical upper bound, not expected in real data.
+- WFC ≈ 0: IS performance contains no usable information about OOS; over-fitted to
+  noise in the IS dataset.
+- WFC < 0: IS inversely predictive of OOS; strategy unstable or a regime shift
+  occurred between IS and OOS periods.
+
+## Diagnostic matrix (p.4)
+
+|              | High Correlation                 | Low Correlation                    |
+|--------------|----------------------------------|------------------------------------|
+| Positive OOS | Structural edge, low over-fitting | Spurious result, high over-fitting |
+| Negative OOS | Consistently loss-making strategy | Noise, no edge                     |
+
+## Illustrative examples (p.5-7)
+
+- Figure 1: High WFC = 0.881; 65.8% of OOS values positive → strong evidence of
+  genuine structural edge.
+- Figure 2: Moderate WFC = 0.581; some predictive information but noise significant;
+  over-fitting limits effectiveness.
+- Figure 3: Low WFC = 0.234; IS does not predict OOS → characteristic of over-fitting.
+- Figure 4: Moderate WFC = 0.471 but NO structural edge — negative performance
+  predominates in both IS and OOS.
+
+Worked example (Figure 4, p.7): Point A is the highest IS performer and appears
+profitable OOS (Sharpe ≈ 0.8) under traditional single-parameter walk-forward
+validation. But point B (second-highest IS) yields slightly negative OOS, and "81%
+of parameter configurations that produce positive IS performance subsequently produce
+negative OOS performance. It is therefore highly likely that the OOS performance of
+point A is due to chance rather than genuine edge. Analysts relying solely on
+single-parameter walk-forward validation may be misled, whereas full WFC immediately
+reveals that the strategy should not be traded."
+
+## Conclusion / future work (p.7-8)
+
+WFC "complements existing techniques" by quantifying predictive consistency,
+evaluating absolute OOS performance, and considering parameter-space topology.
+Future work flagged by the author: formal statistical characterisation of WFC;
+empirical comparison of performance metrics (Sharpe, Sortino, Calmar); integration
+with multi-window Walk Forward Analysis.
+
+## References (p.8)
+
+1. Pardo, R. (2011). The Evaluation and Optimization of Trading Strategies. Wiley.
+2. Bailey, Borwein, Lopez de Prado & Zhu (2014). The Probability of Backtest Overfitting. J. Computational Finance.
+3. White, H. (2000). A Reality Check for Data Snooping. Econometrica.
+4. Hansen, P. (2005). A Test for Superior Predictive Ability. J. Business & Economic Statistics.
+5. Bergmeir & Benítez (2012). On the Use of Cross-Validation for Time Series Predictor Evaluation. Information Sciences.
+6. Lopez de Prado, M. (2018). Advances in Financial Machine Learning. Wiley.
+7. Bailey & Lopez de Prado (2014). The Deflated Sharpe Ratio. J. Risk.

--- a/knowledge/wiki/walk-forward-correlation.md
+++ b/knowledge/wiki/walk-forward-correlation.md
@@ -1,0 +1,79 @@
+---
+title: Walk Forward Correlation (WFC)
+canonical_question: "How does Walk Forward Correlation detect over-fitting and structural edge, and what gap does it fill versus our backtest-robustness stack?"
+status: active
+fresh_until: 2027-05-26
+consensus_level: direct
+sources:
+  - tinsley-walk-forward-correlation-2026.md
+compiled_by: claude-opus-4-7
+compiled_on: 2026-05-26
+tags: [backtesting, overfitting, walk-forward, robustness, structural-edge, optimization-surface, tinsley, deflated-sharpe]
+---
+
+# Walk Forward Correlation (WFC)
+
+Walk Forward Correlation (WFC) is a single-number diagnostic for over-fitting that evaluates the **whole optimisation surface** rather than the single "best" parameter set. Instead of asking "does the best in-sample parameter set survive out-of-sample?" (the question traditional Walk Forward Analysis answers), WFC asks "across *every* parameter combination, does in-sample performance predict out-of-sample performance?" It is the explicit complement to our existing multiple-testing tools (deflated Sharpe / Vertox `K_eff_strat`, [#160]): those correct a *reported* metric for selection bias; WFC instead diagnoses whether the optimisation *as a whole* contains structural edge or just noise. Source: Martyn Tinsley, Feb 2026, SSRN 6324079 ([raw excerpts](../raw/tinsley-walk-forward-correlation-2026.md)).
+
+---
+
+## What WFC is
+
+For a strategy with parameter vector θ = (θ₁,…,θₖ) and full evaluation grid P, compute two metrics for **every** point on the grid: an in-sample metric X(θ) and an out-of-sample metric Y(θ) (Sharpe in the paper's figures). WFC is simply the correlation across that paired cloud:
+
+**WFC = ρ(X, Y)** over all θ ∈ P.
+
+ρ defaults to Pearson; the paper also lists Spearman, Kendall's τ, and distance correlation as alternatives ([raw](../raw/tinsley-walk-forward-correlation-2026.md), Methodology, p.2–3).
+
+> Note: the AlgoAdvantage Substack article describes the default as *weighted* Pearson; the paper itself (eq. 5, p.3) says Pearson. Treat "weighted" as the author's practical default, not stated in the paper.
+
+## Structural edge ≠ correlation
+
+The paper is emphatic: "Correlation alone cannot establish structural edge; it measures the predictive capability of the model, not profitability" (p.3). **Structural edge requires BOTH** (a) positive OOS performance AND (b) high IS↔OOS predictive consistency (high WFC). High WFC with negative OOS just means a reliably loss-making strategy.
+
+## Interpretation (p.4)
+
+| WFC | Meaning |
+|-----|---------|
+| ≈ 1 | IS reliably predicts OOS; edge **only if OOS positive**. 1.0 is a theoretical bound, not seen in real data |
+| ≈ 0 | IS carries no information about OOS → over-fit to IS noise |
+| < 0 | IS inversely predicts OOS → instability or a regime shift between IS and OOS |
+
+### Diagnostic matrix (p.4)
+
+|              | High WFC                          | Low WFC                              |
+|--------------|-----------------------------------|--------------------------------------|
+| **+OOS**     | Structural edge, low over-fitting  | Spurious result, high over-fitting   |
+| **−OOS**     | Consistently loss-making strategy  | Noise, no edge                       |
+
+### Topology
+
+Smooth surfaces (small parameter change → small performance change) align IS and OOS → higher WFC, stable edge. Chaotic surfaces → low WFC, noise. This is the quantified version of "reject isolated peaks" that our `backtest-robustness` heatmap currently checks only visually.
+
+## The worked example that motivates WFC (Figure 4, p.7)
+
+WFC = 0.471 but **no** structural edge. Point A — the highest IS performer — looks profitable OOS (Sharpe ≈ 0.8), so traditional single-parameter walk-forward validation would deploy it. But **81% of configurations with positive IS performance go on to negative OOS performance** ([raw](../raw/tinsley-walk-forward-correlation-2026.md), Examples, p.7). So point A's OOS result is almost certainly luck. The whole-surface view "immediately reveals that the strategy should not be traded" — a verdict single-best WFA cannot reach. (Calibration points from the paper's figures: high WFC = 0.881 with 65.8% OOS-positive; moderate = 0.581; low = 0.234.)
+
+## Gap analysis vs our backtesting stack
+
+> ⚠ AI-inferred: the mapping below is our synthesis of the paper against this project's code/rules as of 2026-05-26, not claims from the paper.
+
+| WFC element | What we have today | Gap |
+|---|---|---|
+| IS↔OOS correlation across the **full** parameter grid (ρ over all θ) | `backtest-robustness` §1 sweep (±20% point degradation) + a *visual* robustness heatmap | We never compute a WFC coefficient — no `wf_correlation` target exists. Our sweep is local; the heatmap is eyeballed |
+| 2×2 (WFC × OOS-sign) separating *spurious luck* from *stable-but-unprofitable* | `hd_delta_z()` tests only the single best IS vs OOS max-Z | delta_z is single-point; WFC characterises the whole surface. Complementary |
+| Topology smoothness as a number | heatmap (reject isolated peak) | Partially covered, not quantified |
+| Position vs DSR / CPCV / PBO / White's RC | deflated Sharpe ✅ ([#160]); 6 null environments ≈ White's-RC-adjacent ✅ | Purged/embargoed CV (CPCV) is a likely separate gap to confirm |
+
+Tunable strategies with a grid suitable for WFC here: DRIF elastic-net (α/λ), XGB DRIF (hyperparameters), MAX (lookback/decile). Walk-forward partitions already exist (`backtest-partitions`: train/test/validation). Tracked in [#297].
+
+## Relation to our existing methods
+
+WFC is a **complement**, not a replacement. The paper itself lists WFA, CPCV, DSR, PBO and White's Reality Check and notes "none directly examine the pairwise relationship between IS and OOS performance for every parameter combination" (p.2). In our terms: deflated Sharpe / `K_eff_strat` ([#160]) corrects a chosen strategy's reported Sharpe for multiple testing; WFC instead asks whether the optimisation surface had any predictive structure to begin with. See [[tinsley-backtest-framework-audit]] for the earlier (closed #143) 14-step Tinsley framework audit — WFC is the newer, method-specific follow-up not covered there.
+
+## Sources
+
+- [tinsley-walk-forward-correlation-2026.md](../raw/tinsley-walk-forward-correlation-2026.md) — key excerpts from the paper (abstract, methodology p.2–3, interpretation + diagnostic matrix p.4, worked example p.7, references p.8).
+- Martyn Tinsley, "Walk Forward Correlation", Trade Like A Machine Ltd, Feb 2026 — [SSRN abstract_id=6324079](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6324079) (Cloudflare-gated; PDF saved locally at `knowledge/raw/Walk Forward Correlation 8pgs 1 Apr 2026 Martyn Tinsley.pdf`, binary not committed per the markdown-only raw/ convention).
+- [AlgoAdvantage podcast #053](https://www.algoadvantage.io/podcast/053-martyn-tinsley-2/) and [Substack article](https://algoadvantage.substack.com/p/053-martyn-tinsley-walk-forward-correlation).
+- Related: [[tinsley-backtest-framework-audit]] (#143, closed); issue [#297] (gap-analysis tracker); [#160] (deflated Sharpe / `K_eff_strat`).


### PR DESCRIPTION
Digests the Tinsley Walk Forward Correlation (WFC) paper into the knowledge base — completes the first acceptance item of #297 (the SSRN PDF, Cloudflare-gated, was supplied manually).

## What's here
- `knowledge/raw/tinsley-walk-forward-correlation-2026.md` — faithful key-excerpts transcript (abstract, methodology, interpretation, 2×2 matrix, worked example, references). The binary PDF is **not** committed — `raw/` convention is markdown transcripts (4 `.md`, 0 PDFs).
- `knowledge/wiki/walk-forward-correlation.md` — digest: WFC = ρ(X,Y) over the **full** IS↔OOS parameter grid; structural-edge = positive OOS **and** high WFC ("correlation is not edge"); 2×2 diagnostic matrix; the Fig-4 trap (WFC=0.471 yet 81% of positive-IS configs → negative OOS, so the single-best WFA pick is luck); and a **gap analysis vs our stack**.
- `knowledge/INDEX.md` — indexed under Backtest Methodology.

## Gap (feeds #297)
We have no `wf_correlation` target — our `backtest-robustness` §1 is a ±20% point sweep + a *visual* heatmap, and `hd_delta_z()` only tests the single best point. WFC quantifies whole-surface IS↔OOS predictiveness. It **complements** deflated Sharpe / Vertox `K_eff_strat` (#160): DSR corrects a chosen strategy's reported metric; WFC asks whether the optimisation surface had predictive structure at all. CPCV (purged CV) flagged as a likely separate gap.

## Provenance
- SSRN abstract_id=6324079 is Cloudflare-JS-gated (not WebFetch/curl-accessible); PDF saved locally to `raw/` by the maintainer.
- Sources cited: the raw excerpts + AlgoAdvantage podcast #053 + Substack article.

Refs #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)