### PR TITLE
fix(roborev): WT-C CI/build batch — pytest noop fallback

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,3 +29,14 @@ jobs:
 
       - name: Run pytest
         run: pytest tests/test_fetch_metadata.py -v
+
+  # No-op job that always completes so required-check gates never stall on
+  # PRs that don't touch Python files (path filter skips `pytest` but does
+  # not report a status — this job ensures `Python Tests` always concludes).
+  # Roborev j4602: a path-filtered workflow used as a required check leaves
+  # unrelated PRs stuck waiting; this fallback job always reports a conclusion.
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No Python files changed — skipping tests
+        run: echo "No Python-related files changed; pytest skipped."


### PR DESCRIPTION
## Summary

- **j4602 (r4369) FIXED**: `.github/workflows/pytest.yml` — added `noop` fallback job so Python Tests always reports a check conclusion, preventing required-check gates from stalling on PRs that don't touch Python files.
- **j4562 (r4328) OBSOLETE**: `data-poll.yml` already has `apt-get install libcurl4-openssl-dev libuv1-dev` on main.
- **j4564 (r4331) OBSOLETE**: `data-poll.yml` already has `mkdir -p data/raw` on main.
- **j4709 (r4476) OBSOLETE**: `flake.nix` already contains the `R_LIBS_SITE` closure-rebuild shellHook on main.

Closes roborev jobs: j4602. Obsolete (closed without code change): j4562, j4564, j4709.

## Test plan

- [ ] Verify YAML parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pytest.yml'))"`
- [ ] Confirm `noop` job runs on a PR that touches no Python files (check always green)
- [ ] Confirm `pytest` job still runs on a PR that touches `scripts/**.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)