### PR TITLE
fix(theme): caption font-size = body + dark-safe green palette (closes #348, #353)

### DIFF
--- a/R/plan_avoid_worst.R
+++ b/R/plan_avoid_worst.R
@@ -268,7 +268,7 @@ plan_avoid_worst <- function() {
       ggplot(events, aes(x = date, y = ret_pct, colour = type)) +
         geom_segment(aes(xend = date, yend = 0), linewidth = 1.2) +
         geom_point(size = 2) +
-        scale_colour_manual(values = c("10 Best Days" = "#2ecc71",
+        scale_colour_manual(values = c("10 Best Days" = "#69d4a0",
                                         "10 Worst Days" = "#e74c3c")) +
         labs(x = NULL, y = "Daily Return (%)", colour = NULL,
              title = "SPY: 10 Worst and 10 Best Days (Temporal Clustering)") +
@@ -405,7 +405,7 @@ plan_avoid_worst <- function() {
         geom_line(linewidth = 0.5, alpha = 0.8) +
         geom_hline(yintercept = 0, linetype = "dotted", colour = "grey50") +
         scale_colour_manual(values = c(
-          "Gain (avoid worst)" = "#2ecc71",
+          "Gain (avoid worst)" = "#69d4a0",
           "Loss (miss best)" = "#e74c3c",
           "Net benefit" = hd_palette(1)
         )) +

--- a/R/plan_falsification_vignette.R
+++ b/R/plan_falsification_vignette.R
@@ -404,7 +404,7 @@ plan_falsification_vignette <- function() {
         geom_point(size = 5, position = position_dodge(width = 0.5)) +
         annotate("text", x = 2.2, y = 0.5, label = "t = 2.0",
                  color = "#e74c3c", hjust = 0, size = 4) +
-        scale_colour_manual(values = c("Naive t" = "#4a90d9", "HAC t" = "#2ecc71")) +
+        scale_colour_manual(values = c("Naive t" = "#4a90d9", "HAC t" = "#69d4a0")) +
         scale_shape_manual(values = c("Naive t" = 16, "HAC t" = 17)) +
         labs(
           title = "Naive vs HAC t-Statistics (Cleveland Dot Plot)",
@@ -451,7 +451,7 @@ plan_falsification_vignette <- function() {
         geom_text(aes(label = strategy), vjust = -1.2, size = 4, color = "#e0e0e0") +
         geom_hline(yintercept = 0, color = "#666", linetype = "dashed") +
         geom_vline(xintercept = 15, color = "#666", linetype = "dashed") +
-        scale_color_manual(values = c("Genuine alpha" = "#2ecc71",
+        scale_color_manual(values = c("Genuine alpha" = "#69d4a0",
                                        "No alpha (beta)" = "#e74c3c")) +
         labs(
           title = "Alpha (%) vs Factor Exposure R² (%)",

--- a/R/plan_mean_reversion.R
+++ b/R/plan_mean_reversion.R
@@ -260,7 +260,7 @@ plan_mean_reversion <- function() {
         geom_vline(xintercept = mr_params$test_start, linetype = "dashed",
                    colour = "grey50") +
         scale_y_log10(labels = scales::dollar) +
-        scale_colour_manual(values = c("Mean Reversion (net)" = "#2ecc71",
+        scale_colour_manual(values = c("Mean Reversion (net)" = "#69d4a0",
                                         "SPY Buy & Hold" = "#4a90d9")) +
         labs(x = NULL, y = "Growth of $1 (log)", colour = NULL,
              title = "Mean Reversion vs SPY") +

--- a/R/plan_multi_strategy.R
+++ b/R/plan_multi_strategy.R
@@ -100,7 +100,7 @@ plan_multi_strategy <- function() {
         geom_line(linewidth = 0.7) +
         scale_y_log10(labels = scales::dollar) +
         scale_colour_manual(values = c(
-          "Weighted" = "#2ecc71", "Equal Weight" = "#e6a817",
+          "Weighted" = "#69d4a0", "Equal Weight" = "#e6a817",
           "DRIF" = "#4a90d9", "LTR" = "#e74c3c"
         )) +
         labs(x = NULL, y = "Growth of $1 (log)", colour = NULL,

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -285,8 +285,8 @@ if (!is.null(monthly)) {
   ) |>
     DT::formatStyle(
       columns = num_cols,
-      color = DT::styleInterval(0, c("#e74c3c", "#2ecc71")),
-      border = DT::styleInterval(0, c("2px solid #e74c3c", "2px solid #2ecc71"))
+      color = DT::styleInterval(0, c("#e74c3c", "#69d4a0")),
+      border = DT::styleInterval(0, c("2px solid #e74c3c", "2px solid #69d4a0"))
     )
 }
 ```

--- a/docs/vignette-shared.css
+++ b/docs/vignette-shared.css
@@ -49,9 +49,9 @@ body { font-size: 1.1em; }
 table.dataTable { white-space: nowrap; }
 table caption, .dataTables_wrapper caption { caption-side: top !important; }
 
-/* Captions: wrap text to window width */
+/* Captions: wrap text to window width; font-size matches body text (#348) */
 .fig-caption {
-  display: block; font-size: 0.85em; color: #ffffff;
+  display: block; font-size: 1em; color: #ffffff;
   margin-top: 0.4em; text-align: left; line-height: 1.5;
   word-wrap: break-word; overflow-wrap: break-word;
   max-width: 100%;


### PR DESCRIPTION
## Wave A — universal CSS / palette fixes

From the 2026-05-30 dashboard audit. Single PR covering two issues that touch many files but are mechanical 1-line changes each.

### #348 — Caption font-size = body

`docs/vignette-shared.css`: `.fig-caption` was `font-size: 0.85em` (≈ 15px against the 17.6px body). Set to `1em`. Cascades to every vignette that uses the shared CSS — leaderboard, falsification, factor-max, drif, stock-backtest, avoid-worst-days, macro-defense-rotation, jst-dashboard, negative-results, quiz, european-overlay.

### #353 — Dark-safe green for positive-value encodings

Replace every `#2ecc71` (bright emerald, fails 4.5:1 contrast on `#000`) with `#69d4a0` from the project's `accessibility` rule dark-mode palette. 7 occurrences across:

- `docs/leaderboard.qmd` — Monthly Returns DT text + border (the user-flagged case)
- `R/plan_mean_reversion.R` — Mean Reversion vs SPY line
- `R/plan_avoid_worst.R` — '10 Best Days' marker + 'Gain (avoid worst)' line
- `R/plan_multi_strategy.R` — 'Weighted' portfolio line
- `R/plan_falsification_vignette.R` — HAC dot-plot + Genuine-alpha scatter

Caption text 'green = positive' stays semantically accurate (the colour is still a green; just a softer, dark-safe variant). Red (`#e74c3c`) left unchanged — not in user scope.

## Test plan

- [x] grep confirms zero remaining `#2ecc71` in qmd or R/
- [ ] Next Pages render shows captions at body-text size
- [ ] Monthly-returns table readable on the dark theme
- [ ] No regression in light mode (the new green is still distinct from red and white)
- [ ] Spot-check 3 vignettes (leaderboard, falsification, avoid-worst-days)