### PR TITLE
feat(targets): plan_mom_prepeak — targets pipeline + 3 sibling strategy registrations (#365 PR 2/4)

### DIFF
--- a/R/plan_mom_prepeak.R
+++ b/R/plan_mom_prepeak.R
@@ -1,0 +1,429 @@
+# Plan: Pre-Peak / Post-Peak 12-2 Momentum Decomposition (#365 PR 2/4)
+#
+# Wires historicaldata::hd_mom_prepeak_signal() into the targets pipeline.
+# Operates on ltr_universe (~51 US non-ETF equities; methodology-demo scope).
+#
+# Three sibling strategies from one shared signal computation:
+#   mom_prepeak  — ranks on pre_peak_return  (84% of paper's alpha)
+#   mom_postpeak — ranks on post_peak_return (standard 52-week-high mechanism)
+#   mom_combined — ranks on total_return     (baseline 12-2 momentum control)
+#
+# Reference: Büsing, Mohrschladt & Siedhoff (2022), DOI 10.2139/ssrn.4298538.
+#
+# Look-ahead safety: signal at t uses prices through formation_end = t - 2 months.
+# Execution: trade at t+1 month-end closing prices (identical to CMR pilot).
+# Transaction cost: cost_per_trade applied on full turnover per leg.
+#
+# Precedent: R/plan_commodities_mean_reversion.R — registry sentinel structure.
+
+plan_mom_prepeak <- function() {
+  list(
+
+    # ── Parameters ──────────────────────────────────────────────────────────────
+
+    targets::tar_target(mom_prepeak_params, {
+      list(
+        lookback_months_start    = 12L,   # "12" in 12-2 momentum
+        lookback_months_end      = 2L,    # "2" in 12-2 (skip recent reversal month)
+        min_obs_days             = 100L,  # minimum trading days in formation window
+        n_quantiles              = 10L,   # deciles
+        min_stocks_per_month     = 30L,   # matches ltr_params$min_stocks_per_month
+        cost_per_trade           = 0.0010 # 10bps per trade (matches ltr_params)
+      )
+    }),
+
+
+    # ── Monthly rebalance dates from ltr_universe ────────────────────────────
+    # Last actual trading day per calendar month appearing in ltr_universe$date.
+    # Returns Date (NOT POSIXct) — consistent with #147 month-end convention.
+
+    targets::tar_target(mom_prepeak_as_of_dates, {
+      library(dplyr)
+
+      ltr_universe |>
+        dplyr::mutate(ym = format(as.Date(.data$date), "%Y-%m")) |>
+        dplyr::group_by(.data$ym) |>
+        dplyr::summarise(as_of_date = max(as.Date(.data$date)), .groups = "drop") |>
+        dplyr::arrange(.data$as_of_date) |>
+        dplyr::pull(.data$as_of_date)
+    }),
+
+
+    # ── Shared signal: one call feeds all 3 sibling strategies ──────────────
+    # Returns one row per (ticker, as_of_date) with 10 columns including
+    # pre_peak_return, post_peak_return, total_return.
+
+    targets::tar_target(mom_prepeak_signal_raw, {
+      historicaldata::hd_mom_prepeak_signal(
+        daily_prices          = ltr_universe,
+        as_of_dates           = mom_prepeak_as_of_dates,
+        lookback_months_start = mom_prepeak_params$lookback_months_start,
+        lookback_months_end   = mom_prepeak_params$lookback_months_end,
+        min_obs_days          = mom_prepeak_params$min_obs_days
+      )
+    }),
+
+
+    # ── Portfolios: cross-sectional decile sort, long top / short bottom ─────
+    # One target per sibling — each calls the shared helper with a different
+    # signal column. Long top decile, short bottom decile, equal-weighted.
+    # Dates with fewer than min_stocks_per_month are dropped.
+
+    targets::tar_target(mom_prepeak_portfolio, {
+      .mom_prepeak_form_portfolio(
+        signal_tbl  = mom_prepeak_signal_raw,
+        signal_col  = "pre_peak_return",
+        n_quantiles = mom_prepeak_params$n_quantiles,
+        min_stocks  = mom_prepeak_params$min_stocks_per_month
+      )
+    }),
+
+    targets::tar_target(mom_postpeak_portfolio, {
+      .mom_prepeak_form_portfolio(
+        signal_tbl  = mom_prepeak_signal_raw,
+        signal_col  = "post_peak_return",
+        n_quantiles = mom_prepeak_params$n_quantiles,
+        min_stocks  = mom_prepeak_params$min_stocks_per_month
+      )
+    }),
+
+    targets::tar_target(mom_combined_portfolio, {
+      .mom_prepeak_form_portfolio(
+        signal_tbl  = mom_prepeak_signal_raw,
+        signal_col  = "total_return",
+        n_quantiles = mom_prepeak_params$n_quantiles,
+        min_stocks  = mom_prepeak_params$min_stocks_per_month
+      )
+    }),
+
+
+    # ── Realised monthly returns (look-ahead-safe, t+1 execution) ───────────
+    # Signal at as_of_date t -> trade executes at t+1 month-end.
+    # Returns: as_of_date (signal date), exec_date (t+1 month-end),
+    #          ret_long, ret_short, ret_ls (net of cost on full turnover).
+
+    targets::tar_target(mom_prepeak_returns, {
+      .mom_prepeak_compute_returns(
+        portfolio_tbl   = mom_prepeak_portfolio,
+        universe_tbl    = ltr_universe,
+        cost_per_trade  = mom_prepeak_params$cost_per_trade
+      )
+    }),
+
+    targets::tar_target(mom_postpeak_returns, {
+      .mom_prepeak_compute_returns(
+        portfolio_tbl   = mom_postpeak_portfolio,
+        universe_tbl    = ltr_universe,
+        cost_per_trade  = mom_prepeak_params$cost_per_trade
+      )
+    }),
+
+    targets::tar_target(mom_combined_returns, {
+      .mom_prepeak_compute_returns(
+        portfolio_tbl   = mom_combined_portfolio,
+        universe_tbl    = ltr_universe,
+        cost_per_trade  = mom_prepeak_params$cost_per_trade
+      )
+    }),
+
+
+    # ── Performance metrics (one row per sibling) ────────────────────────────
+
+    targets::tar_target(mom_prepeak_metrics, {
+      .mom_prepeak_compute_metrics(mom_prepeak_returns, strategy = "mom_prepeak")
+    }),
+
+    targets::tar_target(mom_postpeak_metrics, {
+      .mom_prepeak_compute_metrics(mom_postpeak_returns, strategy = "mom_postpeak")
+    }),
+
+    targets::tar_target(mom_combined_metrics, {
+      .mom_prepeak_compute_metrics(mom_combined_returns, strategy = "mom_combined")
+    }),
+
+
+    # ── Summary: all 3 siblings in one tibble (feeds registry sentinel) ──────
+
+    targets::tar_target(mom_prepeak_summary, {
+      dplyr::bind_rows(
+        mom_prepeak_metrics,
+        mom_postpeak_metrics,
+        mom_combined_metrics
+      )
+    }),
+
+
+    # ── Registry sentinel (#365 PR 2/4) ─────────────────────────────────────
+    # Mirrors .cmr_register_runs() from plan_commodities_mean_reversion.R.
+    # Upserts 3 strategy rows + records one bt.run + bt.metric row each.
+    # Guard: returns empty tibble if DBI / duckdb are unavailable.
+
+    targets::tar_target(mom_prepeak_register_runs, {
+      .mom_prepeak_register_runs(
+        strategy_names    = strategy_names,
+        mom_prepeak_summary = mom_prepeak_summary
+      )
+    })
+
+  )
+}
+
+
+# ── Internal helpers ───────────────────────────────────────────────────────────
+# Prefixed .mom_prepeak_* (private; not exported from the package).
+# These plan-level helpers live here rather than in packages/historicaldata/R/
+# because they are wiring code, not reusable library code.
+
+
+#' Form a long-short decile portfolio from pre/post-peak signals
+#'
+#' @param signal_tbl Tibble from hd_mom_prepeak_signal().
+#' @param signal_col Character. Column name to rank on.
+#' @param n_quantiles Integer. Number of quantile buckets (default 10 = deciles).
+#' @param min_stocks Integer. Drop as_of_dates with fewer stocks than this.
+#'
+#' @return Tibble with columns: as_of_date, ticker, signal_value, decile,
+#'   weight (positive = long leg, negative = short leg).
+#' @noRd
+.mom_prepeak_form_portfolio <- function(signal_tbl,
+                                        signal_col,
+                                        n_quantiles = 10L,
+                                        min_stocks  = 30L) {
+  library(dplyr)
+
+  stopifnot(
+    is.data.frame(signal_tbl),
+    is.character(signal_col),
+    length(signal_col) == 1L,
+    signal_col %in% names(signal_tbl)
+  )
+
+  result <- signal_tbl |>
+    dplyr::select(
+      "as_of_date",
+      "ticker",
+      signal_value = dplyr::all_of(signal_col)
+    ) |>
+    dplyr::filter(!is.na(.data$signal_value)) |>
+    dplyr::group_by(.data$as_of_date) |>
+    dplyr::filter(dplyr::n() >= min_stocks) |>
+    dplyr::mutate(
+      decile = dplyr::ntile(.data$signal_value, n_quantiles)
+    ) |>
+    dplyr::filter(.data$decile == 1L | .data$decile == n_quantiles) |>
+    dplyr::mutate(
+      # Equal weight within each leg
+      n_long  = sum(.data$decile == n_quantiles),
+      n_short = sum(.data$decile == 1L),
+      weight  = dplyr::case_when(
+        .data$decile == n_quantiles ~  1 / .data$n_long,
+        .data$decile == 1L         ~ -1 / .data$n_short,
+        TRUE                       ~  NA_real_
+      )
+    ) |>
+    dplyr::ungroup() |>
+    dplyr::select("as_of_date", "ticker", "signal_value", "decile", "weight")
+
+  result
+}
+
+
+#' Compute realised monthly long-short returns (t+1 execution)
+#'
+#' Signal at as_of_date t -> trade executes at t+1 month-end.
+#' Monthly return per leg = equal-weighted average of constituent returns.
+#' Net return = ret_long - ret_short - 2 * cost_per_trade (full turnover both legs).
+#'
+#' @param portfolio_tbl Tibble from .mom_prepeak_form_portfolio().
+#' @param universe_tbl Tibble with columns ticker, date, adjusted (ltr_universe).
+#' @param cost_per_trade Numeric. One-way transaction cost fraction.
+#'
+#' @return Tibble with: as_of_date, exec_date, ret_long, ret_short, ret_ls.
+#' @noRd
+.mom_prepeak_compute_returns <- function(portfolio_tbl,
+                                          universe_tbl,
+                                          cost_per_trade = 0.001) {
+  library(dplyr)
+
+  # Build monthly return table from universe: for each ticker, compute
+  # the month-over-month return using the last price in each month.
+  monthly_ret <- universe_tbl |>
+    dplyr::mutate(
+      date = as.Date(.data$date),
+      ym   = format(.data$date, "%Y-%m")
+    ) |>
+    dplyr::group_by(.data$ticker, .data$ym) |>
+    dplyr::slice_max(.data$date, n = 1L, with_ties = FALSE) |>
+    dplyr::ungroup() |>
+    dplyr::arrange(.data$ticker, .data$date) |>
+    dplyr::group_by(.data$ticker) |>
+    dplyr::mutate(fwd_ret = dplyr::lead(.data$adjusted) / .data$adjusted - 1) |>
+    dplyr::ungroup() |>
+    dplyr::select("ticker", "date", "ym", "fwd_ret")
+
+  # Build exec_date map: as_of_date -> next month-end date in the universe
+  as_of_dates <- sort(unique(portfolio_tbl$as_of_date))
+
+  exec_map <- purrr::map_dfr(as_of_dates, function(aod) {
+    aod_ym <- format(aod, "%Y-%m")
+    next_dates <- monthly_ret |>
+      dplyr::filter(.data$date > aod) |>
+      dplyr::group_by(.data$ym) |>
+      dplyr::summarise(exec_date = min(.data$date), .groups = "drop") |>
+      dplyr::slice_min(.data$exec_date, n = 1L, with_ties = FALSE)
+
+    if (nrow(next_dates) == 0L) {
+      return(tibble::tibble(
+        as_of_date = aod,
+        exec_date  = as.Date(NA)
+      ))
+    }
+    tibble::tibble(as_of_date = aod, exec_date = next_dates$exec_date[[1L]])
+  })
+
+  # Join portfolio weights with forward returns and exec dates
+  port_with_ret <- portfolio_tbl |>
+    dplyr::left_join(exec_map, by = "as_of_date") |>
+    dplyr::filter(!is.na(.data$exec_date)) |>
+    dplyr::left_join(
+      monthly_ret |> dplyr::select("ticker", "date", "fwd_ret"),
+      by = c("ticker", "exec_date" = "date")
+    ) |>
+    dplyr::filter(!is.na(.data$fwd_ret))
+
+  # Aggregate to monthly long-short return
+  port_with_ret |>
+    dplyr::group_by(.data$as_of_date, .data$exec_date) |>
+    dplyr::summarise(
+      ret_long  = sum(.data$weight[.data$weight > 0] *
+                        .data$fwd_ret[.data$weight > 0]),
+      ret_short = sum(abs(.data$weight[.data$weight < 0]) *
+                        .data$fwd_ret[.data$weight < 0]),
+      .groups   = "drop"
+    ) |>
+    dplyr::mutate(
+      # Net L/S return minus round-trip transaction cost (full turnover assumed)
+      ret_ls = .data$ret_long - .data$ret_short - 2 * cost_per_trade
+    ) |>
+    dplyr::arrange(.data$as_of_date)
+}
+
+
+#' Compute annualised performance metrics for one sibling strategy
+#'
+#' @param returns_tbl Tibble from .mom_prepeak_compute_returns().
+#' @param strategy Character. Strategy code_name label.
+#' @param ann_factor Integer. Annualisation factor (12 for monthly).
+#'
+#' @return One-row tibble: strategy, n_months, sharpe, cagr, vol, max_dd.
+#' @noRd
+.mom_prepeak_compute_metrics <- function(returns_tbl,
+                                          strategy,
+                                          ann_factor = 12L) {
+  r <- returns_tbl$ret_ls
+  r <- r[!is.na(r)]
+  n <- length(r)
+
+  if (n < 12L) {
+    return(tibble::tibble(
+      strategy = strategy, n_months = n,
+      sharpe = NA_real_, cagr = NA_real_, vol = NA_real_, max_dd = NA_real_
+    ))
+  }
+
+  monthly_rf <- (1.02)^(1 / ann_factor) - 1
+  mean_r     <- mean(r)
+  sd_r       <- sd(r)
+  sharpe     <- if (sd_r > 0) (mean_r - monthly_rf) / sd_r * sqrt(ann_factor) else NA_real_
+
+  cum        <- cumprod(1 + r)
+  years      <- n / ann_factor
+  cagr       <- cum[[n]]^(1 / years) - 1
+  vol        <- sd_r * sqrt(ann_factor)
+
+  cum_max    <- cummax(cum)
+  dd         <- (cum - cum_max) / cum_max
+  max_dd     <- min(dd)
+
+  tibble::tibble(
+    strategy = strategy,
+    n_months = n,
+    sharpe   = round(sharpe, 3),
+    cagr     = round(cagr * 100, 1),
+    vol      = round(vol * 100, 1),
+    max_dd   = round(max_dd * 100, 1)
+  )
+}
+
+
+#' Registry sentinel: upsert 3 sibling strategies + record runs + metrics
+#'
+#' Mirrors .cmr_register_runs() from plan_commodities_mean_reversion.R.
+#' Returns empty tibble if DBI / duckdb are unavailable.
+#'
+#' @param strategy_names Tibble from the strategy_names target.
+#' @param mom_prepeak_summary Tibble from the mom_prepeak_summary target.
+#'
+#' @return Tibble with columns: strategy_id, run_uuid.
+#' @noRd
+.mom_prepeak_register_runs <- function(strategy_names, mom_prepeak_summary) {
+  if (!requireNamespace("DBI", quietly = TRUE) ||
+      !requireNamespace("duckdb", quietly = TRUE)) {
+    return(tibble::tibble(
+      strategy_id = character(),
+      run_uuid    = character()
+    ))
+  }
+
+  path <- historicaldata::hd_registry_path()
+  historicaldata::hd_registry_init(path)
+  con <- historicaldata::hd_registry_open(path, read_only = FALSE)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  code_names <- c("mom_prepeak", "mom_postpeak", "mom_combined")
+  strategy_ids <- character(length(code_names))
+  run_uuids    <- character(length(code_names))
+
+  for (i in seq_along(code_names)) {
+    cn <- code_names[[i]]
+
+    strat_row <- strategy_names |>
+      dplyr::filter(.data$code_name == cn) |>
+      dplyr::transmute(
+        strategy_id        = .data$code_name,
+        short_name         = .data$short_name,
+        long_name          = .data$long_name,
+        asset_class        = .data$asset_class,
+        frequency          = .data$frequency,
+        ann_factor         = as.integer(.data$ann_factor),
+        directionality     = as.character(.data$directionality),
+        liquidity_tier     = as.character(.data$liquidity_tier),
+        time_horizon_days  = as.integer(.data$time_horizon_days_avg),
+        trades_per_year    = as.numeric(.data$trades_per_year_avg),
+        turnover_pct       = as.numeric(.data$turnover_pct_per_period_avg),
+        tags               = .data$tags,
+        research_paper_doi = .data$research_paper_doi
+      )
+
+    historicaldata::hd_strategy_upsert(con, strat_row)
+
+    uu <- historicaldata::hd_run_record(
+      con,
+      strategy_id      = cn,
+      partition        = "phase1",
+      pipeline_version = "phase1"
+    )
+
+    metrics_row <- mom_prepeak_summary[mom_prepeak_summary$strategy == cn, , drop = FALSE]
+    if (nrow(metrics_row) == 1L) {
+      metric_cols <- setdiff(names(metrics_row), "strategy")
+      wide <- metrics_row[, metric_cols, drop = FALSE]
+      historicaldata::hd_metric_record(con, uu, wide)
+    }
+
+    strategy_ids[[i]] <- cn
+    run_uuids[[i]]    <- uu
+  }
+
+  tibble::tibble(strategy_id = strategy_ids, run_uuid = run_uuids)
+}

--- a/R/plan_strategy_names.R
+++ b/R/plan_strategy_names.R
@@ -3,6 +3,9 @@
 # Provides a unified tibble of all strategies in the project.
 # All downstream plans (falsification vignette, leaderboard, etc.)
 # should filter this target rather than defining their own name tables.
+#
+# Current count: 14 strategies (rows 1-11 original; rows 12-14 mom_prepeak
+# siblings added in #365 PR 2/4).
 
 plan_strategy_names <- function() {
   list(
@@ -11,12 +14,15 @@ plan_strategy_names <- function() {
         code_name = c(
           "avoid_worst", "drif", "fac_max", "rsc", "ltr", "tom",
           "stk_max", "stk_drif", "xgb_drif", "pso_optimal",
-          "cmr"
+          "cmr",
+          # ── #365: pre-peak / post-peak 12-2 momentum decomposition ──
+          "mom_prepeak", "mom_postpeak", "mom_combined"
         ),
         short_name = c(
           "Avoid Worst", "DRIF", "Factor MAX", "Risk State", "LTR", "TOM",
           "Stock MAX", "Stock DRIF", "XGB DRIF", "PSO Optimal",
-          "MR"
+          "MR",
+          "Mom Pre-Peak", "Mom Post-Peak", "Mom 12-2"
         ),
         long_name = c(
           "Avoid Worst Days (VIX Protection)",
@@ -29,53 +35,65 @@ plan_strategy_names <- function() {
           "Stock DRIF (Elastic Net Stock Selection)",
           "XGB DRIF (XGBoost Stock Selection)",
           "PSO Optimal (Portfolio Optimisation)",
-          "Commodities Mean Reversion"
+          "Commodities Mean Reversion",
+          "Pre-Peak 12-2 Momentum (Büsing 2022)",
+          "Post-Peak 12-2 Momentum (Büsing 2022)",
+          "Standard 12-2 Momentum (Büsing baseline)"
         ),
         asset_class = c(
           "overlay", "factor", "factor", "overlay", "equity", "overlay",
           "equity", "equity", "equity", "combined",
-          "commodities"
+          "commodities",
+          "equity", "equity", "equity"
         ),
         frequency = c(
           "daily", "monthly", "monthly", "daily", "monthly", "daily",
           "monthly", "monthly", "monthly", "monthly",
-          "monthly"
+          "monthly",
+          "monthly", "monthly", "monthly"
         ),
-        ann_factor = c(252L, 12L, 12L, 252L, 12L, 252L, 12L, 12L, 12L, 12L, 12L),
+        ann_factor = c(252L, 12L, 12L, 252L, 12L, 252L, 12L, 12L, 12L, 12L, 12L,
+                       12L, 12L, 12L),
         vignette_url = c(
           "avoid-worst-days.html", "drif.html", "factor-max.html",
           "leaderboard.html", "leaderboard.html", "turn-of-month.html",
           "stock-backtest.html", "stock-backtest.html",
           "stock-backtest.html", "leaderboard.html",
-          "commodities-mean-reversion.html"
+          "commodities-mean-reversion.html",
+          "momentum-prepeak.html", "momentum-prepeak.html", "momentum-prepeak.html"
         ),
         # ── #346 strategy registry keywords (rough first-pass; refine after a full tar_make) ──
-        # Order matches code_name above (1 avoid_worst .. 11 cmr).
+        # Order matches code_name above (1 avoid_worst .. 11 cmr, 12-14 mom_prepeak siblings).
         time_horizon_days_avg = c(
           1L,  21L, 21L, 1L,  252L, 1L,
           21L, 21L, 21L, 90L,
-          21L
+          21L,
+          21L, 21L, 21L
         ),
         trades_per_year_avg = c(
           12,  12,  12,  12,  12,  12,
           12,  12,  12,   4,
-          12
+          12,
+          12, 12, 12
         ),
         liquidity_tier = factor(
           c("high", "high", "high", "high", "med", "high",
             "med",  "med",  "med",  "high",
-            "med"),
+            "med",
+            "med", "med", "med"),
           levels = c("high", "med", "low")
         ),
         turnover_pct_per_period_avg = c(
           50, 30, 30, 50, 20, 10,
           100, 100, 100, 10,
-          100
+          100,
+          100, 100, 100
         ),
         directionality = factor(
           c("overlay",    "long_only",  "long_only",  "overlay",    "long_short", "overlay",
             "long_short", "long_short", "long_short", "long_only",
-            "long_short"),
+            "long_short",
+            "long_short", "long_short", "long_short"),
           levels = c("long_only", "long_short", "market_neutral", "overlay")
         ),
         # Tags as JSON-encoded character vectors so duckplyr can pick them
@@ -91,7 +109,10 @@ plan_strategy_names <- function() {
           '["elastic_net","ml","stock_level"]',
           '["xgboost","ml","stock_level","monotonic"]',
           '["portfolio","pso","optimisation","combined"]',
-          '["mean_reversion","commodities"]'
+          '["mean_reversion","commodities"]',
+          '["momentum","cross_sectional","decomposition","prepeak"]',
+          '["momentum","cross_sectional","decomposition","postpeak"]',
+          '["momentum","cross_sectional","baseline"]'
         ),
         research_paper_doi = c(
           NA_character_,                  # 1 avoid_worst (folk wisdom; no single paper)
@@ -104,7 +125,10 @@ plan_strategy_names <- function() {
           "10.2139/ssrn.5520615",         # 8 stk_drif
           NA_character_,                  # 9 xgb_drif (no paper)
           NA_character_,                  # 10 pso_optimal (PSO is engineering)
-          NA_character_                   # 11 cmr (internal — #134/#138)
+          NA_character_,                  # 11 cmr (internal — #134/#138)
+          "10.2139/ssrn.4298538",         # 12 mom_prepeak (Büsing, Mohrschladt & Siedhoff 2022)
+          "10.2139/ssrn.4298538",         # 13 mom_postpeak
+          "10.2139/ssrn.4298538"          # 14 mom_combined (baseline)
         )
       )
     })

--- a/docs/_targets.R
+++ b/docs/_targets.R
@@ -122,6 +122,7 @@ source(here::here("R/plan_regime_momentum.R"))
 source(here::here("R/plan_zakamulin_allocation.R"))
 source(here::here("R/plan_commodities_momentum.R"))
 source(here::here("R/plan_commodities_mean_reversion.R"))
+source(here::here("R/plan_mom_prepeak.R"))
 source(here::here("R/plan_crypto_momentum.R"))
 source(here::here("R/plan_solana_momentum.R"))
 source(here::here("R/plan_olmar.R"))
@@ -169,6 +170,7 @@ c(plan_strategy_names(),
   plan_zakamulin_allocation(),
   plan_commodities_momentum(),
   plan_commodities_mean_reversion(),
+  plan_mom_prepeak(),
   plan_crypto_momentum(),
   plan_solana_momentum(),
   plan_olmar(),

--- a/packages/historicaldata/tests/testthat/_snaps/mom-prepeak-portfolio.md
+++ b/packages/historicaldata/tests/testthat/_snaps/mom-prepeak-portfolio.md
@@ -1,0 +1,12 @@
+# portfolio output structure is stable
+
+    Code
+      str(result)
+    Output
+      tibble [10 x 5] (S3: tbl_df/tbl/data.frame)
+       $ as_of_date  : Date[1:10], format: "2026-01-31" "2026-01-31" ...
+       $ ticker      : chr [1:10] "T01" "T02" "T03" "T04" ...
+       $ signal_value: num [1:10] 0.02 0.04 0.06 0.08 0.1 0.92 0.94 0.96 0.98 1
+       $ decile      : int [1:10] 1 1 1 1 1 10 10 10 10 10
+       $ weight      : num [1:10] -0.2 -0.2 -0.2 -0.2 -0.2 0.2 0.2 0.2 0.2 0.2
+

--- a/packages/historicaldata/tests/testthat/test-mom-prepeak-portfolio.R
+++ b/packages/historicaldata/tests/testthat/test-mom-prepeak-portfolio.R
@@ -1,0 +1,191 @@
+# Tests for .mom_prepeak_form_portfolio() — portfolio-formation helper
+# defined in R/plan_mom_prepeak.R.
+#
+# These tests are self-contained (no ltr_universe, no parquet files).
+# The helper is accessed via source() of the plan file in a temp env,
+# since it is a plan-level private function not exported from the package.
+#
+# Strategy: source the plan into a local environment, extract the helper,
+# then test it directly with manufactured fixtures.
+
+# ---- Setup: source the plan helper ----------------------------------------
+
+# We need to source plan_mom_prepeak.R to get .mom_prepeak_form_portfolio().
+# Skip gracefully if the plan file is not findable (e.g., during isolated
+# package-only test runs on CI without the project root).
+
+plan_file <- tryCatch(
+  here::here("R", "plan_mom_prepeak.R"),
+  error = function(e) NULL
+)
+
+skip_no_plan <- function() {
+  if (is.null(plan_file) || !file.exists(plan_file)) {
+    testthat::skip("R/plan_mom_prepeak.R not found — skipping plan helper tests")
+  }
+}
+
+# Source once into a test environment so we don't pollute global env.
+# The helper functions are defined at top-level in the plan file, so they land
+# in the test env after source().
+plan_env <- new.env(parent = baseenv())
+
+if (!is.null(plan_file) && file.exists(plan_file)) {
+  # Suppress messages from library() calls inside helpers
+  suppressMessages(
+    source(plan_file, local = plan_env)
+  )
+}
+
+# Convenience extractor
+form_portfolio <- function(...) {
+  skip_no_plan()
+  plan_env$.mom_prepeak_form_portfolio(...)
+}
+
+
+# ---- Shared fixture builder --------------------------------------------------
+
+# Build a synthetic signal tibble with `n_stocks` tickers and one as_of_date.
+# signal values are deterministic: ticker "T01" gets signal 1, "T02" gets 2, etc.
+make_signal_tbl <- function(n_stocks     = 50L,
+                             as_of_date   = as.Date("2026-01-31"),
+                             signal_col   = "pre_peak_return") {
+  tickers <- sprintf("T%02d", seq_len(n_stocks))
+  signals <- seq_len(n_stocks) / n_stocks  # 0.02, 0.04, ... 1.00
+  tibble::tibble(
+    ticker         = tickers,
+    as_of_date     = as_of_date,
+    pre_peak_return  = signals,
+    post_peak_return = rev(signals),
+    total_return     = signals * 0.5 + 0.1
+  )
+}
+
+
+# ---- 1. Drop dates with fewer stocks than min_stocks -----------------------
+
+test_that(".mom_prepeak_form_portfolio drops dates with < min_stocks", {
+  skip_no_plan()
+
+  small_tbl <- make_signal_tbl(n_stocks = 20L)  # < 30 (default min)
+
+  result <- form_portfolio(
+    signal_tbl  = small_tbl,
+    signal_col  = "pre_peak_return",
+    n_quantiles = 10L,
+    min_stocks  = 30L
+  )
+
+  expect_equal(nrow(result), 0L,
+    info = "Dates with fewer stocks than min_stocks must be dropped entirely")
+})
+
+
+# ---- 2. Long top decile / short bottom decile ------------------------------
+
+test_that(".mom_prepeak_form_portfolio: long top decile / short bottom decile", {
+  skip_no_plan()
+
+  tbl <- make_signal_tbl(n_stocks = 50L)
+
+  result <- form_portfolio(
+    signal_tbl  = tbl,
+    signal_col  = "pre_peak_return",
+    n_quantiles = 10L,
+    min_stocks  = 30L
+  )
+
+  # Top 5 (tickers T46..T50, highest signal) must be in long leg (weight > 0)
+  long_leg  <- result[result$weight > 0, ]
+  short_leg <- result[result$weight < 0, ]
+
+  # With 50 stocks and 10 deciles: 5 per decile
+  expect_equal(nrow(long_leg),  5L, info = "Long leg: top decile = 5 stocks")
+  expect_equal(nrow(short_leg), 5L, info = "Short leg: bottom decile = 5 stocks")
+
+  # Long leg should have the 5 highest signal values
+  top5_signal <- sort(tbl$pre_peak_return, decreasing = TRUE)[1:5]
+  long_signals <- sort(long_leg$signal_value, decreasing = TRUE)
+  expect_equal(long_signals, top5_signal, tolerance = 1e-10)
+
+  # Short leg should have the 5 lowest signal values
+  bottom5_signal <- sort(tbl$pre_peak_return)[1:5]
+  short_signals  <- sort(short_leg$signal_value)
+  expect_equal(short_signals, bottom5_signal, tolerance = 1e-10)
+})
+
+
+# ---- 3. Weights sum to ±1 --------------------------------------------------
+
+test_that(".mom_prepeak_form_portfolio: long and short weights sum to ±1", {
+  skip_no_plan()
+
+  tbl <- make_signal_tbl(n_stocks = 50L)
+
+  result <- form_portfolio(
+    signal_tbl  = tbl,
+    signal_col  = "pre_peak_return",
+    n_quantiles = 10L,
+    min_stocks  = 30L
+  )
+
+  long_wgt  <- sum(result$weight[result$weight > 0])
+  short_wgt <- sum(result$weight[result$weight < 0])
+
+  expect_equal(long_wgt,  1,  tolerance = 1e-10,
+    info = "Long leg weights must sum to +1 (equal-weighted)")
+  expect_equal(short_wgt, -1, tolerance = 1e-10,
+    info = "Short leg weights must sum to -1 (equal-weighted)")
+})
+
+
+# ---- 4. Tied signals resolve via ntile (no spurious splitting) -------------
+
+test_that(".mom_prepeak_form_portfolio: tied signals fall in the same decile", {
+  skip_no_plan()
+
+  # 50 stocks: all have the SAME signal value (complete tie).
+  # ntile distributes ties sequentially — each decile gets exactly 5 stocks.
+  # No stock should be missing from any decile due to a tie-break error.
+  tied_tbl <- tibble::tibble(
+    ticker           = sprintf("T%02d", 1:50),
+    as_of_date       = as.Date("2026-01-31"),
+    pre_peak_return  = rep(0.5, 50L),  # all identical
+    post_peak_return = rep(0.3, 50L),
+    total_return     = rep(0.4, 50L)
+  )
+
+  result <- form_portfolio(
+    signal_tbl  = tied_tbl,
+    signal_col  = "pre_peak_return",
+    n_quantiles = 10L,
+    min_stocks  = 30L
+  )
+
+  # ntile with ties: should still produce long and short legs (5 stocks each)
+  expect_equal(nrow(result), 10L,
+    info = "Tied signals must still produce 10 portfolio members (5 long + 5 short)")
+
+  long_n  <- sum(result$weight > 0)
+  short_n <- sum(result$weight < 0)
+  expect_equal(long_n,  5L, info = "5 in long leg even with ties")
+  expect_equal(short_n, 5L, info = "5 in short leg even with ties")
+})
+
+
+# ---- 5. Snapshot: portfolio output structure is stable ---------------------
+
+test_that("portfolio output structure is stable", {
+  skip_no_plan()
+
+  tbl    <- make_signal_tbl(n_stocks = 50L)
+  result <- form_portfolio(
+    signal_tbl  = tbl,
+    signal_col  = "pre_peak_return",
+    n_quantiles = 10L,
+    min_stocks  = 30L
+  )
+
+  expect_snapshot(str(result))
+})


### PR DESCRIPTION
## Summary

Second of four PRs implementing the Büsing pre-peak / post-peak 12-2 momentum decomposition (#365).

| PR | Scope | Status |
|----|-------|--------|
| 1/4 | `hd_mom_prepeak_signal()` + tests | Merged (#371) |
| **2/4** (this) | Targets pipeline + 3 registry rows | This PR |
| 3/4 | `vignettes/articles/momentum-prepeak.qmd` (peak-date histogram, 84/16 table) | Pending |
| 4/4 | Gauntlet: WFC, CPCV, falsification, Pillar-8 | Pending |

## Test plan

- [x] `parse()` on `R/plan_mom_prepeak.R`, `R/plan_strategy_names.R`, `docs/_targets.R`
- [x] `testthat::test_local(filter = "mom-prepeak")` — portfolio formation tests pass
- [x] Full suite passes (3 pre-existing failures unrelated)
- [x] `strategy_names` grows 11 → 14 rows; new code_names tail = `mom_prepeak`, `mom_postpeak`, `mom_combined`
- [x] `r_code_check.sh` clean
- [ ] Reviewer: confirm look-ahead-safe t+1 execution in `mom_*_returns` targets

Refs: #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)
