### PR TITLE
fix(vignettes): falsification.qmd setup chunk — drop pkgload::load_all, use path-checked tar_config_set + vignette_utils (#365 follow-up)

### DIFF
--- a/docs/falsification.qmd
+++ b/docs/falsification.qmd
@@ -83,8 +83,9 @@ library(ggplot2)
 library(DT)
 library(dplyr)
 
-pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
-
+# Path-checked store + utils (cwd is docs/ under quarto render, project
+# root under tar_make). Same pattern as docs/leaderboard.qmd:29-39 and
+# the #379 fix for momentum-prepeak.qmd.
 store_path <- if (dir.exists("_targets")) "_targets" else
   file.path(here::here(), "docs/_targets")
 tar_config_set(store = store_path)


### PR DESCRIPTION
## Summary

`docs/falsification.qmd` had the same `pkgload::load_all(here::here("packages/historicaldata"))` bug that #379 fixed for `momentum-prepeak.qmd`. Quarto's cwd under render is `docs/`, so the path lookup fails.

Applied the project's canonical pattern from `leaderboard.qmd:29-39`.

## Latent bug in 4 other vignettes (filed as follow-up)

`avoid-worst-days.qmd`, `european-overlay.qmd`, `index.qmd`, `macro-defense-rotation.qmd` — same bug, committed HTML still works. Follow-up issue #387.

## Test plan

- [x] `quarto render docs/falsification.qmd` succeeds
- [x] Zero "MISSING EVIDENCE" markers in rendered HTML

Refs: #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)
