### PR TITLE
feat(mom_prepeak): gauntlet — Pillar-8 metrics + WFC + random-peak null + HAC+FF5 + CPCV PBO (#365 PR 4/4)

### DIFF
--- a/R/plan_mom_prepeak_gauntlet.R
+++ b/R/plan_mom_prepeak_gauntlet.R
@@ -1,0 +1,551 @@
+# Plan: Pre-Peak Momentum Gauntlet (#365 PR 4/4)
+#
+# Robustness battery for the mom_prepeak strategy only (heavy treatment).
+# Pillar-8 metrics are computed for all 3 siblings via utils_mom_prepeak_metrics.R
+# (already extended in PR 4/4); this plan adds the remaining gauntlet tests that
+# only make sense for the viable mom_prepeak strategy:
+#
+#   B1 — Walk-Forward Correlation (WFC) over n_quantiles ∈ {5, 10, 20}
+#   B2 — Random-day-as-peak null (strategy-specific falsification)
+#   B3 — HAC Sharpe + Fama-French 5+Momentum regression (monthly factors)
+#   B4 — CPCV + Probability of Backtest Overfitting (PBO)
+#   B5 — Registry sentinel extension (gauntlet metrics recorded into bt.metric)
+#
+# Heavy gauntlet treatment of the bankrupt siblings (mom_postpeak, mom_combined)
+# would add noise without insight.  Generic 7-null-environment falsification
+# deferred to v2 follow-up (#380).
+#
+# WFC grid: only n_quantiles varies (3 values × IS+OOS = 6 portfolio evaluations).
+# The raw signal is invariant to n_quantiles; only portfolio-formation (decile sort)
+# is re-run per grid point.  This keeps WFC computation to seconds.
+#
+# Precedent patterns:
+#   - WFC:    R/plan_wf_correlation.R (wfc_fm_grid_is / _oos / _grid / _result)
+#   - CPCV:   R/plan_drif.R:444 (drif_pbo)
+#   - FF5:    R/plan_falsification.R (fals_ff_avoid_worst pattern)
+
+plan_mom_prepeak_gauntlet <- function() {
+  list(
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # B1 — Walk-Forward Correlation
+    # Grid: n_quantiles ∈ {5, 10, 20}; min_obs_days fixed at production value.
+    # IS = first half of mom_prepeak_returns; OOS = second half.
+    # ══════════════════════════════════════════════════════════════════════════
+
+    targets::tar_target(mom_prepeak_wfc_params, {
+      # IS/OOS split at the midpoint of the mom_prepeak return series.
+      # Returns are arranged by as_of_date; split at row n/2.
+      list(
+        n_quantiles_grid = c(5L, 10L, 20L),
+        min_obs_days     = 100L,            # fixed at production value
+        min_stocks       = 30L,             # matches mom_prepeak_params
+        ann_factor       = 12L,
+        wfc_threshold    = 0.70             # project threshold (plan_wf_correlation.R)
+      )
+    }),
+
+    # IS Sharpe for each n_quantiles value (portfolio re-formed on first half of dates)
+    targets::tar_target(mom_prepeak_wfc_grid_is, {
+      library(dplyr)
+      params   <- mom_prepeak_wfc_params
+      sig_raw  <- mom_prepeak_signal_raw
+      ret_full <- mom_prepeak_returns
+
+      # IS = first half of execution months
+      n        <- nrow(ret_full)
+      is_dates <- ret_full$as_of_date[seq_len(floor(n / 2))]
+
+      purrr::map_dfr(params$n_quantiles_grid, function(nq) {
+        port <- .mom_prepeak_form_portfolio(
+          signal_tbl  = sig_raw |> dplyr::filter(.data$as_of_date %in% is_dates),
+          signal_col  = "pre_peak_return",
+          n_quantiles = nq,
+          min_stocks  = params$min_stocks
+        )
+        ret  <- .mom_prepeak_compute_returns(
+          portfolio_tbl  = port,
+          universe_tbl   = ltr_universe,
+          cost_per_trade = 0.001
+        )
+        r    <- ret$ret_ls[!is.na(ret$ret_ls)]
+        ann_ret <- mean(r) * params$ann_factor
+        ann_vol <- stats::sd(r) * sqrt(params$ann_factor)
+        sharpe  <- if (length(r) >= 4L && ann_vol > 0) ann_ret / ann_vol else NA_real_
+        tibble::tibble(
+          theta_id    = nq,
+          theta_label = paste0("n_quantiles=", nq),
+          IS_metric   = sharpe
+        )
+      })
+    }),
+
+    # OOS Sharpe for each n_quantiles value (portfolio re-formed on second half of dates)
+    targets::tar_target(mom_prepeak_wfc_grid_oos, {
+      library(dplyr)
+      params   <- mom_prepeak_wfc_params
+      sig_raw  <- mom_prepeak_signal_raw
+      ret_full <- mom_prepeak_returns
+
+      # OOS = second half of execution months
+      n         <- nrow(ret_full)
+      oos_dates <- ret_full$as_of_date[(floor(n / 2) + 1L):n]
+
+      purrr::map_dfr(params$n_quantiles_grid, function(nq) {
+        port <- .mom_prepeak_form_portfolio(
+          signal_tbl  = sig_raw |> dplyr::filter(.data$as_of_date %in% oos_dates),
+          signal_col  = "pre_peak_return",
+          n_quantiles = nq,
+          min_stocks  = params$min_stocks
+        )
+        ret  <- .mom_prepeak_compute_returns(
+          portfolio_tbl  = port,
+          universe_tbl   = ltr_universe,
+          cost_per_trade = 0.001
+        )
+        r    <- ret$ret_ls[!is.na(ret$ret_ls)]
+        ann_ret <- if (length(r) >= 1L) mean(r) * params$ann_factor else NA_real_
+        ann_vol <- if (length(r) >= 2L) stats::sd(r) * sqrt(params$ann_factor) else NA_real_
+        sharpe  <- if (!is.na(ann_vol) && ann_vol > 0) ann_ret / ann_vol else NA_real_
+        tibble::tibble(
+          theta_id    = nq,
+          theta_label = paste0("n_quantiles=", nq),
+          OOS_metric  = sharpe
+        )
+      })
+    }),
+
+    # Combined IS+OOS grid (one row per theta) — shape required by hd_wf_correlation()
+    targets::tar_target(mom_prepeak_wfc_grid, {
+      library(dplyr)
+      dplyr::inner_join(
+        mom_prepeak_wfc_grid_is  |> dplyr::select("theta_id", "theta_label", "IS_metric"),
+        mom_prepeak_wfc_grid_oos |> dplyr::select("theta_id", "OOS_metric"),
+        by = "theta_id"
+      )
+    }),
+
+    # WFC diagnostic: Pearson + Spearman + 2×2 classification
+    targets::tar_target(mom_prepeak_wfc_result, {
+      hd_wf_correlation(
+        mom_prepeak_wfc_grid,
+        wfc_threshold_high = mom_prepeak_wfc_params$wfc_threshold
+      )
+    }),
+
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # B2 — Random-day-as-peak falsification
+    #
+    # Strategy-specific null: pick a random day within the formation window
+    # as the "peak" instead of the actual max-price day.  If our strategy's
+    # alpha survives this null (random-peak Sharpe ≥ actual), the peak-finding
+    # adds no edge.
+    # ══════════════════════════════════════════════════════════════════════════
+
+    targets::tar_target(mom_prepeak_random_peak_signal, {
+      .mom_prepeak_random_peak_signal(
+        daily_prices = ltr_universe,
+        as_of_dates  = mom_prepeak_as_of_dates,
+        seed         = 42L
+      )
+    }),
+
+    targets::tar_target(mom_prepeak_random_peak_portfolio, {
+      .mom_prepeak_form_portfolio(
+        signal_tbl  = mom_prepeak_random_peak_signal,
+        signal_col  = "pre_peak_return",
+        n_quantiles = mom_prepeak_params$n_quantiles,
+        min_stocks  = mom_prepeak_params$min_stocks_per_month
+      )
+    }),
+
+    targets::tar_target(mom_prepeak_random_peak_returns, {
+      .mom_prepeak_compute_returns(
+        portfolio_tbl  = mom_prepeak_random_peak_portfolio,
+        universe_tbl   = ltr_universe,
+        cost_per_trade = mom_prepeak_params$cost_per_trade
+      )
+    }),
+
+    targets::tar_target(mom_prepeak_random_peak_metrics, {
+      .mom_prepeak_compute_metrics(
+        mom_prepeak_random_peak_returns,
+        strategy = "mom_prepeak_random_peak"
+      )
+    }),
+
+    # Comparison: random-peak Sharpe vs actual Sharpe
+    targets::tar_target(mom_prepeak_random_peak_test, {
+      actual_sharpe <- mom_prepeak_metrics$sharpe
+      random_sharpe <- mom_prepeak_random_peak_metrics$sharpe
+      tibble::tibble(
+        actual_sharpe = actual_sharpe,
+        random_sharpe = random_sharpe,
+        null_dominates = if (is.na(random_sharpe) || is.na(actual_sharpe)) {
+          NA
+        } else {
+          random_sharpe >= actual_sharpe
+        }
+      )
+    }),
+
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # B3 — HAC Sharpe + Fama-French 5+Momentum regression (monthly)
+    #
+    # mom_prepeak uses MONTHLY returns; we use monthly FF5 + Momentum factors.
+    # hd_factor_null_test() joins on date — monthly dates must align.
+    # The strategy input format is {date, strategy_ret} where date is the
+    # execution date (exec_date from mom_prepeak_returns).
+    # ══════════════════════════════════════════════════════════════════════════
+
+    targets::tar_target(mom_prepeak_hac, {
+      hd_hac_sharpe(mom_prepeak_returns$ret_ls, ann_factor = 12L)
+    }),
+
+    # Monthly FF5 + Momentum factors for the regression
+    targets::tar_target(mom_prepeak_ff_factors_monthly, {
+      library(dplyr)
+      ff5 <- hd_factors(dataset = "FF5", frequency = "monthly")
+      mom <- hd_factors(dataset = "Mom", frequency = "monthly")
+      dplyr::bind_rows(ff5, mom) |>
+        dplyr::filter(.data$factor_name != "RF") |>
+        dplyr::mutate(
+          value = .data$value / 100,
+          date  = as.Date(.data$date)
+        ) |>
+        dplyr::select("date", "factor_name", "value")
+    }),
+
+    targets::tar_target(mom_prepeak_rf_monthly, {
+      library(dplyr)
+      hd_factors(dataset = "FF5", frequency = "monthly") |>
+        dplyr::filter(.data$factor_name == "RF") |>
+        dplyr::mutate(
+          rf   = .data$value / 100,
+          date = as.Date(.data$date)
+        ) |>
+        dplyr::select("date", "rf")
+    }),
+
+    # FF5+Momentum alpha regression for mom_prepeak
+    # Input to hd_factor_null_test: {date, strategy_ret} using exec_date.
+    targets::tar_target(mom_prepeak_ff_reg, {
+      library(dplyr)
+      strategy_monthly <- mom_prepeak_returns |>
+        dplyr::select(date = "exec_date", strategy_ret = "ret_ls") |>
+        dplyr::filter(!is.na(.data$strategy_ret)) |>
+        dplyr::mutate(date = as.Date(.data$date))
+
+      hd_factor_null_test(
+        strategy_daily = strategy_monthly,
+        rf_daily       = mom_prepeak_rf_monthly,
+        factors_daily  = mom_prepeak_ff_factors_monthly
+      )
+    }),
+
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # B4 — CPCV + Probability of Backtest Overfitting
+    #
+    # Since mom_prepeak has no scalar tuning parameter in production, we use
+    # n_quantiles ∈ {5, 10, 20} as the "strategy dimension" for PBO.
+    # This gives a real overfitting test: the PBO measures whether the IS-best
+    # n_quantiles value also dominates OOS.
+    #
+    # C(6, 2) = 15 paths with n_groups=6, n_test_groups=2.
+    # Label horizon = 1 (monthly L/S: each portfolio uses t+1 execution).
+    # Embargo = 1 month (drop train rows immediately after each test fold).
+    # ══════════════════════════════════════════════════════════════════════════
+
+    targets::tar_target(mom_prepeak_cpcv_params, {
+      list(
+        n_groups      = 6L,
+        n_test_groups = 2L,
+        label_horizon = 1L,
+        embargo_n     = 1L,
+        ann_factor    = 12L
+      )
+    }),
+
+    # PBO over the 3 n_quantiles configurations
+    # (mirrors drif_pbo from R/plan_drif.R:444 — see that target for pattern notes)
+    targets::tar_target(mom_prepeak_pbo, {
+      library(dplyr)
+
+      params   <- mom_prepeak_cpcv_params
+      sig_raw  <- mom_prepeak_signal_raw
+      ret_full <- mom_prepeak_returns
+      n        <- nrow(ret_full)
+
+      # Assign each observation to a group (contiguous time blocks)
+      group_id   <- cut(seq_len(n), breaks = params$n_groups,
+                        labels = FALSE, include.lowest = TRUE)
+      group_rows <- lapply(seq_len(params$n_groups), function(g) which(group_id == g))
+
+      paths    <- hd_cpcv_paths(
+        n_groups      = params$n_groups,
+        n_test_groups = params$n_test_groups
+      )
+      n_paths    <- length(paths)
+      nq_vals    <- c(5L, 10L, 20L)
+      n_strat    <- length(nq_vals)
+      strat_labs <- paste0("nq", nq_vals)
+
+      # Helper: compute annualised Sharpe from a vector of monthly returns
+      sharpe_monthly <- function(ret) {
+        ret <- ret[!is.na(ret)]
+        if (length(ret) < 3L) return(NA_real_)
+        ann_ret <- mean(ret) * params$ann_factor
+        ann_vol <- stats::sd(ret) * sqrt(params$ann_factor)
+        if (ann_vol <= 0) return(NA_real_)
+        ann_ret / ann_vol
+      }
+
+      is_mat  <- matrix(NA_real_, nrow = n_paths, ncol = n_strat,
+                        dimnames = list(NULL, strat_labs))
+      oos_mat <- is_mat
+
+      for (i in seq_len(n_paths)) {
+        p           <- paths[[i]]
+        train_rows  <- sort(unlist(group_rows[p$train]))
+        test_rows   <- sort(unlist(group_rows[p$test]))
+        train_purged <- hd_cpcv_purge(train_rows, test_rows, params$label_horizon)
+        train_clean  <- hd_cpcv_embargo(train_purged, test_rows, params$embargo_n)
+
+        # as_of_dates for train / test folds (from ret_full row positions)
+        train_aod <- ret_full$as_of_date[train_clean]
+        test_aod  <- ret_full$as_of_date[test_rows]
+
+        for (j in seq_along(nq_vals)) {
+          nq <- nq_vals[[j]]
+
+          # IS score
+          port_is <- tryCatch({
+            .mom_prepeak_form_portfolio(
+              signal_tbl  = sig_raw |> dplyr::filter(.data$as_of_date %in% train_aod),
+              signal_col  = "pre_peak_return",
+              n_quantiles = nq,
+              min_stocks  = 10L   # relaxed for cross-val folds (fewer obs)
+            )
+          }, error = function(e) NULL)
+
+          if (!is.null(port_is) && nrow(port_is) > 0L) {
+            ret_is <- tryCatch(
+              .mom_prepeak_compute_returns(port_is, ltr_universe, 0.001),
+              error = function(e) NULL
+            )
+            if (!is.null(ret_is)) is_mat[i, j] <- sharpe_monthly(ret_is$ret_ls)
+          }
+
+          # OOS score
+          port_oos <- tryCatch({
+            .mom_prepeak_form_portfolio(
+              signal_tbl  = sig_raw |> dplyr::filter(.data$as_of_date %in% test_aod),
+              signal_col  = "pre_peak_return",
+              n_quantiles = nq,
+              min_stocks  = 10L
+            )
+          }, error = function(e) NULL)
+
+          if (!is.null(port_oos) && nrow(port_oos) > 0L) {
+            ret_oos <- tryCatch(
+              .mom_prepeak_compute_returns(port_oos, ltr_universe, 0.001),
+              error = function(e) NULL
+            )
+            if (!is.null(ret_oos)) oos_mat[i, j] <- sharpe_monthly(ret_oos$ret_ls)
+          }
+        }
+      }
+
+      hd_pbo(is_scores = is_mat, oos_scores = oos_mat)
+    }),
+
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # B5 — Registry sentinel extension
+    #
+    # Record gauntlet metrics (hac_sharpe, hac_pvalue, ff5_alpha, ff5_alpha_t,
+    # pbo, wfc_pearson, avg_dd_days, max_dd_days, max_cons_losses) into bt.metric
+    # under the existing mom_prepeak run_uuid from mom_prepeak_register_runs.
+    #
+    # NOTE: idempotency bug #375 is known — deterministic UUID re-running produces
+    # duplicate rows.  This target writes correctly on the FIRST tar_make invocation.
+    # Manual cleanup handled by the orchestrator if needed.
+    # ══════════════════════════════════════════════════════════════════════════
+
+    targets::tar_target(mom_prepeak_gauntlet_register, {
+      .mom_prepeak_gauntlet_register(
+        mom_prepeak_register_runs  = mom_prepeak_register_runs,
+        mom_prepeak_metrics        = mom_prepeak_metrics,
+        mom_prepeak_hac            = mom_prepeak_hac,
+        mom_prepeak_ff_reg         = mom_prepeak_ff_reg,
+        mom_prepeak_pbo            = mom_prepeak_pbo,
+        mom_prepeak_wfc_result     = mom_prepeak_wfc_result
+      )
+    })
+
+  )
+}
+
+
+# ── Internal helpers ───────────────────────────────────────────────────────────
+
+
+#' Random-day-as-peak signal (strategy-specific falsification null)
+#'
+#' Mirrors hd_mom_prepeak_signal() but replaces which.max() (true peak detection)
+#' with sample.int() — a uniformly random day within the formation window.
+#' Using set.seed(seed) ensures reproducibility.
+#'
+#' If the random index falls on the first day: pre_peak_return = 0,
+#' post_peak_return = total_return (same as if peak were on day 1).
+#'
+#' @param daily_prices Tibble: ticker, date (Date), adjusted.
+#' @param as_of_dates Date vector of rebalance dates.
+#' @param seed Integer random seed (default 42L).
+#' @param lookback_months_start Integer (default 12L).
+#' @param lookback_months_end Integer (default 2L).
+#' @param min_obs_days Integer minimum trading days in window (default 100L).
+#'
+#' @return Tibble with same columns as hd_mom_prepeak_signal().
+#' @noRd
+.mom_prepeak_random_peak_signal <- function(daily_prices,
+                                             as_of_dates,
+                                             seed                  = 42L,
+                                             lookback_months_start = 12L,
+                                             lookback_months_end   = 2L,
+                                             min_obs_days          = 100L) {
+  set.seed(seed)
+
+  if (inherits(daily_prices$date, "POSIXct")) {
+    daily_prices$date <- as.Date(daily_prices$date)
+  }
+  as_of_dates <- as.Date(as_of_dates)
+
+  prices_by_ticker <- split(daily_prices, daily_prices$ticker)
+
+  dplyr::bind_rows(purrr::map(
+    names(prices_by_ticker),
+    function(tk) {
+      tk_prices <- prices_by_ticker[[tk]]
+      tk_prices <- tk_prices[order(tk_prices$date), ]
+
+      dplyr::bind_rows(purrr::map(
+        as_of_dates,
+        function(aod) {
+          formation_start <- lubridate::`%m-%`(aod, months(lookback_months_start))
+          formation_end   <- lubridate::`%m-%`(aod, months(lookback_months_end))
+
+          win <- tk_prices[
+            tk_prices$date >= formation_start &
+              tk_prices$date <= formation_end, ,
+            drop = FALSE
+          ]
+          n_obs <- nrow(win)
+          if (n_obs < min_obs_days) return(tibble::tibble(
+            ticker          = character(0),
+            as_of_date      = as.Date(character(0)),
+            formation_start = as.Date(character(0)),
+            formation_end   = as.Date(character(0)),
+            peak_date       = as.Date(character(0)),
+            n_obs           = integer(0),
+            pre_peak_return  = numeric(0),
+            post_peak_return = numeric(0),
+            total_return     = numeric(0),
+            peak_position    = numeric(0)
+          ))
+
+          # Key difference: random index instead of which.max()
+          peak_idx  <- sample.int(n_obs, 1L)
+          peak_date <- win$date[peak_idx]
+
+          price_start <- win$adjusted[1L]
+          price_peak  <- win$adjusted[peak_idx]
+          price_end   <- win$adjusted[n_obs]
+
+          pre_peak_return  <- price_peak  / price_start - 1
+          post_peak_return <- price_end   / price_peak  - 1
+          total_return     <- price_end   / price_start - 1
+          peak_position    <- (peak_idx - 1L) / (n_obs - 1L)
+
+          tibble::tibble(
+            ticker          = tk,
+            as_of_date      = aod,
+            formation_start = win$date[1L],
+            formation_end   = win$date[n_obs],
+            peak_date       = peak_date,
+            n_obs           = n_obs,
+            pre_peak_return  = pre_peak_return,
+            post_peak_return = post_peak_return,
+            total_return     = total_return,
+            peak_position    = peak_position
+          )
+        }
+      ))
+    }
+  ))
+}
+
+
+#' Register gauntlet metrics into bt.metric for the mom_prepeak run
+#'
+#' Appends HAC, FF5, PBO, and WFC metrics to the bt.metric table for the
+#' mom_prepeak run_uuid established in mom_prepeak_register_runs.
+#' Returns an empty tibble if DBI / duckdb are unavailable.
+#'
+#' @noRd
+.mom_prepeak_gauntlet_register <- function(mom_prepeak_register_runs,
+                                            mom_prepeak_metrics,
+                                            mom_prepeak_hac,
+                                            mom_prepeak_ff_reg,
+                                            mom_prepeak_pbo,
+                                            mom_prepeak_wfc_result) {
+  if (!requireNamespace("DBI", quietly = TRUE) ||
+      !requireNamespace("duckdb", quietly = TRUE)) {
+    return(tibble::tibble(run_uuid = character(), metric_rows = integer()))
+  }
+
+  # Identify the mom_prepeak run_uuid from the sentinel
+  reg_row <- mom_prepeak_register_runs[
+    mom_prepeak_register_runs$strategy_id == "mom_prepeak", ,
+    drop = FALSE
+  ]
+  if (nrow(reg_row) == 0L) {
+    cli::cli_warn("mom_prepeak run_uuid not found in mom_prepeak_register_runs — skipping gauntlet registry write.")
+    return(tibble::tibble(run_uuid = character(), metric_rows = integer()))
+  }
+  uu <- reg_row$run_uuid[[1L]]
+
+  path <- historicaldata::hd_registry_path()
+  con  <- historicaldata::hd_registry_open(path, read_only = FALSE)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  # Build gauntlet metric row (wide format: one column per metric)
+  gauntlet_wide <- tibble::tibble(
+    hac_sharpe     = if (!is.null(mom_prepeak_hac$naive_sharpe))
+      mom_prepeak_hac$naive_sharpe else NA_real_,
+    hac_tstat      = if (!is.null(mom_prepeak_hac$hac_tstat))
+      mom_prepeak_hac$hac_tstat else NA_real_,
+    ff5_alpha      = if (nrow(mom_prepeak_ff_reg) == 1L)
+      mom_prepeak_ff_reg$alpha_annual else NA_real_,
+    ff5_alpha_t    = if (nrow(mom_prepeak_ff_reg) == 1L)
+      mom_prepeak_ff_reg$alpha_tstat_hac else NA_real_,
+    ff5_r2         = if (nrow(mom_prepeak_ff_reg) == 1L)
+      mom_prepeak_ff_reg$r_squared else NA_real_,
+    pbo            = if (!is.null(mom_prepeak_pbo$pbo))
+      mom_prepeak_pbo$pbo else NA_real_,
+    wfc_pearson    = if (!is.null(mom_prepeak_wfc_result$pearson_rho))
+      mom_prepeak_wfc_result$pearson_rho else NA_real_,
+    wfc_class      = if (!is.null(mom_prepeak_wfc_result$classification))
+      mom_prepeak_wfc_result$classification else NA_character_,
+    avg_dd_days    = mom_prepeak_metrics$avg_dd_days,
+    max_dd_days    = mom_prepeak_metrics$max_dd_days,
+    max_cons_losses = mom_prepeak_metrics$max_cons_losses
+  )
+
+  historicaldata::hd_metric_record(con, uu, gauntlet_wide)
+
+  tibble::tibble(run_uuid = uu, metric_rows = 1L)
+}

--- a/docs/_targets.R
+++ b/docs/_targets.R
@@ -123,6 +123,7 @@ source(here::here("R/plan_zakamulin_allocation.R"))
 source(here::here("R/plan_commodities_momentum.R"))
 source(here::here("R/plan_commodities_mean_reversion.R"))
 source(here::here("R/plan_mom_prepeak.R"))
+source(here::here("R/plan_mom_prepeak_gauntlet.R"))
 source(here::here("R/plan_crypto_momentum.R"))
 source(here::here("R/plan_solana_momentum.R"))
 source(here::here("R/plan_olmar.R"))
@@ -171,6 +172,7 @@ c(plan_strategy_names(),
   plan_commodities_momentum(),
   plan_commodities_mean_reversion(),
   plan_mom_prepeak(),
+  plan_mom_prepeak_gauntlet(),
   plan_crypto_momentum(),
   plan_solana_momentum(),
   plan_olmar(),

--- a/docs/momentum-prepeak.qmd
+++ b/docs/momentum-prepeak.qmd
@@ -694,16 +694,355 @@ The following analyses are **not included in this PR** and are tracked in issue 
 | Pillar-8 risk metrics (skewness of daily returns, tail ratio) | Deferred to PR 4/4 |
 | Full CRSP-scale replication (60/40 result matching paper's 84/16) | Open question in #365 |
 
+# Pillar-8 Risk Metrics
+
+## Row
+
+### {.tabset}
+
+#### Risk Metrics Table
+
+```{r}
+# Read gauntlet summary: mom_prepeak_summary now includes Pillar-8 columns
+# (avg_dd_days, max_dd_days, max_cons_losses, loss_clustered).
+p8_cols <- c("avg_dd_days", "max_dd_days", "max_cons_losses", "loss_clustered")
+
+p8_available <- !is.null(summary_tbl) && all(p8_cols %in% names(summary_tbl))
+
+if (p8_available) {
+  p8_display <- summary_tbl |>
+    dplyr::left_join(
+      mom_names |> dplyr::select("code_name", "short_name"),
+      by = c("strategy" = "code_name")
+    ) |>
+    dplyr::mutate(
+      Strategy          = dplyr::coalesce(.data$short_name, .data$strategy),
+      `Avg DD (months)` = dplyr::if_else(
+        is.na(.data$avg_dd_days), "—", as.character(round(.data$avg_dd_days, 1))),
+      `Max DD (months)` = dplyr::if_else(
+        is.na(.data$max_dd_days), "—", as.character(round(.data$max_dd_days, 1))),
+      `Max Consec Losses` = dplyr::if_else(
+        is.na(.data$max_cons_losses), "—", as.character(.data$max_cons_losses)),
+      `Loss Clustered` = dplyr::case_when(
+        is.na(.data$loss_clustered)   ~ "—",
+        isTRUE(.data$loss_clustered)  ~ "YES",
+        TRUE                          ~ "No"
+      ),
+      Sharpe = round(.data$sharpe, 2),
+      `Blown Up` = dplyr::if_else(.data$blown_up, "YES", "No")
+    ) |>
+    dplyr::select(
+      Strategy, Sharpe, `Blown Up`,
+      `Avg DD (months)`, `Max DD (months)`, `Max Consec Losses`, `Loss Clustered`
+    )
+
+  # Extract pre-peak values for dynamic prose
+  pre_p8 <- summary_tbl[summary_tbl$strategy == "mom_prepeak", , drop = FALSE]
+  pre_avg_dd  <- if (nrow(pre_p8) == 1L && !is.na(pre_p8$avg_dd_days))
+    round(pre_p8$avg_dd_days, 1) else "N/A"
+  pre_max_dd_d <- if (nrow(pre_p8) == 1L && !is.na(pre_p8$max_dd_days))
+    round(pre_p8$max_dd_days, 1) else "N/A"
+  pre_max_cons <- if (nrow(pre_p8) == 1L && !is.na(pre_p8$max_cons_losses))
+    pre_p8$max_cons_losses else "N/A"
+
+  DT::datatable(
+    p8_display,
+    caption = htmltools::tags$caption(
+      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      paste0(
+        "Pillar-8 risk metrics for all three momentum decomposition strategies. ",
+        "Avg/Max DD duration is measured in months (index positions, no date column). ",
+        "Max Consecutive Losses = longest losing streak in the pre-bankruptcy slice. ",
+        "Loss Clustered = TRUE when both the Wald-Wolfowitz runs test p < 0.05 AND ",
+        "lag-1 autocorrelation > 0.2 (dual-signal composite). ",
+        "Metrics for blown-up strategies are computed on the pre-bankruptcy slice only."
+      )
+    ),
+    rownames = FALSE,
+    options  = list(pageLength = 5, scrollX = TRUE, dom = "t")
+  )
+} else {
+  cat("*Pillar-8 metrics not available — run tar_make() after PR 4/4 merge.*")
+  pre_avg_dd <- pre_max_dd_d <- pre_max_cons <- "N/A"
+}
+```
+
+#### Interpretation
+
+The Pillar-8 risk framework adds three drawdown-duration and loss-clustering metrics beyond the standard max_dd percentage reported in the summary table:
+
+- **Avg DD duration** — average number of months spent in a drawdown event (defined as a contiguous run below the prior peak by more than 1%). For the pre-peak strategy this is `r pre_avg_dd` months on average.
+- **Max DD duration** — longest single drawdown event: `r pre_max_dd_d` months. This captures the "pain duration" dimension of drawdown risk that the peak loss percentage alone does not convey.
+- **Max consecutive losses** — longest uninterrupted run of negative monthly returns: `r pre_max_cons` months. A high count warns of momentum-crash-style tail events.
+
+Blown-up strategies (mom_postpeak, mom_combined) have these metrics computed only on the pre-bankruptcy slice because post-bankruptcy returns are economically meaningless — the portfolio has zero equity.
+
+
+# Walk-Forward Correlation
+
+## Row
+
+### {.tabset}
+
+#### WFC Grid
+
+```{r}
+wfc_grid   <- safe_tar_read("mom_prepeak_wfc_grid")
+wfc_result <- safe_tar_read("mom_prepeak_wfc_result")
+
+wfc_available <- !is.null(wfc_grid) && !is.null(wfc_result)
+
+if (wfc_available) {
+  pearson_rho   <- round(wfc_result$pearson_rho,   3)
+  spearman_rho  <- round(wfc_result$spearman_rho,  3)
+  wfc_class_val <- wfc_result$classification
+  median_oos    <- round(wfc_result$median_oos, 3)
+
+  wfc_display <- wfc_grid |>
+    dplyr::mutate(
+      `N Quantiles`  = .data$theta_label,
+      `IS Sharpe`    = round(.data$IS_metric,  3),
+      `OOS Sharpe`   = round(.data$OOS_metric, 3)
+    ) |>
+    dplyr::select(`N Quantiles`, `IS Sharpe`, `OOS Sharpe`)
+
+  DT::datatable(
+    wfc_display,
+    caption = htmltools::tags$caption(
+      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      paste0(
+        "Walk-Forward Correlation grid for mom_prepeak over n_quantiles ∈ {5, 10, 20}. ",
+        "IS = annualised Sharpe on the first half of the sample (~1973–mid). ",
+        "OOS = annualised Sharpe on the second half. ",
+        "Pearson ρ = ", pearson_rho, "; Spearman ρ = ", spearman_rho, ". ",
+        "WFC classification: ", wfc_class_val, ". ",
+        "A positive Pearson ρ with positive OOS Sharpe = 'structural_edge'; ",
+        "a classification of 'spurious_luck' or 'noise' would flag concern."
+      )
+    ),
+    rownames = FALSE,
+    options  = list(pageLength = 5, scrollX = TRUE, dom = "t")
+  )
+} else {
+  cat("*WFC results not available — run tar_make() after PR 4/4 merge.*")
+  pearson_rho <- spearman_rho <- wfc_class_val <- median_oos <- "N/A"
+}
+```
+
+#### WFC Chart
+
+```{r}
+#| fig-height: 4
+#| fig-alt: "Scatter plot of IS Sharpe vs OOS Sharpe across 3 n_quantiles values (5, 10, 20) for the mom_prepeak strategy. Each point represents one parameter configuration. A positive correlation between IS and OOS Sharpe supports structural edge; a negative correlation would suggest overfitting. The Pearson correlation coefficient is annotated on the chart."
+if (wfc_available && !is.null(wfc_grid)) {
+  ggplot(wfc_grid, aes(x = .data$IS_metric, y = .data$OOS_metric,
+                       label = .data$theta_label)) +
+    geom_point(colour = PALETTE["mom_prepeak"], size = 4) +
+    ggplot2::geom_text(
+      colour = "#e0e0e0", size = 3.5,
+      nudge_y = 0.02
+    ) +
+    geom_hline(yintercept = 0, colour = "white", linetype = "dotted") +
+    geom_vline(xintercept = 0, colour = "white", linetype = "dotted") +
+    annotate("text",
+      x = min(wfc_grid$IS_metric, na.rm = TRUE),
+      y = max(wfc_grid$OOS_metric, na.rm = TRUE),
+      label = paste0("Pearson ρ = ", if (is.character(pearson_rho)) pearson_rho else round(as.numeric(pearson_rho), 3)),
+      colour = "#e0e0e0", hjust = 0, vjust = 1, size = 4
+    ) +
+    labs(
+      x     = "IS Sharpe (first half)",
+      y     = "OOS Sharpe (second half)",
+      title = paste0("Walk-Forward Correlation — mom_prepeak (n_quantiles grid)")
+    ) +
+    theme_dark() +
+    theme(
+      panel.background  = element_rect(fill = "#1a1a1a", colour = NA),
+      plot.background   = element_rect(fill = "#1a1a1a", colour = NA),
+      text              = element_text(colour = "#e0e0e0"),
+      axis.text         = element_text(colour = "#cccccc"),
+      panel.grid.major  = element_line(colour = "#333333"),
+      panel.grid.minor  = element_line(colour = "#222222"),
+      plot.title        = element_text(size = 11, face = "bold")
+    )
+} else {
+  cat("*WFC chart not available — run tar_make() after PR 4/4 merge.*")
+}
+```
+
+::: {.fig-caption}
+**Walk-forward correlation scatter** for mom_prepeak over 3 n_quantiles values. Pearson ρ = `r pearson_rho`, Spearman ρ = `r spearman_rho`. WFC classification: **`r wfc_class_val`**. The Tinsley (2024) framework labels a strategy as having "structural edge" when WFC Pearson ≥ 0.70 AND the median OOS Sharpe is positive. A classification of "spurious_luck" (high WFC, negative OOS) or "noise" (low WFC) would raise concern about the strategy's robustness. This WFC grid uses n_quantiles as the sole tuning dimension; a v2 follow-up will expand the grid over formation-window parameters.
+:::
+
+#### Verdict
+
+The Walk-Forward Correlation test asks: when we vary the portfolio-construction parameter (number of quantile buckets), does IS performance predict OOS performance? A positive correlation indicates that what works in training also works out of sample — a sign of structural edge rather than parameter overfitting.
+
+WFC result for mom_prepeak:
+
+- **Pearson ρ:** `r pearson_rho` (IS vs OOS Sharpe across n_quantiles ∈ {5, 10, 20})
+- **Spearman ρ:** `r spearman_rho`
+- **Classification:** `r wfc_class_val`
+- **Median OOS Sharpe:** `r median_oos`
+
+`r if (is.character(wfc_class_val) && wfc_class_val == "structural_edge") "The classification of structural_edge supports robustness of the pre-peak momentum signal across portfolio-formation choices." else if (is.character(wfc_class_val) && wfc_class_val %in% c("spurious_luck", "noise")) paste0("The classification of ", wfc_class_val, " warrants caution — the strategy may not be robust to n_quantiles choice.") else "WFC classification not available — run tar_make()."`
+
+Note: only n_quantiles is varied here; WFC over lookback-window parameters (which require re-running the signal computation) is deferred to the v2 follow-up.
+
+
+# Random-Day-as-Peak Null
+
+## Row
+
+### {.tabset}
+
+#### Null Test Result
+
+```{r}
+rand_peak_test    <- safe_tar_read("mom_prepeak_random_peak_test")
+rand_peak_metrics <- safe_tar_read("mom_prepeak_random_peak_metrics")
+
+rand_available <- !is.null(rand_peak_test)
+
+if (rand_available) {
+  actual_s <- round(rand_peak_test$actual_sharpe, 3)
+  random_s <- round(rand_peak_test$random_sharpe, 3)
+  null_dom  <- rand_peak_test$null_dominates
+
+  null_display <- tibble::tibble(
+    Strategy        = c("mom_prepeak (actual)", "Random-day-as-peak null"),
+    Sharpe          = c(actual_s, random_s),
+    `Null Dominates` = c("—", if (isTRUE(null_dom)) "YES — edge may be spurious" else "No — peak-finding adds alpha")
+  )
+
+  DT::datatable(
+    null_display,
+    caption = htmltools::tags$caption(
+      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      paste0(
+        "Random-day-as-peak null test. The null strategy uses the same ",
+        "formation window, portfolio construction, and transaction costs, ",
+        "but selects a uniformly random day as the 'peak' instead of the ",
+        "actual price maximum (set.seed(42) for reproducibility). ",
+        "If the null Sharpe >= actual Sharpe, peak-finding adds no edge. ",
+        "Actual Sharpe = ", actual_s, "; ",
+        "Random-peak Sharpe = ", random_s, "."
+      )
+    ),
+    rownames = FALSE,
+    options  = list(pageLength = 5, scrollX = TRUE, dom = "t")
+  )
+} else {
+  cat("*Random-peak null test not available — run tar_make() after PR 4/4 merge.*")
+  actual_s <- random_s <- null_dom <- "N/A"
+}
+```
+
+#### Interpretation
+
+The random-day-as-peak null is a strategy-specific falsification test. The logic:
+
+1. Take the same 10-month formation window for every stock.
+2. Instead of finding the actual price peak (maximum adjusted price), pick a **uniformly random day** within the window and treat it as the "peak."
+3. Compute pre-peak return (price from day 1 to the random day) and post-peak return (price from the random day to formation end).
+4. Sort stocks on this randomised pre-peak return and form the same long-short portfolio.
+
+If the actual mom_prepeak Sharpe (**`r actual_s`**) is substantially higher than the random-peak Sharpe (**`r random_s`**), the true peak-finding is doing real work. If they are similar, the alpha likely comes from some other feature of the formation window (e.g., early-window momentum, late-window reversal) that the decomposition happens to capture but doesn't require an accurate peak date.
+
+`r if (!is.null(null_dom) && is.logical(null_dom)) { if (isTRUE(null_dom)) "The null dominates: random-peak Sharpe ≥ actual Sharpe. This is a warning sign that peak-finding may be spurious or that the pre-peak signal is robust to how the 'peak' is defined." else "The null does NOT dominate: actual Sharpe > random-peak Sharpe. Peak-finding adds measurable alpha — the strategy is identifying a genuine signal from the true price-peak location." } else "Result not available — run tar_make()."`
+
+
+# HAC + FF5 + CPCV PBO
+
+## Row
+
+### {.tabset}
+
+#### Statistical Hardening
+
+```{r}
+hac_res  <- safe_tar_read("mom_prepeak_hac")
+ff_reg   <- safe_tar_read("mom_prepeak_ff_reg")
+pbo_res  <- safe_tar_read("mom_prepeak_pbo")
+
+hac_available <- !is.null(hac_res)
+ff_available  <- !is.null(ff_reg) && nrow(ff_reg) == 1L
+pbo_available <- !is.null(pbo_res)
+
+# Dynamic values for prose
+hac_tstat  <- if (hac_available && !is.null(hac_res$hac_tstat))   round(hac_res$hac_tstat, 3)   else "N/A"
+hac_sharpe <- if (hac_available && !is.null(hac_res$naive_sharpe)) round(hac_res$naive_sharpe, 3) else "N/A"
+ff5_alpha  <- if (ff_available) round(ff_reg$alpha_annual, 4)    else "N/A"
+ff5_alpha_t <- if (ff_available) round(ff_reg$alpha_tstat_hac, 3) else "N/A"
+ff5_r2     <- if (ff_available) round(ff_reg$r_squared, 3)       else "N/A"
+pbo_val    <- if (pbo_available) round(pbo_res$pbo, 3)           else "N/A"
+pbo_paths  <- if (pbo_available) pbo_res$n_paths                 else "N/A"
+
+stat_display <- tibble::tibble(
+  Test    = c(
+    "HAC Sharpe (Newey-West)",
+    "HAC t-stat",
+    "FF5+Mom alpha (annualised)",
+    "FF5+Mom alpha t-stat (HAC)",
+    "FF5+Mom R²",
+    "CPCV PBO (n_quantiles grid)"
+  ),
+  Value   = c(
+    as.character(hac_sharpe),
+    as.character(hac_tstat),
+    as.character(ff5_alpha),
+    as.character(ff5_alpha_t),
+    as.character(ff5_r2),
+    as.character(pbo_val)
+  ),
+  Interpretation = c(
+    "Annualised Sharpe from monthly returns (12× ann factor)",
+    "t-statistic for H0: mean(ret_ls) = 0; HAC-robust to serial correlation",
+    "Intercept from FF5+Momentum regression (monthly factors); annualised",
+    "HAC t-stat on the regression alpha",
+    "Fraction of return variance explained by FF5+Momentum factors",
+    paste0("Fraction of CPCV paths (n=", pbo_paths, ") where IS-best n_quantiles ranks below OOS median; 0 = no overfitting, 1 = full overfitting")
+  )
+)
+
+DT::datatable(
+  stat_display,
+  caption = htmltools::tags$caption(
+    style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+    paste0(
+      "Statistical hardening metrics for mom_prepeak. ",
+      "HAC inference uses Newey-West bandwidth (floor(4*(T/100)^(2/9))). ",
+      "FF5 regression uses monthly Fama-French 5-factor + Momentum factors from Kenneth French's data library. ",
+      "CPCV PBO uses C(6,2) = 15 paths over n_quantiles ∈ {5, 10, 20}, with 1-month purge + 1-month embargo."
+    )
+  ),
+  rownames = FALSE,
+  options  = list(pageLength = 8, scrollX = TRUE, dom = "t")
+)
+```
+
+#### Interpretation
+
+**HAC Inference (Newey-West):** The strategy's mean monthly return is tested against H0: μ = 0 using a heteroskedasticity- and autocorrelation-consistent standard error. HAC t-stat = **`r hac_tstat`**. A t-stat above 1.96 indicates significance at the 5% level. Monthly returns can exhibit serial correlation (especially in momentum strategies), so HAC inference is more reliable than a naive OLS t-stat.
+
+**Fama-French 5-Factor + Momentum Regression:** The monthly excess returns are regressed on Mkt-RF, SMB, HML, RMW, CMA, and the UMD (momentum) factor. The intercept (alpha) measures the strategy's return not explained by standard systematic risks. Alpha = **`r ff5_alpha`** (annualised), with HAC t-stat = **`r ff5_alpha_t`**. R² = **`r ff5_r2`**. A positive alpha with a t-stat > 2 provides statistical evidence of genuine risk-adjusted returns. The UMD factor captures conventional momentum exposure; a positive alpha after including UMD would suggest pre-peak momentum captures something beyond standard momentum.
+
+**CPCV PBO:** The Combinatorial Purged Cross-Validation Probability of Backtest Overfitting measures how often the IS-best configuration (n_quantiles value) underperforms the OOS median. PBO = **`r pbo_val`** (across `r pbo_paths` paths). PBO near 0 means the IS-best choice also tends to be OOS-best — little evidence of overfitting. PBO near 1 means IS selection is anti-predictive for OOS — strong evidence of overfitting. Since mom_prepeak is not a highly tuned strategy, this PBO is more of a sanity check than a critical test.
+
 ## Methodology
 
 ### What this vignette computes
 
-This vignette reads the pre-computed `mom_prepeak_signal_raw`, `mom_prepeak_summary`, `mom_prepeak_returns`, `mom_postpeak_returns`, and `mom_combined_returns` targets from the targets pipeline, then builds four charts inline: a peak-date distribution histogram (replicating paper Figure 1), a 84/16 decomposition table from `mom_prepeak_summary`, a cumulative-return chart for all three strategies with bankruptcy annotation at month `r if (!is.na(bankrupt_mo)) bankrupt_mo else "N/A"`, and a skewness comparison across strategies.
+This vignette reads pre-computed targets from the pipeline and builds eight sections: a peak-date distribution histogram (replicating paper Figure 1); a 84/16 decomposition table from `mom_prepeak_summary`; cumulative-return curves for all three strategies with bankruptcy annotation at month `r if (!is.na(bankrupt_mo)) bankrupt_mo else "N/A"`; a skewness comparison; Pillar-8 risk metrics (dd duration, consecutive losses, loss clustering) from the extended `mom_prepeak_summary`; a Walk-Forward Correlation grid over n_quantiles ∈ {5, 10, 20}; a random-day-as-peak null test; and a statistical hardening panel (HAC Sharpe, FF5+Momentum regression alpha, CPCV PBO).
 
 ### Data sources
 
 - `mom_prepeak_signal_raw` — output of [`historicaldata::hd_mom_prepeak_signal()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/strategy_mom_prepeak.R#L67) applied to `ltr_universe` (~51 US non-ETF equities, daily adjusted prices, 1973-onwards). One row per (ticker, as_of_date) with columns `pre_peak_return`, `post_peak_return`, `total_return`, `peak_position`.
-- `mom_prepeak_summary`, `mom_*_returns` targets — computed by [`R/plan_mom_prepeak.R`](https://github.com/JohnGavin/historical/blob/main/R/plan_mom_prepeak.R) using `.mom_prepeak_compute_metrics()` from [`packages/historicaldata/R/utils_mom_prepeak_metrics.R`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/utils_mom_prepeak_metrics.R#L1).
+- `mom_prepeak_summary`, `mom_*_returns` targets — computed by [`R/plan_mom_prepeak.R`](https://github.com/JohnGavin/historical/blob/main/R/plan_mom_prepeak.R) using [`.mom_prepeak_compute_metrics()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/utils_mom_prepeak_metrics.R#L24) from `packages/historicaldata/R/utils_mom_prepeak_metrics.R`, extended in PR 4/4 to include Pillar-8 columns.
+- `mom_prepeak_wfc_grid`, `mom_prepeak_wfc_result` — Walk-Forward Correlation targets from [`R/plan_mom_prepeak_gauntlet.R`](https://github.com/JohnGavin/historical/blob/main/R/plan_mom_prepeak_gauntlet.R), using [`hd_wf_correlation()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/wf_correlation.R#L84).
+- `mom_prepeak_random_peak_test`, `mom_prepeak_random_peak_metrics` — random-day-as-peak null from [`.mom_prepeak_random_peak_signal()`](https://github.com/JohnGavin/historical/blob/main/R/plan_mom_prepeak_gauntlet.R) in the gauntlet plan.
+- `mom_prepeak_hac`, `mom_prepeak_ff_reg` — HAC Sharpe and FF5+Momentum regression via [`hd_hac_sharpe()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/falsification.R#L80) and [`hd_factor_null_test()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/falsification.R#L738) on monthly Fama-French factors from `hd_factors(frequency="monthly")`.
+- `mom_prepeak_pbo` — CPCV Probability of Backtest Overfitting via [`hd_pbo()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/cpcv.R#L267) over n_quantiles ∈ {5, 10, 20}.
 - `strategy_names` — single source of truth for display names, defined in [`R/plan_strategy_names.R`](https://github.com/JohnGavin/historical/blob/main/R/plan_strategy_names.R).
 - Paper: Büsing, Mohrschladt & Siedhoff (2022), *Pre-peak and post-peak momentum*, [SSRN 4298538](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4298538).
 

--- a/packages/historicaldata/R/utils_mom_prepeak_metrics.R
+++ b/packages/historicaldata/R/utils_mom_prepeak_metrics.R
@@ -14,12 +14,19 @@
 #'
 #' Sharpe is computed from per-period returns and is unaffected by bankruptcy.
 #'
+#' Pillar-8 drawdown-duration and loss-clustering metrics (avg_dd_days,
+#' max_dd_days, max_cons_losses, loss_clustered) are computed on the
+#' pre-bankruptcy slice of returns when blown_up == TRUE.  Post-bankruptcy
+#' "returns" are economically meaningless (the portfolio has zero equity) so
+#' including them would inflate dd duration and loss-cluster metrics.
+#'
 #' @param returns_tbl Tibble with column `ret_ls` (numeric monthly L/S returns).
 #' @param strategy Character. Strategy code_name label.
 #' @param ann_factor Integer. Annualisation factor (12 for monthly).
 #'
 #' @return One-row tibble: strategy, n_months, sharpe, cagr, vol, max_dd,
-#'   blown_up (logical), bankrupt_month (integer or NA).
+#'   blown_up (logical), bankrupt_month (integer or NA), avg_dd_days (numeric),
+#'   max_dd_days (numeric), max_cons_losses (integer), loss_clustered (logical).
 #' @noRd
 .mom_prepeak_compute_metrics <- function(returns_tbl,
                                           strategy,
@@ -30,14 +37,18 @@
 
   if (n < 12L) {
     return(tibble::tibble(
-      strategy       = strategy,
-      n_months       = n,
-      sharpe         = NA_real_,
-      cagr           = NA_real_,
-      vol            = NA_real_,
-      max_dd         = NA_real_,
-      blown_up       = NA,
-      bankrupt_month = NA_integer_
+      strategy        = strategy,
+      n_months        = n,
+      sharpe          = NA_real_,
+      cagr            = NA_real_,
+      vol             = NA_real_,
+      max_dd          = NA_real_,
+      blown_up        = NA,
+      bankrupt_month  = NA_integer_,
+      avg_dd_days     = NA_real_,
+      max_dd_days     = NA_real_,
+      max_cons_losses = NA_integer_,
+      loss_clustered  = NA
     ))
   }
 
@@ -70,14 +81,56 @@
 
   vol <- sd_r * sqrt(ann_factor)
 
+  # ── Pillar-8: dd-duration + loss-clustering ──────────────────────────────
+  # Use only the pre-bankruptcy slice so post-bankruptcy zero-equity "returns"
+  # do not inflate duration estimates.  When not blown_up the full series is used.
+  r_pillar <- if (blown_up && !is.na(bankrupt_idx)) {
+    r[seq_len(bankrupt_idx - 1L)]
+  } else {
+    r
+  }
+
+  if (length(r_pillar) >= 3L) {
+    dd_dur  <- hd_dd_duration(r_pillar)
+    lc      <- hd_loss_clustering(r_pillar)
+    avg_dd_days     <- dd_dur$avg_dd_duration
+    max_dd_days     <- dd_dur$max_dd_duration
+    max_cons_losses <- .max_consecutive_losses(r_pillar)
+    loss_clustered  <- lc$clustered
+  } else {
+    avg_dd_days     <- NA_real_
+    max_dd_days     <- NA_real_
+    max_cons_losses <- NA_integer_
+    loss_clustered  <- NA
+  }
+
   tibble::tibble(
-    strategy       = strategy,
-    n_months       = n,
-    sharpe         = round(sharpe, 3),
-    cagr           = if (is.na(cagr)) NA_real_ else round(cagr * 100, 1),
-    vol            = round(vol * 100, 1),
-    max_dd         = round(max_dd * 100, 1),
-    blown_up       = blown_up,
-    bankrupt_month = if (blown_up) as.integer(bankrupt_idx) else NA_integer_
+    strategy        = strategy,
+    n_months        = n,
+    sharpe          = round(sharpe, 3),
+    cagr            = if (is.na(cagr)) NA_real_ else round(cagr * 100, 1),
+    vol             = round(vol * 100, 1),
+    max_dd          = round(max_dd * 100, 1),
+    blown_up        = blown_up,
+    bankrupt_month  = if (blown_up) as.integer(bankrupt_idx) else NA_integer_,
+    avg_dd_days     = avg_dd_days,
+    max_dd_days     = max_dd_days,
+    max_cons_losses = as.integer(max_cons_losses),
+    loss_clustered  = loss_clustered
   )
+}
+
+
+# ── Internal: maximum consecutive losses ──────────────────────────────────────
+# Counts the longest run of negative returns in a return vector.
+# Returns 0L if no negative returns, NA_integer_ if input is empty.
+.max_consecutive_losses <- function(r) {
+  r <- r[!is.na(r)]
+  if (length(r) == 0L) return(NA_integer_)
+  is_loss <- r < 0
+  if (!any(is_loss)) return(0L)
+  rle_obj <- rle(is_loss)
+  loss_runs <- rle_obj$lengths[rle_obj$values]
+  if (length(loss_runs) == 0L) return(0L)
+  as.integer(max(loss_runs))
 }

--- a/packages/historicaldata/tests/testthat/_snaps/mom-prepeak-metrics.md
+++ b/packages/historicaldata/tests/testthat/_snaps/mom-prepeak-metrics.md
@@ -3,13 +3,17 @@
     Code
       str(result)
     Output
-      tibble [1 x 8] (S3: tbl_df/tbl/data.frame)
-       $ strategy      : chr "test_struct"
-       $ n_months      : int 24
-       $ sharpe        : num -0.59
-       $ cagr          : num NA
-       $ vol           : num 85.6
-       $ max_dd        : num -100
-       $ blown_up      : logi TRUE
-       $ bankrupt_month: int 13
+      tibble [1 x 12] (S3: tbl_df/tbl/data.frame)
+       $ strategy       : chr "test_struct"
+       $ n_months       : int 24
+       $ sharpe         : num -0.59
+       $ cagr           : num NA
+       $ vol            : num 85.6
+       $ max_dd         : num -100
+       $ blown_up       : logi TRUE
+       $ bankrupt_month : int 13
+       $ avg_dd_days    : num NA
+       $ max_dd_days    : num NA
+       $ max_cons_losses: int 0
+       $ loss_clustered : logi NA
 

--- a/packages/historicaldata/tests/testthat/test-mom-prepeak-metrics.R
+++ b/packages/historicaldata/tests/testthat/test-mom-prepeak-metrics.R
@@ -110,3 +110,67 @@ test_that("output tibble structure includes blown_up and bankrupt_month columns"
 
   expect_snapshot(str(result))
 })
+
+# ---- 7. Pillar-8: normal case has finite metrics ────────────────────────────
+
+test_that("Pillar-8 metrics present and finite in normal (non-bankrupt) case", {
+  # 36 months: 6 months of 2% gains then 3% drawdown then recover
+  r <- c(rep(0.02, 12), rep(-0.03, 6), rep(0.02, 18))
+
+  result <- historicaldata:::.mom_prepeak_compute_metrics(
+    make_returns_tbl(r), strategy = "test_pillar8_normal"
+  )
+
+  expect_false(result$blown_up)
+  expect_true("avg_dd_days"     %in% names(result))
+  expect_true("max_dd_days"     %in% names(result))
+  expect_true("max_cons_losses" %in% names(result))
+  expect_true("loss_clustered"  %in% names(result))
+
+  # With a drawdown period, these should be finite (not NA)
+  expect_true(!is.na(result$avg_dd_days))
+  expect_true(!is.na(result$max_dd_days))
+  expect_true(!is.na(result$max_cons_losses))
+  expect_true(result$max_cons_losses >= 0L)
+})
+
+# ---- 8. Pillar-8: blown-up case uses pre-bankruptcy slice only ──────────────
+
+test_that("Pillar-8 metrics computed on pre-bankruptcy slice when blown_up", {
+  # 30 months; bankruptcy at month 20.
+  # Months 21-30 are post-bankruptcy; their loss runs should NOT be counted.
+  r <- rep(0.01, 30)
+  r[20] <- -1.5   # bankruptcy at month 20
+
+  result <- historicaldata:::.mom_prepeak_compute_metrics(
+    make_returns_tbl(r), strategy = "test_pillar8_blown"
+  )
+
+  expect_true(result$blown_up)
+  expect_equal(result$bankrupt_month, 20L)
+
+  # max_cons_losses should be based on months 1-19 only (all positive +1%)
+  # — no consecutive losses in pre-bankruptcy slice, so max_cons_losses = 0
+  expect_equal(result$max_cons_losses, 0L)
+
+  # avg_dd_days and max_dd_days: monotone-up series before bankruptcy → NA (no dd events)
+  # (hd_dd_duration returns NA avg/max when no drawdown events exist)
+  # We just check they are not informed by post-bankruptcy returns (which would have negative runs)
+  expect_true(is.na(result$avg_dd_days) || result$avg_dd_days >= 0)
+})
+
+# ---- 9. Pillar-8: sharpe preserved when blown_up ────────────────────────────
+
+test_that("sharpe preserved and Pillar-8 columns present even when blown_up", {
+  r <- rep(0.01, 24)
+  r[13] <- -1.2
+
+  result <- historicaldata:::.mom_prepeak_compute_metrics(
+    make_returns_tbl(r), strategy = "test_pillar8_sharpe_blown"
+  )
+
+  expect_true(result$blown_up)
+  expect_false(is.na(result$sharpe))
+  # All four Pillar-8 columns must exist
+  expect_true(all(c("avg_dd_days", "max_dd_days", "max_cons_losses", "loss_clustered") %in% names(result)))
+})

--- a/packages/historicaldata/tests/testthat/test-mom-prepeak-random-peak.R
+++ b/packages/historicaldata/tests/testthat/test-mom-prepeak-random-peak.R
@@ -1,0 +1,168 @@
+# Tests for the random-day-as-peak falsification helper.
+#
+# The helper `.mom_prepeak_random_peak_signal()` lives in R/plan_mom_prepeak_gauntlet.R
+# and is a plan-level internal function, NOT a package export.
+# These tests exercise the reproducibility and structural properties via
+# sourcing the plan file inside a temporary environment.
+#
+# Because the helper uses `set.seed()` internally, we test:
+#   1. Same seed => identical signal
+#   2. Different seeds => different signals
+#   3. Output structure matches hd_mom_prepeak_signal() (same columns, same row count
+#      for the same input)
+#
+# NOTE: These tests source plan_mom_prepeak_gauntlet.R; they do NOT run tar_make().
+# The sourcing loads the helper into the global env via the plan file's internal
+# function definitions. If the plan file cannot be sourced (e.g., missing packages),
+# tests are skipped gracefully.
+
+# ── Shared fixture ─────────────────────────────────────────────────────────────
+# A small synthetic daily-price tibble: 5 tickers × 60 months of trading days.
+# This matches the expected input shape of hd_mom_prepeak_signal().
+
+.make_tiny_universe <- function(n_tickers = 5L, n_days = 600L) {
+  set.seed(99L)
+  tickers  <- paste0("T", seq_len(n_tickers))
+  start_dt <- as.Date("2000-01-03")
+  dates    <- seq.Date(start_dt, by = "day", length.out = n_days * 1.5)
+  # Keep only weekdays
+  dates    <- dates[weekdays(dates) %in% c("Monday", "Tuesday", "Wednesday", "Thursday", "Friday")]
+  dates    <- head(dates, n_days)
+
+  dplyr::bind_rows(lapply(tickers, function(tk) {
+    price_path <- cumprod(c(100, 1 + stats::rnorm(n_days - 1L, 0, 0.01)))
+    tibble::tibble(
+      ticker   = tk,
+      date     = dates,
+      adjusted = price_path
+    )
+  }))
+}
+
+.make_as_of_dates <- function(universe_tbl) {
+  universe_tbl |>
+    dplyr::mutate(ym = format(as.Date(.data$date), "%Y-%m")) |>
+    dplyr::group_by(.data$ym) |>
+    dplyr::summarise(as_of_date = max(as.Date(.data$date)), .groups = "drop") |>
+    dplyr::arrange(.data$as_of_date) |>
+    dplyr::pull(.data$as_of_date)
+}
+
+# ── Helper loader ──────────────────────────────────────────────────────────────
+# Source the gauntlet plan file to pull in .mom_prepeak_random_peak_signal().
+# Returns FALSE (invisible) if the file cannot be sourced.
+.load_gauntlet_helpers <- function() {
+  plan_path <- here::here("R/plan_mom_prepeak_gauntlet.R")
+  if (!file.exists(plan_path)) return(invisible(FALSE))
+  tryCatch(
+    { source(plan_path, local = FALSE); invisible(TRUE) },
+    error = function(e) invisible(FALSE)
+  )
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+test_that("same seed gives reproducible random-peak signal", {
+  skip_if_not(
+    .load_gauntlet_helpers(),
+    "plan_mom_prepeak_gauntlet.R not loadable — skipping"
+  )
+  skip_if_not(exists(".mom_prepeak_random_peak_signal"),
+              ".mom_prepeak_random_peak_signal not found after source()")
+
+  univ  <- .make_tiny_universe()
+  aods  <- .make_as_of_dates(univ)
+
+  sig1 <- .mom_prepeak_random_peak_signal(univ, aods, seed = 42L)
+  sig2 <- .mom_prepeak_random_peak_signal(univ, aods, seed = 42L)
+
+  expect_equal(sig1, sig2)
+})
+
+test_that("different seeds give different signals", {
+  skip_if_not(
+    .load_gauntlet_helpers(),
+    "plan_mom_prepeak_gauntlet.R not loadable — skipping"
+  )
+  skip_if_not(exists(".mom_prepeak_random_peak_signal"),
+              ".mom_prepeak_random_peak_signal not found after source()")
+
+  univ  <- .make_tiny_universe()
+  aods  <- .make_as_of_dates(univ)
+
+  sig_a <- .mom_prepeak_random_peak_signal(univ, aods, seed = 1L)
+  sig_b <- .mom_prepeak_random_peak_signal(univ, aods, seed = 999L)
+
+  # The random peak dates should differ between seeds for at least some rows
+  expect_false(identical(sig_a, sig_b),
+               info = "Two different seeds produced identical outputs — unexpected")
+})
+
+test_that("random-peak output has same columns as hd_mom_prepeak_signal()", {
+  skip_if_not(
+    .load_gauntlet_helpers(),
+    "plan_mom_prepeak_gauntlet.R not loadable — skipping"
+  )
+  skip_if_not(exists(".mom_prepeak_random_peak_signal"),
+              ".mom_prepeak_random_peak_signal not found after source()")
+
+  univ  <- .make_tiny_universe()
+  aods  <- .make_as_of_dates(univ)
+
+  # Reference: run the real signal
+  ref <- tryCatch(
+    historicaldata::hd_mom_prepeak_signal(
+      daily_prices          = univ,
+      as_of_dates           = aods,
+      lookback_months_start = 12L,
+      lookback_months_end   = 2L,
+      min_obs_days          = 30L   # low threshold so tiny fixture gets rows
+    ),
+    error = function(e) NULL
+  )
+  skip_if(is.null(ref), "hd_mom_prepeak_signal() failed on tiny fixture — skipping")
+
+  rand <- .mom_prepeak_random_peak_signal(
+    univ, aods,
+    seed         = 42L,
+    min_obs_days = 30L   # match reference threshold
+  )
+
+  # Must have the same column names
+  expect_setequal(names(rand), names(ref))
+})
+
+test_that("random-peak output has the same number of rows as reference signal", {
+  skip_if_not(
+    .load_gauntlet_helpers(),
+    "plan_mom_prepeak_gauntlet.R not loadable — skipping"
+  )
+  skip_if_not(exists(".mom_prepeak_random_peak_signal"),
+              ".mom_prepeak_random_peak_signal not found after source()")
+
+  univ  <- .make_tiny_universe()
+  aods  <- .make_as_of_dates(univ)
+
+  # Use min_obs_days=30L (low threshold so tiny fixture gets rows).
+  # Must match the same threshold in the random-peak call so both functions
+  # apply identical filtering; default min_obs_days=100L would produce fewer rows.
+  ref <- tryCatch(
+    historicaldata::hd_mom_prepeak_signal(
+      daily_prices          = univ,
+      as_of_dates           = aods,
+      lookback_months_start = 12L,
+      lookback_months_end   = 2L,
+      min_obs_days          = 30L
+    ),
+    error = function(e) NULL
+  )
+  skip_if(is.null(ref), "hd_mom_prepeak_signal() failed on tiny fixture — skipping")
+
+  rand <- .mom_prepeak_random_peak_signal(
+    univ, aods,
+    seed         = 42L,
+    min_obs_days = 30L   # match reference threshold
+  )
+
+  expect_equal(nrow(rand), nrow(ref))
+})


### PR DESCRIPTION
## Summary

- **Deliverable A**: Extended `.mom_prepeak_compute_metrics()` with 4 Pillar-8 risk metrics (`avg_dd_days`, `max_dd_days`, `max_cons_losses`, `loss_clustered`) computed on the pre-bankruptcy return slice; snapshot updated to `tibble [1 x 12]`
- **Deliverable B**: New `R/plan_mom_prepeak_gauntlet.R` with 16 targets covering WFC (B1), random-day-as-peak null (B2), HAC + FF5+Momentum regression (B3), CPCV PBO over `n_quantiles ∈ {5, 10, 20}` (B4), and registry sentinel extension (B5)
- **Deliverable C**: `docs/momentum-prepeak.qmd` — 4 new sections (Pillar-8, WFC, random-peak null, HAC+FF5+CPCV) inserted before `## Methodology`; Methodology block updated with all 8 new targets and function links
- **Deliverable D**: `docs/_targets.R` — `source(plan_mom_prepeak_gauntlet.R)` + `plan_mom_prepeak_gauntlet()` wired into pipeline
- **Deliverable E**: `test-mom-prepeak-random-peak.R` (4 tests: reproducibility × 2, column structure, row-count with matched `min_obs_days` threshold)
- **Deliverable F**: GitHub issue [#380](https://github.com/JohnGavin/historical/issues/380) filed (v2 follow-up: idempotency, 7-null siblings, WFC expansion, render QA)

## Test plan

- [x] `parse(file = "docs/_targets.R")` — PASS
- [x] `pkgload::load_all("packages/historicaldata")` — PASS (via nix develop)
- [x] `testthat::test_local(filter = "mom-prepeak")` — PASS (0 failures; "standard deviation is zero" warnings are pre-existing fixture artefacts)
- [x] Full test suite — 3 pre-existing failures only (`test-query.R:64`, `test-query.R:94`, `test-registry.R:59`; all about `adjusted_close` rename from prior PRs); 0 new failures
- [x] `r_code_check.sh` on `R/plan_mom_prepeak_gauntlet.R` and `packages/historicaldata/R/` — clean (0 ast-grep violations, 0 jarl findings)
- [x] Vignette YAML front matter — PASS
- [ ] `tar_make()` — not run per task constraint; pipeline parse confirms no syntax errors
- [ ] `quarto render docs/momentum-prepeak.qmd` — not run per task constraint; tracked in #380

## Changes

### New files
- `R/plan_mom_prepeak_gauntlet.R` — 16 targets for the gauntlet battery
- `packages/historicaldata/tests/testthat/test-mom-prepeak-random-peak.R` — 4 tests for `.mom_prepeak_random_peak_signal()`

### Modified files
- `packages/historicaldata/R/utils_mom_prepeak_metrics.R` — Pillar-8 extension (12-col output)
- `packages/historicaldata/tests/testthat/test-mom-prepeak-metrics.R` — tests 7-9 added
- `packages/historicaldata/tests/testthat/_snaps/mom-prepeak-metrics.md` — snapshot updated
- `docs/_targets.R` — gauntlet plan sourced + called
- `docs/momentum-prepeak.qmd` — 4 new gauntlet sections + updated Methodology

Closes #365 (PR 4/4). Follow-up tracked in #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
