### PR TITLE
feat(signal): ADD as candidate signal scaffold (#279 Angle B)

### DIFF
--- a/R/plan_add_signal.R
+++ b/R/plan_add_signal.R
@@ -1,0 +1,128 @@
+# plan_add_signal.R — Anomaly-Driven Demand (ADD) scaffold
+#
+# Angle B of issue #279: ADD as a candidate signal.
+# Kjær & Posselt (2025) "Anomaly-Driven Demand" — Aarhus University / DFI.
+# See knowledge/wiki/anomaly-driven-demand.md for full digest.
+#
+# ── Multiple-testing budget NOTE (#160) ─────────────────────────────────────
+#
+# Before ADD is promoted to the leaderboard, its effective degree of freedom
+# must be budgeted against the existing K_eff_strat count tracked in #160.
+#
+# ADD is a cross-sectional long/short signal derived from the 209
+# Chen-Zimmermann anomalies.  Its H-L spread (Sharpe ~0.61) will be
+# correlated with every other anomaly-based strategy on our leaderboard,
+# since all draw from the same US equity universe.  Adding ADD without
+# deflating for this correlation inflates the apparent menu size and
+# overstates the expected maximum in-sample Sharpe.
+#
+# Required before leaderboard integration:
+#   1. Compute ADD's pairwise correlation with existing leaderboard strategies
+#      using their monthly return series.
+#   2. Update K_eff_strat (via the SR_eff formula in plan_tail_keff.R) to
+#      include ADD.
+#   3. Apply the deflated Sharpe ratio threshold at the updated K_eff_strat.
+#
+# See also: R/plan_tail_keff.R, R/plan_falsification.R
+#
+# ── Pipeline overview ────────────────────────────────────────────────────────
+#
+# Stage 1 — source registration (no download)
+#   add_dataset_meta  ← hd_register_add_dataset()
+#
+# Stage 2 — load quintile assignments (PLACEHOLDER — download not yet wired)
+#   add_quintiles_raw ← placeholder; downstream targets depend on this
+#
+# Stage 3 — compute ADD
+#   add_signal_tbl    ← hd_compute_add(add_quintiles_raw)
+#
+# Stage 4 — aggregate
+#   add_composite     ← hd_aggregate_add(add_signal_tbl)
+#
+# ── NOT wired into plan_leaderboard.R in this PR ────────────────────────────
+# Integration is a follow-up: after (a) actual dataset download, (b) K_eff
+# budget, (c) falsification plan.
+
+plan_add_signal <- function() {
+
+  list(
+
+    # ── Stage 1: Dataset source registration ────────────────────────────────
+    #
+    # Returns the metadata list from hd_register_add_dataset().
+    # This target is always valid and costs nothing to re-run.
+    tar_target(
+      add_dataset_meta,
+      hd_register_add_dataset()
+    ),
+
+    # ── Stage 2: Load quintile assignments (PLACEHOLDER) ────────────────────
+    #
+    # TODO: Replace this stub with real data ingestion once the Chen-Zimmermann
+    # quintile CSV has been downloaded and validated.  The expected schema is:
+    #   (stock, date, anomaly_id, quintile)
+    # where:
+    #   stock      = PERMNO or ticker identifier
+    #   date       = first-of-month Date (monthly frequency)
+    #   anomaly_id = one of the 209 anomaly identifiers from the dataset
+    #   quintile   = integer 1-5 (1 = short, 5 = long leg)
+    #
+    # Source details: hd_register_add_dataset()$portal_url
+    # Data coverage:  1990-01 to 2023-12 (US NYSE, AMEX, NASDAQ)
+    # Look-ahead note: only post-publication anomalies count at each date.
+    tar_target(
+      add_quintiles_raw,
+      {
+        # Placeholder: returns an empty tibble with the correct schema so
+        # downstream targets fail gracefully rather than with a cryptic error.
+        # Remove once real ingestion is wired.
+        cli::cli_inform(c(
+          "i" = "add_quintiles_raw is a PLACEHOLDER target.",
+          "i" = "Download Chen-Zimmermann quintile data from: {add_dataset_meta$portal_url}",
+          "i" = "See hd_register_add_dataset() for schema and citation."
+        ))
+        tibble::tibble(
+          stock      = character(),
+          date       = as.Date(character()),
+          anomaly_id = character(),
+          quintile   = integer()
+        )
+      },
+      packages = "tibble"
+    ),
+
+    # ── Stage 3: Compute per-anomaly ADD ────────────────────────────────────
+    #
+    # hd_compute_add() expects a non-empty tibble; this target will abort
+    # with an informative message from hd_compute_add() when Stage 2 is
+    # still a placeholder (empty tibble).
+    # Un-comment the tar_skip() guard below once Stage 2 is populated.
+    tar_target(
+      add_signal_tbl,
+      {
+        if (nrow(add_quintiles_raw) == 0L) {
+          cli::cli_abort(c(
+            "x" = "{.target add_signal_tbl} cannot proceed: {.target add_quintiles_raw} is empty.",
+            "i" = "Populate {.target add_quintiles_raw} with Chen-Zimmermann quintile data first.",
+            "i" = "See {.fn hd_register_add_dataset} and issue #279."
+          ))
+        }
+        hd_compute_add(add_quintiles_raw)
+      },
+      packages = c("dplyr", "tibble", "cli")
+    ),
+
+    # ── Stage 4: Aggregate to per-stock composite ADD score ─────────────────
+    #
+    # Collapses across all 209 anomalies to produce one ADD score per
+    # (stock, month) pair.  The add_sum column is the quantity to use as the
+    # trading signal: long high-add_sum, short low-add_sum stocks, with
+    # rebalancing in the first ~6 trading days of the month.
+    tar_target(
+      add_composite,
+      hd_aggregate_add(add_signal_tbl, by = "stock_date"),
+      packages = c("dplyr", "tibble", "cli")
+    )
+
+  )
+}

--- a/packages/historicaldata/R/add_data.R
+++ b/packages/historicaldata/R/add_data.R
@@ -1,0 +1,103 @@
+# Chen-Zimmermann "Open Asset Pricing" dataset registration
+#
+# Source:
+#   Chen, Andrew Y. and Zimmermann, Tom (2022). "Open Source Cross-Sectional
+#   Asset Pricing." Critical Finance Review, 11(2), 207-264.
+#   DOI: 10.1561/104.00000112
+#   Dataset portal: https://www.openassetpricing.com/
+#
+# The dataset covers 209 anomaly signals for US common stocks (NYSE, AMEX,
+# NASDAQ) 1990-2023.  The anomaly data is free to download; the portal
+# provides CSV downloads for both the sorted-portfolio returns and the
+# underlying characteristic quintile assignments.
+#
+# Characteristic/quintile CSV download note (2026-05):
+#   The underlying per-stock quintile assignments needed to compute ADD are
+#   available from the "Signals" section at openassetpricing.com.
+#   TODO: confirm whether the direct download URL requires an authenticated
+#   session or is openly accessible at a stable canonical URL.  As of the
+#   wiki compilation on 2026-05-25 (knowledge/wiki/anomaly-driven-demand.md)
+#   the site was accessible without login.  The exact download path is:
+#     https://www.openassetpricing.com/                (landing page)
+#     → "Data" → "Signals" → annual/monthly CSV bundles
+#   Do NOT hard-code a URL until confirmed stable; fill in hd_add_quintile_url()
+#   once a stable canonical path is verified.
+#
+# References:
+#   Kjær, M.M. & Posselt, A.M. (2025). "Anomaly-Driven Demand."
+#   Aarhus University / Danish Finance Institute working paper, Nov 2025.
+#   Presented at Cavalcade Asia-Pacific 2025.
+#   See knowledge/wiki/anomaly-driven-demand.md for digest.
+#
+# Related issues:
+#   #279 — ADD crowding / candidate signal
+#   #160 — effective number of tested strategies (K_eff_strat) — must budget
+#          ADD against existing correlated-strategy count before deployment
+
+#' Register the Chen-Zimmermann Open Asset Pricing dataset source
+#'
+#' Returns a named list describing the Chen & Zimmermann (2022) "Open Source
+#' Cross-Sectional Asset Pricing" dataset used to construct Anomaly-Driven
+#' Demand (ADD) signals.  This is a *registration* function only — it does
+#' **not** download any data.  Use the returned metadata to locate and
+#' retrieve the data when the pipeline is ready for a full download step.
+#'
+#' The dataset contains per-stock anomaly characteristic values and
+#' quintile-portfolio assignments for 209 anomalies spanning US common
+#' stocks (NYSE, AMEX, NASDAQ) from January 1990 to December 2023.
+#'
+#' ADD construction requires the monthly quintile-assignment file — a tidy
+#' long table with columns (stock, date, anomaly_id, quintile) indicating
+#' which quintile each stock was assigned to for each anomaly in each month.
+#' See [hd_compute_add()] for the computation step.
+#'
+#' @return A named list with fields:
+#'   \describe{
+#'     \item{source_name}{Human-readable name of the data source.}
+#'     \item{portal_url}{URL of the data portal (no authentication required
+#'       as of 2026-05).}
+#'     \item{download_url}{Canonical direct download URL for the monthly
+#'       quintile CSV bundle, or \code{NA_character_} if not yet confirmed
+#'       stable.}
+#'     \item{expected_schema}{Character vector of expected column names in
+#'       the quintile-assignment table.}
+#'     \item{frequency}{Rebalancing frequency of the anomaly portfolios.}
+#'     \item{universe}{Description of the stock universe covered.}
+#'     \item{sample_start}{Start of the data sample (character "YYYY-MM").}
+#'     \item{sample_end}{End of the data sample (character "YYYY-MM").}
+#'     \item{n_anomalies}{Number of anomaly signals in the dataset (integer).}
+#'     \item{citation}{Full citation string for the dataset.}
+#'     \item{related_issues}{Character vector of GitHub issue numbers
+#'       relevant to this dataset.}
+#'   }
+#' @family add
+#' @export
+hd_register_add_dataset <- function() {
+  list(
+    source_name    = "Chen-Zimmermann Open Asset Pricing (2022)",
+    portal_url     = "https://www.openassetpricing.com/",
+    # TODO: replace NA with the stable direct-download URL once confirmed.
+    # The portal hosts CSV bundles for sorted-portfolio returns and per-stock
+    # quintile assignments under the "Signals" section.  As of 2026-05-25
+    # no stable canonical URL has been verified to be authentication-free.
+    download_url   = NA_character_,
+    expected_schema = c("permno", "date", "anomaly_id", "quintile"),
+    frequency      = "monthly",
+    universe       = paste0(
+      "US common stocks on NYSE, AMEX, NASDAQ. ",
+      "Only post-publication anomalies counted at each point in time ",
+      "(look-ahead-safe by construction)."
+    ),
+    sample_start   = "1990-01",
+    sample_end     = "2023-12",
+    n_anomalies    = 209L,
+    citation       = paste0(
+      "Chen, A.Y. and Zimmermann, T. (2022). ",
+      "'Open Source Cross-Sectional Asset Pricing.' ",
+      "Critical Finance Review, 11(2), 207-264. ",
+      "DOI: 10.1561/104.00000112. ",
+      "Dataset: https://www.openassetpricing.com/"
+    ),
+    related_issues = c("#279", "#160")
+  )
+}

--- a/packages/historicaldata/R/add_signal.R
+++ b/packages/historicaldata/R/add_signal.R
@@ -1,0 +1,227 @@
+# Anomaly-Driven Demand (ADD) Signal
+#
+# Implements the ADD signal from:
+#   Kjær, M.M. & Posselt, A.M. (2025). "Anomaly-Driven Demand."
+#   Aarhus University / Danish Finance Institute working paper, Nov 2025.
+#
+# Construction logic (from knowledge/wiki/anomaly-driven-demand.md):
+#
+#   For each stock j and anomaly k at time t:
+#     1. Count net inclusions:
+#          NET_{j,k,t} = 1[j in long_leg_{k,t}] - 1[j in short_leg_{k,t}]
+#          (0 if neither, +1 if only long, -1 if only short)
+#     2. Take the first difference:
+#          ADD_{j,k,t} = NET_{j,k,t} - NET_{j,k,t-1}
+#
+#   High ADD = stock entered more long legs this month (coordinated buying
+#   pressure incoming).  Low ADD = stock entered more short legs.
+#
+# Input data (from Chen-Zimmermann quintile assignments):
+#   Quintile 1 = short leg, quintile 5 = long leg (standard convention).
+#   Quintiles 2-4 = neither leg.
+#
+# Look-ahead safety:
+#   ADD_{j,k,t} uses quintile assignments from t and t-1 ONLY.
+#   The forward return test (is high-ADD predictive?) uses returns from t+1
+#   onward.  hd_compute_add() forms ADD at time t from lagged quintiles —
+#   the consumer is responsible for matching ADD_t to returns_{t+1}.
+#
+# Related issues:  #279 (ADD scaffold), #160 (K_eff_strat budget)
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+.is_long_leg  <- function(q) !is.na(q) & q == 5L
+.is_short_leg <- function(q) !is.na(q) & q == 1L
+
+# ── Core computation ─────────────────────────────────────────────────────────
+
+#' Compute per-stock per-anomaly Anomaly-Driven Demand (ADD)
+#'
+#' Given a tidy tibble of monthly quintile assignments across multiple anomaly
+#' signals, computes ADD as the month-over-month change in net long-minus-short
+#' leg inclusions.
+#'
+#' Formally, for stock *j*, anomaly *k*, and month *t*:
+#'
+#' \deqn{
+#'   \text{NET}_{j,k,t} = \mathbf{1}[j \in \text{long}_{k,t}]
+#'                      - \mathbf{1}[j \in \text{short}_{k,t}]
+#' }
+#' \deqn{
+#'   \text{ADD}_{j,k,t} = \text{NET}_{j,k,t} - \text{NET}_{j,k,t-1}
+#' }
+#'
+#' where long leg = quintile 5 and short leg = quintile 1 (standard
+#' Chen-Zimmermann convention; quintiles 2-4 contribute 0 to NET).
+#'
+#' **Look-ahead safety**: ADD at time *t* is computed from quintile assignments
+#' at *t* and *t-1*.  It predicts returns starting from *t+1*; the caller is
+#' responsible for this shift.
+#'
+#' @param quintile_assignments A tibble (or data frame) with columns:
+#'   \describe{
+#'     \item{stock}{Character stock identifier (e.g., permno or ticker).}
+#'     \item{date}{Date (first day of each month, or any consistent monthly
+#'       anchor).}
+#'     \item{anomaly_id}{Character or factor identifying the anomaly.}
+#'     \item{quintile}{Integer 1-5; quintile assignment for (stock, date,
+#'       anomaly_id).  \code{NA} means the stock was not ranked (not covered)
+#'       in this anomaly this month.}
+#'   }
+#'   Every (stock, date, anomaly_id) combination should appear at most once.
+#'
+#' @return A tibble with the same (stock, date, anomaly_id) key and an
+#'   additional column:
+#'   \describe{
+#'     \item{add}{Integer ADD value in \{-2, -1, 0, 1, 2\}.  \code{NA} on
+#'       the first month a (stock, anomaly_id) pair is observed (no prior
+#'       quintile available).}
+#'   }
+#'   Rows are ordered by stock, anomaly_id, date (ascending).
+#'
+#' @examples
+#' \dontrun{
+#' # Minimal synthetic example (3 stocks x 3 months x 2 anomalies)
+#' tbl <- tibble::tibble(
+#'   stock      = rep(c("A", "B", "C"), times = 6),
+#'   date       = rep(rep(as.Date(c("2023-01-01", "2023-02-01", "2023-03-01")),
+#'                        each = 3), 2),
+#'   anomaly_id = rep(c("val", "mom"), each = 9),
+#'   quintile   = c(1L, 3L, 5L, 5L, 3L, 1L, 5L, 3L, 1L,   # val
+#'                  3L, 5L, 3L, 5L, 1L, 3L, 1L, 5L, 3L)    # mom
+#' )
+#' hd_compute_add(tbl)
+#' }
+#'
+#' @family add
+#' @export
+hd_compute_add <- function(quintile_assignments) {
+  # ── Input validation ────────────────────────────────────────────────────────
+  if (!is.data.frame(quintile_assignments)) {
+    cli::cli_abort(c(
+      "x" = "{.arg quintile_assignments} must be a data frame or tibble.",
+      "i" = "Got {.cls {class(quintile_assignments)}}."
+    ))
+  }
+
+  required_cols <- c("stock", "date", "anomaly_id", "quintile")
+  missing_cols  <- setdiff(required_cols, names(quintile_assignments))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "{.arg quintile_assignments} is missing required columns: {.field {missing_cols}}.",
+      "i" = "Found columns: {.field {names(quintile_assignments)}}."
+    ))
+  }
+
+  if (nrow(quintile_assignments) == 0L) {
+    cli::cli_abort(c(
+      "x" = "{.arg quintile_assignments} must not be empty.",
+      "i" = "Pass a tibble with at least one row."
+    ))
+  }
+
+  if (!inherits(quintile_assignments$date, c("Date", "POSIXct"))) {
+    cli::cli_abort(c(
+      "x" = "Column {.field date} must be a {.cls Date} or {.cls POSIXct}.",
+      "i" = "Got {.cls {class(quintile_assignments$date)}}."
+    ))
+  }
+
+  quintile_vals <- quintile_assignments$quintile
+  valid_quintiles <- quintile_vals[!is.na(quintile_vals)]
+  if (length(valid_quintiles) > 0L && (!is.numeric(valid_quintiles) ||
+      any(valid_quintiles < 1L | valid_quintiles > 5L))) {
+    cli::cli_abort(c(
+      "x" = "Column {.field quintile} must contain integers in 1-5 or NA.",
+      "i" = "Got values outside [1, 5]."
+    ))
+  }
+
+  # ── Computation ─────────────────────────────────────────────────────────────
+  quintile_assignments |>
+    dplyr::arrange(stock, anomaly_id, date) |>
+    dplyr::group_by(stock, anomaly_id) |>
+    dplyr::mutate(
+      # NET at t: +1 if in long leg (Q5), -1 if in short leg (Q1), 0 otherwise
+      net = dplyr::case_when(
+        .is_long_leg(quintile)  ~  1L,
+        .is_short_leg(quintile) ~ -1L,
+        TRUE                    ~  0L
+      ),
+      # ADD at t = NET_t - NET_{t-1}; NA on first observation per group
+      add = net - dplyr::lag(net, n = 1L, default = NA_integer_)
+    ) |>
+    dplyr::ungroup() |>
+    dplyr::select(stock, date, anomaly_id, quintile, add)
+}
+
+
+#' Aggregate per-anomaly ADD into a per-stock-per-month composite score
+#'
+#' Collapses the per-(stock, date, anomaly_id) ADD values produced by
+#' [hd_compute_add()] into a single composite ADD score per stock per month,
+#' summing across all anomalies.  The resulting value equals the number of
+#' anomaly long legs newly entered by the stock this month minus the number of
+#' anomaly short legs newly entered (net of reversals in both directions).
+#'
+#' @param add_tbl A tibble returned by [hd_compute_add()] with columns
+#'   \code{stock}, \code{date}, \code{anomaly_id}, \code{quintile}, \code{add}.
+#' @param by Aggregation granularity.  Currently only \code{"stock_date"} is
+#'   supported (sum across anomalies within each stock-month).
+#'
+#' @return A tibble with columns:
+#'   \describe{
+#'     \item{stock}{Stock identifier.}
+#'     \item{date}{Month date (same anchor as input).}
+#'     \item{add_sum}{Integer sum of ADD across all anomalies for this
+#'       (stock, date) pair.  \code{NA} rows (first month per anomaly) are
+#'       excluded from the sum via \code{na.rm = TRUE}; if ALL anomalies are
+#'       NA for a given stock-month, \code{add_sum} is \code{NA}.}
+#'     \item{n_anomalies_valid}{Number of anomalies contributing a non-NA ADD
+#'       value for this stock-month (integer).}
+#'   }
+#'
+#' @family add
+#' @export
+hd_aggregate_add <- function(add_tbl, by = "stock_date") {
+  # ── Input validation ─────────────────────────────────────────────────────
+  if (!is.data.frame(add_tbl)) {
+    cli::cli_abort(c(
+      "x" = "{.arg add_tbl} must be a data frame or tibble.",
+      "i" = "Got {.cls {class(add_tbl)}}."
+    ))
+  }
+
+  required_cols <- c("stock", "date", "anomaly_id", "add")
+  missing_cols  <- setdiff(required_cols, names(add_tbl))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "{.arg add_tbl} is missing required columns: {.field {missing_cols}}.",
+      "i" = "These are produced by {.fn hd_compute_add}."
+    ))
+  }
+
+  if (!identical(by, "stock_date")) {
+    cli::cli_abort(c(
+      "x" = "Only {.val stock_date} is supported for {.arg by}.",
+      "i" = "Got {.val {by}}."
+    ))
+  }
+
+  if (nrow(add_tbl) == 0L) {
+    cli::cli_abort(c(
+      "x" = "{.arg add_tbl} must not be empty."
+    ))
+  }
+
+  # ── Aggregation ───────────────────────────────────────────────────────────
+  add_tbl |>
+    dplyr::group_by(stock, date) |>
+    dplyr::summarise(
+      add_sum          = if (all(is.na(add))) NA_integer_
+                         else sum(add, na.rm = TRUE),
+      n_anomalies_valid = sum(!is.na(add)),
+      .groups = "drop"
+    ) |>
+    dplyr::arrange(stock, date)
+}

--- a/packages/historicaldata/tests/testthat/test-add-signal.R
+++ b/packages/historicaldata/tests/testthat/test-add-signal.R
@@ -1,0 +1,301 @@
+# Tests for ADD (Anomaly-Driven Demand) signal computation
+# References:
+#   Kjær & Posselt (2025) "Anomaly-Driven Demand"
+#   knowledge/wiki/anomaly-driven-demand.md
+#
+# All tests are OFFLINE — no network calls, no file I/O.
+# testthat edition 3.
+
+# ── Synthetic data helpers ────────────────────────────────────────────────────
+
+# 3 stocks × 6 months × 2 anomalies
+# Quintile convention: Q1 = short leg, Q5 = long leg, Q2-4 = neutral
+make_quintile_tbl <- function() {
+  tibble::tibble(
+    stock      = rep(c("A", "B", "C"), times = 12),
+    date       = rep(
+      rep(as.Date(paste0("2023-0", 1:6, "-01")), each = 3),
+      2
+    ),
+    anomaly_id = rep(c("val", "mom"), each = 18),
+    quintile   = as.integer(c(
+      # anomaly "val": A, B, C × months 1-6
+      # month 1: A=1, B=3, C=5
+      # month 2: A=5, B=3, C=1   (A jumps to long; C drops to short)
+      # month 3: A=5, B=3, C=1   (no change)
+      # month 4: A=3, B=5, C=3   (A exits long; B enters long; C exits short)
+      # month 5: A=3, B=5, C=3   (no change)
+      # month 6: A=1, B=3, C=5   (A enters short; B exits long; C enters long)
+      1, 3, 5,   # month 1
+      5, 3, 1,   # month 2
+      5, 3, 1,   # month 3
+      3, 5, 3,   # month 4
+      3, 5, 3,   # month 5
+      1, 3, 5,   # month 6
+      # anomaly "mom": A, B, C × months 1-6
+      # month 1: A=3, B=5, C=3
+      # month 2: A=5, B=1, C=3
+      # month 3: A=1, B=5, C=3
+      # month 4: A=5, B=1, C=3
+      # month 5: A=5, B=1, C=3
+      # month 6: A=3, B=5, C=3
+      3, 5, 3,   # month 1
+      5, 1, 3,   # month 2
+      1, 5, 3,   # month 3
+      5, 1, 3,   # month 4
+      5, 1, 3,   # month 5
+      3, 5, 3    # month 6
+    ))
+  )
+}
+
+# ── hd_compute_add: basic structure ──────────────────────────────────────────
+
+test_that("hd_compute_add: returns expected columns", {
+  tbl <- hd_compute_add(make_quintile_tbl())
+  expect_s3_class(tbl, "tbl_df")
+  expect_true(all(c("stock", "date", "anomaly_id", "quintile", "add") %in% names(tbl)))
+})
+
+test_that("hd_compute_add: same number of rows as input", {
+  input <- make_quintile_tbl()
+  tbl   <- hd_compute_add(input)
+  expect_equal(nrow(tbl), nrow(input))
+})
+
+test_that("hd_compute_add: ADD is NA on the first month of each (stock, anomaly_id) pair", {
+  tbl <- hd_compute_add(make_quintile_tbl())
+  first_months <- tbl |>
+    dplyr::group_by(stock, anomaly_id) |>
+    dplyr::slice_min(date, n = 1L) |>
+    dplyr::ungroup()
+  expect_true(all(is.na(first_months$add)))
+})
+
+# ── hd_compute_add: hand-calculated values ────────────────────────────────────
+
+test_that("hd_compute_add: correct ADD for 'val' anomaly transition month 2", {
+  # "val" month 2:
+  #   A: Q1→Q5 → NET changes from -1 to +1 → ADD = +2
+  #   B: Q3→Q3 → NET stays   0       → ADD =  0
+  #   C: Q5→Q1 → NET changes from +1 to -1 → ADD = -2
+  tbl   <- hd_compute_add(make_quintile_tbl())
+  month2 <- as.Date("2023-02-01")
+  result <- tbl |>
+    dplyr::filter(anomaly_id == "val", date == month2) |>
+    dplyr::arrange(stock)
+  expect_equal(result$add[result$stock == "A"],  2L)
+  expect_equal(result$add[result$stock == "B"],  0L)
+  expect_equal(result$add[result$stock == "C"], -2L)
+})
+
+test_that("hd_compute_add: ADD is 0 when quintile does not change", {
+  # "val" months 3 and 5 have no quintile change
+  tbl    <- hd_compute_add(make_quintile_tbl())
+  months <- c(as.Date("2023-03-01"), as.Date("2023-05-01"))
+  result <- tbl |> dplyr::filter(anomaly_id == "val", date %in% months)
+  expect_true(all(result$add == 0L))
+})
+
+test_that("hd_compute_add: stock entering long leg AND exiting short leg → ADD = +2", {
+  # "val" month 2: stock A transitions Q1 (short) → Q5 (long)
+  #   NET(month 1) = -1, NET(month 2) = +1 → ADD = +2
+  tbl    <- hd_compute_add(make_quintile_tbl())
+  month2 <- as.Date("2023-02-01")
+  add_A  <- tbl |>
+    dplyr::filter(stock == "A", anomaly_id == "val", date == month2) |>
+    dplyr::pull(add)
+  expect_equal(add_A, 2L)
+})
+
+test_that("hd_compute_add: entering long leg only (from neutral) → ADD = +1", {
+  # "mom" month 2: B goes Q5→Q1 but A goes Q3→Q5 (neutral to long).
+  # For A, anomaly "mom": month 1 Q3 (NET=0), month 2 Q5 (NET=+1) → ADD = +1
+  tbl    <- hd_compute_add(make_quintile_tbl())
+  month2 <- as.Date("2023-02-01")
+  add_A  <- tbl |>
+    dplyr::filter(stock == "A", anomaly_id == "mom", date == month2) |>
+    dplyr::pull(add)
+  expect_equal(add_A, 1L)
+})
+
+test_that("hd_compute_add: exiting short leg only (to neutral) → ADD = +1", {
+  # "val" month 4: C transitions Q1 (short) → Q3 (neutral)
+  #   NET(month 3) = -1, NET(month 4) = 0 → ADD = +1
+  tbl    <- hd_compute_add(make_quintile_tbl())
+  month4 <- as.Date("2023-04-01")
+  add_C  <- tbl |>
+    dplyr::filter(stock == "C", anomaly_id == "val", date == month4) |>
+    dplyr::pull(add)
+  expect_equal(add_C, 1L)
+})
+
+# ── hd_compute_add: look-ahead protection ────────────────────────────────────
+
+test_that("hd_compute_add: LOOK-AHEAD GUARD — perturbing only future quintiles does not change past ADD values", {
+  # Create two versions: identical up to month 4, diverge at month 5 onwards.
+  # ADD at months 2-4 must be identical in both versions.
+  base_tbl <- make_quintile_tbl()
+
+  # Perturb: flip all quintiles in months 5 and 6
+  perturbed_tbl <- base_tbl |>
+    dplyr::mutate(
+      quintile = dplyr::if_else(
+        date >= as.Date("2023-05-01"),
+        dplyr::case_when(
+          quintile == 1L ~ 5L,
+          quintile == 5L ~ 1L,
+          TRUE            ~ quintile
+        ),
+        quintile
+      )
+    )
+
+  add_base      <- hd_compute_add(base_tbl)
+  add_perturbed <- hd_compute_add(perturbed_tbl)
+
+  # Months 2-4 must be unchanged
+  months_2_4 <- seq(as.Date("2023-02-01"), as.Date("2023-04-01"), by = "month")
+  base_early      <- add_base      |> dplyr::filter(date %in% months_2_4)
+  perturbed_early <- add_perturbed |> dplyr::filter(date %in% months_2_4)
+
+  expect_equal(
+    base_early$add,
+    perturbed_early$add,
+    info = "ADD values before perturbation window must be identical"
+  )
+})
+
+# ── hd_compute_add: error handling ───────────────────────────────────────────
+
+test_that("hd_compute_add: errors on non-data-frame input", {
+  expect_error(hd_compute_add("not a tibble"), "data frame or tibble")
+})
+
+test_that("hd_compute_add: errors on missing required columns", {
+  bad <- tibble::tibble(stock = "A", date = Sys.Date())
+  expect_error(hd_compute_add(bad), "missing required columns")
+})
+
+test_that("hd_compute_add: errors on empty input", {
+  empty <- tibble::tibble(
+    stock = character(), date = as.Date(character()),
+    anomaly_id = character(), quintile = integer()
+  )
+  expect_error(hd_compute_add(empty), "must not be empty")
+})
+
+test_that("hd_compute_add: errors on non-Date date column", {
+  bad <- tibble::tibble(
+    stock = "A", date = "2023-01-01",
+    anomaly_id = "val", quintile = 3L
+  )
+  expect_error(hd_compute_add(bad), "Date")
+})
+
+test_that("hd_compute_add: errors on out-of-range quintile values", {
+  bad <- tibble::tibble(
+    stock = "A", date = as.Date("2023-01-01"),
+    anomaly_id = "val", quintile = 6L
+  )
+  expect_error(hd_compute_add(bad), "1-5")
+})
+
+test_that("hd_compute_add: allows NA quintile (stock not ranked)", {
+  tbl <- tibble::tibble(
+    stock      = c("A", "A"),
+    date       = as.Date(c("2023-01-01", "2023-02-01")),
+    anomaly_id = c("val", "val"),
+    quintile   = c(NA_integer_, 3L)
+  )
+  result <- hd_compute_add(tbl)
+  # Row 1: first month → ADD = NA
+  # Row 2: NET(t-1) from NA quintile treated as 0; NET(t) = 0 (Q3) → ADD = 0
+  expect_equal(nrow(result), 2L)
+  expect_true(is.na(result$add[1L]))
+  expect_equal(result$add[2L], 0L)
+})
+
+# ── hd_aggregate_add: basic structure ────────────────────────────────────────
+
+test_that("hd_aggregate_add: returns expected columns", {
+  add_tbl <- hd_compute_add(make_quintile_tbl())
+  agg     <- hd_aggregate_add(add_tbl)
+  expect_s3_class(agg, "tbl_df")
+  expect_true(all(c("stock", "date", "add_sum", "n_anomalies_valid") %in% names(agg)))
+})
+
+test_that("hd_aggregate_add: one row per (stock, date)", {
+  add_tbl <- hd_compute_add(make_quintile_tbl())
+  agg     <- hd_aggregate_add(add_tbl)
+  n_stock_dates <- nrow(dplyr::distinct(add_tbl, stock, date))
+  expect_equal(nrow(agg), n_stock_dates)
+})
+
+test_that("hd_aggregate_add: add_sum equals sum of individual anomaly ADDs", {
+  # Month 2 for stock A: val=+2, mom=+1 → sum = 3
+  add_tbl <- hd_compute_add(make_quintile_tbl())
+  agg     <- hd_aggregate_add(add_tbl)
+  month2  <- as.Date("2023-02-01")
+  sum_A   <- agg |>
+    dplyr::filter(stock == "A", date == month2) |>
+    dplyr::pull(add_sum)
+  expect_equal(sum_A, 3L)
+})
+
+test_that("hd_aggregate_add: n_anomalies_valid is 0 on the first month (all NAs)", {
+  add_tbl <- hd_compute_add(make_quintile_tbl())
+  agg     <- hd_aggregate_add(add_tbl)
+  month1  <- as.Date("2023-01-01")
+  n_valid <- agg |>
+    dplyr::filter(date == month1) |>
+    dplyr::pull(n_anomalies_valid)
+  expect_true(all(n_valid == 0L))
+})
+
+# ── hd_aggregate_add: error handling ─────────────────────────────────────────
+
+test_that("hd_aggregate_add: errors on non-data-frame input", {
+  expect_error(hd_aggregate_add("bad"), "data frame or tibble")
+})
+
+test_that("hd_aggregate_add: errors on missing columns", {
+  bad <- tibble::tibble(stock = "A", date = Sys.Date())
+  expect_error(hd_aggregate_add(bad), "missing required columns")
+})
+
+test_that("hd_aggregate_add: errors on unsupported 'by' argument", {
+  add_tbl <- hd_compute_add(make_quintile_tbl())
+  expect_error(hd_aggregate_add(add_tbl, by = "anomaly_date"), "stock_date")
+})
+
+test_that("hd_aggregate_add: errors on empty input", {
+  empty <- tibble::tibble(
+    stock = character(), date = as.Date(character()),
+    anomaly_id = character(), quintile = integer(), add = integer()
+  )
+  expect_error(hd_aggregate_add(empty), "must not be empty")
+})
+
+# ── hd_register_add_dataset ───────────────────────────────────────────────────
+
+test_that("hd_register_add_dataset: returns a named list with required fields", {
+  reg <- hd_register_add_dataset()
+  expect_type(reg, "list")
+  expected_fields <- c(
+    "source_name", "portal_url", "download_url", "expected_schema",
+    "frequency", "universe", "sample_start", "sample_end",
+    "n_anomalies", "citation", "related_issues"
+  )
+  expect_true(all(expected_fields %in% names(reg)))
+})
+
+test_that("hd_register_add_dataset: n_anomalies is 209", {
+  reg <- hd_register_add_dataset()
+  expect_equal(reg$n_anomalies, 209L)
+})
+
+test_that("hd_register_add_dataset: portal_url is plausible", {
+  reg <- hd_register_add_dataset()
+  expect_match(reg$portal_url, "openassetpricing\\.com")
+})


### PR DESCRIPTION
## Summary

Closes Angle B scaffold of #279. Angle A (crowding clause in `priced-in-prohibition`) already on main via #300.

- **Core computation** (`packages/historicaldata/R/add_signal.R`): `hd_compute_add()` and `hd_aggregate_add()` implement the Kjær & Posselt (2025) ADD formula. Look-ahead-safe: ADD at month *t* uses only quintile history at *t* and *t−1*. `hd_aggregate_add()` collapses across all 209 anomalies to a per-stock-per-month composite score.
- **Dataset registration** (`packages/historicaldata/R/add_data.R`): `hd_register_add_dataset()` registers the Chen-Zimmermann open asset pricing source metadata (209 anomalies, 1990–2023, openassetpricing.com). No data is downloaded — `download_url = NA_character_` until a stable direct URL is confirmed.
- **33 unit tests** (`packages/historicaldata/tests/testthat/test-add-signal.R`): hand-calculated ADD values (Q1→Q5 yields +2; Q3→Q5 yields +1; Q1→Q3 yields +1), look-ahead guard, NA handling, all error paths. All 33 PASS.
- **Targets plan** (`R/plan_add_signal.R`): 4-stage scaffold (register → load-quintiles-stub → compute-ADD → aggregate). Stage 2 is a placeholder that fails informatively. Not wired into `plan_leaderboard.R`.
- **Multiple-testing note** in plan header: ADD must be budgeted against `K_eff_strat` (#160) before leaderboard integration.

## What is NOT in this PR (follow-ups)

- Actual Chen-Zimmermann quintile CSV download + ingestion
- Full backtest of the long/short ADD signal
- Leaderboard integration (requires K_eff deflated-Sharpe budget per #160)
- Falsification plan (`plan_falsification.R` entry)

## Test plan

- [x] `test-add-signal.R`: 33 tests, FAIL 0 | WARN 0 | SKIP 0 | PASS 33
- [ ] Reviewer: confirm ADD formula matches wiki digest at `knowledge/wiki/anomaly-driven-demand.md` (formal definition section)
- [ ] Reviewer: confirm look-ahead guard test covers the right perturbation window
- [ ] Follow-up #279: populate `add_quintiles_raw` when download URL confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)