### PR TITLE
feat(commodities): mean-reversion strategy + falsification wiring (closes #138)

### DIFF
--- a/R/plan_commodities_mean_reversion.R
+++ b/R/plan_commodities_mean_reversion.R
@@ -1,0 +1,199 @@
+# Plan: Commodities Mean Reversion (Issue #138)
+#
+# Counterpart to plan_commodities_momentum.R (#134).
+# #134 found commodity momentum is broken (Sharpe -0.85 baseline,
+# -0.89 to -0.91 decomposed). This plan tests the counter-hypothesis:
+# if momentum doesn't work, mean reversion might — commodities have
+# backwardation/contango cycles, supply/demand seasonality, and supply
+# shocks that reverse.
+#
+# A clear negative result is fine and valuable.
+#
+# Data: re-uses commodities_raw + commodities_returns from
+#       plan_commodities_momentum.R (DO NOT re-define those targets here).
+# Frequency: monthly (ann_factor = 12).
+# Look-ahead safety: signal at t uses returns through t-1 only.
+# Execution: signal at t -> trade at t+1 close.
+# Transaction cost: 0.2% per trade (same as commodity momentum, #134).
+
+plan_commodities_mean_reversion <- function() {
+  list(
+
+    # ── Signals: three lookback windows ──────────────────────────────────
+    # Re-uses commodities_returns from plan_commodities_momentum.R.
+    # Each signal: mr_signal = -(cumulative return over prior L months).
+    # Higher signal -> bigger recent loser -> long candidate.
+
+    targets::tar_target(cmr_signals_1m, {
+      hd_commodity_mr_signal(commodities_returns, lookback_months = 1L)
+    }),
+
+    targets::tar_target(cmr_signals_3m, {
+      hd_commodity_mr_signal(commodities_returns, lookback_months = 3L)
+    }),
+
+    targets::tar_target(cmr_signals_6m, {
+      hd_commodity_mr_signal(commodities_returns, lookback_months = 6L)
+    }),
+
+
+    # ── Portfolios: long-losers / short-winners ───────────────────────────
+    # t+1 execution: signal at t -> trade executes at t+1 closing prices.
+    # 10 long + 10 short, equal weight within each leg.
+    # 0.2% one-way transaction cost.
+
+    targets::tar_target(cmr_portfolio_1m, {
+      hd_commodity_mr_portfolio(
+        signal_tbl  = cmr_signals_1m,
+        returns_tbl = commodities_returns,
+        n_long      = 10L,
+        n_short     = 10L,
+        cost_bps    = 20
+      )
+    }),
+
+    targets::tar_target(cmr_portfolio_3m, {
+      hd_commodity_mr_portfolio(
+        signal_tbl  = cmr_signals_3m,
+        returns_tbl = commodities_returns,
+        n_long      = 10L,
+        n_short     = 10L,
+        cost_bps    = 20
+      )
+    }),
+
+    targets::tar_target(cmr_portfolio_6m, {
+      hd_commodity_mr_portfolio(
+        signal_tbl  = cmr_signals_6m,
+        returns_tbl = commodities_returns,
+        n_long      = 10L,
+        n_short     = 10L,
+        cost_bps    = 20
+      )
+    }),
+
+
+    # ── Monthly net returns (thin wrappers for falsification bridge) ──────
+
+    targets::tar_target(cmr_returns_1m, {
+      cmr_portfolio_1m |>
+        dplyr::select(date, strategy_ret = net_ret)
+    }),
+
+    targets::tar_target(cmr_returns_3m, {
+      cmr_portfolio_3m |>
+        dplyr::select(date, strategy_ret = net_ret)
+    }),
+
+    targets::tar_target(cmr_returns_6m, {
+      cmr_portfolio_6m |>
+        dplyr::select(date, strategy_ret = net_ret)
+    }),
+
+
+    # ── Performance metrics per lookback ──────────────────────────────────
+    # Sharpe, MDD, max DD duration (hd_dd_duration from risk_metrics.R).
+
+    targets::tar_target(cmr_metrics_1m, {
+      .compute_cmr_metrics(cmr_portfolio_1m, lookback = "1m", ann_factor = 12L)
+    }),
+
+    targets::tar_target(cmr_metrics_3m, {
+      .compute_cmr_metrics(cmr_portfolio_3m, lookback = "3m", ann_factor = 12L)
+    }),
+
+    targets::tar_target(cmr_metrics_6m, {
+      .compute_cmr_metrics(cmr_portfolio_6m, lookback = "6m", ann_factor = 12L)
+    }),
+
+
+    # ── Summary: comparison across lookbacks ─────────────────────────────
+
+    targets::tar_target(cmr_summary, {
+      dplyr::bind_rows(cmr_metrics_1m, cmr_metrics_3m, cmr_metrics_6m) |>
+        dplyr::arrange(lookback)
+    }),
+
+
+    # ── Head-to-head: mean reversion vs momentum (Part C) ─────────────────
+    # Joins commodity-momentum metrics (from plan_commodities_momentum.R)
+    # with MR metrics. Lightweight: no new data fetch.
+    # Momentum baseline = 12m lookback (Sharpe -0.85 per #134).
+
+    targets::tar_target(cmr_vs_mom_compare, {
+      library(dplyr)
+
+      mom_metrics <- commodities_perf_summary |>
+        dplyr::filter(strategy == "baseline") |>
+        dplyr::transmute(
+          lookback     = "12m (momentum)",
+          mom_sharpe   = round(sharpe, 3),
+          mom_mdd      = round(max_dd, 3)
+        )
+
+      mr_metrics <- cmr_summary |>
+        dplyr::transmute(
+          lookback   = paste0(lookback, " (MR)"),
+          mr_sharpe  = round(sharpe, 3),
+          mr_mdd     = round(max_dd, 3)
+        )
+
+      # One row per configuration; NA where comparison doesn't apply.
+      tibble::tibble(
+        lookback    = c(mr_metrics$lookback, mom_metrics$lookback),
+        type        = c(rep("mean_reversion", nrow(mr_metrics)), "momentum"),
+        sharpe      = c(mr_metrics$mr_sharpe, mom_metrics$mom_sharpe),
+        max_dd      = c(mr_metrics$mr_mdd,    mom_metrics$mom_mdd)
+      ) |>
+        dplyr::arrange(type, lookback)
+    })
+
+  )
+}
+
+
+# ── Internal helper ────────────────────────────────────────────────────────────
+# Not exported; called only within this plan's targets.
+
+.compute_cmr_metrics <- function(portfolio_tbl, lookback, ann_factor = 12L) {
+  library(dplyr)
+
+  r    <- portfolio_tbl$net_ret
+  r    <- r[!is.na(r)]
+  n    <- length(r)
+
+  if (n < 12L) {
+    return(tibble::tibble(
+      lookback = lookback, n_months = n,
+      sharpe = NA_real_, cagr = NA_real_, vol = NA_real_,
+      max_dd = NA_real_, avg_dd_duration = NA_real_, max_dd_duration = NA_real_
+    ))
+  }
+
+  monthly_rf <- (1.02)^(1 / ann_factor) - 1
+  mean_r     <- mean(r)
+  sd_r       <- sd(r)
+  sharpe     <- if (sd_r > 0) (mean_r - monthly_rf) / sd_r * sqrt(ann_factor) else NA_real_
+
+  cum        <- cumprod(1 + r)
+  years      <- n / ann_factor
+  cagr       <- (cum[n])^(1 / years) - 1
+  vol        <- sd_r * sqrt(ann_factor)
+
+  cum_max    <- cummax(cum)
+  dd         <- (cum - cum_max) / cum_max
+  max_dd     <- min(dd)
+
+  dd_stats   <- hd_dd_duration(r)
+
+  tibble::tibble(
+    lookback        = lookback,
+    n_months        = n,
+    sharpe          = round(sharpe, 3),
+    cagr            = round(cagr * 100, 1),
+    vol             = round(vol * 100, 1),
+    max_dd          = round(max_dd * 100, 1),
+    avg_dd_duration = dd_stats$avg_dd_duration,
+    max_dd_duration = dd_stats$max_dd_duration
+  )
+}

--- a/R/plan_falsification.R
+++ b/R/plan_falsification.R
@@ -595,6 +595,293 @@ plan_falsification <- function() {
 
 
     # ═══════════════════════════════════════════════════════════════════
+    # Per-strategy tests: cmr (Commodities Mean Reversion — #138)
+    # Monthly strategy. Three lookback variants (1m, 3m, 6m).
+    # Bridge targets fals_cmr_input_*m live in plan_commodities_mean_reversion.R
+    # via the cmr_returns_*m targets.
+    # Note: FF alpha test is omitted for CMR — the commodity universe does
+    # not overlap with the Fama-French equity factor universe, so the
+    # FF5+Mom regression is not meaningful here.
+    # ═══════════════════════════════════════════════════════════════════
+
+    # Bridge target: use 3m lookback as the primary CMR series (middle ground).
+    # Individual lookback variants are tested via fals_hac_cmr_*m targets below.
+    targets::tar_target(fals_cmr_input, {
+      library(dplyr)
+      cmr_returns_3m |>
+        dplyr::select(date, strategy_ret)
+    }),
+
+    # ── 1m lookback ──────────────────────────────────────────────────────
+    targets::tar_target(fals_hac_cmr_1m, {
+      hd_hac_sharpe(cmr_returns_1m$strategy_ret, ann_factor = 12L)
+    }),
+    targets::tar_target(fals_wn_cmr_1m, {
+      ret   <- cmr_returns_1m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_white_noise(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_rv_cmr_1m, {
+      ret   <- cmr_returns_1m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_regime_vol(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_ma1_cmr_1m, {
+      ret   <- cmr_returns_1m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_ma1(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_fn_cmr_1m, {
+      ret   <- cmr_returns_1m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_factor_null(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_garch_cmr_1m, {
+      ret   <- cmr_returns_1m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_garch11(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_gjr_cmr_1m, {
+      ret   <- cmr_returns_1m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_gjr_garch(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_dsr_cmr_1m, {
+      hd_deflated_sharpe(cmr_returns_1m$strategy_ret, K_trials = 3L, ann_factor = 12L)
+    }),
+
+    # ── 3m lookback ──────────────────────────────────────────────────────
+    targets::tar_target(fals_hac_cmr_3m, {
+      hd_hac_sharpe(cmr_returns_3m$strategy_ret, ann_factor = 12L)
+    }),
+    targets::tar_target(fals_wn_cmr_3m, {
+      ret   <- cmr_returns_3m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_white_noise(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_rv_cmr_3m, {
+      ret   <- cmr_returns_3m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_regime_vol(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_ma1_cmr_3m, {
+      ret   <- cmr_returns_3m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_ma1(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_fn_cmr_3m, {
+      ret   <- cmr_returns_3m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_factor_null(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_garch_cmr_3m, {
+      ret   <- cmr_returns_3m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_garch11(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_gjr_cmr_3m, {
+      ret   <- cmr_returns_3m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_gjr_garch(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_dsr_cmr_3m, {
+      hd_deflated_sharpe(cmr_returns_3m$strategy_ret, K_trials = 3L, ann_factor = 12L)
+    }),
+
+    # ── 6m lookback ──────────────────────────────────────────────────────
+    targets::tar_target(fals_hac_cmr_6m, {
+      hd_hac_sharpe(cmr_returns_6m$strategy_ret, ann_factor = 12L)
+    }),
+    targets::tar_target(fals_wn_cmr_6m, {
+      ret   <- cmr_returns_6m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_white_noise(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_rv_cmr_6m, {
+      ret   <- cmr_returns_6m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_regime_vol(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_ma1_cmr_6m, {
+      ret   <- cmr_returns_6m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_ma1(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_fn_cmr_6m, {
+      ret   <- cmr_returns_6m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_factor_null(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_garch_cmr_6m, {
+      ret   <- cmr_returns_6m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_garch11(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_gjr_cmr_6m, {
+      ret   <- cmr_returns_6m$strategy_ret
+      T_obs <- sum(!is.na(ret))
+      nulls <- hd_null_env_gjr_garch(T_obs, M = fals_params$M, seed = fals_params$seed)
+      hd_null_rejection_rate(
+        strategy_fn = function(r) hd_hac_tstat(r)$t_stat,
+        null_series = nulls,
+        alpha_level = fals_params$alpha_level
+      )
+    }),
+    targets::tar_target(fals_dsr_cmr_6m, {
+      hd_deflated_sharpe(cmr_returns_6m$strategy_ret, K_trials = 3L, ann_factor = 12L)
+    }),
+
+    # ── CMR falsification summary (standalone; not in main fals_summary) ──
+    # Separate from fals_summary to avoid breaking the existing 6-strategy table.
+    # Used by plan_falsification_vignette.R to append a CMR section.
+    targets::tar_target(fals_cmr_summary, {
+      tibble::tibble(
+        lookback = c("1m", "3m", "6m"),
+        hac_tstat = c(
+          fals_hac_cmr_1m$hac_tstat,
+          fals_hac_cmr_3m$hac_tstat,
+          fals_hac_cmr_6m$hac_tstat
+        ),
+        hac_sharpe = c(
+          fals_hac_cmr_1m$naive_sharpe,
+          fals_hac_cmr_3m$naive_sharpe,
+          fals_hac_cmr_6m$naive_sharpe
+        ),
+        rej_rate_wn = c(
+          fals_wn_cmr_1m$rejection_rate,
+          fals_wn_cmr_3m$rejection_rate,
+          fals_wn_cmr_6m$rejection_rate
+        ),
+        rej_rate_rv = c(
+          fals_rv_cmr_1m$rejection_rate,
+          fals_rv_cmr_3m$rejection_rate,
+          fals_rv_cmr_6m$rejection_rate
+        ),
+        rej_rate_ma1 = c(
+          fals_ma1_cmr_1m$rejection_rate,
+          fals_ma1_cmr_3m$rejection_rate,
+          fals_ma1_cmr_6m$rejection_rate
+        ),
+        rej_rate_fn = c(
+          fals_fn_cmr_1m$rejection_rate,
+          fals_fn_cmr_3m$rejection_rate,
+          fals_fn_cmr_6m$rejection_rate
+        ),
+        rej_rate_garch = c(
+          fals_garch_cmr_1m$rejection_rate,
+          fals_garch_cmr_3m$rejection_rate,
+          fals_garch_cmr_6m$rejection_rate
+        ),
+        rej_rate_gjr = c(
+          fals_gjr_cmr_1m$rejection_rate,
+          fals_gjr_cmr_3m$rejection_rate,
+          fals_gjr_cmr_6m$rejection_rate
+        ),
+        dsr = c(
+          fals_dsr_cmr_1m$dsr,
+          fals_dsr_cmr_3m$dsr,
+          fals_dsr_cmr_6m$dsr
+        ),
+        dsr_pvalue = c(
+          fals_dsr_cmr_1m$dsr_pvalue,
+          fals_dsr_cmr_3m$dsr_pvalue,
+          fals_dsr_cmr_6m$dsr_pvalue
+        ),
+        dsr_haircut_pct = c(
+          fals_dsr_cmr_1m$haircut_pct,
+          fals_dsr_cmr_3m$haircut_pct,
+          fals_dsr_cmr_6m$haircut_pct
+        )
+      )
+    }),
+
+
+    # ═══════════════════════════════════════════════════════════════════
     # Cross-strategy targets
     # ═══════════════════════════════════════════════════════════════════
 

--- a/R/plan_falsification_vignette.R
+++ b/R/plan_falsification_vignette.R
@@ -471,6 +471,85 @@ plan_falsification_vignette <- function() {
           panel.grid.major = element_line(color = "#333"),
           panel.grid.minor = element_blank()
         )
+    }),
+
+
+    # ── CMR: Commodities Mean Reversion (#138) ───────────────────────────
+    # Separate section appended to falsification.qmd.
+    # Uses fals_cmr_summary (from plan_falsification.R) and
+    # cmr_vs_mom_compare (from plan_commodities_mean_reversion.R).
+
+    targets::tar_target(fals_vig_cmr_table, {
+      library(dplyr)
+
+      fals_cmr_summary |>
+        dplyr::transmute(
+          Lookback   = lookback,
+          `HAC t`    = round(hac_tstat, 2),
+          `Naive Sharpe` = round(hac_sharpe, 2),
+          `WN rej`   = round(rej_rate_wn, 3),
+          `RV rej`   = round(rej_rate_rv, 3),
+          `MA1 rej`  = round(rej_rate_ma1, 3),
+          `FN rej`   = round(rej_rate_fn, 3),
+          `GARCH rej` = round(rej_rate_garch, 3),
+          `GJR rej`  = round(rej_rate_gjr, 3),
+          DSR        = round(dsr, 3),
+          `DSR p`    = round(dsr_pvalue, 3)
+        )
+    }),
+
+    targets::tar_target(fals_vig_cmr_caption, {
+      best_lb  <- fals_cmr_summary$lookback[which.max(fals_cmr_summary$hac_sharpe)]
+      best_sh  <- round(max(fals_cmr_summary$hac_sharpe, na.rm = TRUE), 3)
+      mom_sh   <- round(
+        cmr_vs_mom_compare$sharpe[cmr_vs_mom_compare$type == "momentum"][1],
+        3
+      )
+      paste0(
+        "Commodities Mean Reversion falsification scorecard (Issue #138). ",
+        "Three lookback windows (1m, 3m, 6m); long-losers / short-winners, ",
+        "0.2% transaction cost, monthly (ann_factor = 12). ",
+        "Best lookback: ", best_lb, " (naive Sharpe ", best_sh, "). ",
+        "Commodity momentum baseline (12m) had Sharpe ", mom_sh, " (Issue #134). ",
+        "Columns: HAC t = Newey-West t-statistic; ",
+        "WN/RV/MA1/FN/GARCH/GJR = null-environment rejection rates ",
+        "(ideally <= 0.075); DSR = Deflated Sharpe Ratio (K=3 lookbacks). ",
+        "FF alpha omitted: Fama-French equity factors are not appropriate for ",
+        "the commodity universe."
+      )
+    }),
+
+    targets::tar_target(fals_vig_cmr_head_to_head, {
+      library(dplyr)
+
+      cmr_vs_mom_compare |>
+        dplyr::transmute(
+          Configuration = lookback,
+          Type          = type,
+          Sharpe        = sharpe,
+          `Max DD (%)`  = max_dd
+        )
+    }),
+
+    targets::tar_target(fals_vig_cmr_head_to_head_caption, {
+      mr_sharpes  <- fals_cmr_summary$hac_sharpe
+      mom_sharpe  <- round(
+        cmr_vs_mom_compare$sharpe[cmr_vs_mom_compare$type == "momentum"][1],
+        3
+      )
+      best_mr     <- round(max(mr_sharpes, na.rm = TRUE), 3)
+      verdict     <- if (best_mr > mom_sharpe) "outperforms" else "does not outperform"
+      paste0(
+        "Head-to-head: Commodities Mean Reversion (1m/3m/6m lookbacks) vs ",
+        "Commodity Momentum (12m baseline, Issue #134). ",
+        "Best MR Sharpe (naive): ", best_mr, "; ",
+        "Momentum baseline Sharpe: ", mom_sharpe, ". ",
+        "Mean reversion ", verdict, " momentum in this commodity universe. ",
+        "Source: ",
+        gh_base,
+        "/R/plan_commodities_mean_reversion.R",
+        " | Transaction costs: 0.2% one-way for both strategies."
+      )
     })
 
   )

--- a/R/plan_strategy_names.R
+++ b/R/plan_strategy_names.R
@@ -10,11 +10,13 @@ plan_strategy_names <- function() {
       tibble::tibble(
         code_name = c(
           "avoid_worst", "drif", "fac_max", "rsc", "ltr", "tom",
-          "stk_max", "stk_drif", "xgb_drif", "pso_optimal"
+          "stk_max", "stk_drif", "xgb_drif", "pso_optimal",
+          "cmr"
         ),
         short_name = c(
           "Avoid Worst", "DRIF", "Factor MAX", "Risk State", "LTR", "TOM",
-          "Stock MAX", "Stock DRIF", "XGB DRIF", "PSO Optimal"
+          "Stock MAX", "Stock DRIF", "XGB DRIF", "PSO Optimal",
+          "MR"
         ),
         long_name = c(
           "Avoid Worst Days (VIX Protection)",
@@ -26,22 +28,26 @@ plan_strategy_names <- function() {
           "Stock MAX (Daily Return Sorting)",
           "Stock DRIF (Elastic Net Stock Selection)",
           "XGB DRIF (XGBoost Stock Selection)",
-          "PSO Optimal (Portfolio Optimisation)"
+          "PSO Optimal (Portfolio Optimisation)",
+          "Commodities Mean Reversion"
         ),
         asset_class = c(
           "overlay", "factor", "factor", "overlay", "equity", "overlay",
-          "equity", "equity", "equity", "combined"
+          "equity", "equity", "equity", "combined",
+          "commodities"
         ),
         frequency = c(
           "daily", "monthly", "monthly", "daily", "monthly", "daily",
-          "monthly", "monthly", "monthly", "monthly"
+          "monthly", "monthly", "monthly", "monthly",
+          "monthly"
         ),
-        ann_factor = c(252L, 12L, 12L, 252L, 12L, 252L, 12L, 12L, 12L, 12L),
+        ann_factor = c(252L, 12L, 12L, 252L, 12L, 252L, 12L, 12L, 12L, 12L, 12L),
         vignette_url = c(
           "avoid-worst-days.html", "drif.html", "factor-max.html",
           "leaderboard.html", "leaderboard.html", "turn-of-month.html",
           "stock-backtest.html", "stock-backtest.html",
-          "stock-backtest.html", "leaderboard.html"
+          "stock-backtest.html", "leaderboard.html",
+          "commodities-mean-reversion.html"
         )
       )
     })

--- a/docs/_targets.R
+++ b/docs/_targets.R
@@ -121,6 +121,7 @@ source(here::here("R/plan_volatility_spikes.R"))
 source(here::here("R/plan_regime_momentum.R"))
 source(here::here("R/plan_zakamulin_allocation.R"))
 source(here::here("R/plan_commodities_momentum.R"))
+source(here::here("R/plan_commodities_mean_reversion.R"))
 source(here::here("R/plan_crypto_momentum.R"))
 source(here::here("R/plan_solana_momentum.R"))
 source(here::here("R/plan_olmar.R"))
@@ -166,6 +167,7 @@ c(plan_strategy_names(),
   plan_regime_momentum(),
   plan_zakamulin_allocation(),
   plan_commodities_momentum(),
+  plan_commodities_mean_reversion(),
   plan_crypto_momentum(),
   plan_solana_momentum(),
   plan_olmar(),

--- a/packages/historicaldata/R/commodities_mean_reversion.R
+++ b/packages/historicaldata/R/commodities_mean_reversion.R
@@ -1,0 +1,225 @@
+# Commodities Mean Reversion Functions (Issue #138)
+#
+# Counterpart to commodities_momentum.R (Issue #134).
+# #134 found momentum in commodities is broken (Sharpe -0.85 baseline,
+# -0.89 to -0.91 decomposed). Hypothesis: if momentum doesn't work, mean
+# reversion might — commodities have backwardation/contango cycles,
+# supply/demand seasonality, and supply shocks that reverse.
+#
+# Strategy: long-losers / short-winners (opposite of momentum).
+# Signal at month t uses returns through t-1 only (look-ahead-safe).
+# Execution: signal at t -> trade at t+1 close (t+1 execution discipline).
+#
+# Data: monthly commodity prices (37 series, 1992-2026, ann_factor=12).
+# Universe re-uses commodities_returns from plan_commodities_momentum.R.
+
+
+#' Commodity Mean Reversion Signal
+#'
+#' Compute a monthly mean-reversion signal for a commodity universe.
+#' The signal is the *negative* of the lookback-period return: commodities
+#' that have fallen the most receive the highest (most positive) signal,
+#' while those that have risen the most receive the lowest (most negative)
+#' signal.
+#'
+#' Look-ahead safety: the signal at month \code{t} is constructed from
+#' cumulative returns over months \code{(t - lookback_months)} through
+#' \code{(t - 1)}.  The one-period lag is enforced via
+#' \code{dplyr::lag(cumret)} before the negation, so no return at or after
+#' month \code{t} ever enters signal formation.
+#'
+#' @param returns_tbl Tibble with columns \code{date} (Date, month-end),
+#'   \code{series_id} (character), and \code{monthly_ret} (numeric monthly
+#'   return).  Produced by \code{calculate_commodity_returns()}.
+#' @param lookback_months Integer. Number of months used to compute the
+#'   mean-reversion signal (default 3).  Typical values: 1, 3, 6.
+#'
+#' @return Tibble with columns:
+#'   \describe{
+#'     \item{date}{Month-end date.}
+#'     \item{series_id}{Commodity identifier.}
+#'     \item{mr_signal}{Mean-reversion signal = negative of cumulative
+#'       return over the prior \code{lookback_months} months. Higher values
+#'       (bigger recent losers) rank first for the long leg.}
+#'   }
+#'   Rows with \code{NA} signals (insufficient history) are dropped.
+#'
+#' @details
+#' The cumulative return over a rolling window is computed as
+#' \eqn{\prod_{i=1}^{L}(1 + r_{t-i}) - 1}, where \eqn{L} is
+#' \code{lookback_months}.  This product is formed using
+#' \code{slider::slide_dbl} with \code{.complete = TRUE} so partial windows
+#' produce \code{NA}.  The result is then lagged by one period to guarantee
+#' look-ahead safety, and the signal is the negation of the lagged cumulative
+#' return.
+#'
+#' @family commodities_mr
+#' @export
+hd_commodity_mr_signal <- function(returns_tbl, lookback_months = 3L) {
+  if (!is.data.frame(returns_tbl)) {
+    cli::cli_abort(c(
+      "x" = "{.arg returns_tbl} must be a data frame, not {.cls {class(returns_tbl)}}."
+    ))
+  }
+  required_cols <- c("date", "series_id", "monthly_ret")
+  missing_cols <- setdiff(required_cols, names(returns_tbl))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "{.arg returns_tbl} is missing required columns: {.field {missing_cols}}."
+    ))
+  }
+  if (!is.numeric(lookback_months) || length(lookback_months) != 1L ||
+      is.na(lookback_months) || lookback_months < 1L) {
+    cli::cli_abort(c(
+      "x" = "{.arg lookback_months} must be a positive integer, got {lookback_months}."
+    ))
+  }
+  lookback_months <- as.integer(lookback_months)
+
+  returns_tbl |>
+    dplyr::arrange(series_id, date) |>
+    dplyr::group_by(series_id) |>
+    dplyr::mutate(
+      # Cumulative return over the lookback window ending at t (inclusive of t).
+      # .complete = TRUE ensures NA for partial windows.
+      cumret_raw = slider::slide_dbl(
+        monthly_ret,
+        .f = function(r) prod(1 + r) - 1,
+        .before = lookback_months - 1L,
+        .after  = 0L,
+        .complete = TRUE
+      ),
+      # Lag by 1: cumret at position t becomes the lookback return through t-1.
+      # Signal = negation so recent losers have high (positive) signal.
+      mr_signal = -dplyr::lag(cumret_raw, n = 1L)
+    ) |>
+    dplyr::ungroup() |>
+    dplyr::select(date, series_id, mr_signal) |>
+    dplyr::filter(!is.na(mr_signal))
+}
+
+
+#' Commodity Mean Reversion Portfolio
+#'
+#' Convert a mean-reversion signal tibble into monthly long/short portfolio
+#' weights with t+1 execution.
+#'
+#' Execution discipline: the signal from month \code{t} (formed from returns
+#' through \code{t-1}) drives trades that are executed at month \code{t+1}
+#' closing prices.  This is enforced by joining the signal at date \code{t}
+#' to the return realised at date \code{t+1} via \code{dplyr::lead()}.
+#'
+#' @param signal_tbl Tibble returned by \code{\link{hd_commodity_mr_signal}},
+#'   with columns \code{date}, \code{series_id}, \code{mr_signal}.
+#' @param returns_tbl Tibble with columns \code{date}, \code{series_id},
+#'   \code{monthly_ret}.  Must overlap in date range with \code{signal_tbl}.
+#' @param n_long Integer. Number of top-ranked (biggest losers) commodities
+#'   to hold long (default 10).
+#' @param n_short Integer. Number of bottom-ranked (biggest winners) commodities
+#'   to sell short (default 10).
+#' @param cost_bps Numeric. One-way transaction cost in basis points
+#'   (default 20 = 0.2\%).  The same 0.2\% used in commodity momentum (#134).
+#'
+#' @return Tibble with one row per month and columns:
+#'   \describe{
+#'     \item{date}{Month-end date (the execution month, i.e. t+1).}
+#'     \item{gross_ret}{Gross portfolio return for the month.}
+#'     \item{turnover}{One-way turnover fraction.}
+#'     \item{cost}{Transaction cost deducted (= turnover * cost_bps/10000).}
+#'     \item{net_ret}{Net return after transaction costs.}
+#'     \item{n_long}{Number of long positions held.}
+#'     \item{n_short}{Number of short positions held.}
+#'   }
+#'   Months where fewer than \code{n_long + n_short} commodities have valid
+#'   signals are silently included with actual position counts; months with
+#'   zero valid signals produce \code{gross_ret = 0}.
+#'
+#' @family commodities_mr
+#' @export
+hd_commodity_mr_portfolio <- function(signal_tbl,
+                                       returns_tbl,
+                                       n_long  = 10L,
+                                       n_short = 10L,
+                                       cost_bps = 20) {
+  if (!is.data.frame(signal_tbl)) {
+    cli::cli_abort(c("x" = "{.arg signal_tbl} must be a data frame."))
+  }
+  if (!is.data.frame(returns_tbl)) {
+    cli::cli_abort(c("x" = "{.arg returns_tbl} must be a data frame."))
+  }
+  n_long  <- as.integer(n_long)
+  n_short <- as.integer(n_short)
+  if (n_long < 1L || n_short < 1L) {
+    cli::cli_abort(c(
+      "x" = "{.arg n_long} and {.arg n_short} must each be >= 1."
+    ))
+  }
+
+  cost_per_unit <- cost_bps / 10000
+
+  # t+1 execution: for each commodity build (signal_date -> next_ret) pairs.
+  # signal at t -> realised return at t+1 (lead by 1 within each series).
+  ret_with_lead <- returns_tbl |>
+    dplyr::arrange(series_id, date) |>
+    dplyr::group_by(series_id) |>
+    dplyr::mutate(next_ret = dplyr::lead(monthly_ret, n = 1L)) |>
+    dplyr::ungroup() |>
+    dplyr::filter(!is.na(next_ret)) |>
+    dplyr::select(series_id, signal_date = date, next_ret)
+
+  # Join signal (at t) to execution return (at t+1).
+  combined <- signal_tbl |>
+    dplyr::inner_join(ret_with_lead, by = c("date" = "signal_date", "series_id"))
+
+  # Rank within each signal date; assign long/short weights.
+  ranked <- combined |>
+    dplyr::group_by(date) |>
+    dplyr::mutate(
+      rk = dplyr::row_number(dplyr::desc(mr_signal)),  # rank 1 = highest signal = biggest loser
+      n_avail = dplyr::n()
+    ) |>
+    dplyr::filter(rk <= n_long | rk > (n_avail - n_short)) |>
+    dplyr::mutate(
+      leg    = dplyr::if_else(rk <= n_long, "long", "short"),
+      n_leg  = dplyr::if_else(rk <= n_long, n_long, n_short),
+      weight = dplyr::if_else(leg == "long", 1 / n_long, -1 / n_short)
+    ) |>
+    dplyr::ungroup()
+
+  # Monthly gross returns and position counts.
+  monthly <- ranked |>
+    dplyr::group_by(date) |>
+    dplyr::summarise(
+      gross_ret = sum(weight * next_ret, na.rm = TRUE),
+      n_long_pos  = sum(leg == "long",  na.rm = TRUE),
+      n_short_pos = sum(leg == "short", na.rm = TRUE),
+      .groups = "drop"
+    )
+
+  # Turnover: sum of absolute weight changes relative to prior month.
+  # Use series_id-level lag of weight within the ranked dataset.
+  weight_tbl <- ranked |>
+    dplyr::select(date, series_id, weight) |>
+    dplyr::arrange(series_id, date) |>
+    dplyr::group_by(series_id) |>
+    dplyr::mutate(prev_weight = dplyr::lag(weight, default = 0)) |>
+    dplyr::ungroup()
+
+  turnover_tbl <- weight_tbl |>
+    dplyr::group_by(date) |>
+    dplyr::summarise(
+      turnover = sum(abs(weight - prev_weight), na.rm = TRUE) / 2,
+      .groups = "drop"
+    )
+
+  monthly |>
+    dplyr::left_join(turnover_tbl, by = "date") |>
+    dplyr::mutate(
+      turnover = dplyr::if_else(is.na(turnover), 0, turnover),
+      cost     = turnover * cost_per_unit,
+      net_ret  = gross_ret - cost,
+      n_long   = n_long_pos,
+      n_short  = n_short_pos
+    ) |>
+    dplyr::select(date, gross_ret, turnover, cost, net_ret, n_long, n_short)
+}

--- a/packages/historicaldata/tests/testthat/test-commodities-mean-reversion.R
+++ b/packages/historicaldata/tests/testthat/test-commodities-mean-reversion.R
@@ -1,0 +1,186 @@
+test_that("hd_commodity_mr_signal: look-ahead guard — signal at t uses only returns <= t-1", {
+  # Synthetic series: 24 months, one commodity
+  # months 1-12: return 0.05 (rising), months 13-24: return -0.05 (falling)
+  dates <- seq.Date(as.Date("2010-01-31"), by = "month", length.out = 24)
+  rets  <- c(rep(0.05, 12), rep(-0.05, 12))
+  tbl   <- tibble::tibble(date = dates, series_id = "A", monthly_ret = rets)
+
+  sig <- hd_commodity_mr_signal(tbl, lookback_months = 3L)
+
+  # For any row with signal date d, the signal must equal
+  # -(prod(1 + r[d-3:d-1]) - 1), NOT using return at d itself.
+  # We verify by constructing the expected signal manually.
+  for (i in seq_len(nrow(sig))) {
+    d      <- sig$date[i]
+    d_idx  <- which(tbl$date == d)
+    # Signal window: indices (d_idx-3) to (d_idx-1) relative to tbl
+    lb_idx <- (d_idx - 3):(d_idx - 1)
+    if (any(lb_idx < 1)) next  # skip if window not fully populated
+    expected_signal <- -(prod(1 + tbl$monthly_ret[lb_idx]) - 1)
+    expect_equal(sig$mr_signal[i], expected_signal, tolerance = 1e-10,
+                 info = paste("date =", d))
+  }
+})
+
+
+test_that("hd_commodity_mr_signal: no NA signals are returned", {
+  dates <- seq.Date(as.Date("2010-01-31"), by = "month", length.out = 20)
+  tbl   <- tibble::tibble(
+    date       = dates,
+    series_id  = "X",
+    monthly_ret = rnorm(20, 0, 0.03)
+  )
+  sig <- hd_commodity_mr_signal(tbl, lookback_months = 3L)
+  expect_false(any(is.na(sig$mr_signal)))
+})
+
+
+test_that("hd_commodity_mr_signal: sign matches expected reversal direction", {
+  # A commodity that has been falling for 3 months should have a positive
+  # mean-reversion signal (long candidate).
+  # A commodity that has been rising should have a negative signal (short candidate).
+  dates <- seq.Date(as.Date("2015-01-31"), by = "month", length.out = 10)
+
+  # Loser: consistent -5% per month
+  loser <- tibble::tibble(
+    date = dates, series_id = "loser",
+    monthly_ret = rep(-0.05, 10)
+  )
+  # Winner: consistent +5% per month
+  winner <- tibble::tibble(
+    date = dates, series_id = "winner",
+    monthly_ret = rep(0.05, 10)
+  )
+  tbl <- dplyr::bind_rows(loser, winner)
+  sig <- hd_commodity_mr_signal(tbl, lookback_months = 3L)
+
+  loser_sigs  <- sig$mr_signal[sig$series_id == "loser"]
+  winner_sigs <- sig$mr_signal[sig$series_id == "winner"]
+
+  # Loser's signal is positive (-(negative return) > 0)
+  expect_true(all(loser_sigs > 0), info = "loser should have positive MR signal")
+  # Winner's signal is negative (-(positive return) < 0)
+  expect_true(all(winner_sigs < 0), info = "winner should have negative MR signal")
+})
+
+
+test_that("hd_commodity_mr_portfolio: long weights sum to 1 per period", {
+  set.seed(42)
+  n_months <- 36
+  n_assets <- 15
+  dates    <- seq.Date(as.Date("2000-01-31"), by = "month", length.out = n_months)
+  ids      <- paste0("C", seq_len(n_assets))
+
+  tbl <- tidyr::expand_grid(date = dates, series_id = ids) |>
+    dplyr::mutate(monthly_ret = rnorm(dplyr::n(), 0, 0.04))
+
+  sig  <- hd_commodity_mr_signal(tbl, lookback_months = 3L)
+  port <- hd_commodity_mr_portfolio(sig, tbl, n_long = 5L, n_short = 5L)
+
+  # For every month: n_long weights sum = 1 / n_long * n_long = 1
+  # We verify via the weighted portfolio directly at the signal level.
+  # Because the function returns aggregate returns, we just check n_long/n_short.
+  expect_true(all(port$n_long <= 5L),
+              info = "n_long positions never exceeds n_long parameter")
+  expect_true(all(port$n_short <= 5L),
+              info = "n_short positions never exceeds n_short parameter")
+})
+
+
+test_that("hd_commodity_mr_portfolio: net_ret = gross_ret - cost", {
+  set.seed(7)
+  dates <- seq.Date(as.Date("2005-01-31"), by = "month", length.out = 30)
+  ids   <- paste0("D", 1:12)
+  tbl   <- tidyr::expand_grid(date = dates, series_id = ids) |>
+    dplyr::mutate(monthly_ret = rnorm(dplyr::n(), 0, 0.03))
+
+  sig  <- hd_commodity_mr_signal(tbl, lookback_months = 3L)
+  port <- hd_commodity_mr_portfolio(sig, tbl, n_long = 3L, n_short = 3L, cost_bps = 20)
+
+  expect_equal(port$net_ret, port$gross_ret - port$cost, tolerance = 1e-12)
+})
+
+
+test_that("hd_commodity_mr_portfolio: turnover is non-negative", {
+  set.seed(11)
+  dates <- seq.Date(as.Date("2008-01-31"), by = "month", length.out = 24)
+  ids   <- paste0("E", 1:10)
+  tbl   <- tidyr::expand_grid(date = dates, series_id = ids) |>
+    dplyr::mutate(monthly_ret = rnorm(dplyr::n(), 0, 0.05))
+
+  sig  <- hd_commodity_mr_signal(tbl, lookback_months = 3L)
+  port <- hd_commodity_mr_portfolio(sig, tbl, n_long = 3L, n_short = 3L)
+
+  expect_true(all(port$turnover >= 0))
+})
+
+
+test_that("hd_commodity_mr_signal: edge case — all NA returns yields empty output", {
+  dates <- seq.Date(as.Date("2010-01-31"), by = "month", length.out = 5)
+  tbl   <- tibble::tibble(
+    date = dates, series_id = "Z",
+    monthly_ret = rep(NA_real_, 5)
+  )
+  # With all NA returns, the cumulative product in the lookback window will be NA,
+  # so mr_signal will be NA and all rows will be filtered out.
+  sig <- hd_commodity_mr_signal(tbl, lookback_months = 3L)
+  expect_equal(nrow(sig), 0L)
+})
+
+
+test_that("hd_commodity_mr_signal: edge case — single ticker", {
+  dates <- seq.Date(as.Date("2020-01-31"), by = "month", length.out = 12)
+  tbl   <- tibble::tibble(
+    date = dates, series_id = "SINGLE",
+    monthly_ret = seq(0.01, 0.12, by = 0.01)
+  )
+  sig <- hd_commodity_mr_signal(tbl, lookback_months = 3L)
+  # Should return some rows (enough history for 3m lookback + 1 lag = 4 months)
+  expect_true(nrow(sig) > 0L)
+  expect_equal(unique(sig$series_id), "SINGLE")
+})
+
+
+test_that("hd_commodity_mr_signal: empty universe returns 0 rows", {
+  tbl <- tibble::tibble(
+    date        = as.Date(character(0)),
+    series_id   = character(0),
+    monthly_ret = numeric(0)
+  )
+  sig <- hd_commodity_mr_signal(tbl, lookback_months = 3L)
+  expect_equal(nrow(sig), 0L)
+})
+
+
+test_that("hd_commodity_mr_signal: input validation — missing column", {
+  bad_tbl <- tibble::tibble(date = Sys.Date(), wrong_col = 1.0)
+  expect_error(
+    hd_commodity_mr_signal(bad_tbl, lookback_months = 3L),
+    class = "rlang_error"
+  )
+})
+
+
+test_that("hd_commodity_mr_signal: input validation — invalid lookback", {
+  tbl <- tibble::tibble(
+    date = Sys.Date(), series_id = "X", monthly_ret = 0.01
+  )
+  expect_error(
+    hd_commodity_mr_signal(tbl, lookback_months = 0L),
+    class = "rlang_error"
+  )
+  expect_error(
+    hd_commodity_mr_signal(tbl, lookback_months = -1L),
+    class = "rlang_error"
+  )
+})
+
+
+test_that("hd_commodity_mr_portfolio: input validation — invalid n_long", {
+  sig <- tibble::tibble(date = Sys.Date(), series_id = "A", mr_signal = 0.1)
+  ret <- tibble::tibble(date = Sys.Date(), series_id = "A", monthly_ret = 0.02)
+  expect_error(
+    hd_commodity_mr_portfolio(sig, ret, n_long = 0L, n_short = 5L),
+    class = "rlang_error"
+  )
+})


### PR DESCRIPTION
Closes #138. Counterpart to #134's failed momentum result (Sharpe -0.85).

## Summary

- Implements long-losers/short-winners across 1m/3m/6m lookbacks for the same 37-commodity monthly universe used in #134
- Look-ahead-safe: signal at t uses returns through t-1 only; t+1 execution discipline enforced via `dplyr::lead()`
- Transaction cost 0.2% one-way (same as commodity momentum #134)
- Falsification-wired: 3 x 6 null environments (WN, RV, MA1, FN, GARCH, GJR) + Deflated Sharpe (K=3 lookbacks); FF alpha omitted as Fama-French equity factors are inappropriate for the commodity universe
- Head-to-head comparison table (`cmr_vs_mom_compare`) joins MR metrics to existing momentum metrics
- Strategy registered in `strategy_names` (code_name="cmr", monthly, ann_factor=12, asset_class="commodities")
- 36 tests: look-ahead guard, sign-direction, position caps, cost accounting, edge cases, input validation

## Files

- `packages/historicaldata/R/commodities_mean_reversion.R` — `hd_commodity_mr_signal()`, `hd_commodity_mr_portfolio()`
- `packages/historicaldata/tests/testthat/test-commodities-mean-reversion.R` — 36 tests
- `R/plan_commodities_mean_reversion.R` — targets pipeline
- `R/plan_falsification.R` — CMR null-environment + DSR section + `fals_cmr_summary`
- `R/plan_falsification_vignette.R` — CMR vignette targets appended
- `R/plan_strategy_names.R` — cmr row added
- `docs/_targets.R` — `plan_commodities_mean_reversion()` wired

## Notes

- Re-uses `commodities_raw` and `commodities_returns` from `plan_commodities_momentum.R` — no data-layer duplication
- Data is monthly (ann_factor=12) — confirmed from plan_commodities_momentum.R comment "37 series, monthly, 1992-2026"
- A clear negative result (if MR also fails in commodities) is valid and expected; the falsification framework will report honestly

## Test plan

- [x] `parse()` clean on all 5 modified/new R files
- [x] `testthat::test_file()`: 36 PASS, 0 FAIL — run inside project nix flake shell
- [ ] CI will run full `tar_make()` — targets are defined and parseable; no full pipeline run locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)