### PR TITLE
feat(leaderboard): surface max_consecutive_losses (closes #331)

### DIFF
--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -179,9 +179,10 @@ plan_leaderboard <- function() {
           )
       }
 
-      # ── Pillar 8: risk-architecture columns (#269) ────────────────────────
-      # Join avg_dd_days, max_dd_days, loss_clustered from fals_results_db.
-      # fals_results_db uses strategy_id (internal code); map to leaderboard labels.
+      # ── Pillar 8: risk-architecture columns (#269, #331) ─────────────────────
+      # Join avg_dd_days, max_dd_days, loss_clustered, max_cons_losses from
+      # fals_results_db. fals_results_db uses strategy_id (internal code); map
+      # to leaderboard labels.
       # Only "Full Period" rows carry meaningful full-history risk values.
       if (!is.null(fals_results_db) && nrow(fals_results_db) > 0) {
         fals_id_to_label <- c(
@@ -193,15 +194,17 @@ plan_leaderboard <- function() {
           filter(strategy_id %in% names(fals_id_to_label)) |>
           mutate(strategy = fals_id_to_label[strategy_id]) |>
           select(strategy,
-                 avg_dd_days    = avg_dd_duration_days,
-                 max_dd_days    = max_dd_duration_days,
-                 loss_clustered = loss_clustered)
+                 avg_dd_days      = avg_dd_duration_days,
+                 max_dd_days      = max_dd_duration_days,
+                 loss_clustered   = loss_clustered,
+                 max_cons_losses  = max_consecutive_losses)
         all_metrics <- all_metrics |>
           left_join(pillar8_join, by = "strategy") |>
           mutate(
-            avg_dd_days    = ifelse(period == "Full Period", avg_dd_days, NA_real_),
-            max_dd_days    = ifelse(period == "Full Period", max_dd_days, NA_real_),
-            loss_clustered = ifelse(period == "Full Period", loss_clustered, NA)
+            avg_dd_days     = ifelse(period == "Full Period", avg_dd_days,     NA_real_),
+            max_dd_days     = ifelse(period == "Full Period", max_dd_days,     NA_real_),
+            loss_clustered  = ifelse(period == "Full Period", loss_clustered,  NA),
+            max_cons_losses = ifelse(period == "Full Period", max_cons_losses, NA_integer_)
           )
       }
 

--- a/docs/falsification.qmd
+++ b/docs/falsification.qmd
@@ -696,16 +696,18 @@ exhausting capital before recovery). Two metrics quantify this distinction:
 fals_db <- safe_tar_read("fals_results_db")
 if (!is.null(fals_db) && nrow(fals_db) > 0 &&
     all(c("avg_dd_duration_days", "max_dd_duration_days",
-          "loss_runs_p", "loss_acf_lag1", "loss_clustered") %in% names(fals_db))) {
+          "loss_runs_p", "loss_acf_lag1", "loss_clustered",
+          "max_consecutive_losses") %in% names(fals_db))) {
 
   risk_tbl <- fals_db |>
     dplyr::select(
-      Strategy     = strategy_id,
+      Strategy         = strategy_id,
       `Avg DD days`    = avg_dd_duration_days,
       `Max DD days`    = max_dd_duration_days,
       `Runs p-val`     = loss_runs_p,
       `ACF lag-1`      = loss_acf_lag1,
-      `Clustered`      = loss_clustered
+      `Clustered`      = loss_clustered,
+      `Max Cons. Losses` = max_consecutive_losses
     ) |>
     dplyr::mutate(
       Strategy  = dplyr::case_match(
@@ -742,6 +744,14 @@ if (!is.null(fals_db) && nrow(fals_db) > 0 &&
   } else {
     paste(clustered_strats, collapse = ", ")
   }
+  worst_cons_losses_strat <- risk_tbl |>
+    dplyr::filter(!is.na(`Max Cons. Losses`)) |>
+    dplyr::slice_max(`Max Cons. Losses`, n = 1L) |>
+    dplyr::pull(Strategy)
+  worst_cons_losses_n <- risk_tbl |>
+    dplyr::filter(!is.na(`Max Cons. Losses`)) |>
+    dplyr::slice_max(`Max Cons. Losses`, n = 1L) |>
+    dplyr::pull(`Max Cons. Losses`)
 
   DT::datatable(
     risk_tbl,
@@ -756,10 +766,15 @@ if (!is.null(fals_db) && nrow(fals_db) > 0 &&
         worst_max_dd_days, " days). ",
         "Strategies with clustered losses (runs p &lt; 0.05 AND ACF lag-1 &gt; 0.2): <b>",
         clustered_label, "</b>. ",
+        "Longest consecutive losing run: <b>",
+        worst_cons_losses_strat, "</b> (",
+        worst_cons_losses_n, " trades). ",
         "Clustering indicates losses arrive in bursts rather than uniformly, ",
         "reducing practical survivability. ",
         "Source: <a href='https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/risk_metrics.R' target='_blank'>",
-        "hd_dd_duration() + hd_loss_clustering()</a> in packages/historicaldata, ",
+        "hd_dd_duration() + hd_loss_clustering()</a> + ",
+        "<a href='https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/trades.R' target='_blank'>",
+        "hd_trade_metrics()</a> in packages/historicaldata, ",
         "wired via <a href='https://github.com/JohnGavin/historical/blob/main/R/plan_falsification.R' target='_blank'>",
         "plan_falsification.R</a>."
       ))

--- a/packages/historicaldata/tests/testthat/test-risk-metrics.R
+++ b/packages/historicaldata/tests/testthat/test-risk-metrics.R
@@ -98,3 +98,25 @@ test_that("hd_loss_clustering: all same sign returns p=0 (degenerate single run)
   expect_false(is.na(res$runs_test_p))
   expect_equal(res$runs_test_p, 0)
 })
+
+# ── hd_trade_metrics: max_consecutive_losses is populated (#331) ─────────────
+
+test_that("hd_trade_metrics: max_consecutive_losses is non-NA for any strategy with trades", {
+  # Build a minimal monthly-strategy data frame with mixed wins and losses
+  set.seed(77)
+  n_months <- 24L
+  monthly_ret <- tibble::tibble(
+    date         = seq.Date(as.Date("2020-01-01"), by = "month", length.out = n_months),
+    strategy_ret = c(rep(0.02, 6), rep(-0.01, 3), rep(0.015, 5),
+                     rep(-0.008, 4), rep(0.01, 6))
+  )
+  trades  <- hd_monthly_trades(monthly_ret)
+  metrics <- hd_trade_metrics(trades, ann_factor = 12L, n_years = n_months / 12)
+
+  # Core contract: max_consecutive_losses must be a non-NA integer
+  expect_false(is.na(metrics$max_consecutive_losses),
+    info = "max_consecutive_losses should be populated for any strategy with trade data")
+  expect_type(metrics$max_consecutive_losses, "integer")
+  # With 3 and 4 consecutive loss runs, max must be >= 3
+  expect_gte(metrics$max_consecutive_losses, 3L)
+})


### PR DESCRIPTION
## Summary

- `max_consecutive_losses` was already computed by `hd_trade_metrics()` and stored in `fals_results_db` — this PR surfaces it in three places
- `R/plan_leaderboard.R`: added `max_cons_losses = max_consecutive_losses` to the Pillar 8 `select()` and a matching `ifelse(period == "Full Period", ...)` guard in `mutate()`, alongside `avg_dd_days` / `max_dd_days` / `loss_clustered`
- `docs/falsification.qmd`: added `Max Cons. Losses` column to the Risk Architecture DT table; extended the guard condition to require `max_consecutive_losses` in `names(fals_db)`; extended the dynamic caption with the strategy holding the longest consecutive losing run (all values via `r expr` per `dynamic-prose-values` rule); added link to `hd_trade_metrics()` source
- `packages/historicaldata/tests/testthat/test-risk-metrics.R`: smoke test asserting `hd_trade_metrics()` returns a non-NA integer `max_consecutive_losses` for any strategy with trade data; 30/30 tests pass

Closes #331. Completes the Pillar 8 Risk Architecture story from #269 / PR #330. Pattern-matched against the existing Pillar 8 join block from PR #330.

## Test plan

- [x] `timeout 60 Rscript -e 'parse("R/plan_leaderboard.R")'` — no error
- [x] `nix develop --command Rscript -e 'pkgload::load_all(...); testthat::test_file("test-risk-metrics.R")'` — FAIL 0 | WARN 0 | SKIP 0 | PASS 30

🤖 Generated with [Claude Code](https://claude.com/claude-code)