### PR TITLE
feat(wfc): extend to DRIF elastic-net + leaderboard wiring (closes #318)

### DIFF
--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -155,6 +155,30 @@ plan_leaderboard <- function() {
           )
       }
 
+      # ── Walk-Forward Correlation columns (#318) ────────────────────────────
+      # wf_corr:    Pearson IS↔OOS correlation across the full parameter grid.
+      # wfc_verdict: 2×2 classification from hd_wf_correlation() —
+      #   "structural_edge", "consistently_loss_making", "spurious_luck", "noise".
+      #
+      # Strategies without a tunable parameter grid (OLMAR, TOM, Stock MAX,
+      # Stock DRIF, XGB DRIF, PSO Optimal) receive NA for both columns.
+      # XGB DRIF operates at the stock level (stk_drif_features) — no
+      # factor-rotation grid exists; factor-level XGB is a follow-up to #318.
+      #
+      # wfc_all_summary is keyed by strategy (display label).  Only the
+      # "Full Period" leaderboard row gets meaningful values; sub-period rows
+      # receive NA (WFC is a full-history property, not a sub-period one).
+      if (!is.null(wfc_all_summary) && nrow(wfc_all_summary) > 0) {
+        wfc_join <- wfc_all_summary |>
+          select(strategy, wf_corr = wfc_pearson, wfc_verdict = classification)
+        all_metrics <- all_metrics |>
+          left_join(wfc_join, by = "strategy") |>
+          mutate(
+            wf_corr    = ifelse(period == "Full Period", wf_corr,    NA_real_),
+            wfc_verdict = ifelse(period == "Full Period", wfc_verdict, NA_character_)
+          )
+      }
+
       all_metrics
     }),
 

--- a/R/plan_wf_correlation.R
+++ b/R/plan_wf_correlation.R
@@ -4,12 +4,20 @@
 # have structural predictive power by correlating IS and OOS Sharpe across
 # the full parameter grid.
 #
-# Scope (this PR — #297): Factor MAX (fac_max) scaffold only.
-# TODO #297-follow-up: add DRIF elastic-net (alpha/lambda) and XGB DRIF grids.
+# Scope (PR #318):
+#   - Factor MAX: top_n ∈ {1..5} (from PR #309, unchanged)
+#   - DRIF elastic-net: alpha ∈ {0.0, 0.25, 0.5, 0.75, 1.0}, lambda chosen
+#     by cv.glmnet's internal cross-validation (lambda.min rule)
+#   - XGB DRIF: NOT included.  The existing xgb_drif strategy operates at
+#     the stock level (stk_drif_features / xgb_drif_portfolio), not as a
+#     factor-rotation grid sweep.  A factor-level XGB is a separate effort;
+#     tracked as follow-up to #318.
 #
 # No IS/OOS overlap: IS grid uses dates <= bt_partitions$factor$train_end;
 # OOS grid uses bt_partitions$factor$test_start to test_end.
-# Enforces t+1 execution (factors held month AFTER signal — see plan_factormax.R).
+# Enforces t+1 execution (factors held month AFTER signal — see plan_factormax.R,
+# plan_drif.R).  t+0 execution is impossible per the look-ahead-bias-prevention
+# rule and project memory (alpha-decay min t+1).
 #
 # Reference: knowledge/wiki/walk-forward-correlation.md
 
@@ -235,32 +243,304 @@ plan_wf_correlation <- function() {
 
 
     # ══════════════════════════════════════════════════════════════════
-    # WFC summary: one-row tibble consumable by the leaderboard vignette
+    # DRIF elastic-net: IS × OOS grid sweep over alpha ∈ {0,0.25,0.5,0.75,1}
+    # ══════════════════════════════════════════════════════════════════
+    #
+    # DRIF uses an expanding-window elastic net (glmnet::cv.glmnet) on the
+    # 42 chronological+rank features from drif_features.  The single free
+    # tuning scalar visible to the WFC diagnostic is alpha (mix between L1
+    # and L2 penalty).  Lambda is always chosen by cv.glmnet's own
+    # cross-validation (lambda.min), consistent with the production target in
+    # plan_drif.R.
+    #
+    # IS window:  dates up to   wfc_params$is_end
+    # OOS window: dates from    wfc_params$oos_start to wfc_params$oos_end
+    # Annualised Sharpe (monthly, ann_factor=12) is the WFC metric.
+    #
+    # Depends on: drif_features, drif_params, wfc_params
+
+    targets::tar_target(wfc_drif_grid_is, {
+      library(dplyr)
+      rlang::check_installed("glmnet")
+
+      features  <- drif_features
+      params    <- drif_params
+      wfc_p     <- wfc_params
+
+      # Feature column names (match plan_drif.R)
+      lb         <- params$lookback_days
+      chrono_cols <- paste0("c", seq_len(lb))
+      rank_cols   <- paste0("r", seq_len(lb))
+      feat_cols   <- c(chrono_cols, rank_cols)
+
+      min_train <- params$min_train_months
+      all_factors <- c(params$factors, params$benchmark_factor)
+      months    <- sort(unique(features$ym))
+
+      # IS window: only months up to is_end
+      is_end_ym <- format(wfc_p$is_end, "%Y-%m")
+      is_months <- months[months <= is_end_ym]
+      trade_months_is <- is_months[(min_train + 1L):length(is_months)]
+      if (length(trade_months_is) < 6L) {
+        return(tibble::tibble(theta_id = integer(0), theta_label = character(0),
+                              IS_metric = numeric(0), partition = character(0)))
+      }
+
+      # ── Helper: run DRIF portfolio for one alpha value on one window ──
+      run_drif_window <- function(trade_months_w, alpha_val) {
+        predictions <- lapply(trade_months_w, function(m) {
+          m_idx        <- which(months == m)
+          train_months <- months[1L:(m_idx - 1L)]
+
+          train <- features |> filter(ym %in% train_months,
+                                      factor_name %in% all_factors)
+          test  <- features |> filter(ym == m,
+                                      factor_name %in% params$factors)
+          if (nrow(train) == 0L || nrow(test) == 0L) return(NULL)
+
+          X_train <- as.matrix(train[, feat_cols])
+          y_train <- train$target_ret
+          X_test  <- as.matrix(test[, feat_cols])
+
+          cc <- complete.cases(X_train, y_train)
+          X_train <- X_train[cc, , drop = FALSE]
+          y_train <- y_train[cc]
+          if (length(y_train) < 50L) return(NULL)
+
+          fit <- tryCatch(
+            glmnet::cv.glmnet(X_train, y_train,
+                              alpha = alpha_val,
+                              nfolds = 5L,
+                              type.measure = "mse"),
+            error = function(e) NULL
+          )
+          if (is.null(fit)) return(NULL)
+
+          pred <- as.numeric(predict(fit, X_test, s = "lambda.min"))
+          tibble::tibble(
+            factor_name   = test$factor_name,
+            ym            = m,
+            predicted_ret = pred,
+            actual_ret    = test$target_ret
+          )
+        })
+
+        preds <- dplyr::bind_rows(Filter(Negate(is.null), predictions))
+        if (nrow(preds) == 0L) return(NULL)
+
+        # Select top-N (same as drif_params$top_n = 2) by predicted return
+        port <- preds |>
+          group_by(ym) |>
+          dplyr::mutate(pred_rank = rank(-predicted_ret, ties.method = "min")) |>
+          dplyr::filter(pred_rank <= params$top_n) |>
+          dplyr::summarise(portfolio_ret = mean(actual_ret), .groups = "drop")
+        port
+      }
+
+      # ── Annualised Sharpe helper ───────────────────────────────────
+      ann_sharpe <- function(port_df, ann_factor) {
+        if (is.null(port_df) || nrow(port_df) < 4L) return(NA_real_)
+        ret <- port_df$portfolio_ret[!is.na(port_df$portfolio_ret)]
+        if (length(ret) < 4L) return(NA_real_)
+        ann_vol <- stats::sd(ret) * sqrt(ann_factor)
+        if (ann_vol <= 0) return(NA_real_)
+        mean(ret) * ann_factor / ann_vol
+      }
+
+      alpha_grid <- c(0.00, 0.25, 0.50, 0.75, 1.00)
+
+      purrr::map_dfr(seq_along(alpha_grid), function(i) {
+        a    <- alpha_grid[[i]]
+        port <- run_drif_window(trade_months_is, alpha_val = a)
+        tibble::tibble(
+          theta_id    = i,
+          theta_label = paste0("alpha=", a),
+          IS_metric   = ann_sharpe(port, wfc_p$ann_factor),
+          partition   = "IS"
+        )
+      })
+    }),
+
+
+    targets::tar_target(wfc_drif_grid_oos, {
+      library(dplyr)
+      rlang::check_installed("glmnet")
+
+      features  <- drif_features
+      params    <- drif_params
+      wfc_p     <- wfc_params
+
+      lb          <- params$lookback_days
+      chrono_cols <- paste0("c", seq_len(lb))
+      rank_cols   <- paste0("r", seq_len(lb))
+      feat_cols   <- c(chrono_cols, rank_cols)
+
+      min_train   <- params$min_train_months
+      all_factors <- c(params$factors, params$benchmark_factor)
+      months      <- sort(unique(features$ym))
+
+      # OOS window: months from oos_start to oos_end
+      oos_start_ym <- format(wfc_p$oos_start, "%Y-%m")
+      oos_end_ym   <- format(wfc_p$oos_end,   "%Y-%m")
+      oos_months   <- months[months >= oos_start_ym & months <= oos_end_ym]
+      if (length(oos_months) < 3L) {
+        return(tibble::tibble(theta_id = integer(0), theta_label = character(0),
+                              OOS_metric = numeric(0), partition = character(0)))
+      }
+
+      run_drif_oos <- function(oos_months_w, alpha_val) {
+        predictions <- lapply(oos_months_w, function(m) {
+          m_idx        <- which(months == m)
+          train_months <- months[1L:(m_idx - 1L)]
+
+          train <- features |> filter(ym %in% train_months,
+                                      factor_name %in% all_factors)
+          test  <- features |> filter(ym == m,
+                                      factor_name %in% params$factors)
+          if (nrow(train) == 0L || nrow(test) == 0L) return(NULL)
+
+          X_train <- as.matrix(train[, feat_cols])
+          y_train <- train$target_ret
+          X_test  <- as.matrix(test[, feat_cols])
+
+          cc <- complete.cases(X_train, y_train)
+          X_train <- X_train[cc, , drop = FALSE]
+          y_train <- y_train[cc]
+          if (length(y_train) < 50L) return(NULL)
+
+          fit <- tryCatch(
+            glmnet::cv.glmnet(X_train, y_train,
+                              alpha = alpha_val,
+                              nfolds = 5L,
+                              type.measure = "mse"),
+            error = function(e) NULL
+          )
+          if (is.null(fit)) return(NULL)
+
+          pred <- as.numeric(predict(fit, X_test, s = "lambda.min"))
+          tibble::tibble(
+            factor_name   = test$factor_name,
+            ym            = m,
+            predicted_ret = pred,
+            actual_ret    = test$target_ret
+          )
+        })
+
+        preds <- dplyr::bind_rows(Filter(Negate(is.null), predictions))
+        if (nrow(preds) == 0L) return(NULL)
+
+        port <- preds |>
+          group_by(ym) |>
+          dplyr::mutate(pred_rank = rank(-predicted_ret, ties.method = "min")) |>
+          dplyr::filter(pred_rank <= params$top_n) |>
+          dplyr::summarise(portfolio_ret = mean(actual_ret), .groups = "drop")
+        port
+      }
+
+      ann_sharpe_oos <- function(port_df, ann_factor) {
+        if (is.null(port_df) || nrow(port_df) < 3L) return(NA_real_)
+        ret <- port_df$portfolio_ret[!is.na(port_df$portfolio_ret)]
+        if (length(ret) < 3L) return(NA_real_)
+        ann_vol <- stats::sd(ret) * sqrt(ann_factor)
+        if (ann_vol <= 0) return(NA_real_)
+        mean(ret) * ann_factor / ann_vol
+      }
+
+      alpha_grid <- c(0.00, 0.25, 0.50, 0.75, 1.00)
+
+      purrr::map_dfr(seq_along(alpha_grid), function(i) {
+        a    <- alpha_grid[[i]]
+        port <- run_drif_oos(oos_months, alpha_val = a)
+        tibble::tibble(
+          theta_id    = i,
+          theta_label = paste0("alpha=", a),
+          OOS_metric  = ann_sharpe_oos(port, wfc_p$ann_factor),
+          partition   = "OOS"
+        )
+      })
+    }),
+
+
+    # ══════════════════════════════════════════════════════════════════
+    # DRIF combined IS+OOS grid
     # ══════════════════════════════════════════════════════════════════
 
-    targets::tar_target(wfc_summary, {
-      tibble::tibble(
-        strategy       = "fac_max",
-        wfc_pearson    = wfc_fm_result$pearson,
-        wfc_spearman   = wfc_fm_result$spearman,
-        wfc_n_points   = wfc_fm_result$n_points,
-        wfc_category   = wfc_fm_result$wfc_category,
-        classification = wfc_fm_result$classification,
-        median_oos     = wfc_fm_result$median_oos,
-        pct_pos_oos    = wfc_fm_result$pct_positive_oos,
+    targets::tar_target(wfc_drif_grid, {
+      dplyr::inner_join(
+        wfc_drif_grid_is  |> dplyr::select(theta_id, theta_label, IS_metric),
+        wfc_drif_grid_oos |> dplyr::select(theta_id, OOS_metric),
+        by = "theta_id"
+      )
+    }),
 
-        # Metadata for audit trail
-        is_end   = wfc_params$is_end,
-        oos_start = wfc_params$oos_start,
-        oos_end   = wfc_params$oos_end,
+
+    # ══════════════════════════════════════════════════════════════════
+    # DRIF WFC diagnostic
+    # ══════════════════════════════════════════════════════════════════
+
+    targets::tar_target(wfc_drif_result, {
+      hd_wf_correlation(
+        wfc_drif_grid,
+        wfc_threshold_high = wfc_params$wfc_threshold
+      )
+    }),
+
+
+    # ══════════════════════════════════════════════════════════════════
+    # WFC all-strategy summary (FM + DRIF): leaderboard-ready tibble
+    # ══════════════════════════════════════════════════════════════════
+    #
+    # XGB DRIF is not included: the existing xgb_drif operates at the
+    # stock level (stk_drif_features) with no factor-rotation grid, so
+    # there is no (IS, OOS) Sharpe pair per parameter to correlate.
+    # A factor-level XGB is tracked as a follow-up to #318.
+    #
+    # OLMAR, TOM, and other non-parametric strategies have no tunable
+    # grid — wf_corr and wfc_verdict will be NA_real_ / NA_character_
+    # for those rows in the leaderboard (see plan_leaderboard.R).
+
+    targets::tar_target(wfc_all_summary, {
+      audit <- list(
+        is_end        = wfc_params$is_end,
+        oos_start     = wfc_params$oos_start,
+        oos_end       = wfc_params$oos_end,
         wfc_threshold = wfc_params$wfc_threshold,
         computed_on   = Sys.Date()
       )
 
-      # TODO (#297 follow-up): add DRIF and XGB DRIF rows once those
-      # parameter grids are wired as targets.  The plan structure above
-      # (wfc_fm_grid_is / wfc_fm_grid_oos / wfc_fm_grid / wfc_fm_result)
-      # is the canonical scaffold to replicate for each strategy.
+      make_row <- function(strategy_name, result) {
+        tibble::tibble(
+          strategy       = strategy_name,
+          wfc_pearson    = result$pearson,
+          wfc_spearman   = result$spearman,
+          wfc_n_points   = result$n_points,
+          wfc_category   = result$wfc_category,
+          classification = result$classification,
+          median_oos     = result$median_oos,
+          pct_pos_oos    = result$pct_positive_oos,
+          is_end         = audit$is_end,
+          oos_start      = audit$oos_start,
+          oos_end        = audit$oos_end,
+          wfc_threshold  = audit$wfc_threshold,
+          computed_on    = audit$computed_on
+        )
+      }
+
+      dplyr::bind_rows(
+        make_row("Factor MAX",   wfc_fm_result),
+        make_row("Factor DRIF",  wfc_drif_result)
+      )
+    }),
+
+
+    # ══════════════════════════════════════════════════════════════════
+    # wfc_summary: backward-compatible one-row alias (FM only)
+    # Kept for targets cache compatibility with PR #309.
+    # New code should use wfc_all_summary.
+    # ══════════════════════════════════════════════════════════════════
+
+    targets::tar_target(wfc_summary, {
+      wfc_all_summary |> dplyr::filter(strategy == "Factor MAX")
     })
 
   )

--- a/docs/_targets.R
+++ b/docs/_targets.R
@@ -125,6 +125,7 @@ source(here::here("R/plan_crypto_momentum.R"))
 source(here::here("R/plan_solana_momentum.R"))
 source(here::here("R/plan_olmar.R"))
 source(here::here("R/plan_turn_of_month.R"))
+source(here::here("R/plan_wf_correlation.R"))
 
 # Combine: strategy_names FIRST, then partitions, strategies, portfolio, ETF replication, leaderboard, QA
 c(plan_strategy_names(),
@@ -169,6 +170,7 @@ c(plan_strategy_names(),
   plan_solana_momentum(),
   plan_olmar(),
   plan_turn_of_month(),
+  plan_wf_correlation(),
 
   # Phase 1 of #149: date-type consistency across all registered datasets.
   # tar_target_raw + explicit deps so targets schedules dv_join_key_types

--- a/docs/falsification.qmd
+++ b/docs/falsification.qmd
@@ -400,6 +400,73 @@ Delta-Z = max(t_IS) - max(t_OOS) — the gap between the best in-sample and best
 In this framework, "in-sample" = HAC t-stat (strategy returns), "out-of-sample" = FF alpha t-stat (after removing known factor exposure). The OOS test is not a temporal holdout but a *structural* holdout — does the signal survive factor decomposition?
 
 
+# Walk-Forward Correlation {#wfc}
+
+## Row
+
+### {.tabset}
+
+#### WFC 2×2 Matrix
+
+```{r}
+#| label: wfc-table
+#| results: asis
+wfc_tbl <- safe_tar_read("wfc_all_summary")
+if (!is.null(wfc_tbl) && nrow(wfc_tbl) > 0) {
+  library(dplyr)
+  display_tbl <- wfc_tbl |>
+    transmute(
+      Strategy      = strategy,
+      `Pearson ρ`   = round(wfc_pearson,  3),
+      `Spearman ρ`  = round(wfc_spearman, 3),
+      `N grid pts`  = wfc_n_points,
+      `WFC category` = wfc_category,
+      `Median OOS`  = round(median_oos,   3),
+      `% OOS > 0`   = paste0(round(pct_pos_oos * 100, 0), "%"),
+      Verdict       = classification
+    )
+  caption_text <- paste0(
+    "Walk-Forward Correlation diagnostic (Tinsley 2026, SSRN 6324079). ",
+    "Pearson ρ computed across IS↔OOS annualised Sharpe for every parameter ",
+    "combination in each strategy’s grid. ",
+    "IS window ends ", format(wfc_tbl$is_end[[1]], "%Y-%m-%d"), "; ",
+    "OOS window ", format(wfc_tbl$oos_start[[1]], "%Y-%m-%d"),
+    " – ", format(wfc_tbl$oos_end[[1]], "%Y-%m-%d"), ". ",
+    "Computed ", format(wfc_tbl$computed_on[[1]], "%Y-%m-%d"), "."
+  )
+  fals_dt(display_tbl, caption_text)
+} else {
+  cat("*WFC summary not yet computed — run `tar_make()` to build `wfc_all_summary`.*")
+}
+```
+
+#### Methodology
+
+**What Walk-Forward Correlation measures:**
+
+[WFC](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6324079){target="_blank" rel="noopener noreferrer"} (Martyn Tinsley, 2026) is a single-number diagnostic for over-fitting across the *whole* optimisation surface. Traditional walk-forward analysis asks "does the best in-sample parameter survive out-of-sample?" WFC instead asks "across *every* parameter combination, does in-sample performance predict out-of-sample performance?"
+
+**Calculation:** For each strategy with a tunable parameter vector θ, compute the in-sample Sharpe X(θ) and out-of-sample Sharpe Y(θ) for every point on the grid. WFC = Pearson ρ(X, Y) over all θ.
+
+**Diagnostic 2×2 matrix (Tinsley p.4):**
+
+|              | High WFC (ρ ≥ 0.70)               | Low WFC (ρ < 0.40)                    |
+|--------------|-----------------------------------|---------------------------------------|
+| **+OOS**     | `structural_edge` — low over-fitting | `spurious_luck` — high over-fitting  |
+| **−OOS**     | `consistently_loss_making`         | `noise` — no edge                    |
+
+**Calibration points from the paper (Figure 4):** high ≈ 0.881, moderate ≈ 0.581, low ≈ 0.234. This project uses 0.70 as the high/moderate boundary (midpoint of moderate–high range).
+
+**Strategies included:**
+
+- **Factor MAX** — parameter grid: `top_n ∈ {1, 2, 3, 4, 5}` (5 grid points)
+- **Factor DRIF** — parameter grid: `alpha ∈ {0.00, 0.25, 0.50, 0.75, 1.00}` (5 grid points); lambda chosen by `cv.glmnet` internal CV
+
+**Strategies not included:** OLMAR, TOM, and other non-parametric strategies have no tunable grid. XGB DRIF operates at the stock level (not a factor-rotation grid); factor-level XGB is tracked as a follow-up to [#318](https://github.com/JohnGavin/historical/issues/318){target="_blank" rel="noopener noreferrer"}.
+
+**Reference:** Tinsley, M. (2026). "Walk Forward Correlation." Trade Like A Machine Ltd. [SSRN 6324079](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6324079){target="_blank" rel="noopener noreferrer"}. Implemented in [`hd_wf_correlation()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/wf_correlation.R){target="_blank" rel="noopener noreferrer"}.
+
+
 # Assumptions {#assumptions}
 
 ## Row

--- a/packages/historicaldata/tests/testthat/test-wf-correlation.R
+++ b/packages/historicaldata/tests/testthat/test-wf-correlation.R
@@ -200,3 +200,105 @@ test_that("pct_positive_oos matches manual calculation", {
 
   expect_equal(result$pct_positive_oos, 3 / 5)
 })
+
+
+# ── 8. wfc_all_summary shape (smoke tests for #318 — DRIF extension) ──────────
+#
+# These tests verify that hd_wf_correlation() accepts grids in the shape
+# that wfc_drif_grid_is / wfc_drif_grid_oos / wfc_drif_grid will produce:
+# 5 rows (alpha ∈ {0.00, 0.25, 0.50, 0.75, 1.00}), integer theta_id,
+# character theta_label of the form "alpha=X.XX".
+
+make_drif_grid <- function() {
+  alpha_grid <- c(0.00, 0.25, 0.50, 0.75, 1.00)
+  # Simulate plausible IS and OOS Sharpe values (positive, partial correlation)
+  set.seed(318L)
+  is_vals  <- 0.3 + 0.4 * seq_along(alpha_grid) + stats::rnorm(5L, sd = 0.05)
+  oos_vals <- 0.1 + 0.3 * seq_along(alpha_grid) + stats::rnorm(5L, sd = 0.10)
+  data.frame(
+    theta_id    = seq_along(alpha_grid),
+    theta_label = paste0("alpha=", alpha_grid),
+    IS_metric   = is_vals,
+    OOS_metric  = oos_vals
+  )
+}
+
+test_that("DRIF-shaped grid (5 alpha values) produces well-formed WFC result", {
+  grid   <- make_drif_grid()
+  result <- hd_wf_correlation(grid)
+
+  # Must have all required return fields
+  expect_named(result,
+    c("pearson", "spearman", "n_points", "classification",
+      "wfc_category", "median_oos", "pct_positive_oos"),
+    ignore.order = TRUE
+  )
+
+  # n_points = 5 (all rows complete)
+  expect_equal(result$n_points, 5L)
+
+  # Pearson and Spearman are in [-1, 1]
+  expect_true(result$pearson  >= -1 & result$pearson  <= 1)
+  expect_true(result$spearman >= -1 & result$spearman <= 1)
+})
+
+test_that("DRIF-shaped grid: classification is one of the four valid labels", {
+  grid   <- make_drif_grid()
+  result <- hd_wf_correlation(grid)
+
+  valid_labels <- c("structural_edge", "consistently_loss_making",
+                    "spurious_luck",   "noise")
+  expect_true(result$classification %in% valid_labels)
+})
+
+test_that("DRIF-shaped grid: wfc_category is one of 'high', 'moderate', 'low'", {
+  grid   <- make_drif_grid()
+  result <- hd_wf_correlation(grid)
+
+  expect_true(result$wfc_category %in% c("high", "moderate", "low"))
+})
+
+test_that("wfc_all_summary shape: two-strategy tibble has expected columns", {
+  # Simulate wfc_all_summary structure as produced by plan_wf_correlation.R
+  # (one row per strategy, same columns for FM and DRIF)
+  grid_fm   <- make_grid(c(0.2, 0.5, 1.0, 1.5, 1.8),
+                          c(0.1, 0.4, 0.9, 1.3, 1.6))
+  grid_drif <- make_drif_grid()
+
+  res_fm   <- hd_wf_correlation(grid_fm)
+  res_drif <- hd_wf_correlation(grid_drif)
+
+  make_row <- function(strategy, res) {
+    tibble::tibble(
+      strategy       = strategy,
+      wfc_pearson    = res$pearson,
+      wfc_spearman   = res$spearman,
+      wfc_n_points   = res$n_points,
+      wfc_category   = res$wfc_category,
+      classification = res$classification,
+      median_oos     = res$median_oos,
+      pct_pos_oos    = res$pct_positive_oos
+    )
+  }
+
+  summary_tbl <- dplyr::bind_rows(
+    make_row("Factor MAX",  res_fm),
+    make_row("Factor DRIF", res_drif)
+  )
+
+  # Two rows — one per strategy
+  expect_equal(nrow(summary_tbl), 2L)
+
+  # strategy column contains both names
+  expect_true("Factor MAX"  %in% summary_tbl$strategy)
+  expect_true("Factor DRIF" %in% summary_tbl$strategy)
+
+  # All numeric WFC columns are finite or NA (no NaN or Inf)
+  numeric_cols <- c("wfc_pearson", "wfc_spearman", "wfc_n_points",
+                    "median_oos", "pct_pos_oos")
+  for (col in numeric_cols) {
+    vals <- summary_tbl[[col]]
+    expect_true(all(is.finite(vals) | is.na(vals)),
+                info = paste0("Column '", col, "' contains non-finite value"))
+  }
+})


### PR DESCRIPTION
## Summary

Closes #318. Extends the WFC scaffold from PR #309 (Factor MAX only) to Factor DRIF elastic-net, wires `wfc_all_summary` into the leaderboard, and adds a WFC section to the falsification vignette.

**Scope decision — XGB DRIF not included:** the existing `xgb_drif` strategy operates at the stock level (`stk_drif_features`, `xgb_drif_portfolio`) with no factor-rotation parameter grid. There is no `(IS, OOS) Sharpe per alpha/eta/nrounds` pair for a factor-level sweep. Factor-level XGB is a follow-up.

### New targets

| Target | Description |
|--------|-------------|
| `wfc_drif_grid_is` | IS annualised Sharpe for `alpha ∈ {0, 0.25, 0.5, 0.75, 1.0}` |
| `wfc_drif_grid_oos` | OOS annualised Sharpe for same alpha grid |
| `wfc_drif_grid` | Inner-joined IS+OOS tibble (5 rows) |
| `wfc_drif_result` | `hd_wf_correlation()` result for DRIF |
| `wfc_all_summary` | Multi-strategy tibble (Factor MAX + Factor DRIF) |
| `wfc_summary` | Backward-compatible alias (FM only, from #309) |

### Leaderboard

Two new columns on the `leaderboard` target: `wf_corr` (Pearson ρ) and `wfc_verdict` (2×2 classification). Populated for Full-Period rows only. Strategies without a tunable grid (OLMAR, TOM, Stock MAX, Stock DRIF, XGB DRIF, PSO Optimal) receive `NA`.

### Strategies now on leaderboard with WFC columns
**Factor MAX** and **Factor DRIF** — both have `wf_corr` and `wfc_verdict` in the Full-Period leaderboard row.

## Test plan

- [x] `parse("R/plan_wf_correlation.R")` — OK
- [x] `parse("R/plan_leaderboard.R")` — OK
- [x] `test-wf-correlation.R` — 39/39 PASS (35 existing + 4 new smoke-test groups for DRIF grid shape and `wfc_all_summary` structure)
- [ ] `tar_make()` full pipeline — not run (CI will verify)

## Look-ahead safety

Uses existing `bt_partitions` train/test split. Lambda chosen by `cv.glmnet` internal CV (`lambda.min`). `t+0` execution is impossible per the `look-ahead-bias-prevention` rule and project memory (`alpha-decay-min-t1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)