### PR TITLE
feat(leaderboard): surface 9 missing strategies + QA coverage gate (#345)

### DIFF
--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -25,6 +25,93 @@ plan_leaderboard <- function() {
         m |> mutate(strategy = name, level = level, signal = signal, definition = url)
       }
 
+      # ── Schema-normalisation helpers for strategies with non-standard schemas ──
+      # Each helper returns a tibble with at minimum: period, months, cagr, vol,
+      # sharpe, max_dd. Extra columns are preserved so the final bind_rows()
+      # fills NA for columns absent in some strategies.
+
+      # ltr_metrics has hac_sharpe instead of sharpe; no months column
+      .norm_ltr <- function(m) {
+        if (is.null(m) || nrow(m) == 0) return(NULL)
+        m |> rename(sharpe = hac_sharpe)
+      }
+
+      # olmar_metrics has `days` instead of `months`; daily ann_factor
+      .norm_olmar <- function(m) {
+        if (is.null(m) || nrow(m) == 0) return(NULL)
+        m |> rename(months = days)
+      }
+
+      # tom_metrics uses cagr_tom, vol_tom, sharpe_tom, max_dd_tom
+      # Drop benchmark columns; keep TOM strategy row only
+      .norm_tom <- function(m) {
+        if (is.null(m) || nrow(m) == 0) return(NULL)
+        m |> transmute(
+          period = period,
+          months = n_days,
+          cagr   = cagr_tom,
+          vol    = vol_tom,
+          sharpe = sharpe_tom,
+          max_dd = max_dd_tom
+        )
+      }
+
+      # cmr_summary has lookback (1m/3m/6m) instead of period; no period column.
+      # Pick the best-Sharpe lookback for the leaderboard row.
+      # We create one synthetic "Full Period" row = the best lookback.
+      .norm_cmr <- function(m) {
+        if (is.null(m) || nrow(m) == 0) return(NULL)
+        best <- m |> filter(!is.na(sharpe)) |> arrange(desc(sharpe)) |> slice(1)
+        if (nrow(best) == 0L) return(NULL)
+        best |> transmute(
+          period = "Full Period",
+          months = n_months,
+          cagr   = cagr,
+          vol    = vol,
+          sharpe = sharpe,
+          max_dd = max_dd,
+          cmr_lookback = lookback  # preserve for inspection
+        )
+      }
+
+      # rsc_metrics contains multiple internal strategy variants (SPY_overlay,
+      # DRIF_overlay, etc.). Pick only the SPY_overlay rows which represent the
+      # strategy's own performance.
+      .norm_rsc <- function(m) {
+        if (is.null(m) || nrow(m) == 0) return(NULL)
+        m |>
+          filter(strategy == "SPY_overlay") |>
+          select(-strategy) |>
+          rename(sharpe = hac_sharpe)
+      }
+
+      # mom_prepeak_metrics / siblings have no period column (one row per
+      # strategy); column n_months not months; no period. Synthesise
+      # "Full Period" as the single row.
+      .norm_mom_sibling <- function(m) {
+        if (is.null(m) || nrow(m) == 0) return(NULL)
+        m |>
+          select(-any_of("strategy")) |>  # strategy is set by add_meta name=
+          transmute(
+            period = "Full Period",
+            months = n_months,
+            cagr   = cagr,
+            vol    = vol,
+            sharpe = sharpe,
+            max_dd = max_dd
+          )
+      }
+
+      # aw_metrics has scenario × period; keep the "Remove 10 Worst" rows
+      # (the protection scenario) and drop the extra scenario column.
+      .norm_aw <- function(m) {
+        if (is.null(m) || nrow(m) == 0) return(NULL)
+        m |>
+          filter(scenario == "Remove 10 Worst") |>
+          select(-scenario) |>
+          rename(months = n_days)
+      }
+
       all_metrics <- bind_rows(
         add_meta(fm_metrics, "Factor MAX", "Factor", "Max daily return",
                  "factor-max.html"),
@@ -35,7 +122,34 @@ plan_leaderboard <- function() {
         add_meta(stk_drif_metrics, "Stock DRIF", "Stock", "Elastic net (42 feat)",
                  "stock-backtest.html#stock-drif"),
         add_meta(xgb_drif_metrics, "XGB DRIF", "Stock", "XGBoost monotonic (42 feat)",
-                 "stock-backtest.html#stock-drif")
+                 "stock-backtest.html#stock-drif"),
+        # ── Added in #345: wire missing strategies ──
+        add_meta(.norm_ltr(ltr_metrics), "LTR", "Equity", "Cross-sectional momentum",
+                 "leaderboard.html"),
+        add_meta(.norm_olmar(olmar_metrics), "OLMAR-1", "Equity",
+                 "Online mean-reversion (Li & Hoi 2012)",
+                 "leaderboard.html"),
+        add_meta(.norm_tom(tom_metrics), "TOM", "Overlay",
+                 "Turn-of-the-month calendar effect",
+                 "turn-of-month.html"),
+        add_meta(.norm_cmr(cmr_summary), "CMR", "Commodities",
+                 "Commodities mean reversion (best lookback)",
+                 "commodities-mean-reversion.html"),
+        add_meta(.norm_rsc(rsc_metrics), "Risk State", "Overlay",
+                 "VIX regime overlay on SPY",
+                 "leaderboard.html"),
+        add_meta(.norm_aw(aw_metrics), "Avoid Worst", "Overlay",
+                 "VIX protection: remove 10 worst days",
+                 "avoid-worst-days.html"),
+        add_meta(.norm_mom_sibling(mom_prepeak_metrics), "Mom Pre-Peak", "Equity",
+                 "Pre-peak 12-2 momentum (Büsing 2022)",
+                 "momentum-prepeak.html"),
+        add_meta(.norm_mom_sibling(mom_postpeak_metrics), "Mom Post-Peak", "Equity",
+                 "Post-peak 12-2 momentum (Büsing 2022)",
+                 "momentum-prepeak.html"),
+        add_meta(.norm_mom_sibling(mom_combined_metrics), "Mom 12-2", "Equity",
+                 "Standard 12-2 momentum (Büsing baseline)",
+                 "momentum-prepeak.html")
       )
 
       # Add portfolio optimal
@@ -196,8 +310,13 @@ plan_leaderboard <- function() {
       if (!is.null(fals_results_db) && nrow(fals_results_db) > 0) {
         fals_id_to_label <- c(
           fac_max     = "Factor MAX",
-          drif        = "Factor DRIF"
-          # avoid_worst, rsc, ltr, tom are not yet in the leaderboard
+          drif        = "Factor DRIF",
+          # ── #345: added to leaderboard ──
+          avoid_worst = "Avoid Worst",
+          rsc         = "Risk State",
+          ltr         = "LTR",
+          tom         = "TOM"
+          # cmr, olmar, mom_prepeak siblings: not yet in fals_results_db
         )
         pillar8_join <- fals_results_db |>
           filter(strategy_id %in% names(fals_id_to_label)) |>

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -189,6 +189,40 @@ check_anchor_in_range <- function(html_dir,
   dplyr::bind_rows(results)
 }
 
+#' Check that every strategy in strategy_names appears in the leaderboard (S7)
+#'
+#' Exported as a standalone helper so unit tests can exercise the logic without
+#' running `tar_make()`.  The `qa_leaderboard_coverage` target calls this
+#' function directly.
+#'
+#' @param strategy_names Tibble with at least `short_name` and `code_name`
+#'   columns (the output of the `strategy_names` targets pipeline target).
+#' @param leaderboard Tibble with at least a `strategy` column (the output of
+#'   the `leaderboard` targets pipeline target).
+#' @return `TRUE` invisibly on success.
+#' @noRd
+check_leaderboard_coverage <- function(strategy_names, leaderboard) {
+  expected <- strategy_names$short_name
+  observed <- unique(leaderboard$strategy)
+  missing  <- setdiff(expected, observed)
+
+  if (length(missing) > 0L) {
+    cli::cli_abort(c(
+      "x" = "Leaderboard missing {length(missing)}/{length(expected)} strategy/strategies:",
+      setNames(
+        sprintf("  %s (code_name: %s)",
+                missing,
+                strategy_names$code_name[match(missing, strategy_names$short_name)]),
+        rep("i", length(missing))
+      ),
+      "i" = "Add the corresponding add_meta() calls in R/plan_leaderboard.R."
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+
 # ---- QA gate plan ----
 
 plan_qa_gates <- function() {
@@ -299,6 +333,27 @@ plan_qa_gates <- function() {
         }
         cli::cli_inform(c("v" = "qa_anchor_in_range: S6 passed (all anchors in range)"))
         nrow(hits)
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: every strategy in strategy_names must appear in the leaderboard (S7)
+    #
+    # strategy_names$short_name holds the canonical display labels.
+    # leaderboard$strategy holds the labels set by add_meta(name = ...).
+    # Both sets MUST match; missing strategies indicate a wiring gap in
+    # plan_leaderboard.R. (#345)
+    targets::tar_target(
+      qa_leaderboard_coverage,
+      command = {
+        check_leaderboard_coverage(strategy_names, leaderboard)
+        cli::cli_inform(c(
+          "v" = paste0(
+            "qa_leaderboard_coverage: S7 passed — all ",
+            length(strategy_names$short_name), " strategies present in leaderboard"
+          )
+        ))
+        TRUE
       },
       cue = targets::tar_cue(mode = "always")
     )

--- a/docs/_targets.R
+++ b/docs/_targets.R
@@ -130,6 +130,7 @@ source(here::here("R/plan_olmar.R"))
 source(here::here("R/plan_turn_of_month.R"))
 source(here::here("R/plan_wf_correlation.R"))
 source(here::here("R/plan_artefact_registry.R"))
+source(here::here("R/plan_qa_gates.R"))
 
 # Combine: strategy_names FIRST, then partitions, strategies, portfolio, ETF replication, leaderboard, QA
 c(plan_strategy_names(),
@@ -179,6 +180,7 @@ c(plan_strategy_names(),
   plan_turn_of_month(),
   plan_wf_correlation(),
   plan_artefact_registry(),
+  plan_qa_gates(),
 
   # Phase 1 of #149: date-type consistency across all registered datasets.
   # tar_target_raw + explicit deps so targets schedules dv_join_key_types

--- a/packages/historicaldata/tests/testthat/test-leaderboard-coverage.R
+++ b/packages/historicaldata/tests/testthat/test-leaderboard-coverage.R
@@ -1,0 +1,121 @@
+# Tests for check_leaderboard_coverage() — leaderboard strategy coverage gate (S7)
+# All tests are offline — no pipeline, no file I/O.
+# testthat edition 3.
+
+# check_leaderboard_coverage() lives in R/plan_qa_gates.R (plan-level, not
+# exported from historicaldata).  When running devtools::test() from the package,
+# source the plan file from the repo root so the helper is available.
+# In CI the repo root is two levels up from packages/historicaldata/.
+.repo_root <- function() {
+  # Walk up until we find docs/_targets.R (reliable repo-root indicator).
+  p <- normalizePath(".", mustWork = FALSE)
+  for (i in seq_len(8L)) {
+    if (file.exists(file.path(p, "docs", "_targets.R"))) return(p)
+    p <- dirname(p)
+  }
+  stop("Cannot locate repo root from: ", normalizePath(".", mustWork = FALSE))
+}
+
+# Source plan_qa_gates.R only if the helper is not already in scope.
+# This avoids double-sourcing when the plan is already loaded in the test
+# runner's process.
+if (!existsFunction("check_leaderboard_coverage")) {
+  root <- .repo_root()
+  source(file.path(root, "R", "plan_qa_gates.R"))
+}
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+.make_strategy_names <- function(short_names) {
+  tibble::tibble(
+    code_name  = tolower(gsub(" ", "_", short_names)),
+    short_name = short_names
+  )
+}
+
+.make_leaderboard <- function(strategies) {
+  tibble::tibble(
+    strategy = strategies,
+    period   = "Full Period",
+    cagr     = 5.0,
+    sharpe   = 0.5
+  )
+}
+
+
+# ── Tests: missing strategies → error ────────────────────────────────────────
+
+test_that("check_leaderboard_coverage: throws when a strategy is missing", {
+  sn <- .make_strategy_names(c("Alpha", "Beta", "Gamma"))
+  lb <- .make_leaderboard(c("Alpha", "Beta"))  # Gamma missing
+
+  expect_error(
+    check_leaderboard_coverage(sn, lb),
+    regexp = "missing"
+  )
+})
+
+test_that("check_leaderboard_coverage: error message names the missing strategy", {
+  sn <- .make_strategy_names(c("Alpha", "Beta", "Gamma"))
+  lb <- .make_leaderboard(c("Alpha", "Beta"))
+
+  expect_error(
+    check_leaderboard_coverage(sn, lb),
+    regexp = "Gamma"
+  )
+})
+
+test_that("check_leaderboard_coverage: error cites count correctly", {
+  sn <- .make_strategy_names(c("Alpha", "Beta", "Gamma"))
+  lb <- .make_leaderboard("Alpha")  # 2 of 3 missing
+
+  expect_error(
+    check_leaderboard_coverage(sn, lb),
+    regexp = "2/3"
+  )
+})
+
+
+# ── Tests: complete coverage → TRUE ──────────────────────────────────────────
+
+test_that("check_leaderboard_coverage: returns TRUE when all strategies present", {
+  sn <- .make_strategy_names(c("Alpha", "Beta", "Gamma"))
+  lb <- .make_leaderboard(c("Alpha", "Beta", "Gamma"))
+
+  result <- check_leaderboard_coverage(sn, lb)
+  expect_true(result)
+})
+
+test_that("check_leaderboard_coverage: returns TRUE when leaderboard has extra strategies", {
+  # Extra strategies (e.g. benchmarks) in leaderboard are fine
+  sn <- .make_strategy_names(c("Alpha", "Beta"))
+  lb <- .make_leaderboard(c("Alpha", "Beta", "Extra"))
+
+  result <- check_leaderboard_coverage(sn, lb)
+  expect_true(result)
+})
+
+test_that("check_leaderboard_coverage: handles duplicate strategy rows in leaderboard", {
+  # Leaderboard has one row per period; strategy name repeats across periods
+  sn <- .make_strategy_names(c("Alpha", "Beta"))
+  lb <- tibble::tibble(
+    strategy = rep(c("Alpha", "Beta"), each = 4L),
+    period   = rep(c("Training", "Testing", "Validation", "Full Period"), times = 2L),
+    cagr     = 5.0,
+    sharpe   = 0.5
+  )
+
+  result <- check_leaderboard_coverage(sn, lb)
+  expect_true(result)
+})
+
+test_that("check_leaderboard_coverage: empty leaderboard with non-empty strategy_names throws", {
+  sn <- .make_strategy_names(c("Alpha", "Beta"))
+  lb <- .make_leaderboard(character(0))
+
+  expect_error(
+    check_leaderboard_coverage(sn, lb),
+    regexp = "missing"
+  )
+})


### PR DESCRIPTION
## Summary

- **Part A (survey):** Identified 9 missing strategies in `plan_leaderboard.R`. Each has a `*_metrics` target in the pipeline but was never wired into `bind_rows()`.
- **Part B (wiring):** Added schema-normalisation helpers (`.norm_ltr`, `.norm_olmar`, `.norm_tom`, `.norm_cmr`, `.norm_rsc`, `.norm_aw`, `.norm_mom_sibling`) and 9 new `add_meta()` calls in `R/plan_leaderboard.R`. Also extended `fals_id_to_label` for Pillar-8 drawdown-duration joins.
- **Part C (QA gate):** Added `check_leaderboard_coverage()` standalone helper + `qa_leaderboard_coverage` target (S7) in `R/plan_qa_gates.R`. Added `plan_qa_gates()` to `docs/_targets.R` (it was not previously wired in at all — the QA gate targets never ran before this PR).
- **Part D (deploy):** Deferred — see below.

## Strategy mapping

| code_name | metrics target | leaderboard label | status |
|---|---|---|---|
| fac_max | `fm_metrics` | "Factor MAX" | was already wired |
| drif | `drif_metrics` | "Factor DRIF" | was already wired |
| stk_max | `stk_max_metrics` | "Stock MAX" | was already wired |
| stk_drif | `stk_drif_metrics` | "Stock DRIF" | was already wired |
| xgb_drif | `xgb_drif_metrics` | "XGB DRIF" | was already wired |
| pso_optimal | `port_metrics` | "PSO Optimal" | was already wired |
| ltr | `ltr_metrics` | "LTR" | **added — `.norm_ltr` renames `hac_sharpe` → `sharpe`** |
| olmar | `olmar_metrics` | "OLMAR-1" | **added — `.norm_olmar` renames `days` → `months`** |
| tom | `tom_metrics` | "TOM" | **added — `.norm_tom` transmutes `cagr_tom`/`sharpe_tom` etc.** |
| cmr | `cmr_summary` | "CMR" | **added — `.norm_cmr` picks best-Sharpe lookback row** |
| rsc | `rsc_metrics` | "Risk State" | **added — `.norm_rsc` filters to `SPY_overlay` rows** |
| avoid_worst | `aw_metrics` | "Avoid Worst" | **added — `.norm_aw` filters to "Remove 10 Worst" scenario** |
| mom_prepeak | `mom_prepeak_metrics` | "Mom Pre-Peak" | **added — `.norm_mom_sibling`** |
| mom_postpeak | `mom_postpeak_metrics` | "Mom Post-Peak" | **added — `.norm_mom_sibling`** |
| mom_combined | `mom_combined_metrics` | "Mom 12-2" | **added — `.norm_mom_sibling`** |

Note: `olmar` is wired using the `olmar_metrics` target but is NOT currently in `strategy_names` (it has no row there). The `qa_leaderboard_coverage` gate checks `strategy_names$short_name ⊆ leaderboard$strategy`, not the reverse, so extra strategies in the leaderboard are allowed. OLMAR does not need to be in `strategy_names` for the gate to pass.

## QA target

`qa_leaderboard_coverage` (S7) calls `check_leaderboard_coverage(strategy_names, leaderboard)` on every `tar_make()`. It aborts if any `strategy_names$short_name` is absent from `leaderboard$strategy`, printing the missing strategy names and their `code_name` values. This is the permanent guard that prevents future regressions of this issue.

## Deferred work

- **Part D (vignette re-render):** Not attempted in this PR. The vignette requires a full `tar_make()` over all upstream metrics targets, several of which may be stale. Once the pipeline has been run (separate session), re-rendering `docs/leaderboard.qmd` will surface the new rows.
- **OLMAR in `strategy_names`:** OLMAR (#276) has a `olmar_metrics` target but is not in `strategy_names`. Adding it is out of scope for this PR (requires amending `plan_strategy_names.R` with a new row and all associated metadata). Filed as a follow-up.
- **RSC / Avoid Worst Pillar-8:** `fals_results_db` does not yet cover `avoid_worst`, `rsc`, `ltr`, or `tom`. The `fals_id_to_label` mapping has been extended for those four; once `fals_results_db` includes them, the join will populate automatically.

## Test plan

- [x] `devtools::test(filter = "leaderboard-coverage")` → 7/7 PASS
- [x] `devtools::test()` full suite → 776/779 pass (3 pre-existing failures in test-query.R and test-registry.R unrelated to this PR)
- [x] `parse("docs/_targets.R")` → OK
- [x] `parse("R/plan_leaderboard.R")` → OK
- [x] `parse("R/plan_qa_gates.R")` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
