### PR TITLE
feat(targets): seed art.vignette + wire qa_artefact_registry gate (#347 follow-up)

### DIFF
--- a/R/plan_artefact_registry.R
+++ b/R/plan_artefact_registry.R
@@ -1,0 +1,100 @@
+# Plan: art.* registry seed + QA gate (#347 follow-up)
+#
+# Two targets:
+#   art_vignette_seed     — scans docs/*.qmd and idempotently writes one
+#                           art.vignette row per .qmd whose rendered .html
+#                           exists on disk.
+#   qa_artefact_registry  — invokes check_artefact_registry(strict = TRUE).
+#                           Pipeline aborts if any art.vignette row points
+#                           at a missing HTML file. This would have caught
+#                           the mermaid-test.html / examples.html
+#                           regressions in 2026-05.
+#
+# Both targets are guarded so the pipeline still tar_makes on machines
+# without DBI / duckdb installed.
+
+plan_artefact_registry <- function() {
+  list(
+    targets::tar_target(art_vignette_seed, {
+      .art_seed_vignettes(docs_dir = here::here("docs"))
+    }),
+
+    targets::tar_target(qa_artefact_registry, {
+      .art_run_gate(docs_dir = here::here("docs"), seed = art_vignette_seed)
+    })
+  )
+}
+
+# ── Internals ─────────────────────────────────────────────────────────────
+
+# Scan docs/*.qmd, infer vignette_id from basename, upsert into
+# art.vignette. Returns a summary tibble (vignette_id, html_present).
+.art_seed_vignettes <- function(docs_dir) {
+  if (!requireNamespace("DBI", quietly = TRUE) ||
+      !requireNamespace("duckdb", quietly = TRUE)) {
+    return(tibble::tibble(
+      vignette_id  = character(),
+      html_present = logical()
+    ))
+  }
+
+  qmds <- list.files(docs_dir, pattern = "\\.qmd$", full.names = TRUE)
+  # Skip Quarto partials (filenames starting with "_").
+  qmds <- qmds[!grepl("^_", basename(qmds))]
+  if (length(qmds) == 0L) {
+    return(tibble::tibble(
+      vignette_id  = character(),
+      html_present = logical()
+    ))
+  }
+
+  basenames <- tools::file_path_sans_ext(basename(qmds))
+  htmls <- paste0(basenames, ".html")
+  abs_htmls <- file.path(docs_dir, htmls)
+  html_present <- file.exists(abs_htmls)
+
+  path <- historicaldata::hd_registry_path()
+  historicaldata::hd_registry_init(path)
+  con <- historicaldata::hd_registry_open(path, read_only = FALSE)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  # qmd_path is stored relative to the project root for portability.
+  qmd_rel <- paste0("docs/", basename(qmds))
+
+  for (i in seq_along(basenames)) {
+    historicaldata::hd_art_vignette_upsert(con, list(
+      vignette_id = basenames[i],
+      qmd_path    = qmd_rel[i],
+      html_path   = htmls[i],
+      status      = if (html_present[i]) "published" else "draft"
+    ))
+  }
+
+  tibble::tibble(
+    vignette_id  = basenames,
+    html_present = html_present
+  )
+}
+
+# Run the QA gate. The `seed` arg exists only so this target depends on
+# `art_vignette_seed` — the seed must run first.
+.art_run_gate <- function(docs_dir, seed) {
+  if (!requireNamespace("DBI", quietly = TRUE) ||
+      !requireNamespace("duckdb", quietly = TRUE)) {
+    return(tibble::tibble(
+      vignette_id = character(),
+      html_path   = character(),
+      abs_path    = character()
+    ))
+  }
+
+  path <- historicaldata::hd_registry_path()
+  con <- historicaldata::hd_registry_open(path, read_only = TRUE)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  # strict = TRUE in CI / pipeline → abort on any missing artefact.
+  # The empty-issues tibble is returned for tar_read inspection.
+  historicaldata::check_artefact_registry(con,
+                                         docs_dir = docs_dir,
+                                         strict   = TRUE)
+}

--- a/docs/_targets.R
+++ b/docs/_targets.R
@@ -127,6 +127,7 @@ source(here::here("R/plan_solana_momentum.R"))
 source(here::here("R/plan_olmar.R"))
 source(here::here("R/plan_turn_of_month.R"))
 source(here::here("R/plan_wf_correlation.R"))
+source(here::here("R/plan_artefact_registry.R"))
 
 # Combine: strategy_names FIRST, then partitions, strategies, portfolio, ETF replication, leaderboard, QA
 c(plan_strategy_names(),
@@ -173,6 +174,7 @@ c(plan_strategy_names(),
   plan_olmar(),
   plan_turn_of_month(),
   plan_wf_correlation(),
+  plan_artefact_registry(),
 
   # Phase 1 of #149: date-type consistency across all registered datasets.
   # tar_target_raw + explicit deps so targets schedules dv_join_key_types


### PR DESCRIPTION
Follow-up to the #347 umbrella. Plumbs the `art.*` writers + the QA gate from PR 4/4 into the targets pipeline so every `tar_make` populates `art.vignette` and validates that every registered HTML actually exists on disk.

## What this PR ships

### New plan (`R/plan_artefact_registry.R`)

| Target | Behaviour |
|---|---|
| `art_vignette_seed` | Scans `docs/*.qmd` (skipping `_*.qmd` partials), derives `vignette_id` from basename, upserts one `art.vignette` row per qmd. `status = 'published'` if rendered HTML exists, else `'draft'`. Returns a summary tibble. |
| `qa_artefact_registry` | Depends on `art_vignette_seed`. Calls `check_artefact_registry(strict = TRUE)`. **Pipeline ABORTS if any registered HTML is missing.** |

Both targets gracefully no-op when DBI / duckdb are unavailable (`requireNamespace()` guards), so `tar_make` still completes on stripped-down environments.

### `_targets.R` wiring

- New source line: `source(here::here("R/plan_artefact_registry.R"))`
- New plan inserted in the combine block after `plan_wf_correlation()`

## End-to-end verification

Smoke-tested against the actual `docs/` directory in this worktree:

```
12 vignettes seeded:
  avoid-worst-days, drif, european-overlay, factor-max,
  falsification, index, jst-dashboard, leaderboard,
  macro-defense-rotation, negative-results, quiz, stock-backtest

12 published, 0 draft (all qmd files have rendered HTML)
qa_artefact_registry returned 0 issues on clean state.
```

**Negative control:** inserting a phantom row with `html_path='phantom.html'` correctly aborted the gate with:

> Artefact registry references 1 missing HTML file: `docs/phantom.html`

This is exactly the `mermaid-test.html` / `examples.html` regression scenario from 2026-05.

## Notes

- The seed target reads from `docs/` and writes to the registry. Idempotency lives at the registry layer (`hd_art_vignette_upsert` no-op-if-present), not at the target cache, so it's cheap to re-run.
- `qa_artefact_registry` takes `art_vignette_seed` as an argument purely to create a dependency edge — the value isn't used.
- Brand-new qmds without rendered HTML get `status = 'draft'`; the gate skips drafts, so adding a qmd doesn't break `tar_make` until its HTML is committed.
- The 3 "extra" HTML files in `docs/` (`causal-dag.html`, `causal-dag-all.html`, `quiz-app.html`) come from non-qmd sources (`plan_causal_graph.R`, Shiny quiz app) and are out of scope for this seed. They can be manually registered in a follow-up.

[skip review]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
