### PR TITLE
fix(qa_summary): include olmar + tom metrics (closes #317)

### DIFF
--- a/R/plan_qa_vignette.R
+++ b/R/plan_qa_vignette.R
@@ -61,6 +61,7 @@ plan_qa_vignette <- function() {
         ltr_metrics,
         mr_metrics,
         ms_metrics,
+        olmar_metrics,
         persistence_metrics,
         port_metrics,
         rafi_metrics,
@@ -68,6 +69,7 @@ plan_qa_vignette <- function() {
         rsc_metrics,
         stk_drif_metrics,
         stk_max_metrics,
+        tom_metrics,
         xgb_drif_metrics
       ))
 


### PR DESCRIPTION
## Summary

- Closes #317
- `test-qa-summary-deps.R:196` was failing because `qa_summary` missed `olmar_metrics` (added to the pipeline via #276) and `tom_metrics` (added via #289)
- Wires both targets into the `invisible(list(...))` dependency block in `R/plan_qa_vignette.R`, in alphabetical order

## Files touched

- `R/plan_qa_vignette.R` — +2 lines: `olmar_metrics` (between `ms_metrics` and `persistence_metrics`) and `tom_metrics` (between `stk_max_metrics` and `xgb_drif_metrics`)

## Test plan

- [x] `test-qa-summary-deps.R` — all 4 tests pass (was 1 failure before fix)
- [x] `R/plan_qa_vignette.R` parses cleanly
- [x] No registry-based refactor needed — no `strategy_registry` target exists; added entries directly as per task instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)