### PR TITLE
fix(roborev): WT-D docs/Mermaid batch

### DIFF
--- a/docs/stock-backtest.qmd
+++ b/docs/stock-backtest.qmd
@@ -65,7 +65,7 @@ Two signals applied at two levels, producing four strategies:
 
 ```{r}
 #| fig-height: 6
-{ p <- safe_tar_read("stk_all_comparison_plot"); if (!is.null(p)) p else cat("*Chart not available — run tar_make() to generate.*\n") }
+{ p <- safe_tar_read("stk_all_comparison_plot"); if (!is.null(p)) p else { cat("*Chart not available — run tar_make() to generate.*\n"); invisible(NULL) } }
 ```
 
 ::: {.fig-caption}
@@ -181,7 +181,7 @@ if (!is.null(stk_max) && !is.null(stk_drif) && !is.null(fac_max) && !is.null(fac
 
 ```{r}
 #| fig-height: 6
-{ p <- safe_tar_read("stk_max_plot"); if (!is.null(p)) p else cat("*Chart not available — run tar_make() to generate.*\n") }
+{ p <- safe_tar_read("stk_max_plot"); if (!is.null(p)) p else { cat("*Chart not available — run tar_make() to generate.*\n"); invisible(NULL) } }
 ```
 
 ::: {.fig-caption}
@@ -205,7 +205,7 @@ if (!is.null(metrics)) {
 
 ```{r}
 #| fig-height: 6
-{ p <- safe_tar_read("stk_max_vs_factor_plot"); if (!is.null(p)) p else cat("*Chart not available — run tar_make() to generate.*\n") }
+{ p <- safe_tar_read("stk_max_vs_factor_plot"); if (!is.null(p)) p else { cat("*Chart not available — run tar_make() to generate.*\n"); invisible(NULL) } }
 ```
 
 ::: {.fig-caption}
@@ -258,7 +258,7 @@ if (!is.null(metrics)) {
 
 ```{r}
 #| fig-height: 6
-{ p <- safe_tar_read("stk_drif_plot"); if (!is.null(p)) p else cat("*Chart not available — run tar_make() to generate.*\n") }
+{ p <- safe_tar_read("stk_drif_plot"); if (!is.null(p)) p else { cat("*Chart not available — run tar_make() to generate.*\n"); invisible(NULL) } }
 ```
 
 ::: {.fig-caption}
@@ -319,7 +319,7 @@ if (!is.null(metrics)) {
 
 ```{r}
 #| fig-height: 6
-{ p <- safe_tar_read("xgb_vs_enet_plot"); if (!is.null(p)) p else cat("*Chart not available — run tar_make() to generate.*\n") }
+{ p <- safe_tar_read("xgb_vs_enet_plot"); if (!is.null(p)) p else { cat("*Chart not available — run tar_make() to generate.*\n"); invisible(NULL) } }
 ```
 
 ::: {.fig-caption}
@@ -387,7 +387,7 @@ Stock-level long-short strategies lose ~20%/yr after realistic costs (1.85%/mont
 
 ```{r}
 #| fig-height: 6
-{ p <- safe_tar_read("etf_comparison_plot"); if (!is.null(p)) p else cat("*Chart not available — run tar_make() to generate.*\n") }
+{ p <- safe_tar_read("etf_comparison_plot"); if (!is.null(p)) p else { cat("*Chart not available — run tar_make() to generate.*\n"); invisible(NULL) } }
 ```
 
 ::: {.fig-caption}


### PR DESCRIPTION
## Summary

- Fixes roborev j4037: prevent `NULL` leaking from plot chunks in `docs/stock-backtest.qmd` when pipeline targets are absent
- Closes roborev j4530 as OBSOLETE: both QA gate scope and missing-file findings already fixed in main before this PR

## Changes

### `docs/stock-backtest.qmd` (j4037 — FIXED)

Six plot code chunks used `cat(fallback_text)` as the else-branch when a target is NULL. In Quarto dashboard mode with `fig-height:` set, `cat()` returns `invisible(NULL)` which knitr then auto-prints as literal `NULL` in the HTML artifact. The committed HTML at SHA 646f3fb showed this as `<pre><code>NULL</code></pre>` in the XGBoost vs Elastic Net and ETF Equity Curves panels.

Fix: add `invisible(NULL)` after each `cat(...)` fallback so the chunk's last expression is invisible. Affects 6 plot chunks: `stk_all_comparison_plot`, `stk_max_plot`, `stk_max_vs_factor_plot`, `stk_drif_plot`, `xgb_vs_enet_plot`, `etf_comparison_plot`.

### j4530 — OBSOLETE

Both findings were already addressed in main before this PR:
1. `check_no_bare_diagram_urls()` scopes to Mermaid click directives only via `^\\s*click\\s+` pattern — no false positives from prose/caption links
2. `check_anchor_in_range()` already treats missing `abs_path` as a violation (returns a tibble row with `NA max_line`)

Review closed with comment explaining obsolescence.

## Test plan

- [x] `testthat::test_file("tests/testthat/test-vignette-utils.R")` — 39 tests pass
- [x] `parse("R/plan_qa_gates.R")` — clean parse
- [x] roborev j4037 closed, j4530 closed