### PR TITLE
fix(plan_mom_prepeak): guard CAGR / max_dd against L/S bankruptcy (cum <= 0) (#365 follow-up)

### DIFF
--- a/R/plan_mom_prepeak.R
+++ b/R/plan_mom_prepeak.R
@@ -309,51 +309,12 @@ plan_mom_prepeak <- function() {
 }
 
 
-#' Compute annualised performance metrics for one sibling strategy
-#'
-#' @param returns_tbl Tibble from .mom_prepeak_compute_returns().
-#' @param strategy Character. Strategy code_name label.
-#' @param ann_factor Integer. Annualisation factor (12 for monthly).
-#'
-#' @return One-row tibble: strategy, n_months, sharpe, cagr, vol, max_dd.
-#' @noRd
-.mom_prepeak_compute_metrics <- function(returns_tbl,
-                                          strategy,
-                                          ann_factor = 12L) {
-  r <- returns_tbl$ret_ls
-  r <- r[!is.na(r)]
-  n <- length(r)
-
-  if (n < 12L) {
-    return(tibble::tibble(
-      strategy = strategy, n_months = n,
-      sharpe = NA_real_, cagr = NA_real_, vol = NA_real_, max_dd = NA_real_
-    ))
-  }
-
-  monthly_rf <- (1.02)^(1 / ann_factor) - 1
-  mean_r     <- mean(r)
-  sd_r       <- sd(r)
-  sharpe     <- if (sd_r > 0) (mean_r - monthly_rf) / sd_r * sqrt(ann_factor) else NA_real_
-
-  cum        <- cumprod(1 + r)
-  years      <- n / ann_factor
-  cagr       <- cum[[n]]^(1 / years) - 1
-  vol        <- sd_r * sqrt(ann_factor)
-
-  cum_max    <- cummax(cum)
-  dd         <- (cum - cum_max) / cum_max
-  max_dd     <- min(dd)
-
-  tibble::tibble(
-    strategy = strategy,
-    n_months = n,
-    sharpe   = round(sharpe, 3),
-    cagr     = round(cagr * 100, 1),
-    vol      = round(vol * 100, 1),
-    max_dd   = round(max_dd * 100, 1)
-  )
-}
+# .mom_prepeak_compute_metrics() is defined in
+# packages/historicaldata/R/utils_mom_prepeak_metrics.R and loaded via
+# pkgload::load_all() / library(historicaldata) at pipeline run time.
+# The implementation was extracted there so it can be unit-tested
+# independently of the plan file's tar_target library() calls.
+# See also: packages/historicaldata/tests/testthat/test-mom-prepeak-metrics.R
 
 
 #' Registry sentinel: upsert 3 sibling strategies + record runs + metrics

--- a/packages/historicaldata/R/utils_mom_prepeak_metrics.R
+++ b/packages/historicaldata/R/utils_mom_prepeak_metrics.R
@@ -1,0 +1,83 @@
+# Internal helper: annualised performance metrics for one L/S strategy.
+# Extracted from R/plan_mom_prepeak.R so it can be tested independently
+# without sourcing the full plan file (which has tar_target library() calls).
+
+
+#' Compute annualised performance metrics for one sibling strategy
+#'
+#' Bankruptcy-aware version: when the L/S portfolio's cumulative product goes
+#' non-positive (extreme short-leg return causes ret_ls < -1), reported metrics
+#' are:
+#'   - blown_up = TRUE, bankrupt_month = first index where cum <= 0
+#'   - cagr = NA_real_ (no meaningful CAGR after bankruptcy)
+#'   - max_dd = -100% (floor; -100 on the percentage scale returned)
+#'
+#' Sharpe is computed from per-period returns and is unaffected by bankruptcy.
+#'
+#' @param returns_tbl Tibble with column `ret_ls` (numeric monthly L/S returns).
+#' @param strategy Character. Strategy code_name label.
+#' @param ann_factor Integer. Annualisation factor (12 for monthly).
+#'
+#' @return One-row tibble: strategy, n_months, sharpe, cagr, vol, max_dd,
+#'   blown_up (logical), bankrupt_month (integer or NA).
+#' @noRd
+.mom_prepeak_compute_metrics <- function(returns_tbl,
+                                          strategy,
+                                          ann_factor = 12L) {
+  r <- returns_tbl$ret_ls
+  r <- r[!is.na(r)]
+  n <- length(r)
+
+  if (n < 12L) {
+    return(tibble::tibble(
+      strategy       = strategy,
+      n_months       = n,
+      sharpe         = NA_real_,
+      cagr           = NA_real_,
+      vol            = NA_real_,
+      max_dd         = NA_real_,
+      blown_up       = NA,
+      bankrupt_month = NA_integer_
+    ))
+  }
+
+  monthly_rf <- (1.02)^(1 / ann_factor) - 1
+  mean_r     <- mean(r)
+  sd_r       <- sd(r)
+  sharpe     <- if (sd_r > 0) (mean_r - monthly_rf) / sd_r * sqrt(ann_factor) else NA_real_
+
+  cum   <- cumprod(1 + r)
+  years <- n / ann_factor
+
+  # Bankruptcy detection: an unrisk-managed L/S portfolio can go to / past zero
+  # equity when ret_ls < -1 in a single month (extreme short squeeze in a single
+  # rebalance window — see #365 follow-up). The cumulative product passes through
+  # zero; reported cagr and max_dd must reflect bankruptcy honestly rather than
+  # returning NaN or impossible values like max_dd < -100%.
+  blown_up <- any(cum <= 0)
+
+  if (blown_up) {
+    bankrupt_idx <- which(cum <= 0)[1]
+    cagr         <- NA_real_
+    max_dd       <- -1.0                    # capped at -100% by definition
+  } else {
+    bankrupt_idx <- NA_integer_
+    cagr         <- cum[[n]]^(1 / years) - 1
+    cum_max      <- cummax(cum)
+    dd           <- (cum - cum_max) / cum_max
+    max_dd       <- min(dd)
+  }
+
+  vol <- sd_r * sqrt(ann_factor)
+
+  tibble::tibble(
+    strategy       = strategy,
+    n_months       = n,
+    sharpe         = round(sharpe, 3),
+    cagr           = if (is.na(cagr)) NA_real_ else round(cagr * 100, 1),
+    vol            = round(vol * 100, 1),
+    max_dd         = round(max_dd * 100, 1),
+    blown_up       = blown_up,
+    bankrupt_month = if (blown_up) as.integer(bankrupt_idx) else NA_integer_
+  )
+}

--- a/packages/historicaldata/tests/testthat/_snaps/mom-prepeak-metrics.md
+++ b/packages/historicaldata/tests/testthat/_snaps/mom-prepeak-metrics.md
@@ -1,0 +1,15 @@
+# output tibble structure includes blown_up and bankrupt_month columns
+
+    Code
+      str(result)
+    Output
+      tibble [1 x 8] (S3: tbl_df/tbl/data.frame)
+       $ strategy      : chr "test_struct"
+       $ n_months      : int 24
+       $ sharpe        : num -0.59
+       $ cagr          : num NA
+       $ vol           : num 85.6
+       $ max_dd        : num -100
+       $ blown_up      : logi TRUE
+       $ bankrupt_month: int 13
+

--- a/packages/historicaldata/tests/testthat/test-mom-prepeak-metrics.R
+++ b/packages/historicaldata/tests/testthat/test-mom-prepeak-metrics.R
@@ -1,0 +1,112 @@
+# Tests for .mom_prepeak_compute_metrics() — bankruptcy-aware L/S metric helper.
+#
+# The helper lives in packages/historicaldata/R/utils_mom_prepeak_metrics.R
+# and is a non-exported internal function.  Access via `:::`.
+#
+# Fixtures are fully self-contained: no parquet files, no ltr_universe, no
+# database.  All return series are manufactured analytically.
+
+# Helper: build a minimal returns_tbl from a numeric vector of ret_ls values.
+make_returns_tbl <- function(r) {
+  tibble::tibble(ret_ls = r)
+}
+
+# ---- 1. Normal case: no bankruptcy -----------------------------------------
+
+test_that("normal case: no bankruptcy — cagr, max_dd computed normally", {
+  # 24 months of constant 1% returns — monotone cumulative path, zero drawdown.
+  r <- rep(0.01, 24)
+  result <- historicaldata:::.mom_prepeak_compute_metrics(
+    make_returns_tbl(r), strategy = "test_strategy"
+  )
+
+  expect_equal(result$blown_up, FALSE)
+  expect_true(is.na(result$bankrupt_month))
+  expect_true(result$cagr > 0)
+  expect_equal(result$max_dd, 0)          # monotone series → no drawdown
+  expect_equal(result$strategy, "test_strategy")
+  expect_equal(result$n_months, 24L)
+})
+
+# ---- 2. Bankruptcy: ret_ls < -1 in single month ----------------------------
+
+test_that("bankruptcy: ret_ls < -1 in single month — blown_up TRUE, max_dd == -100, cagr NA", {
+  # 24 months; month 13 is an extreme short squeeze that wipes the portfolio.
+  r <- rep(0.01, 24)
+  r[13] <- -1.2   # single month return < -1 → cumprod goes negative
+
+  result <- historicaldata:::.mom_prepeak_compute_metrics(
+    make_returns_tbl(r), strategy = "test_blown_up"
+  )
+
+  expect_true(result$blown_up)
+  expect_equal(result$bankrupt_month, 13L)
+  expect_equal(result$max_dd, -100.0)
+  expect_true(is.na(result$cagr))
+})
+
+# ---- 3. cumprod exactly zero -----------------------------------------------
+
+test_that("cumprod exactly zero — blown_up TRUE", {
+  # Month 13 = exactly -1.0 → cum[13] = 0 (bankruptcy floor).
+  r <- rep(0.01, 24)
+  r[13] <- -1.0
+
+  result <- historicaldata:::.mom_prepeak_compute_metrics(
+    make_returns_tbl(r), strategy = "test_exact_zero"
+  )
+
+  expect_true(result$blown_up)
+  expect_equal(result$bankrupt_month, 13L)
+  expect_equal(result$max_dd, -100.0)
+  expect_true(is.na(result$cagr))
+})
+
+# ---- 4. Normal drawdown without bankruptcy ---------------------------------
+
+test_that("normal drawdown without bankruptcy: max_dd between (-100, 0)", {
+  # Returns that draw down to ~50% of starting equity but never cross zero.
+  # Pattern: 6 months up, 6 months down (but not below starting equity cumulative),
+  # then recover.  Use a simple sequence: 12 months of -0.05 (draw down to ~0.54
+  # of starting equity) then 12 months of +0.10 (recover).
+  r <- c(rep(-0.05, 12), rep(0.10, 12))
+  cum_check <- cumprod(1 + r)
+  # Verify fixture: no zero crossing
+  expect_true(all(cum_check > 0))
+
+  result <- historicaldata:::.mom_prepeak_compute_metrics(
+    make_returns_tbl(r), strategy = "test_drawdown"
+  )
+
+  expect_false(result$blown_up)
+  expect_true(is.na(result$bankrupt_month))
+  expect_true(result$max_dd > -100)
+  expect_true(result$max_dd < 0)         # there IS a drawdown
+})
+
+# ---- 5. Sharpe computable even when blown_up --------------------------------
+
+test_that("sharpe still computable even when blown_up", {
+  r <- rep(0.01, 24)
+  r[13] <- -1.2   # same bankruptcy fixture as test 2
+
+  result <- historicaldata:::.mom_prepeak_compute_metrics(
+    make_returns_tbl(r), strategy = "test_sharpe_blown_up"
+  )
+
+  expect_true(result$blown_up)
+  expect_false(is.na(result$sharpe))     # sharpe uses per-period r, unaffected
+})
+
+# ---- 6. Snapshot: output tibble structure includes new columns --------------
+
+test_that("output tibble structure includes blown_up and bankrupt_month columns", {
+  r <- rep(0.01, 24)
+  r[13] <- -1.2   # bankruptcy fixture
+
+  result <- historicaldata:::.mom_prepeak_compute_metrics(
+    make_returns_tbl(r), strategy = "test_struct"
+  )
+
+  expect_snapshot(str(result))
+})


### PR DESCRIPTION
## Summary

Small follow-up to #365 PRs 1-2. Makes `.mom_prepeak_compute_metrics()` robust to L/S bankruptcy (cumulative product going non-positive). Surfaces this honestly via two new columns `blown_up` (logical) and `bankrupt_month` (integer).

Bug surfaced when `tar_make()` materialised the new mom_* metrics targets in the main checkout — `mom_postpeak` reported `max_dd = -102%` and `mom_combined` reported `max_dd = -125%`, both mathematically impossible.

## Changes

| | Before | After |
|---|--------|-------|
| `cagr` (blown-up portfolio) | `NaN` from `negative^(1/n)` | `NA_real_` |
| `max_dd` (blown-up portfolio) | `< -100%` (impossible) | `-100%` (capped) |
| `sharpe` | unaffected | unaffected |
| New columns | — | `blown_up`, `bankrupt_month` |

The implementation was extracted from `R/plan_mom_prepeak.R` into `packages/historicaldata/R/utils_mom_prepeak_metrics.R` so it can be unit-tested independently of the plan file's `tar_target` library() calls.

The underlying L/S construction allowing `ret_ls < -1` is filed as a follow-up issue.

## Test plan

- [x] `testthat::test_local(filter = "mom-prepeak-metrics")` — 6 new tests pass
- [x] Full suite passes (3 pre-existing failures in `query`/`registry` from `adjusted_close` rename — unrelated)
- [x] `r_code_check.sh` clean
- [ ] Reviewer: confirm sharpe is correctly preserved for blown-up series

Refs: #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)
