### PR TITLE
fix(roborev): WT-B strategy-plans batch (8 reviews)

### DIFF
--- a/R/plan_drif_v2.R
+++ b/R/plan_drif_v2.R
@@ -36,9 +36,10 @@ plan_drif_v2 <- function() {
       ) |>
         dplyr::mutate(
           spec_id = sprintf("S%02d", dplyr::row_number()),
+          # Production plan_drif.R uses feat_cols = c(chrono_cols, rank_cols) = "both"
           is_current = alpha == 0.5 &
                        nfolds == 5L &
-                       feature_set == "chrono" &
+                       feature_set == "both" &
                        lambda_rule == "lambda.min"
         )
     }),
@@ -140,7 +141,8 @@ plan_drif_v2 <- function() {
 
         ann_ret <- prod(1 + ret)^(12 / n) - 1
         ann_vol <- sd(ret) * sqrt(12)
-        sharpe  <- if (ann_vol > 0) ann_ret / ann_vol else NA_real_
+        ann_xret <- prod(1 + xret)^(12 / n) - 1
+        sharpe  <- if (ann_vol > 0) ann_xret / ann_vol else NA_real_
         cum     <- cumprod(1 + ret)
         max_dd  <- min(cum / cummax(cum) - 1)
         hit     <- mean(ret > 0, na.rm = TRUE)

--- a/R/plan_olmar.R
+++ b/R/plan_olmar.R
@@ -143,12 +143,13 @@ plan_olmar <- function() {
         )
       }
 
-      port   <- olmar_portfolio |> dplyr::mutate(date = as.Date(date))
-      oos    <- as.Date(olmar_params$test_start)
+      port     <- olmar_portfolio |> dplyr::mutate(date = as.Date(date))
+      oos      <- as.Date(olmar_params$test_start)
+      test_end <- as.Date(olmar_params$test_end)
 
       dplyr::bind_rows(
-        calc(port |> dplyr::filter(date < oos), "Training"),
-        calc(port |> dplyr::filter(date >= oos), "Testing"),
+        calc(port |> dplyr::filter(date < oos),                         "Training"),
+        calc(port |> dplyr::filter(date >= oos & date <= test_end),     "Testing"),
         calc(port, "Full Period")
       )
     }),

--- a/R/plan_solana_momentum.R
+++ b/R/plan_solana_momentum.R
@@ -121,6 +121,11 @@ plan_solana_momentum <- function() {
 
     # -------------------------------------------------------------------------
     # Backtest targets: 3 signals x 2 frequencies = 6 targets
+    # NOTE (roborev j4568): vol_weight is computed and stored in sol_signals but
+    # not yet threaded into the backtest functions. backtest_crypto_momentum() and
+    # backtest_weekly_momentum() currently use rank-based equal weighting. To apply
+    # volatility-adjusted sizing, extend those helpers to accept a weight column
+    # from the signals tibble. Tracked in issue #??? (TODO: file).
     # -------------------------------------------------------------------------
 
     # 8. Monthly: Baseline (total) momentum

--- a/R/plan_strategy_correlation.R
+++ b/R/plan_strategy_correlation.R
@@ -50,21 +50,26 @@ plan_strategy_correlation <- function() {
 
       # Core four strategies already aligned in port_returns.
       # Columns: ym, stk_max, stk_drif, fac_max, fac_drif, rf_ret, date
+      # NOTE: port_returns\ is a synthetic ym-15 anchor (paste0(ym, "-15")),
+      # while ltr_portfolio\ is the actual trading date from the parquet.
+      # Joining on raw date produces an empty or near-empty result (#147/#215).
+      # Fix: derive ym from both sides and join on ym; use port_returns\ as
+      # the canonical date column.
       base <- port_returns |>
-        select(date, stk_max, stk_drif, fac_max, fac_drif) |>
+        select(ym, date, stk_max, stk_drif, fac_max, fac_drif) |>
         filter(!is.na(stk_max), !is.na(stk_drif),
                !is.na(fac_max), !is.na(fac_drif))
 
-      # LTR momentum: port_ret column, Date-typed date
+      # LTR momentum: derive ym for stable join key
       ltr_col <- ltr_portfolio |>
         filter(!is.na(port_ret)) |>
-        select(date, ltr = port_ret) |>
-        mutate(date = as.Date(date))  # ensure Date type (#147/#215)
+        mutate(ym = format(as.Date(date), "%Y-%m")) |>
+        select(ym, ltr = port_ret)
 
-      # Inner-join: only periods where both series are available
+      # Inner-join on ym (stable month key, not date) then drop ym
       aligned <- base |>
-        mutate(date = as.Date(date)) |>
-        inner_join(ltr_col, by = "date") |>
+        inner_join(ltr_col, by = "ym") |>
+        select(-ym) |>
         arrange(date)
 
       aligned

--- a/R/plan_turn_of_month.R
+++ b/R/plan_turn_of_month.R
@@ -176,13 +176,14 @@ plan_turn_of_month <- function() {
         )
       }
 
-      port <- tom_portfolio |>
+      port     <- tom_portfolio |>
         dplyr::mutate(date = as.Date(date))
-      oos  <- as.Date(tom_params$oos_start)
+      oos      <- as.Date(tom_params$oos_start)
+      oos_end  <- as.Date(tom_params$oos_end)
 
       dplyr::bind_rows(
-        calc(port |> dplyr::filter(date < oos),  "Training"),
-        calc(port |> dplyr::filter(date >= oos), "Testing"),
+        calc(port |> dplyr::filter(date < oos),                       "Training"),
+        calc(port |> dplyr::filter(date >= oos & date <= oos_end),    "Testing"),
         calc(port, "Full Period")
       )
     }),

--- a/R/solana_defi_data.R
+++ b/R/solana_defi_data.R
@@ -48,7 +48,9 @@ fetch_birdeye_spot <- function(tokens, start_date, end_date,
   )
 
   start_unix <- as.numeric(as.POSIXct(start_date))
-  end_unix <- as.numeric(as.POSIXct(end_date))
+  # Use end-of-day (23:59:59) so we include the full final day; midnight would
+  # drop almost all data from the last day (off-by-one in Birdeye time filter).
+  end_unix <- as.numeric(as.POSIXct(end_date)) + 86399L
 
   results <- purrr::map_dfr(tokens, function(token) {
     mint <- mint_map[[token]]
@@ -193,17 +195,22 @@ calculate_liquidity_metrics <- function(spot_data, perp_data,
     dplyr::mutate(ticker = sub("-PERP", "", market)) |>
     dplyr::group_by(ticker) |>
     dplyr::summarise(
-      avg_daily_volume_perp = mean(open_interest * mark_price, na.rm = TRUE),
+      # NOTE: Drift API does not provide perp traded volume directly; using
+      # open_interest * mark_price as a proxy for OI notional (USD).
+      # This is NOT traded volume — rename to clarify, and adjust thresholds
+      # if actual volume data becomes available.
+      avg_oi_notional_perp = mean(open_interest * mark_price, na.rm = TRUE),
       .groups = "drop"
     )
 
   spot_liquidity |>
     dplyr::left_join(perp_liquidity, by = "ticker") |>
     dplyr::mutate(
-      avg_daily_volume_perp = tidyr::replace_na(avg_daily_volume_perp, 0),
-      liquidity_ratio = avg_daily_volume_perp / avg_daily_volume_spot,
+      avg_oi_notional_perp = tidyr::replace_na(avg_oi_notional_perp, 0),
+      # liquidity_ratio: OI notional relative to spot volume (proxy, not like-for-like)
+      liquidity_ratio = avg_oi_notional_perp / avg_daily_volume_spot,
       is_liquid = avg_daily_volume_spot >= min_daily_volume &
-                  avg_daily_volume_perp >= min_daily_volume &
+                  avg_oi_notional_perp >= min_daily_volume &
                   liquidity_ratio >= 0.5 &
                   liquidity_ratio <= 2.0
     )

--- a/R/volatility_spike_analysis.R
+++ b/R/volatility_spike_analysis.R
@@ -24,7 +24,8 @@ detect_volatility_spikes <- function(vix_daily, threshold = 1.5, window_days = 6
     dplyr::mutate(
       vix_ma = roll_mean_safe(vix, n = window_days),
       spike_threshold = vix_ma * threshold,
-      is_spike = !is.na(vix_ma) & vix >= spike_threshold
+      # NA-safe: holiday rows have vix = NA; treat as non-spike (FALSE) to keep cumsum clean
+      is_spike = !is.na(vix_ma) & !is.na(vix) & vix >= spike_threshold
     )
 
   # Assign spike_id to consecutive spike periods

--- a/packages/historicaldata/R/topological_risk_parity.R
+++ b/packages/historicaldata/R/topological_risk_parity.R
@@ -140,19 +140,22 @@
 
 #' Cluster inverse-variance (scalar)
 #'
-#' For a sub-cluster of assets, returns 1 / Var(equal-weight portfolio).
-#' Used during recursive bisection to split risk between two sub-clusters.
+#' For a sub-cluster of assets, returns 1 / Var(inverse-variance-weight portfolio).
+#' Uses inverse-variance (IVP) weights as required by Lopez de Prado (2016) HRP
+#' recursive bisection. Equal-weight was incorrect: when cluster variances differ,
+#' it produced wrong capital splits between sub-clusters.
 #'
 #' @param cov_mat Full covariance matrix (named).
 #' @param assets Character vector of asset names in this sub-cluster.
-#' @return Scalar: inverse of the equal-weight sub-cluster portfolio variance.
+#' @return Scalar: inverse of the IVP sub-cluster portfolio variance.
 #' @noRd
 .cluster_inv_var <- function(cov_mat, assets) {
   sub <- cov_mat[assets, assets, drop = FALSE]
-  k   <- length(assets)
-  w   <- rep(1 / k, k)
+  diag_var <- diag(sub)
+  # Inverse-variance portfolio weights (Lopez de Prado 2016)
+  ivp <- (1 / diag_var) / sum(1 / diag_var)
   # portfolio variance = w' Sigma w
-  pvar <- as.numeric(t(w) %*% sub %*% w)
+  pvar <- as.numeric(t(ivp) %*% sub %*% ivp)
   if (!is.finite(pvar) || pvar <= 0) return(1e-12)
   1 / pvar
 }
@@ -378,6 +381,25 @@ trp_weights <- function(cov_mat, fallback_to_hrp = TRUE) {
     cli::cli_abort(c(
       "x" = "{.arg cov_mat} must have at least 2 assets.",
       "i" = "Got {nrow(cov_mat)} asset(s)."
+    ))
+  }
+  if (!is.numeric(cov_mat)) {
+    cli::cli_abort(c(
+      "x" = "{.arg cov_mat} must be numeric.",
+      "i" = "Got storage mode {.val {storage.mode(cov_mat)}}."
+    ))
+  }
+  if (anyNA(cov_mat) || any(!is.finite(cov_mat))) {
+    cli::cli_abort(c(
+      "x" = "{.arg cov_mat} must contain only finite, non-NA values.",
+      "i" = "Found {sum(!is.finite(cov_mat) | is.na(cov_mat))} non-finite or NA element(s)."
+    ))
+  }
+  # Symmetry check (tolerance-based to handle floating-point rounding)
+  if (max(abs(cov_mat - t(cov_mat))) > sqrt(.Machine$double.eps) * max(abs(cov_mat))) {
+    cli::cli_abort(c(
+      "x" = "{.arg cov_mat} must be symmetric.",
+      "i" = "Maximum asymmetry: {.val {max(abs(cov_mat - t(cov_mat)))}}."
     ))
   }
   invisible(TRUE)


### PR DESCRIPTION
## Summary

Triage and fix batch for 8 open roborev FAIL reviews on strategy plan files.

## Fixes applied (7 commits)

| Review job | File(s) | Fix |
|---|---|---|
| j4589 | `R/volatility_spike_analysis.R` | NA-safe `is_spike`: add `!is.na(vix)` guard so holiday rows produce `FALSE` not `NA`, preventing `cumsum` corruption |
| j4604 | `R/plan_drif_v2.R` | `is_current` flag corrected to `feature_set == "both"` (production uses both chrono+ranked features); Sharpe now computed from excess returns |
| j4694 | `R/plan_olmar.R` | Testing partition capped at `test_end` to exclude locked validation data |
| j4718 | `R/plan_turn_of_month.R` | Testing partition capped at `oos_end` to exclude locked validation data |
| j4721 | `R/plan_strategy_correlation.R` | `strat_returns_aligned` now joins on `ym` (stable month key) instead of raw `date` — fixes empty/near-empty join caused by `port_returns` using synthetic ym-15 anchor vs `ltr_portfolio` using actual trading dates |
| j4605 | `packages/historicaldata/R/topological_risk_parity.R` | `.cluster_inv_var()` uses IVP weights (Lopez de Prado 2016); `.validate_cov_input()` now checks numeric/finite/symmetric |
| j4567 | `R/solana_defi_data.R` | End-date off-by-one fixed (+86399s); `avg_daily_volume_perp` renamed to `avg_oi_notional_perp` with note explaining it is OI notional not traded volume |
| j4568 | `R/plan_solana_momentum.R` | Obsolete findings confirmed (constants already at file scope; path uses `here::here`); TODO comment added for vol_weight not threaded into backtest functions |

## Obsolete findings (request close without code change)

- **j4567 High #1** (BTC not fetched): Already fixed on main — `sol_raw_data` now includes BTC via `filter(ticker %in% c(SOL_UNIVERSE, "BTC"))`.
- **j4567 Medium #2** (OHLC unsorted): `solana_spot_daily` target removed when plan switched from Birdeye API to parquet; finding no longer applies.
- **j4568 High #1** (constants inside function): Fixed on main — `SOL_UNIVERSE`, `SOL_BETA_WIN` etc. are now at file scope.
- **j4568 High #2** (machine-specific path): Fixed on main — now uses `here::here("data", "raw", "crypto_all.parquet")`.

## Findings deferred (NEEDS_HUMAN)

- **j4604 High #2**: DRIF multiverse selection logic (filter-before-rank vs production's rank-before-filter). Requires refactoring `run_spec()` to rank all series first. Filed as separate follow-up.
- **j4605 Medium #2**: `_mst_dfs_order()` DFS traversal not sorted by MST edge weight. Requires reworking adjacency structure. Filed as separate follow-up.
- **j4589 Medium** (regression tests lack NA-interleaved data): Test improvement, no blocking code fix needed.
- **j4718 Medium #1** (rank_end uses last row not exchange calendar): Requires exchange calendar integration.
- **j4718 Medium #2** (fals_tom_input not wired to falsification): Out of scope — plan_falsification.R is in another worktree.
- **j4694 Medium** (returns on wrong date in olmar.R): Out of scope — packages/historicaldata/R/olmar.R return-date shifting.

## Test plan

- [x] All modified `.R` files pass `Rscript -e 'parse("file.R")'` (syntax check)
- [ ] Full `tar_make()` run after merge to validate end-to-end
- [ ] Strategy correlation target should now produce non-empty `strat_returns_aligned`

🤖 Generated with [Claude Code](https://claude.com/claude-code)