### PR TITLE
fix: Wave C — null-heatmap mid-tone + regime linetype + alpha-decay empty guard (closes #350, #357)

### DIFF
--- a/R/plan_falsification_vignette.R
+++ b/R/plan_falsification_vignette.R
@@ -121,8 +121,10 @@ plan_falsification_vignette <- function() {
         geom_text(aes(label = round(pct, 0), colour = text_col),
                   size = 4.5, fontface = "bold", show.legend = FALSE) +
         scale_colour_identity() +
+        # #350: mid 'pale yellow' #ffffbf was near-white in the legend —
+        # use a saturated amber so the green→yellow→red gradient is visible
         scale_fill_gradient2(
-          low = "#1a9850", mid = "#ffffbf", high = "#d73027",
+          low = "#1a9850", mid = "#fee08b", high = "#d73027",
           midpoint = 8, limits = c(0, 100),
           name = "Rejection (%)"
         ) +

--- a/R/plan_regime.R
+++ b/R/plan_regime.R
@@ -233,8 +233,13 @@ plan_regime <- function() {
         ) |>
         tidyr::pivot_longer(-date, names_to = "strategy", values_to = "growth")
 
-      p <- ggplot(plot_data, aes(date, growth, colour = strategy)) +
-        geom_line(linewidth = 0.6)
+      # #357: linetype distinction so the two series are visible even when
+      # regime_cum and base_cum are identical (e.g., all-low-regime periods)
+      p <- ggplot(plot_data, aes(date, growth, colour = strategy,
+                                  linetype = strategy)) +
+        geom_line(linewidth = 0.6, alpha = 0.85) +
+        scale_linetype_manual(values = c("Regime-Adjusted" = "solid",
+                                          "Base Portfolio"  = "dashed"))
 
       # Add high-risk shading if any periods exist
       if (nrow(high_risk_periods) > 0) {

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -363,12 +363,23 @@ if (!is.null(x)) {
 
 ```{r}
 #| fig-height: 6
-safe_tar_read("decay_plot")
+# #356: only render the plot if the upstream metric target produced rows
+dp <- safe_tar_read("decay_plot")
+decay_metrics <- safe_tar_read("decay_metrics")
+if (!is.null(dp) && !is.null(decay_metrics) && nrow(decay_metrics) > 0) {
+  print(dp)
+} else {
+  cat("::: callout-note\n",
+      "**Alpha decay analysis not yet computed.** ",
+      "Run `tar_make(c(\"decay_metrics\", \"decay_plot\", \"decay_half_life\"))` ",
+      "to populate this tab. See [#356](https://github.com/JohnGavin/historical/issues/356).\n",
+      ":::\n", sep = "")
+}
 ```
 
 ```{r}
 decay_hl <- safe_tar_read("decay_half_life")
-if (!is.null(decay_hl)) {
+if (!is.null(decay_hl) && nrow(decay_hl) > 0) {  # #356: don't render an empty DT
   display <- decay_hl |>
     transmute(
       Strategy = dplyr::recode(strategy, stk_max = "Stock MAX", stk_drif = "Stock DRIF"),


### PR DESCRIPTION
## Wave C — defensive plot fixes (now); deeper data investigations stay open

Wave C from the 2026-05-30 dashboard audit. Each issue has a plot-side fix (shipping now) and an underlying data question that needs `tar_make` + data inspection (filed as remaining work).

### #350 — Null Rejection heatmap green-yellow-red gradient

`R/plan_falsification_vignette.R`: `scale_fill_gradient2(mid = '#ffffbf')` (near-white pale yellow) → `'#fee08b'` (saturated amber). The legend now visibly shows green→amber→red rather than appearing as white→red. Prose 'green = low rejection, red = high' is now visually correct.

The 'missing entries for white_noise / MA(1) / factor_null' is a separate upstream compute gap — those rejection rates haven't been computed for the strategies on the page. Stays as the open part of #350.

### #357 — Regime plot only one line visible

`R/plan_regime.R`: Added `linetype = strategy` aesthetic so Regime-Adjusted (solid) and Base Portfolio (dashed) are distinguishable even when numerically close. + `alpha = 0.85` for slight de-emphasis. The question of whether `regime_cum` actually differs from `base_cum` for the rendered period needs a `tar_read(regime_portfolio)` inspection — defensive linetype is the right fix regardless of that answer.

### #356 — Alpha Decay tab empty plot + empty table

`docs/leaderboard.qmd`: Added empty-state guards:

- Plot chunk: only `print(dp)` when `decay_metrics` exists AND has rows; otherwise render a callout-note pointing at #356 and the exact `tar_make()` command
- Table chunk: only render `hd_dt(display, ...)` when `decay_half_life` has rows

Users no longer see 'No data available in table' silently. The underlying 'why is decay_metrics empty?' is the open part of #356.

## Remaining Wave C work (intentionally NOT in this PR)

| Issue | Why not fixed here |
|---|---|
| **#354** XGB vs ENet jumps at 2005 / 2026 | Pure data bug — needs `tar_read(xgb_vs_enet)` and inspection of where xgb_ret is NA/zero |
| **#345** OLMAR / TOM / CMR / WFC missing from leaderboard | Needs full `tar_make()` of leaderboard subtree + re-render |

Both should be one focused PR each after a pipeline run.

## Test plan
- [ ] Next Pages render: heatmap legend visibly shows three-stop green→amber→red
- [ ] Regime tab plot shows two distinct lines (one solid, one dashed)
- [ ] Alpha Decay tab shows callout-note instead of empty plot/table