### PR TITLE
docs(rules): flow-pressure (ADD) crowding clause for priced-in-prohibition (#279)

### DIFF
--- a/.claude/rules/priced-in-prohibition.md
+++ b/.claude/rules/priced-in-prohibition.md
@@ -20,6 +20,25 @@ A signal derived from information available to all market participants is alread
 
 Before incorporating a signal based on public data, require evidence that the signal provides **incremental** predictive power beyond what is already reflected in prices. The burden of proof is on the signal, not on the market.
 
+## CRITICAL: Flow-Pressure Crowding (ADD) Is a Distinct Channel
+
+"Priced-in" above is about **information** being already reflected in prices. There is a **second**, separate way published signals lose (or distort) their edge: **Anomaly-Driven Demand (ADD)**. When many factor investors mechanically rebalance the **same** published anomaly portfolios at the **same** time (month-end), their coordinated *trading flow* moves prices — independent of any new information. "Anomalies discovered as passive predictors become active agents generating those returns" (Kjær & Posselt 2025; digested in [[anomaly-driven-demand]]).
+
+Why this matters for our leaderboard:
+
+- A slice of a published anomaly's backtested return is **mechanical crowding**, not edge — concentrated in the first ~6 trading days of the month, strongest exactly where we are tempted to chase (high-published-t anomalies).
+- This is the *demand-pressure* mechanism; the priced-in checks above test the *information* mechanism. **A signal can pass the information checks and still be contaminated by crowding flow.**
+- Crowding compounds the multiple-testing problem in `backtest-robustness` / Vertox `K_eff_strat` ([#160]): the more correlated published anomalies we stack, the more our portfolio rides the same coordinated flow.
+
+### Required when adding a published-anomaly signal
+
+| Check | Question | Fail/flag condition |
+|-------|----------|--------------------|
+| Crowding concentration | Is the return concentrated in the month-start rebalance window (~first 6 trading days)? | If yes, the edge is partly coordinated flow, not persistent mispricing |
+| Published-significance crowding | Is the anomaly high-published-t (widely traded)? | High-t anomalies attract the most ADD → most crowding contamination |
+| Capacity / reversal | Is the price impact permanent (demand-based) or does it revert? | Permanent impact in crowded windows = capacity risk as more capital chases it |
+| Turn-of-month overlap | Does the signal overlap our Turn-of-the-Month work ([#271])? | TOM overlays must be ADD-aware, not double-counting the same flow |
+
 ## Required Checks
 
 | Check | Question | Fail condition |
@@ -37,6 +56,8 @@ Before incorporating a signal based on public data, require evidence that the si
 | "Analyst consensus is bullish" | Consensus = priced in by definition |
 | "This sector is overvalued based on P/E" | Relative valuation is the most-watched metric |
 | Signal from a widely-followed indicator without decay analysis | No evidence of incremental power |
+| Stacking many published high-t anomalies as if independent | Coordinated ADD flow + multiple-testing — see `K_eff_strat` ([#160]) |
+| Treating an anomaly's month-start return as persistent edge | May be mechanical rebalancing flow (ADD), not mispricing |
 
 ## Acceptable Signals
 
@@ -51,4 +72,7 @@ Before incorporating a signal based on public data, require evidence that the si
 
 - `look-ahead-bias-prevention` — covers temporal leakage; this rule covers information-already-priced
 - `cross-geography-pervasiveness` — pervasiveness test strengthens evidence against data mining
-- `backtest-robustness` — parameter sensitivity; this rule adds information-content scrutiny
+- `backtest-robustness` — parameter sensitivity + `K_eff_strat` deflated-Sharpe; this rule adds information-content + flow-crowding scrutiny
+- [[anomaly-driven-demand]] — wiki digest of Kjær & Posselt (2025) ADD; the flow-pressure channel
+- [#160] — Vertox effective number of tested strategies / deflated Sharpe (crowding ↔ multiple-testing)
+- [#271] — Turn-of-the-Month overlay (month-start return concentration; must be ADD-aware)


### PR DESCRIPTION
Completes the missing rule-clause half of #279. Session #9 landed the ADD **wiki digest** (`anomaly-driven-demand.md`) but the **`priced-in-prohibition` rule clause** was never added (I previously mis-reported it as present — corrected).

## Change
Adds a "Flow-Pressure Crowding (ADD) Is a Distinct Channel" section to `priced-in-prohibition`:
- Distinguishes **demand-pressure crowding** (Anomaly-Driven Demand) from **information-already-priced** — a signal can pass the information checks and still be contaminated by coordinated month-start rebalancing flow.
- Adds a required-checks table (month-start concentration ~first 6 trading days, published-t crowding, capacity/reversal, Turn-of-the-Month overlap), two forbidden-pattern rows, and cross-links.
- Links `[[anomaly-driven-demand]]` (the wiki digest already on main), #160 (`K_eff_strat` / deflated Sharpe — crowding compounds multiple testing), #271 (TOM must be ADD-aware).

Prose-only; no code paths touched.

Refs #279 (leaves #279 open — Angle B, the ADD signal + Chen-Zimmermann data layer, remains a separate scoped item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)