### PR TITLE
fix: Wave B — tab overflow + alpha-scatter legend + bootstrap axes + Full Dashboard tab rename (closes #349, #351, #352, #355)

### DIFF
--- a/R/plan_bootstrap_ci.R
+++ b/R/plan_bootstrap_ci.R
@@ -136,7 +136,7 @@ plan_bootstrap_ci <- function() {
         ggplot(aes(x = sharpe, fill = strategy_label)) +
         geom_histogram(bins = 50, alpha = 0.7) +
         geom_vline(xintercept = 0, linetype = "dashed", colour = "red") +
-        facet_wrap(~strategy_label, scales = "free_y", ncol = 2) +
+        facet_wrap(~strategy_label, ncol = 2) +  # #355: fixed scales (default) so sub-plots are visually comparable
         scale_fill_manual(values = hd_palette(4)) +
         labs(x = "Bootstrapped Sharpe Ratio", y = "Count",
              title = paste0("Bootstrap CI (", boot_params$n_draws,

--- a/R/plan_falsification_vignette.R
+++ b/R/plan_falsification_vignette.R
@@ -448,11 +448,16 @@ plan_falsification_vignette <- function() {
 
       ggplot(df, aes(x = r_squared, y = alpha_annual, color = verdict)) +
         geom_point(size = 6) +
-        geom_text(aes(label = strategy), vjust = -1.2, size = 4, color = "#e0e0e0") +
+        # #351: check_overlap hides colliding labels; vjust positions above point
+        geom_text(aes(label = strategy), vjust = -1.2, size = 4,
+                  color = "#e0e0e0", check_overlap = FALSE) +
         geom_hline(yintercept = 0, color = "#666", linetype = "dashed") +
         geom_vline(xintercept = 15, color = "#666", linetype = "dashed") +
         scale_color_manual(values = c("Genuine alpha" = "#69d4a0",
                                        "No alpha (beta)" = "#e74c3c")) +
+        # #351: expand y axis so top labels (e.g., LTR) aren't clipped at plot edge
+        scale_y_continuous(expand = expansion(mult = c(0.08, 0.18))) +
+        scale_x_continuous(expand = expansion(mult = c(0.05, 0.08))) +
         labs(
           title = "Alpha (%) vs Factor Exposure R² (%)",
           subtitle = "Genuine alpha = top-left (low R², positive Alpha). Beta = right (high R²).",
@@ -465,11 +470,13 @@ plan_falsification_vignette <- function() {
           panel.background = element_rect(fill = "black", color = NA),
           text = element_text(color = "#e0e0e0"),
           axis.text = element_text(color = "#e0e0e0"),
-          legend.position = "top",
+          # #351: legend at bottom frees the top of the panel for labels
+          legend.position = "bottom",
           legend.background = element_rect(fill = "black"),
           legend.text = element_text(color = "#e0e0e0"),
           panel.grid.major = element_line(color = "#333"),
-          panel.grid.minor = element_blank()
+          panel.grid.minor = element_blank(),
+          plot.margin = margin(10, 15, 10, 10)
         )
     }),
 

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -95,7 +95,7 @@ cap <- safe_tar_read("fals_vig_ff_caption")
 if (!is.null(cap)) cat(paste0("\n*", cap, "*\n"))
 ```
 
-#### Full Dashboard
+#### See Also
 
 For detailed methodology, HAC analysis, factor regression betas, multiplicity correction (<abbr title="Effective number of independent strategies (spectral participation ratio)">K_eff</abbr>, delta-Z), and the full null environment heatmap, see the [Strategy Falsification dashboard](falsification.html).
 

--- a/docs/vignette-shared.css
+++ b/docs/vignette-shared.css
@@ -35,10 +35,22 @@ body { font-size: 1.1em; }
   overflow: visible !important; margin-bottom: 1em;
 }
 
-/* Plot height: constrain to reasonable aspect ratio */
+/* Plot height (#349): raised cap 500 → 700 so plots aren't compressed */
 .cell-output-display img {
   display: block; width: 100%; height: auto;
-  min-height: auto; max-height: 500px; object-fit: contain;
+  min-height: auto; max-height: 700px; object-fit: contain;
+  margin-bottom: 1em;
+}
+
+/* #349: Plotly/DT widgets need explicit min-height so they don't collapse onto captions */
+.plotly.html-widget, .dataTables_wrapper {
+  min-height: 400px;
+  margin-bottom: 1em;
+}
+
+/* #349: Tab content has room for plot + caption; vertical scroll if needed */
+.tab-content, .tab-pane {
+  min-height: 700px !important;
 }
 
 /* Tables: block, scrollable */
@@ -49,12 +61,13 @@ body { font-size: 1.1em; }
 table.dataTable { white-space: nowrap; }
 table caption, .dataTables_wrapper caption { caption-side: top !important; }
 
-/* Captions: wrap text to window width; font-size matches body text (#348) */
+/* Captions: wrap text to window width; font-size matches body (#348); margin-top avoids overlap with plot (#349) */
 .fig-caption {
   display: block; font-size: 1em; color: #ffffff;
-  margin-top: 0.4em; text-align: left; line-height: 1.5;
+  margin-top: 1em; text-align: left; line-height: 1.5;
   word-wrap: break-word; overflow-wrap: break-word;
   max-width: 100%;
+  clear: both;
 }
 table caption, .dataTables_wrapper caption, .dt-caption {
   word-wrap: break-word; overflow-wrap: break-word;


### PR DESCRIPTION
## Wave B — small qmd/target tweaks

### #349 — Tab overflow / scrollbar (vignette-shared.css)

- Plot image `max-height` 500 → 700px
- Plot images: `margin-bottom: 1em`
- Plotly/DT widgets: explicit `min-height: 400px`
- `.tab-content` / `.tab-pane`: `min-height: 700px`
- `.fig-caption margin-top` 0.4em → 1em + `clear: both`

Plots no longer compressed inside tabs; captions never overlap above content. Cascades to every tabbed page (leaderboard, falsification, stock-backtest, drif, factor-max if they use tabsets).

### #351 — Alpha vs Factor Exposure (`fals_vig_ff_alpha_plot` in plan_falsification_vignette.R)

- `legend.position` `top` → `bottom` so top of panel is free for labels
- `scale_y_continuous(expand = expansion(mult = c(0.08, 0.18)))` — 18% headroom so the top label (LTR) clears the panel edge
- `scale_x_continuous` expand for right-edge labels
- Explicit `plot.margin`

### #352 — Full Dashboard tab → See Also (leaderboard.qmd)

The tab contained only a pointer to `falsification.html`. Renamed the heading from 'Full Dashboard' to 'See Also' so the title now matches its content. Issue body's Option 1 — smallest possible fix; doesn't preclude later embedding an iframe if that's the desired direction.

### #355 — Bootstrap CI plot (plan_bootstrap_ci.R)

- `facet_wrap(..., scales = 'free_y')` → default `'fixed'` so the four strategy sub-plots share y-axis range and CI widths are visually comparable.

## Test plan
- [ ] Next Pages render: alpha-vs-factor labels including LTR are visible
- [ ] Tab plots in leaderboard render without caption overlap
- [ ] Bootstrap CI panels share y-axis
- [ ] Tab heading reads 'See Also'