### PR TITLE
fix(vignettes): momentum-prepeak.qmd setup — drop pkgload::load_all, use path-checked tar_config_set (#365)

### DIFF
--- a/docs/momentum-prepeak.qmd
+++ b/docs/momentum-prepeak.qmd
@@ -89,12 +89,23 @@ library(targets)
 library(ggplot2)
 library(dplyr)
 library(DT)
-library(gt)
 
-pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
-
-store_path <- if (dir.exists("_targets")) "_targets" else
-  file.path(here::here(), "docs/_targets")
+# Path-checked store + utils (cwd is docs/ under quarto render, project
+# root under tar_make). Three-way fallback handles worktree renders where
+# here::here() resolves to the worktree docs/ rather than project root.
+store_path <- local({
+  if (dir.exists("_targets")) return("_targets")
+  # Worktree: git --git-common-dir points to main .git; strip /.git for root
+  gc <- tryCatch(
+    trimws(system("git rev-parse --git-common-dir 2>/dev/null", intern = TRUE)),
+    error = function(e) character(0)
+  )
+  if (length(gc) == 1L && nzchar(gc)) {
+    cand <- file.path(dirname(gc), "docs", "_targets")
+    if (dir.exists(cand)) return(cand)
+  }
+  file.path(here::here(), "docs/_targets")  # fallback (works from project root)
+})
 tar_config_set(store = store_path)
 
 utils_path <- if (file.exists("vignette_utils.R")) "vignette_utils.R" else


### PR DESCRIPTION
## Summary

Tiny follow-up to #378 — the setup chunk used `pkgload::load_all(here::here("packages/historicaldata"))` which fails under `quarto render` because Quarto runs qmds with cwd = `docs/`, not project root.

Replaced with the project's canonical pattern from `docs/leaderboard.qmd:29-39` (path-checked `tar_config_set()` + `vignette_utils.R`). Also added a `git rev-parse --git-common-dir` fallback so the store path resolves correctly when rendering from a worktree (where `here::here()` resolves to the worktree's `docs/` rather than the main project root). No package load needed — all data access goes through `safe_tar_read()`.

Removed `library(gt)` — no `gt::` calls anywhere in the file.

## Test plan

- [x] `quarto render docs/momentum-prepeak.qmd` succeeds end-to-end
- [x] Zero "MISSING EVIDENCE" / "not available" markers in rendered HTML
- [x] All 6 targets resolved via `safe_tar_read()`
- [x] `grep -n "pkgload::\|historicaldata::"` in R code chunks: 0 hits

Refs: #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)
