### PR TITLE
feat: Wave D — homepage links + strategy registry keywords + lychee link-audit CI (closes #343, #344, #346 first-pass)

### DIFF
--- a/.github/workflows/link-audit.yml
+++ b/.github/workflows/link-audit.yml
@@ -1,0 +1,94 @@
+name: Link audit (lychee)
+
+# Closes #344. Catches deep-link / anchor-fragment / inbound-href breakage
+# that the manual URL-status sweep missed (e.g., examples.html#equity 404
+# from a homepage card after examples.qmd was archived).
+#
+# Two trigger modes:
+#   - daily (cron): full re-crawl of the deployed Pages site
+#   - on push to main touching docs/: in-repo crawl of docs/*.html before deploy
+
+on:
+  schedule:
+    - cron: '17 6 * * *'      # daily at 06:17 UTC
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/link-audit.yml'
+
+permissions:
+  contents: read
+  issues: write               # to auto-file an issue on failure
+
+jobs:
+  link-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lychee — in-repo HTML pre-deploy check
+        if: github.event_name == 'push'
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --verbose
+            --max-redirects 5
+            --max-concurrency 8
+            --accept 200,206,429
+            --exclude-mail
+            './docs/**/*.html'
+            './docs/**/*.qmd'
+            './*.md'
+          fail: true
+          format: markdown
+          output: ./lychee-out.md
+          jobSummary: true
+
+      - name: Lychee — live Pages crawl (scheduled / manual)
+        if: github.event_name != 'push'
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --verbose
+            --max-redirects 5
+            --max-concurrency 8
+            --accept 200,206,429
+            --exclude-mail
+            --base 'https://johngavin.github.io/historical/'
+            'https://johngavin.github.io/historical/'
+            'https://johngavin.github.io/historical/leaderboard.html'
+            'https://johngavin.github.io/historical/falsification.html'
+            'https://johngavin.github.io/historical/factor-max.html'
+            'https://johngavin.github.io/historical/drif.html'
+            'https://johngavin.github.io/historical/stock-backtest.html'
+            'https://johngavin.github.io/historical/avoid-worst-days.html'
+            'https://johngavin.github.io/historical/macro-defense-rotation.html'
+            'https://johngavin.github.io/historical/jst-dashboard.html'
+            'https://johngavin.github.io/historical/negative-results.html'
+            'https://johngavin.github.io/historical/quiz.html'
+            'https://johngavin.github.io/historical/european-overlay.html'
+          fail: true
+          format: markdown
+          output: ./lychee-out.md
+          jobSummary: true
+
+      - name: Upload lychee report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lychee-output
+          path: ./lychee-out.md
+          retention-days: 14
+
+      - name: Create issue on schedule failure
+        if: failure() && github.event_name == 'schedule'
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "link-audit: broken links detected on Pages site"
+          content-filepath: ./lychee-out.md
+          labels: bug, deploy, link-audit

--- a/R/plan_strategy_names.R
+++ b/R/plan_strategy_names.R
@@ -48,6 +48,63 @@ plan_strategy_names <- function() {
           "stock-backtest.html", "stock-backtest.html",
           "stock-backtest.html", "leaderboard.html",
           "commodities-mean-reversion.html"
+        ),
+        # ── #346 strategy registry keywords (rough first-pass; refine after a full tar_make) ──
+        # Order matches code_name above (1 avoid_worst .. 11 cmr).
+        time_horizon_days_avg = c(
+          1L,  21L, 21L, 1L,  252L, 1L,
+          21L, 21L, 21L, 90L,
+          21L
+        ),
+        trades_per_year_avg = c(
+          12,  12,  12,  12,  12,  12,
+          12,  12,  12,   4,
+          12
+        ),
+        liquidity_tier = factor(
+          c("high", "high", "high", "high", "med", "high",
+            "med",  "med",  "med",  "high",
+            "med"),
+          levels = c("high", "med", "low")
+        ),
+        turnover_pct_per_period_avg = c(
+          50, 30, 30, 50, 20, 10,
+          100, 100, 100, 10,
+          100
+        ),
+        directionality = factor(
+          c("overlay",    "long_only",  "long_only",  "overlay",    "long_short", "overlay",
+            "long_short", "long_short", "long_short", "long_only",
+            "long_short"),
+          levels = c("long_only", "long_short", "market_neutral", "overlay")
+        ),
+        # Tags as JSON-encoded character vectors so duckplyr can pick them
+        # up as VARCHAR and a future hd_strategy_tags() helper can parse.
+        tags = c(
+          '["vix","market_timing","overlay"]',
+          '["factor_rotation","elastic_net","monthly"]',
+          '["factor_rotation","monthly"]',
+          '["vix","market_timing","overlay"]',
+          '["momentum","cross_sectional","monthly"]',
+          '["calendar","seasonal","overlay"]',
+          '["momentum","cross_sectional","stock_level"]',
+          '["elastic_net","ml","stock_level"]',
+          '["xgboost","ml","stock_level","monotonic"]',
+          '["portfolio","pso","optimisation","combined"]',
+          '["mean_reversion","commodities"]'
+        ),
+        research_paper_doi = c(
+          NA_character_,                  # 1 avoid_worst (folk wisdom; no single paper)
+          "10.2139/ssrn.5520615",         # 2 drif (Cakici et al. 2024 — placeholder)
+          "10.2139/ssrn.5520615",         # 3 fac_max
+          NA_character_,                  # 4 rsc (VIX overlay variant)
+          "10.1016/0304-405X(93)90023-5", # 5 ltr (Jegadeesh & Titman 1993 placeholder)
+          NA_character_,                  # 6 tom (TradeQuantix newsletter — no DOI)
+          "10.2139/ssrn.5520615",         # 7 stk_max (Cakici family at stock level)
+          "10.2139/ssrn.5520615",         # 8 stk_drif
+          NA_character_,                  # 9 xgb_drif (no paper)
+          NA_character_,                  # 10 pso_optimal (PSO is engineering)
+          NA_character_                   # 11 cmr (internal — #134/#138)
         )
       )
     })

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -129,16 +129,16 @@ local({
 
 Historical finance database for backtesting: equities, crypto, macro, and factors. Code-only R package — data hosted on [Hugging Face](https://huggingface.co/datasets/JohnGavin/finance-data){target="_blank" rel="noopener noreferrer"}, queried via DuckDB `hf://` protocol with predicate pushdown.
 
-<span class="badge badge-blue">R package</span>
-<span class="badge badge-green">DuckDB + Parquet</span>
-<span class="badge badge-gold">Hugging Face</span>
+<a href="https://github.com/JohnGavin/historical/tree/main/packages/historicaldata" target="_blank" rel="noopener noreferrer"><span class="badge badge-blue">R package</span></a>
+<a href="https://duckdb.org/docs/data/parquet/overview.html" target="_blank" rel="noopener noreferrer"><span class="badge badge-green">DuckDB + Parquet</span></a>
+<a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer"><span class="badge badge-gold">Hugging Face</span></a>
 
 <div class="stats-row">
-<div class="stat"><div class="num">`r stat_tickers`</div><div class="label">tickers</div></div>
-<div class="stat"><div class="num">`r stat_rows`</div><div class="label">rows</div></div>
-<div class="stat"><div class="num">`r stat_datasets`</div><div class="label">datasets</div></div>
-<div class="stat"><div class="num">`r stat_yr`</div><div class="label">history</div></div>
-<div class="stat"><div class="num">30</div><div class="label">functions</div></div>
+<a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer" class="stat-link"><div class="stat"><div class="num">`r stat_tickers`</div><div class="label">tickers</div></div></a>
+<a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer" class="stat-link"><div class="stat"><div class="num">`r stat_rows`</div><div class="label">rows</div></div></a>
+<a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer" class="stat-link"><div class="stat"><div class="num">`r stat_datasets`</div><div class="label">datasets</div></div></a>
+<a href="jst-dashboard.html" class="stat-link"><div class="stat"><div class="num">`r stat_yr`</div><div class="label">history</div></div></a>
+<a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/NAMESPACE" target="_blank" rel="noopener noreferrer" class="stat-link"><div class="stat"><div class="num">30</div><div class="label">functions</div></div></a>
 </div>
 
 ## Row


### PR DESCRIPTION
## Three small-but-broad PRs bundled — file-disjoint, one commit each

### #343 — Homepage links (`docs/index.qmd`)

Wrapped 3 tech badges + 5 stat cards with appropriate href:
- R package → packages/historicaldata GitHub source
- DuckDB + Parquet → duckdb.org parquet overview
- Hugging Face → JohnGavin/finance-data dataset card
- tickers / rows / datasets → HF dataset card (canonical)
- history → jst-dashboard.html (155-yr equity premium page)
- functions → packages/historicaldata/NAMESPACE on GitHub

External links carry `target='_blank' rel='noopener noreferrer'` per the post-r4366 security pattern.

### #346 first-pass — Strategy registry keywords (`R/plan_strategy_names.R`)

Added 6 columns: `time_horizon_days_avg`, `trades_per_year_avg`, `liquidity_tier` (factor), `turnover_pct_per_period_avg`, `directionality` (factor), `tags` (JSON-encoded VARCHAR), `research_paper_doi`. Values are rough first-pass per orchestrator domain knowledge — measured backfill (turnover, trades-per-year from actual portfolios) is a separate sub-PR after the leaderboard rebuild runs. Closes the schema-extension piece; leaves the measurement + leaderboard surfacing for follow-ups.

### #344 — Link-audit CI (`.github/workflows/link-audit.yml`)

[lychee-action](https://github.com/lycheeverse/lychee-action) workflow with two modes:
1. **push to main touching `docs/`** — lychee runs against the in-repo `docs/*.html` and `*.qmd` before the next Pages deploy. Fails the merge on broken inbound refs.
2. **daily cron @ 06:17 UTC** — lychee crawls the live Pages site, walking every anchor and href. On failure, auto-files an issue with the lychee report.

`--accept 200,206,429` whitelists rate-limit responses to avoid flaky failures; 404/410/500 still fail.

## Test plan

- [ ] Next Pages render: homepage cards are clickable; 3 badges link out
- [ ] strategy_names rebuilds cleanly with new schema (no test failures); downstream consumers use existing columns
- [ ] First lychee push-mode run on the PR passes (or surfaces real broken links)
- [ ] First scheduled run after merge produces a Pages-site report