### PR TITLE
ci(link-audit): drop --exclude-mail flag removed in lychee v0.23.0 (closes #377)

### DIFF
--- a/.github/workflows/link-audit.yml
+++ b/.github/workflows/link-audit.yml
@@ -39,7 +39,6 @@ jobs:
             --max-redirects 5
             --max-concurrency 8
             --accept 200,206,429
-            --exclude-mail
             './docs/**/*.html'
             './docs/**/*.qmd'
             './*.md'
@@ -58,7 +57,6 @@ jobs:
             --max-redirects 5
             --max-concurrency 8
             --accept 200,206,429
-            --exclude-mail
             --base 'https://johngavin.github.io/historical/'
             'https://johngavin.github.io/historical/'
             'https://johngavin.github.io/historical/leaderboard.html'


### PR DESCRIPTION
## Summary

Closes #377. lychee v0.23.0 removed `--exclude-mail`; mail exclusion is the new default. The flag is now invalid and the action exits with an error on every scheduled run.

## Test plan

- [x] YAML parses
- [x] `grep -n exclude-mail .github/workflows/link-audit.yml` returns no matches
- [ ] Reviewer: confirm next scheduled run (or manual workflow_dispatch) succeeds

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)
