### PR TITLE
fix(vignettes): falsification.qmd causal-implications chunk — path-check source() of R/diagram_node_links.R (#365 follow-up)

### DIFF
--- a/docs/falsification.qmd
+++ b/docs/falsification.qmd
@@ -584,7 +584,9 @@ cg_impl <- safe_tar_read("cg_test_implications")
 if (!is.null(cg_impl) && is.data.frame(cg_impl$results)) {
   # Add source code links to implication labels.
   # Node → file + line is the single source of truth in R/diagram_node_links.R.
-  source(here::here("R/diagram_node_links.R"))
+  diag_links_path <- if (file.exists("../R/diagram_node_links.R")) "../R/diagram_node_links.R" else
+    file.path(here::here(), "R/diagram_node_links.R")
+  source(diag_links_path)
   .dnl <- diagram_node_links()
   # Build a named vector: node → full GitHub URL with #L anchor
   node_links <- stats::setNames(


### PR DESCRIPTION
## Summary

3-line fix to `docs/falsification.qmd`. Setup-chunk fix in #388 fixed `pkgload::load_all(here::here("packages/historicaldata"))`, but a separate `here::here()` call at line 587 in the `[causal-implications]` chunk also failed under render. Same path-checked pattern.

## Test plan

- [x] No more `source(here::here(` in the file
- [x] `quarto render docs/falsification.qmd` succeeds
- [x] Zero "MISSING EVIDENCE" markers in rendered HTML

Refs: #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)
