### PR TITLE
feat(targets): art.diagram seed + non-qmd HTML registration + legacy leaderboard sentinel (#347 follow-up)

### DIFF
--- a/R/plan_artefact_registry.R
+++ b/R/plan_artefact_registry.R
@@ -1,16 +1,21 @@
 # Plan: art.* registry seed + QA gate (#347 follow-up)
 #
-# Two targets:
-#   art_vignette_seed     — scans docs/*.qmd and idempotently writes one
-#                           art.vignette row per .qmd whose rendered .html
-#                           exists on disk.
-#   qa_artefact_registry  — invokes check_artefact_registry(strict = TRUE).
-#                           Pipeline aborts if any art.vignette row points
-#                           at a missing HTML file. This would have caught
-#                           the mermaid-test.html / examples.html
-#                           regressions in 2026-05.
+# Targets:
+#   art_vignette_seed          — scans docs/*.qmd and idempotently writes one
+#                                art.vignette row per .qmd whose rendered .html
+#                                exists on disk. Also registers known non-qmd
+#                                HTMLs (causal-dag, causal-dag-all, quiz-app).
+#   art_diagram_seed           — upserts a static set of known diagrams into
+#                                art.diagram. Depends on art_vignette_seed so
+#                                FK vignette_id rows exist first.
+#   qa_artefact_registry       — invokes check_artefact_registry(strict = TRUE).
+#                                Pipeline aborts if any art.vignette row points
+#                                at a missing HTML file.
+#   qa_legacy_leaderboard_sentinel — soft-sunset signal: cli_inform when the
+#                                registry covers all legacy leaderboard strategies.
+#                                Never aborts.
 #
-# Both targets are guarded so the pipeline still tar_makes on machines
+# All targets are guarded so the pipeline still tar_makes on machines
 # without DBI / duckdb installed.
 
 plan_artefact_registry <- function() {
@@ -19,16 +24,28 @@ plan_artefact_registry <- function() {
       .art_seed_vignettes(docs_dir = here::here("docs"))
     }),
 
+    targets::tar_target(art_diagram_seed, {
+      .art_seed_diagrams(docs_dir = here::here("docs"),
+                         vignette_seed = art_vignette_seed)
+    }),
+
     targets::tar_target(qa_artefact_registry, {
-      .art_run_gate(docs_dir = here::here("docs"), seed = art_vignette_seed)
+      .art_run_gate(docs_dir     = here::here("docs"),
+                    vignette_seed = art_vignette_seed,
+                    diagram_seed  = art_diagram_seed)
+    }),
+
+    targets::tar_target(qa_legacy_leaderboard_sentinel, {
+      .art_leaderboard_sentinel()
     })
   )
 }
 
 # ── Internals ─────────────────────────────────────────────────────────────
 
-# Scan docs/*.qmd, infer vignette_id from basename, upsert into
-# art.vignette. Returns a summary tibble (vignette_id, html_present).
+# Scan docs/*.qmd, infer vignette_id from basename, upsert into art.vignette.
+# Also registers known non-qmd HTMLs (qmd_path = NA).
+# Returns a summary tibble (vignette_id, html_present).
 .art_seed_vignettes <- function(docs_dir) {
   if (!requireNamespace("DBI", quietly = TRUE) ||
       !requireNamespace("duckdb", quietly = TRUE)) {
@@ -41,44 +58,140 @@ plan_artefact_registry <- function() {
   qmds <- list.files(docs_dir, pattern = "\\.qmd$", full.names = TRUE)
   # Skip Quarto partials (filenames starting with "_").
   qmds <- qmds[!grepl("^_", basename(qmds))]
-  if (length(qmds) == 0L) {
-    return(tibble::tibble(
-      vignette_id  = character(),
-      html_present = logical()
-    ))
-  }
-
-  basenames <- tools::file_path_sans_ext(basename(qmds))
-  htmls <- paste0(basenames, ".html")
-  abs_htmls <- file.path(docs_dir, htmls)
-  html_present <- file.exists(abs_htmls)
 
   path <- historicaldata::hd_registry_path()
   historicaldata::hd_registry_init(path)
   con <- historicaldata::hd_registry_open(path, read_only = FALSE)
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
 
-  # qmd_path is stored relative to the project root for portability.
-  qmd_rel <- paste0("docs/", basename(qmds))
+  # ── Pass 1: qmd-backed vignettes ─────────────────────────────────────
+  results <- tibble::tibble(
+    vignette_id  = character(),
+    html_present = logical()
+  )
 
-  for (i in seq_along(basenames)) {
+  if (length(qmds) > 0L) {
+    basenames <- tools::file_path_sans_ext(basename(qmds))
+    htmls <- paste0(basenames, ".html")
+    abs_htmls <- file.path(docs_dir, htmls)
+    html_present <- file.exists(abs_htmls)
+
+    # qmd_path is stored relative to the project root for portability.
+    qmd_rel <- paste0("docs/", basename(qmds))
+
+    for (i in seq_along(basenames)) {
+      historicaldata::hd_art_vignette_upsert(con, list(
+        vignette_id = basenames[i],
+        qmd_path    = qmd_rel[i],
+        html_path   = htmls[i],
+        status      = if (html_present[i]) "published" else "draft"
+      ))
+    }
+
+    results <- tibble::tibble(
+      vignette_id  = basenames,
+      html_present = html_present
+    )
+  }
+
+  # ── Pass 2: known non-qmd HTMLs ──────────────────────────────────────
+  # These HTMLs are hand-authored (no source .qmd) so the qmd scan above
+  # never picks them up. Without explicit registration they are invisible
+  # to check_artefact_registry() — the same gap that allowed
+  # mermaid-test.html / examples.html regressions.
+  known_static_htmls <- c("causal-dag", "causal-dag-all", "quiz-app")
+
+  static_results <- lapply(known_static_htmls, function(name) {
+    html_file <- paste0(name, ".html")
+    present   <- file.exists(file.path(docs_dir, html_file))
     historicaldata::hd_art_vignette_upsert(con, list(
-      vignette_id = basenames[i],
-      qmd_path    = qmd_rel[i],
-      html_path   = htmls[i],
-      status      = if (html_present[i]) "published" else "draft"
+      vignette_id = name,
+      qmd_path    = NA_character_,
+      html_path   = html_file,
+      status      = if (present) "published" else "draft"
+    ))
+    tibble::tibble(vignette_id = name, html_present = present)
+  })
+
+  results <- rbind(results, do.call(rbind, static_results))
+  results
+}
+
+# Upsert a static set of known diagrams into art.diagram.
+# The `vignette_seed` arg creates a targets dependency so art_vignette_seed
+# runs first (ensuring FK vignette_id rows exist).
+# Returns a tibble of (diagram_id, vignette_id, target_name).
+.art_seed_diagrams <- function(docs_dir, vignette_seed) {
+  if (!requireNamespace("DBI", quietly = TRUE) ||
+      !requireNamespace("duckdb", quietly = TRUE)) {
+    return(tibble::tibble(
+      diagram_id  = character(),
+      vignette_id = character(),
+      target_name = character()
     ))
   }
 
+  # Known diagrams. FK vignette_id MUST already exist in art.vignette
+  # (guaranteed by the dependency on art_vignette_seed).
+  # Use NA_character_ for target_name when the diagram is hand-authored
+  # (no targets target backs it).
+  seed_rows <- list(
+    list(
+      diagram_id   = "leaderboard-keff-vertox",
+      vignette_id  = "leaderboard",
+      section      = "robustness",
+      diagram_type = "plotly",
+      target_name  = "strat_keff_vertox",
+      purpose      = "Effective number of strategies (Vertox)"
+    ),
+    list(
+      diagram_id   = "leaderboard-deflated-sharpe",
+      vignette_id  = "leaderboard",
+      section      = "robustness",
+      diagram_type = "ggplot",
+      target_name  = "strat_deflated_sharpe",
+      purpose      = "Deflated Sharpe per strategy"
+    ),
+    list(
+      diagram_id   = "causal-dag-mermaid",
+      vignette_id  = "causal-dag",
+      section      = "overview",
+      diagram_type = "mermaid",
+      target_name  = NA_character_,
+      purpose      = "Causal-DAG project overview"
+    ),
+    list(
+      diagram_id   = "falsification-pillar8",
+      vignette_id  = "falsification",
+      section      = "risk",
+      diagram_type = "ggplot",
+      target_name  = "fals_results_db",
+      purpose      = "Pillar-8 risk-architecture metrics"
+    )
+  )
+
+  path <- historicaldata::hd_registry_path()
+  historicaldata::hd_registry_init(path)
+  con <- historicaldata::hd_registry_open(path, read_only = FALSE)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  for (row in seed_rows) {
+    historicaldata::hd_art_diagram_upsert(con, row)
+  }
+
   tibble::tibble(
-    vignette_id  = basenames,
-    html_present = html_present
+    diagram_id  = vapply(seed_rows, `[[`, character(1), "diagram_id"),
+    vignette_id = vapply(seed_rows, `[[`, character(1), "vignette_id"),
+    target_name = vapply(seed_rows, function(r) {
+      tn <- r[["target_name"]]
+      if (is.null(tn) || is.na(tn)) NA_character_ else tn
+    }, character(1))
   )
 }
 
-# Run the QA gate. The `seed` arg exists only so this target depends on
-# `art_vignette_seed` — the seed must run first.
-.art_run_gate <- function(docs_dir, seed) {
+# Run the QA gate. The `vignette_seed` and `diagram_seed` args exist so
+# this target depends on both seeds — they must run first.
+.art_run_gate <- function(docs_dir, vignette_seed, diagram_seed) {
   if (!requireNamespace("DBI", quietly = TRUE) ||
       !requireNamespace("duckdb", quietly = TRUE)) {
     return(tibble::tibble(
@@ -95,6 +208,82 @@ plan_artefact_registry <- function() {
   # strict = TRUE in CI / pipeline → abort on any missing artefact.
   # The empty-issues tibble is returned for tar_read inspection.
   historicaldata::check_artefact_registry(con,
-                                         docs_dir = docs_dir,
-                                         strict   = TRUE)
+                                          docs_dir = docs_dir,
+                                          strict   = TRUE)
+}
+
+# Soft-sunset sentinel for the legacy `leaderboard` target.
+# Emits cli_inform() messages only — never aborts.
+# Returns a tibble of (strategy, in_registry, in_legacy) for tar_read.
+.art_leaderboard_sentinel <- function() {
+  legacy_strategies <- c(
+    "Factor MAX", "Factor DRIF", "Stock MAX",
+    "Stock DRIF", "XGB DRIF", "PSO Optimal"
+  )
+
+  empty <- tibble::tibble(
+    strategy    = legacy_strategies,
+    in_registry = FALSE,
+    in_legacy   = TRUE
+  )
+
+  if (!requireNamespace("DBI", quietly = TRUE) ||
+      !requireNamespace("duckdb", quietly = TRUE)) {
+    return(empty)
+  }
+
+  path <- historicaldata::hd_registry_path()
+  if (!file.exists(path)) return(empty)
+
+  con <- tryCatch(
+    historicaldata::hd_registry_open(path, read_only = TRUE),
+    error = function(e) NULL
+  )
+  if (is.null(con)) return(empty)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  registry_names <- tryCatch(
+    DBI::dbGetQuery(
+      con,
+      "SELECT short_name FROM bt.strategy"
+    )$short_name,
+    error = function(e) character()
+  )
+
+  # Registry empty → bootstrap still running; silent no-op.
+  if (length(registry_names) == 0L) return(empty)
+
+  in_registry <- legacy_strategies %in% registry_names
+  missing_in_registry <- legacy_strategies[!in_registry]
+
+  if (all(in_registry)) {
+    cli::cli_inform(c(
+      "v" = paste0(
+        "Registry now covers all legacy leaderboard strategies. ",
+        "The {.code leaderboard} target in ",
+        "{.file R/plan_leaderboard.R:11} can be retired."
+      ),
+      "i" = paste0(
+        "Consumers should migrate to ",
+        "{.code historicaldata::hd_leaderboard_from_registry()}."
+      )
+    ))
+  } else {
+    cli::cli_inform(c(
+      "i" = paste0(
+        "Registry does not yet cover {length(missing_in_registry)} legacy ",
+        "leaderboard {?strategy/strategies}:"
+      ),
+      stats::setNames(
+        paste0("{.val ", missing_in_registry, "}"),
+        rep("*", length(missing_in_registry))
+      )
+    ))
+  }
+
+  tibble::tibble(
+    strategy    = legacy_strategies,
+    in_registry = in_registry,
+    in_legacy   = TRUE
+  )
 }

--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -1,3 +1,12 @@
+# DEPRECATED: This plan assembles a hand-coded leaderboard from individual
+# strategy metric targets. The registry-backed replacement is:
+#
+#   historicaldata::hd_leaderboard_from_registry()
+#
+# Once the registry covers all strategies, this target can be retired.
+# Monitor parity via the `qa_legacy_leaderboard_sentinel` target in
+# R/plan_artefact_registry.R.
+#
 # Model leaderboard: collects metrics from all strategies into one table
 #
 # Transposed format: metrics as rows, strategies as columns

--- a/packages/historicaldata/tests/testthat/_snaps/registry-artefacts.md
+++ b/packages/historicaldata/tests/testthat/_snaps/registry-artefacts.md
@@ -1,0 +1,10 @@
+# check_artefact_registry strict-mode error message
+
+    Code
+      check_artefact_registry(s$con, docs_dir = docs, strict = TRUE)
+    Condition
+      Error in `check_artefact_registry()`:
+      ! Artefact registry references 1 missing HTML file:
+      x '<docs_dir>/missing-vignette.html'
+      i Either re-render the vignette or mark its row as `status = 'draft'` / `status = 'archived'`.
+

--- a/packages/historicaldata/tests/testthat/test-registry-artefacts.R
+++ b/packages/historicaldata/tests/testthat/test-registry-artefacts.R
@@ -150,3 +150,90 @@ test_that("check_artefact_registry skips draft and NA html_path rows", {
   issues <- check_artefact_registry(s$con, docs_dir = docs, strict = TRUE)
   expect_equal(nrow(issues), 0L)
 })
+
+# ── New tests (#347 follow-up) ─────────────────────────────────────────────
+
+test_that("hd_art_diagram_upsert is idempotent on (diagram_id)", {
+  skip_if_not_installed("DBI"); skip_if_not_installed("duckdb")
+  s <- .init_art_registry()
+  withr::defer({ DBI::dbDisconnect(s$con, shutdown = TRUE); unlink(s$tmp) })
+
+  # Prerequisite: vignette row must exist first (FK constraint).
+  hd_art_vignette_upsert(s$con,
+    list(vignette_id = "leaderboard", html_path = "leaderboard.html"))
+
+  row <- list(
+    diagram_id   = "leaderboard-keff-vertox",
+    vignette_id  = "leaderboard",
+    section      = "robustness",
+    diagram_type = "plotly",
+    target_name  = "strat_keff_vertox",
+    purpose      = "Effective number of strategies (Vertox)"
+  )
+  hd_art_diagram_upsert(s$con, row)
+  hd_art_diagram_upsert(s$con, row)  # second call — must be a no-op
+
+  n <- DBI::dbGetQuery(s$con, "SELECT COUNT(*) AS n FROM art.diagram")$n
+  expect_equal(n, 1L)
+})
+
+test_that("hd_art_diagram_upsert accepts NA target_name", {
+  skip_if_not_installed("DBI"); skip_if_not_installed("duckdb")
+  s <- .init_art_registry()
+  withr::defer({ DBI::dbDisconnect(s$con, shutdown = TRUE); unlink(s$tmp) })
+
+  hd_art_vignette_upsert(s$con,
+    list(vignette_id = "causal-dag", html_path = "causal-dag.html"))
+
+  hd_art_diagram_upsert(s$con, list(
+    diagram_id   = "causal-dag-mermaid",
+    vignette_id  = "causal-dag",
+    section      = "overview",
+    diagram_type = "mermaid",
+    target_name  = NA_character_,  # hand-authored, no targets target
+    purpose      = "Causal-DAG project overview"
+  ))
+
+  got <- DBI::dbGetQuery(s$con,
+    "SELECT target_name FROM art.diagram WHERE diagram_id = 'causal-dag-mermaid'")
+  expect_equal(nrow(got), 1L)
+  expect_true(is.na(got$target_name))
+})
+
+test_that("hd_art_vignette_upsert handles qmd_path = NA", {
+  skip_if_not_installed("DBI"); skip_if_not_installed("duckdb")
+  s <- .init_art_registry()
+  withr::defer({ DBI::dbDisconnect(s$con, shutdown = TRUE); unlink(s$tmp) })
+
+  hd_art_vignette_upsert(s$con, list(
+    vignette_id = "quiz-app",
+    qmd_path    = NA_character_,
+    html_path   = "quiz-app.html",
+    status      = "published"
+  ))
+
+  got <- DBI::dbGetQuery(s$con,
+    "SELECT qmd_path, html_path FROM art.vignette WHERE vignette_id = 'quiz-app'")
+  expect_equal(nrow(got), 1L)
+  expect_true(is.na(got$qmd_path))
+  expect_equal(got$html_path, "quiz-app.html")
+})
+
+test_that("check_artefact_registry strict-mode error message", {
+  skip_if_not_installed("DBI"); skip_if_not_installed("duckdb")
+  s <- .init_art_registry()
+  withr::defer({ DBI::dbDisconnect(s$con, shutdown = TRUE); unlink(s$tmp) })
+
+  docs <- tempfile("docs_"); dir.create(docs)
+  withr::defer(unlink(docs, recursive = TRUE))
+
+  hd_art_vignette_upsert(s$con,
+    list(vignette_id = "missing-vignette", html_path = "missing-vignette.html",
+         status = "published"))
+
+  expect_snapshot(
+    error = TRUE,
+    check_artefact_registry(s$con, docs_dir = docs, strict = TRUE),
+    transform = function(x) gsub(docs, "<docs_dir>", x, fixed = TRUE)
+  )
+})


### PR DESCRIPTION
## Summary

Closes three gaps left open by the #347 DuckDB registry umbrella (5 prior PRs).

- **art.diagram seed** — first target to write into the diagram table; 4 representative rows so `check_artefact_registry` is exercised on diagrams as well as vignettes.
- **Non-qmd HTML registration** — `causal-dag`, `causal-dag-all`, `quiz-app` are now registered in `art.vignette` with `qmd_path = NA`. Closes the same regression class as `mermaid-test.html` / `examples.html`.
- **Legacy leaderboard sentinel** — soft-sunset informational target that flags when the registry covers all legacy strategies. `R/plan_leaderboard.R` gets a DEPRECATED header pointing at `hd_leaderboard_from_registry()`. No behavioural change for current consumers.

## Test plan

- [x] `testthat::test_local("packages/historicaldata", filter = "registry-artefacts")` passes (existing + 4 new tests)
- [x] `parse()` clean on both edited plans
- [x] No `tar_make()` run in this PR (shared `_targets/` store)
- [ ] Reviewer: confirm registry sentinel does NOT abort the pipeline (informational only)

Refs: #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)
