### PR TITLE
fix(xgb,leaderboard): #354 root cause + #356 base-Sharpe callout (Wave C residual)

### DIFF
--- a/R/plan_xgb_signal.R
+++ b/R/plan_xgb_signal.R
@@ -137,7 +137,14 @@ plan_xgb_signal <- function() {
       xgb <- xgb_drif_portfolio |> select(ym, xgb_ret = port_ret)
       enet <- stk_drif_portfolio |> select(ym, enet_ret = port_ret)
 
+      # #354: inner_join does NOT preserve chronological order; without an
+      # explicit arrange(ym) the subsequent cumprod() runs over rows in
+      # whatever order inner_join leaves them. The plot then draws a line
+      # by date through the out-of-order cumulative series, producing the
+      # ~2005 vertical jump and the apparent "2026 drop" (just the last
+      # out-of-order row plotted at the end of the x-axis).
       inner_join(xgb, enet, by = "ym") |>
+        arrange(ym) |>
         mutate(
           xgb_cum = cumprod(1 + xgb_ret),
           enet_cum = cumprod(1 + enet_ret),

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -363,11 +363,21 @@ if (!is.null(x)) {
 
 ```{r}
 #| fig-height: 6
-# #356: only render the plot if the upstream metric target produced rows
+# #356: Alpha decay needs a positive base Sharpe (decay is the fraction
+# of base Sharpe that survives delay; if base is negative, the metric
+# is meaningless). Surface the actual reason in the callout.
 dp <- safe_tar_read("decay_plot")
 decay_metrics <- safe_tar_read("decay_metrics")
-if (!is.null(dp) && !is.null(decay_metrics) && nrow(decay_metrics) > 0) {
+neg_base <- !is.null(decay_metrics) && nrow(decay_metrics) > 0 &&
+            all(decay_metrics$sharpe[decay_metrics$delay == min(decay_metrics$delay)] <= 0, na.rm = TRUE)
+if (!is.null(dp) && !is.null(decay_metrics) && nrow(decay_metrics) > 0 && !neg_base) {
   print(dp)
+} else if (neg_base) {
+  cat("::: callout-warning\n",
+      "**Alpha decay not meaningful — base Sharpe is non-positive for every strategy on the page.** ",
+      "Decay measures the *fraction of base Sharpe that survives execution delay*; if base Sharpe ≤ 0 there is no alpha to decay. ",
+      "Investigate the strategies' base Sharpe before re-running this tab. See [#356](https://github.com/JohnGavin/historical/issues/356).\n",
+      ":::\n", sep = "")
 } else {
   cat("::: callout-note\n",
       "**Alpha decay analysis not yet computed.** ",


### PR DESCRIPTION
## Investigation findings (read-only `tar_read` against main `_targets` cache)

### #354 — xgb_vs_enet plot vertical jumps — ROOT CAUSE FOUND

`tar_read(xgb_vs_enet)` revealed the tibble's row order is broken:

```
first 5 rows: 2005-01, 2005-04, 2005-05, 2005-06, 2005-07
last 5 rows:  2004-09, 2004-10, 2004-11, 2004-12, 2026-04   ← out of order!
```

`inner_join()` preserves left-side row order (not the join key order). The subsequent `cumprod()` then runs over rows in arbitrary order. The line plot, drawing by `date` through a cumulative series that does not correspond to chronological cumprod, produces:
- The 'jump' circa 2005 — the order breaks here
- The 'drop in 2026' — the last out-of-order row plotted at the right edge

**Fix**: `arrange(ym)` between the `inner_join` and the `cumprod` mutate in `R/plan_xgb_signal.R`. **One line.** Root-causes the entire issue.

### #356 — Alpha decay tab — finding + improved callout

`tar_read(decay_metrics)` returned **20 rows** (not empty), but `tar_read(decay_half_life)` is empty because **every `base_sharpe` (delay==1) is ≤ 0**:

| Strategy | Base Sharpe |
|---|---|
| stk_max | -2.59 |
| stk_drif | -2.59 (comparable) |

`plan_alpha_decay.R` line 241-245 sets `sharpe_pct = NA` when `base_sharpe ≤ 0` (can't measure 'fraction of base Sharpe that survives delay' when there's no base Sharpe). The whole tab silently produces no rows for that reason.

**Fix**: `docs/leaderboard.qmd` now detects the neg-base-Sharpe condition and renders an explicit `callout-warning` explaining the meaning, instead of the generic 'not yet computed' callout from PR #360. The underlying strategy weakness (stk_max + stk_drif have base Sharpe < 0) is a **strategy problem**, not a tab problem — separate.

### #350 — Null Rejection heatmap — DATA IS FINE

`tar_read(fals_summary)` confirmed all 6 `rej_rate_*` columns present, **0 NA values** across all 5 strategies. The user's perception of 'missing rows' on the deployed page is likely a stale-render or visual-gradient artefact. PR #360's mid-tone `#ffffbf` → `#fee08b` swap should resolve perception once redeployed. No data fix needed.

### #345 — Leaderboard only 5 strategies — REAL DATA GAP, SEPARATE PR NEEDED

`tar_read(leaderboard)` has 24 rows = **6 strategies × 4 periods**: Factor MAX, Factor DRIF, Stock MAX, Stock DRIF, XGB DRIF, PSO Optimal. The leaderboard target hardcodes those 5 strategies + portfolio in `bind_rows()` calls. Missing from leaderboard: **LTR, avoid_worst, rsc, OLMAR (#276), TOM (#289), CMR (#334)**. Adding each requires per-strategy `add_meta()` + `slice_portfolio()` calls, plus schema differences for overlays. **Out of scope for this PR — file a dedicated follow-up to #345.**

## Files changed
- `R/plan_xgb_signal.R` — `arrange(ym)` before cumprod (#354)
- `docs/leaderboard.qmd` — neg-base-Sharpe explicit callout (#356)

## Test plan
- [ ] Re-render `leaderboard.qmd` after next Pages deploy
- [ ] XGBoost vs Elastic Net plot draws cleanly chronologically, no 2005/2026 jumps
- [ ] Alpha Decay tab shows the warning callout explaining base Sharpe ≤ 0

Closes #354. Addresses user-visible part of #356. #350 + #345 findings logged for separate PRs.