### PR TITLE
fix(vignettes): momentum-prepeak.qmd WFC section — use hd_wf_correlation()'s actual field names (#365 follow-up)

### DIFF
--- a/docs/momentum-prepeak.qmd
+++ b/docs/momentum-prepeak.qmd
@@ -804,8 +804,8 @@ wfc_result <- safe_tar_read("mom_prepeak_wfc_result")
 wfc_available <- !is.null(wfc_grid) && !is.null(wfc_result)
 
 if (wfc_available) {
-  pearson_rho   <- round(wfc_result$pearson_rho,   3)
-  spearman_rho  <- round(wfc_result$spearman_rho,  3)
+  pearson_rho   <- round(wfc_result$pearson,   3)
+  spearman_rho  <- round(wfc_result$spearman,  3)
   wfc_class_val <- wfc_result$classification
   median_oos    <- round(wfc_result$median_oos, 3)
 


### PR DESCRIPTION
## Summary

2-character fix to `docs/momentum-prepeak.qmd`. `hd_wf_correlation()` returns list fields `pearson` / `spearman`, not `pearson_rho` / `spearman_rho` as the vignette assumed.

## Render finding now visible

| Field | Value |
|-------|-------|
| Pearson ρ (IS↔OOS) | -0.92 |
| Spearman ρ | -1.0 |
| classification | spurious_luck |
| n grid points | 3 (n_quantiles ∈ {5,10,20}) |

The "spurious_luck" classification fires; small grid (3 points) warrants the caveat.

## Test plan

- [x] `quarto render docs/momentum-prepeak.qmd` succeeds
- [x] Zero "MISSING EVIDENCE" markers in rendered HTML
- [x] No other `pearson_rho` / `spearman_rho` usages of `wfc_result$`

Refs: #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)
