### PR TITLE
fix: canonical adjusted_close across datasets (closes #325)

### DIFF
--- a/R/clean.R
+++ b/R/clean.R
@@ -12,16 +12,24 @@
 #' @param static_data Validated equity data from static source (Kaggle)
 #' @return Cleaned, deduplicated tibble
 clean_equity <- function(api_data, static_data) {
-  # Ensure both have adjusted column
-  if (!"adjusted" %in% names(static_data)) {
-    static_data$adjusted <- static_data$close
+  # Ensure both have adjusted_close column; alias old 'adjusted' for backward compat (#325)
+  if ("adjusted" %in% names(static_data) && !"adjusted_close" %in% names(static_data)) {
+    static_data$adjusted_close <- static_data$adjusted
+    static_data$adjusted <- NULL
   }
-  if (!"adjusted" %in% names(api_data)) {
-    api_data$adjusted <- api_data$close
+  if (!"adjusted_close" %in% names(static_data)) {
+    static_data$adjusted_close <- static_data$close
+  }
+  if ("adjusted" %in% names(api_data) && !"adjusted_close" %in% names(api_data)) {
+    api_data$adjusted_close <- api_data$adjusted
+    api_data$adjusted <- NULL
+  }
+  if (!"adjusted_close" %in% names(api_data)) {
+    api_data$adjusted_close <- api_data$close
   }
 
   # Standardise to common schema
-  schema_cols <- c("date", "open", "high", "low", "close", "adjusted",
+  schema_cols <- c("date", "open", "high", "low", "close", "adjusted_close",
                    "volume", "ticker", "source", "asset_class")
 
   api_std <- api_data |>

--- a/packages/historicaldata/R/alphavantage.R
+++ b/packages/historicaldata/R/alphavantage.R
@@ -66,15 +66,15 @@ hd_av_registry <- function() {
 #' Gate on `AV_REFRESH=1` environment variable or use a scheduled workflow.
 #'
 #' @section Column naming (adjusted close):
-#' The `adjusted_close` column name is kept as-is from the AlphaVantage API
-#' response — no rename is performed at ingest.  This differs from the
-#' `equity_daily` dataset (Yahoo Finance / HF parquet), which uses the shorter
-#' `adjusted` column.  The difference is intentional: each dataset retains its
-#' source API's natural column name.  When joining `alphavantage_daily` to
-#' `equity_daily`, rename one side explicitly:
-#' \code{dplyr::rename(av_df, adjusted = adjusted_close)}.
+#' `adjusted_close` is the canonical column name across all datasets in this
+#' package (GitHub issue
+#' \href{https://github.com/JohnGavin/historical/issues/325}{#325}).
+#' AlphaVantage's `TIME_SERIES_DAILY_ADJUSTED` endpoint returns this name
+#' natively — no rename is needed.  The `equity_daily` dataset (Yahoo Finance /
+#' HF parquet) also uses `adjusted_close` from #325 onwards.  Cross-dataset
+#' joins no longer require any rename.
 #' See \code{inst/COLUMN_NAMING.md} and GitHub issue #316 for the full
-#' rationale and the canonical column-name table.
+#' canonical-column table and source-system synonym mapping.
 #'
 #' @param ticker A single ticker symbol (e.g. `"AAPL"`, `"IBM"`).
 #' @param from Start date (character `"YYYY-MM-DD"` or `Date`). Default: 20

--- a/packages/historicaldata/R/quality.R
+++ b/packages/historicaldata/R/quality.R
@@ -19,7 +19,7 @@ hd_jumps <- function(dataset = "equity_daily", threshold = 0.4, n = 100) {
   ds <- hd_datasets()[[dataset]]
   if (is.null(ds)) cli::cli_abort("Unknown dataset: {dataset}")
 
-  price_col <- if ("adjusted" %in% ds$schema) "adjusted" else "close"
+  price_col <- if ("adjusted_close" %in% ds$schema) "adjusted_close" else "close"
 
   sql <- sprintf("
     WITH returns AS (
@@ -59,7 +59,7 @@ hd_quality <- function(dataset = "equity_daily", jump_threshold = 0.4) {
   ds <- hd_datasets()[[dataset]]
   if (is.null(ds)) cli::cli_abort("Unknown dataset: {dataset}")
 
-  price_col <- if ("adjusted" %in% ds$schema) "adjusted" else "close"
+  price_col <- if ("adjusted_close" %in% ds$schema) "adjusted_close" else "close"
 
   sql <- sprintf("
     WITH data AS (

--- a/packages/historicaldata/R/query.R
+++ b/packages/historicaldata/R/query.R
@@ -93,7 +93,7 @@ hd_check_survivorship_bias <- function(dataset) {
 #' @details
 #' Mixed-dataset batches (e.g. `c("AAPL", "BTC")`) are split by detected
 #' dataset, queried separately, and `bind_rows`'d. Columns that exist in
-#' only one dataset (e.g. `adjusted` in equities, `market_cap` in crypto)
+#' only one dataset (e.g. `adjusted_close` in equities, `market_cap` in crypto)
 #' are filled with `NA` for rows from the other dataset. When the batch
 #' spans multiple datasets, the result is always materialised — `collect
 #' = FALSE` cannot be honoured because lazy frames from distinct parquet
@@ -180,6 +180,14 @@ hd_ohlcv_single <- function(ticker, dataset, from, to, local, collect) {
     dplyr::filter(ticker %in% !!ticker) |>
     dplyr::arrange(ticker, date)
 
+  # Backward-compat alias: cached parquets written before #325 use 'adjusted'.
+  # New parquets use 'adjusted_close'.  Alias here so callers always see
+  # 'adjusted_close'. (#325)
+  col_names <- lf |> head(0) |> dplyr::collect() |> names()
+  if ("adjusted" %in% col_names && !("adjusted_close" %in% col_names)) {
+    lf <- lf |> dplyr::rename(adjusted_close = adjusted)
+  }
+
   if (!is.null(from)) lf <- lf |> dplyr::filter(date >= !!as.character(from))
   if (!is.null(to))   lf <- lf |> dplyr::filter(date <= !!as.character(to))
 
@@ -227,7 +235,19 @@ hd_lazy <- function(dataset = "equity_daily", local = FALSE) {
     ds$url
   }
 
-  duckplyr::read_parquet_duckdb(path)
+  lf <- duckplyr::read_parquet_duckdb(path)
+
+  # Backward-compat alias: cached parquets written before #325 use 'adjusted'
+  # (the old yfinance column name from fetch_equity.py).  New parquets use
+  # 'adjusted_close' (canonical, matching alphavantage_daily).  Callers always
+  # see 'adjusted_close' regardless of the underlying parquet column name.
+  # (#325)
+  col_names <- lf |> head(0) |> dplyr::collect() |> names()
+  if ("adjusted" %in% col_names && !("adjusted_close" %in% col_names)) {
+    lf <- lf |> dplyr::rename(adjusted_close = adjusted)
+  }
+
+  lf
 }
 
 #' Query FRED macro series

--- a/packages/historicaldata/R/ranked.R
+++ b/packages/historicaldata/R/ranked.R
@@ -54,7 +54,7 @@ hd_most_volatile <- function(dataset = "equity_daily", n = 5, window_days = 21) 
   if (is.null(ds)) cli::cli_abort("Unknown dataset: {dataset}")
 
   # Use adjusted if available (equity), else close
-  price_col <- if ("adjusted" %in% ds$schema) "adjusted" else "close"
+  price_col <- if ("adjusted_close" %in% ds$schema) "adjusted_close" else "close"
 
   sql <- sprintf("
     WITH returns AS (

--- a/packages/historicaldata/R/registry.R
+++ b/packages/historicaldata/R/registry.R
@@ -6,22 +6,19 @@
 #' @details
 #' ## Column naming conventions
 #'
-#' Each dataset uses a canonical column name for the dividend/split-adjusted
-#' close price.  The names differ by source because the upstream APIs use
-#' different identifiers; renames happen at ingest, not in this package.
+#' All datasets use `adjusted_close` as the canonical column name for the
+#' dividend/split-adjusted close price (GitHub issue
+#' \href{https://github.com/JohnGavin/historical/issues/325}{#325}).
 #'
 #' | Dataset | Column name | Source API field | Rename location |
 #' |---|---|---|---|
-#' | `equity_daily` | `adjusted` | `adj_close` (yfinance) | `scripts/fetch_equity.py` |
+#' | `equity_daily` | `adjusted_close` | `adj_close` (yfinance) | `scripts/fetch_equity.py` L163 |
 #' | `alphavantage_daily` | `adjusted_close` | `adjusted_close` (AV API) | none — native name |
 #'
-#' `alphavantage_daily` keeps `adjusted_close` (the full, unambiguous name)
-#' because the AlphaVantage `TIME_SERIES_DAILY_ADJUSTED` endpoint returns it
-#' natively.  `equity_daily` uses the shorter `adjusted` because yfinance
-#' (the underlying data source) calls the field `adj_close` and
-#' `fetch_equity.py` renames it to `adjusted` for compactness.
-#' The two datasets are intentionally separate; callers must be aware of
-#' the column-name difference when joining them.
+#' Cached parquets written before \href{https://github.com/JohnGavin/historical/issues/325}{#325}
+#' may still contain an `adjusted` column.  The read-time alias in
+#' \code{hd_lazy()} and \code{hd_ohlcv()} transparently renames `adjusted`
+#' to `adjusted_close` so callers see a consistent schema without re-fetching.
 #'
 #' See `inst/COLUMN_NAMING.md` for the full canonical-column table and all
 #' source-system synonyms (GitHub issue \href{https://github.com/JohnGavin/historical/issues/316}{#316}).
@@ -33,7 +30,7 @@ hd_datasets <- function() {
   list(
     equity_daily = list(
       url = hd_base_url("equity_daily.parquet"),
-      schema = c("date", "open", "high", "low", "close", "adjusted",
+      schema = c("date", "open", "high", "low", "close", "adjusted_close",
                  "volume", "ticker", "source", "asset_class", "updated_at"),
       frequency = "daily",
       description = paste0(
@@ -116,23 +113,12 @@ hd_datasets <- function() {
         "US equities daily adjusted OHLCV via AlphaVantage API (not a parquet snapshot). ",
         "Use hd_alphavantage(ticker) to fetch. ",
         "Free tier: 5 req/min, 500/day. Requires ALPHAVANTAGE_API_KEY in ~/.Renviron."
-      ),
-      # Column naming note (issue #316, option A):
-      # AlphaVantage's TIME_SERIES_DAILY_ADJUSTED endpoint natively returns
-      # 'adjusted_close' — no rename is needed at ingest (hd_alphavantage()
-      # passes the column through unchanged).  We chose to keep 'adjusted_close'
-      # as our canonical schema name rather than truncating to 'adjusted',
-      # because the full name is unambiguous alongside the unadjusted 'close'.
-      # Contrast with equity_daily (Yahoo Finance / HF parquet), which uses the
-      # shorter 'adjusted' column: yfinance emits 'adj_close'; fetch_equity.py
-      # renames it to 'adjusted' at ingest.  The two datasets are intentionally
-      # separate and carry different column names.  See inst/COLUMN_NAMING.md
-      # for the canonical column name table and source-system synonym mapping.
-      adjusted_close_note = paste0(
-        "Column 'adjusted_close': canonical schema name retained from the ",
-        "AlphaVantage API response (which natively uses 'adjusted_close'). ",
-        "Contrast with equity_daily which uses 'adjusted' (renamed from ",
-        "yfinance 'Adj Close' at ingest). See inst/COLUMN_NAMING.md (#316)."
+        # Column naming note (issue #325):
+        # 'adjusted_close' is the canonical name across all datasets.
+        # AlphaVantage's TIME_SERIES_DAILY_ADJUSTED endpoint natively returns
+        # 'adjusted_close' — no rename needed.  equity_daily now also uses
+        # 'adjusted_close' (renamed from yfinance 'adj_close' at fetch time in
+        # fetch_equity.py L163; #325).  See inst/COLUMN_NAMING.md.
       )
     )
   )

--- a/packages/historicaldata/inst/COLUMN_NAMING.md
+++ b/packages/historicaldata/inst/COLUMN_NAMING.md
@@ -5,8 +5,9 @@ all datasets in this package.  It documents source-system synonyms and records
 where each rename happens.
 
 See GitHub issue [#316](https://github.com/JohnGavin/historical/issues/316)
-for the design decision that prompted this document (option A: keep
-`adjusted_close` for `alphavantage_daily`).
+for the original design discussion, and
+[#325](https://github.com/JohnGavin/historical/issues/325) for the decision
+to normalise to `adjusted_close` across all datasets.
 
 ---
 
@@ -24,48 +25,43 @@ for the design decision that prompted this document (option A: keep
 
 ---
 
-## Adjusted-close column — per dataset
+## Adjusted-close column — canonical name
 
-This is the column that records the dividend- and split-adjusted close.  The
-name differs by dataset because each upstream API uses a different identifier;
-the rename (where needed) happens at ingest, not inside this package.
+`adjusted_close` is the single canonical column name for the dividend- and
+split-adjusted close across **all** datasets (#325).
 
 | Dataset | Column name | Upstream API field | Rename location | Note |
 |---|---|---|---|---|
-| `equity_daily` | `adjusted` | `adj_close` (yfinance) | [`scripts/fetch_equity.py`](../../../scripts/fetch_equity.py) L163 | Yahoo Finance source; renamed for compactness |
+| `equity_daily` | `adjusted_close` | `adj_close` (yfinance) | [`scripts/fetch_equity.py`](../../../scripts/fetch_equity.py) L163 | Renamed from `adj_close` at fetch time (new parquets from #325 onwards) |
 | `alphavantage_daily` | `adjusted_close` | `adjusted_close` (AV API) | none — native name | AlphaVantage returns this name natively; no rename needed |
 
-### Why the names differ
+### Backward compatibility
 
-`equity_daily` is built from yfinance (Python), which calls the field
-`adj_close`.  The ingest script `fetch_equity.py` renames it to `adjusted`
-(shorter; avoids confusion with the raw `close`).
+Cached parquet files produced before #325 may still contain a column named
+`adjusted` (the old yfinance rename).  The read-time alias in `hd_lazy()` and
+`hd_ohlcv()` transparently renames `adjusted` to `adjusted_close` at load time,
+so callers always see the canonical name without a full re-fetch.
 
-`alphavantage_daily` is built from the AlphaVantage
-`TIME_SERIES_DAILY_ADJUSTED` endpoint, which returns a column literally named
-`adjusted_close`.  We keep that name unchanged — it is explicit and matches
-the schema declared in `hd_datasets()$alphavantage_daily$schema`.
+### Cross-dataset joins (no rename needed from #325 onwards)
 
-### Design decision (issue #316, option A)
-
-The two datasets are intentionally separate and are never joined internally.
-Callers that need to join them must rename one side:
+Both datasets now share `adjusted_close`.  A join that previously required an
+explicit rename:
 
 ```r
-# Joining alphavantage_daily to equity_daily — rename AV side first
+# OLD (before #325): required rename on one side
 av   <- hd_alphavantage("AAPL") |> dplyr::rename(adjusted = adjusted_close)
-eq   <- hd_equity_daily |> dplyr::filter(ticker == "AAPL")
+eq   <- hd_ohlcv("AAPL")
 both <- dplyr::full_join(av, eq, by = c("date", "ticker", "adjusted"))
 ```
 
-Alternatively, use `adjusted_close` as the canonical name on the equity side
-by renaming in the other direction:
+now works without any rename:
 
 ```r
-eq_renamed <- eq |> dplyr::rename(adjusted_close = adjusted)
+# NEW (#325 onwards): column names match — no rename needed
+av   <- hd_alphavantage("AAPL")
+eq   <- hd_ohlcv("AAPL")
+both <- dplyr::full_join(av, eq, by = c("date", "ticker", "adjusted_close"))
 ```
-
-Either approach is valid; be explicit and consistent within a single analysis.
 
 ---
 
@@ -73,7 +69,7 @@ Either approach is valid; be explicit and consistent within a single analysis.
 
 | Concept | This package | Yahoo Finance (yfinance) | AlphaVantage API | Alpaca API |
 |---|---|---|---|---|
-| Adjusted close | `adjusted` or `adjusted_close` (see above) | `Adj Close` | `adjusted_close` | `vwap` (no split-adj close) |
+| Adjusted close | `adjusted_close` | `Adj Close` | `adjusted_close` | `vwap` (no split-adj close) |
 | Unadjusted close | `close` | `Close` | `close` | `close` |
 | Trade date | `date` | `Date` | `timestamp` | `timestamp` |
 | Volume | `volume` | `Volume` | `volume` | `volume` |
@@ -84,9 +80,8 @@ Either approach is valid; be explicit and consistent within a single analysis.
 
 When adding a new data source that includes an adjusted-close concept:
 
-1. Pick a canonical column name (`adjusted_close` preferred for new datasets;
-   it is explicit).
+1. Use `adjusted_close` as the canonical column name.
 2. Document the source API field in this table.
 3. Note the rename location in the ingest script.
-4. Update `hd_datasets()` in `R/registry.R` to include the chosen name in
+4. Update `hd_datasets()` in `R/registry.R` to include `adjusted_close` in
    the `schema` vector.

--- a/packages/historicaldata/tests/testthat/test-column-naming.R
+++ b/packages/historicaldata/tests/testthat/test-column-naming.R
@@ -1,0 +1,90 @@
+# Regression tests for #325: canonical adjusted_close column across datasets.
+
+test_that("equity_daily schema uses adjusted_close, not adjusted", {
+  ds <- hd_datasets()
+  schema <- ds[["equity_daily"]][["schema"]]
+  expect_true("adjusted_close" %in% schema,
+              label = "equity_daily schema must contain 'adjusted_close'")
+  expect_false("adjusted" %in% schema,
+               label = "equity_daily schema must NOT contain bare 'adjusted'")
+})
+
+test_that("alphavantage_daily schema uses adjusted_close", {
+  ds <- hd_datasets()
+  schema <- ds[["alphavantage_daily"]][["schema"]]
+  expect_true("adjusted_close" %in% schema,
+              label = "alphavantage_daily schema must contain 'adjusted_close'")
+  expect_false("adjusted" %in% schema,
+               label = "alphavantage_daily schema must NOT contain bare 'adjusted'")
+})
+
+test_that("backward-compat alias: old 'adjusted' column is renamed to 'adjusted_close'", {
+  # Simulate a parquet-like tibble with the OLD column name
+  old_frame <- tibble::tibble(
+    date          = as.Date(c("2024-01-02", "2024-01-03")),
+    open          = c(185.5, 186.0),
+    high          = c(187.1, 188.0),
+    low           = c(184.9, 185.5),
+    close         = c(186.8, 187.5),
+    adjusted      = c(186.0, 186.7),   # OLD column name
+    volume        = c(50000000L, 48000000L),
+    ticker        = c("AAPL", "AAPL"),
+    source        = c("yahoo", "yahoo"),
+    asset_class   = c("equity", "equity")
+  )
+
+  # Apply the same alias logic used inside hd_lazy() / hd_ohlcv_single()
+  col_names <- names(old_frame)
+  if ("adjusted" %in% col_names && !("adjusted_close" %in% col_names)) {
+    old_frame <- dplyr::rename(old_frame, adjusted_close = adjusted)
+  }
+
+  expect_true("adjusted_close" %in% names(old_frame),
+              label = "alias must produce 'adjusted_close'")
+  expect_false("adjusted" %in% names(old_frame),
+               label = "old 'adjusted' column must be gone after alias")
+})
+
+test_that("backward-compat alias is a no-op when adjusted_close already present", {
+  new_frame <- tibble::tibble(
+    date           = as.Date("2024-01-02"),
+    close          = 186.8,
+    adjusted_close = 186.0,
+    ticker         = "AAPL"
+  )
+
+  col_names <- names(new_frame)
+  if ("adjusted" %in% col_names && !("adjusted_close" %in% col_names)) {
+    new_frame <- dplyr::rename(new_frame, adjusted_close = adjusted)
+  }
+
+  expect_true("adjusted_close" %in% names(new_frame))
+  expect_false("adjusted" %in% names(new_frame))
+  expect_equal(nrow(new_frame), 1L)
+})
+
+test_that("hd_alphavantage output uses adjusted_close", {
+  skip_if_not_installed("alphavantager")
+  mock_result <- tibble::tibble(
+    timestamp         = as.Date(c("2024-01-02", "2024-01-03")),
+    open              = c(185.5, 186.0),
+    high              = c(187.1, 188.0),
+    low               = c(184.9, 185.5),
+    close             = c(186.8, 187.5),
+    adjusted_close    = c(186.0, 186.7),
+    volume            = c(50000000L, 48000000L),
+    dividend_amount   = c(0, 0),
+    split_coefficient = c(1, 1)
+  )
+  testthat::local_mocked_bindings(
+    av_get = function(...) mock_result,
+    .package = "alphavantager"
+  )
+  withr::with_envvar(c(ALPHAVANTAGE_API_KEY = "demo"), {
+    result <- hd_alphavantage("AAPL", from = "2024-01-01")
+  })
+  expect_true("adjusted_close" %in% names(result),
+              label = "hd_alphavantage() must return 'adjusted_close'")
+  expect_false("adjusted" %in% names(result),
+               label = "hd_alphavantage() must NOT return bare 'adjusted'")
+})

--- a/scripts/fetch_equity.py
+++ b/scripts/fetch_equity.py
@@ -160,7 +160,7 @@ def fetch_batch(tickers: list[str], batch_size: int = 0) -> pd.DataFrame:
     # Standardise columns
     col_map = {
         "date": "date", "open": "open", "high": "high", "low": "low",
-        "close": "close", "adj_close": "adjusted", "volume": "volume",
+        "close": "close", "adj_close": "adjusted_close", "volume": "volume",
     }
     combined = combined.rename(columns=col_map)
     combined["source"] = "yahoo"
@@ -171,7 +171,7 @@ def fetch_batch(tickers: list[str], batch_size: int = 0) -> pd.DataFrame:
         combined["date"] = combined["date"].dt.tz_localize(None)
 
     # Keep only standard columns
-    keep = ["date", "open", "high", "low", "close", "adjusted", "volume",
+    keep = ["date", "open", "high", "low", "close", "adjusted_close", "volume",
             "ticker", "source", "asset_class"]
     combined = combined[[c for c in keep if c in combined.columns]]
 


### PR DESCRIPTION
## Summary

Closes #325. Picks `adjusted_close` as the canonical column name for the
dividend/split-adjusted close across all datasets, consistent with the #316
decision to keep the full unambiguous AlphaVantage name.

- **Part A (producer):** `scripts/fetch_equity.py` L163 — rename `adj_close → adjusted_close` instead of `adj_close → adjusted`. New parquet files will use the canonical name.
- **Part B (read-time compat):** `hd_lazy()` and `hd_ohlcv_single()` apply a transparent alias — if the loaded parquet has `adjusted` but not `adjusted_close`, it is renamed at load time. Existing cached parquets keep working without a re-fetch.
- **Part C (consumers):** `registry.R` schema and roxygen docs, `alphavantage.R` docstring (cross-rename guidance removed), `quality.R` and `ranked.R` price-col detection, `R/clean.R` backward-compat handling.
- **Part D (tests + docs):** New `test-column-naming.R` with 5 regression assertions. `COLUMN_NAMING.md` rewritten with single canonical row and updated join examples.

## Test plan

- [ ] `test-column-naming.R` — 5 assertions covering schema, alias logic (old parquet), alias no-op (new parquet), and `hd_alphavantage()` output column
- [ ] `test-registry.R` `hd_datasets snapshot` — snapshot still valid (truncated `str()` output unchanged)
- [ ] `test-alphavantage.R` — existing tests still pass (no column name change for AV side)
- [ ] Python syntax check: `python3 -c "import ast; ast.parse(open('scripts/fetch_equity.py').read())"` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)