### PR TITLE
docs(wiki): clarify crypto momentum-decomp outcome (closes roborev j4566)

### DIFF
--- a/knowledge/wiki/momentum-decomposition-cross-asset.md
+++ b/knowledge/wiki/momentum-decomposition-cross-asset.md
@@ -9,7 +9,7 @@
 Tested momentum decomposition across three asset classes. Found universal failure:
 - Equities: Decomposition destroyed value
 - Commodities: Both baseline AND decomposition failed
-- Crypto: Pipeline debugged and completed (PR #136 merged); result expected negative given cross-asset pattern
+- Crypto: Pipeline debugged and completed (PR #136 merged); quantitative results not separately reported — see Evidence section
 
 ## Evidence
 


### PR DESCRIPTION
## Summary

Single-line wiki prose fix. The Summary section of `knowledge/wiki/momentum-decomposition-cross-asset.md` said the crypto outcome was "result expected negative" — which reads as a quantitative finding — but the Evidence section already clarifies that no separate quantitative result was reported. Brought Summary wording in line with Evidence.

## Origin

Closes roborev review r4333 / job j4566 (HIGH severity, internal-contradiction finding). One of the 20 open FAILs from the session-#10 plan; WT-E triage (read-only quick-fix agent) located the inconsistency and proposed the exact one-line wording.

The other (LOW severity) finding the reviewer cited — that `knowledge/INDEX.md` advertises "30-hour research" — does **not** match the current INDEX content (no hours mentioned). Marked OBSOLETE; no action needed.

## Test plan
- [x] Wiki frontmatter preserved
- [x] `## Sources` section preserved (Wiki Conventions T1)
- [x] No changes outside the single line