### PR TITLE
feat(testing): adopt snapshot-test policy + backfill DRIF + audit (#340)

### DIFF
--- a/.claude/rules/snapshot-test-policy.md
+++ b/.claude/rules/snapshot-test-policy.md
@@ -1,0 +1,144 @@
+# Rule: Snapshot Test Policy (historical project)
+
+## Global rule reference
+
+The authoritative policy lives at
+`~/docs_gh/llm/.claude/rules/snapshot-tests-mandatory.md`.
+This file adds project-specific examples and the per-file audit table.
+When the two conflict, the global rule takes precedence.
+
+## When This Applies
+
+Every test file added or modified in:
+
+- `packages/historicaldata/tests/testthat/test-*.R`
+- `tests/testthat/test-*.R`
+
+## Decision Matrix
+
+| Test type | Snapshot? | testthat function | Why |
+|-----------|-----------|-------------------|-----|
+| Pure algorithmic unit tests (toy inputs, hand-derived expected) | NO — keep `expect_equal` | — | Self-documenting, no fragility |
+| Error / warning messages from `cli_abort` / `cli_warn` | **YES** | `expect_snapshot(error = TRUE, fn())` | Wording drift is meaningful; catches rename of `.arg` / `.field` |
+| CLI informational messages (`cli_inform`) | **YES** | `expect_snapshot(fn_with_message())` | User-facing strings should be reviewed on change |
+| Caption strings (assembled by `paste0`) | **YES** | `expect_snapshot(caption)` | Format/wording drift is detectable without hand-derivation |
+| Function signatures (API stability) | **YES** | `expect_snapshot(args(fn))` | Catches param renames/additions/removals |
+| Real-data target outputs (`tar_read(...)`) | **YES** | `expect_snapshot_value(result, style = "deparse")` | Catches schema drift; no hand-derivation possible |
+| Numerical output with tolerance | Mixed | `expect_equal(tolerance=)` for gist + `expect_snapshot_value(style="deparse", tolerance=)` for structure | Both signals matter |
+| Plot artefacts / Quarto HTML | **YES** | `expect_snapshot_file()` | Visual/structural regression |
+
+## Minimum ratios (from global rule)
+
+| test_that blocks in file | Minimum snapshots |
+|--------------------------|-------------------|
+| 1–3 | At least 1 |
+| 4–8 | At least 2 |
+| 9+ | At least 30% |
+
+## Concrete patterns used in this project
+
+### Error message snapshots (see test-drif-selection.R)
+
+```r
+test_that("non-data-frame predictions throws informative cli_abort", {
+  expect_snapshot(
+    error = TRUE,
+    hd_drif_select_topn("not_a_df", make_params(), 2L)
+  )
+})
+```
+
+### Caption string snapshot (see tests/testthat/test-drif.R)
+
+```r
+test_that("drif_multiverse_caption format is stable", {
+  caption <- build_caption(toy_mv)
+  expect_snapshot(cat(caption))
+})
+```
+
+### Function signature stability (see test-hd_strat_keff_vertox.R)
+
+```r
+test_that("function signature is stable (catches API drift)", {
+  expect_snapshot(args(hd_drif_select_topn))
+})
+```
+
+## DO NOT use snapshots for
+
+- Tests where the expected value is easily hand-derived and hand-verified
+  (e.g., `expect_equal(nrow(result), 4L)` is more readable than a snapshot)
+- Tests with random / timestamp-dependent output unless `transform =` is used
+  to strip non-deterministic parts
+
+## Commit rule
+
+Snapshot files (`_snaps/*.md`) MUST be committed alongside the test file
+changes that produce them. They are part of the test suite, not generated
+artefacts.
+
+## Per-file audit (as of 2026-05-31, issue #340)
+
+### packages/historicaldata/tests/testthat/
+
+| File | Total assertions | Snap | Non-snap | Verdict |
+|------|-----------------|------|----------|---------|
+| test-add-signal.R | 30 | 0 | 30 | algorithmic |
+| test-alphavantage.R | 13 | 0 | 13 | algorithmic |
+| test-column-naming.R | 11 | 0 | 11 | algorithmic |
+| test-commodities-mean-reversion.R | 16 | 0 | 16 | algorithmic |
+| test-cpcv.R | 34 | 0 | 34 | algorithmic |
+| test-drif-selection.R | 22 | 0 | 22 | mixed — error msgs snapshottable |
+| test-ecb.R | 15 | 0 | 15 | algorithmic |
+| test-guardian.R | 11 | 0 | 11 | algorithmic |
+| test-hd_strat_keff_vertox.R | 16 | 5 | 11 | compliant |
+| test-jst.R | 27 | 0 | 27 | algorithmic |
+| test-mom-prepeak-ff-join.R | 3 | 0 | 3 | algorithmic |
+| test-mom-prepeak-metrics.R | 38 | 1 | 37 | mixed — more snapshots needed |
+| test-mom-prepeak-portfolio.R | 19 | 1 | 18 | mixed — more snapshots needed |
+| test-mom-prepeak-random-peak.R | 4 | 0 | 4 | algorithmic |
+| test-mom-prepeak.R | 24 | 4 | 20 | compliant |
+| test-olmar.R | 33 | 0 | 33 | algorithmic |
+| test-pit-guard.R | 7 | 0 | 7 | algorithmic |
+| test-query.R | 30 | 4 | 26 | compliant |
+| test-registry-artefacts.R | 19 | 1 | 18 | mixed — more snapshots needed |
+| test-registry-db.R | 12 | 0 | 12 | algorithmic |
+| test-registry-metrics.R | 16 | 0 | 16 | algorithmic |
+| test-registry-upsert.R | 11 | 0 | 11 | algorithmic |
+| test-registry-writers.R | 12 | 0 | 12 | algorithmic |
+| test-registry.R | 14 | 1 | 13 | mixed — more snapshots needed |
+| test-research_log.R | 36 | 0 | 36 | algorithmic |
+| test-risk-metrics.R | 27 | 0 | 27 | algorithmic |
+| test-survivorship-bias.R | 8 | 0 | 8 | algorithmic |
+| test-topological-risk-parity.R | 28 | 0 | 28 | algorithmic |
+| test-vintages.R | 3 | 0 | 3 | algorithmic |
+| test-wf-correlation.R | 34 | 0 | 34 | algorithmic |
+
+### tests/testthat/ (root-level, targets pipeline helpers)
+
+| File | Total assertions | Snap | Non-snap | Verdict |
+|------|-----------------|------|----------|---------|
+| test-cpcv-integration.R | 16 | 0 | 16 | algorithmic |
+| test-drif.R | 17 | 0 | 17 | mixed — caption string snapshottable |
+| test-momentum-decomposition.R | 12 | 3 | 9 | compliant |
+| test-pairwise-alignment.R | 27 | 3 | 24 | compliant |
+| test-plan-factormax.R | 5 | 0 | 5 | algorithmic |
+| test-plan-portfolio-opt.R | 8 | 0 | 8 | algorithmic |
+| test-qa-look-ahead-bias.R | 17 | 0 | 17 | algorithmic |
+| test-qa-summary-deps.R | 5 | 0 | 5 | algorithmic |
+| test-stock-backtest.R | 21 | 0 | 21 | mixed — warning msgs snapshottable |
+| test-utils_align.R | 33 | 4 | 29 | compliant |
+| test-utils_dates.R | 11 | 2 | 9 | compliant |
+| test-utils_rolling.R | 16 | 3 | 13 | compliant |
+| test-utils_validation.R | 49 | 3 | 46 | mixed — more snapshots needed |
+| test-utils-metrics.R | 27 | 0 | 27 | algorithmic |
+| test-vignette-utils.R | 32 | 0 | 32 | algorithmic |
+| test-volatility-spike-na-alignment.R | 5 | 0 | 5 | algorithmic |
+
+## Related
+
+- `~/docs_gh/llm/.claude/rules/snapshot-tests-mandatory.md` — global rule
+- `packages/historicaldata/tests/testthat/_snaps/` — existing snapshots
+- `tests/testthat/_snaps/` — root-level snapshots
+- Issue #340 — origin of this policy

--- a/packages/historicaldata/tests/testthat/_snaps/drif-selection.md
+++ b/packages/historicaldata/tests/testthat/_snaps/drif-selection.md
@@ -1,0 +1,35 @@
+# non-data-frame predictions throws cli_abort
+
+    Code
+      hd_drif_select_topn("not_a_df", make_params(), 2L)
+    Condition
+      Error in `hd_drif_select_topn()`:
+      x `predictions` must be a data frame.
+      i Got <character>.
+
+# missing params$factors throws cli_abort
+
+    Code
+      hd_drif_select_topn(make_preds(), list(), 2L)
+    Condition
+      Error in `hd_drif_select_topn()`:
+      x `params` must be a list with a factors element.
+      i Got <list>.
+
+# non-positive top_n throws cli_abort
+
+    Code
+      hd_drif_select_topn(make_preds(), make_params(), 0L)
+    Condition
+      Error in `hd_drif_select_topn()`:
+      x `top_n` must be a positive integer scalar.
+      i Got 0.
+
+# hd_drif_select_topn function signature is stable (catches API drift)
+
+    Code
+      args(hd_drif_select_topn)
+    Output
+      function (predictions, params, top_n) 
+      NULL
+

--- a/packages/historicaldata/tests/testthat/test-drif-selection.R
+++ b/packages/historicaldata/tests/testthat/test-drif-selection.R
@@ -181,22 +181,46 @@ test_that("helper ranks internally from 'predicted' column (multiverse style)", 
 # ── input validation ──────────────────────────────────────────────────────────
 
 test_that("non-data-frame predictions throws cli_abort", {
+  # Existing guard: class check (algorithmic)
   expect_error(
     hd_drif_select_topn("not_a_df", make_params(), 2L),
     class = "rlang_error"
   )
+  # Snapshot guard: exact error wording (#340)
+  expect_snapshot(
+    error = TRUE,
+    hd_drif_select_topn("not_a_df", make_params(), 2L)
+  )
 })
 
 test_that("missing params$factors throws cli_abort", {
+  # Existing guard: class check (algorithmic)
   expect_error(
     hd_drif_select_topn(make_preds(), list(), 2L),
     class = "rlang_error"
   )
+  # Snapshot guard: exact error wording (#340)
+  expect_snapshot(
+    error = TRUE,
+    hd_drif_select_topn(make_preds(), list(), 2L)
+  )
 })
 
 test_that("non-positive top_n throws cli_abort", {
+  # Existing guard: class check (algorithmic)
   expect_error(
     hd_drif_select_topn(make_preds(), make_params(), 0L),
     class = "rlang_error"
   )
+  # Snapshot guard: exact error wording (#340)
+  expect_snapshot(
+    error = TRUE,
+    hd_drif_select_topn(make_preds(), make_params(), 0L)
+  )
+})
+
+# ── API stability ──────────────────────────────────────────────────────────────
+
+test_that("hd_drif_select_topn function signature is stable (catches API drift)", {
+  expect_snapshot(args(hd_drif_select_topn))
 })

--- a/tests/testthat/_snaps/drif.md
+++ b/tests/testthat/_snaps/drif.md
@@ -1,0 +1,7 @@
+# drif_multiverse_caption is a non-empty string
+
+    Code
+      cat(caption)
+    Output
+      Of 3 specifications tested (varying elastic-net alpha, CV folds, feature set, and lambda rule), the current DRIF spec (S01: alpha=0.5, k=5, chrono, lambda.min) ranks 2 by OOS Sharpe (0.82). Sharpe range across specs: 0.74 to 0.91. Source: plan_drif_v2.R; paper: Cakici et al. 2024 (SSRN 6005614).
+

--- a/tests/testthat/test-drif.R
+++ b/tests/testthat/test-drif.R
@@ -1,4 +1,5 @@
 # Tests for plan_drif.R (factor-level) and plan_drif_v2.R (multiverse)
+testthat::local_edition(3)
 
 test_that("plan_drif cumprod survives scattered NA in returns", {
   df <- tibble::tibble(
@@ -95,6 +96,8 @@ test_that("drif_multiverse_caption is a non-empty string", {
   expect_gt(nchar(caption), 50L)
   expect_true(grepl("SSRN 6005614", caption))
   expect_true(grepl("plan_drif_v2", caption))
+  # Snapshot guard: catches format/wording drift in the assembled caption (#340)
+  expect_snapshot(cat(caption))
 })
 
 test_that("run_spec helper computes OOS Sharpe from a toy dataset", {


### PR DESCRIPTION
## Summary

- **Policy doc** (Part B): `.claude/rules/snapshot-test-policy.md` — decision matrix, per-file audit table, concrete in-project examples, and reference to the global rule at `~/docs_gh/llm/.claude/rules/snapshot-tests-mandatory.md` (exists; not duplicated here)
- **Backfill file 1** (Part D): `packages/historicaldata/tests/testthat/test-drif-selection.R` — 4 new snapshot assertions added alongside existing guards; `_snaps/drif-selection.md` committed
- **Backfill file 2** (Part D): `tests/testthat/test-drif.R` — 1 new caption snapshot added; `_snaps/drif.md` committed; `testthat::local_edition(3)` added (required for root-level snapshot tests)

Closes #340.

---

## Policy

Global rule `~/docs_gh/llm/.claude/rules/snapshot-tests-mandatory.md` **exists** and is referenced by the new project-level `.claude/rules/snapshot-test-policy.md`. No cross-project edits were made (per `cross-project-scope` rule).

---

## Audit table

### packages/historicaldata/tests/testthat/

| File | Total | Snap | Non-snap | Verdict |
|------|-------|------|----------|---------|
| test-add-signal.R | 30 | 0 | 30 | algorithmic |
| test-alphavantage.R | 13 | 0 | 13 | algorithmic |
| test-column-naming.R | 11 | 0 | 11 | algorithmic |
| test-commodities-mean-reversion.R | 16 | 0 | 16 | algorithmic |
| test-cpcv.R | 34 | 0 | 34 | algorithmic |
| test-drif-selection.R | 22→26 | **0→4** | 22 | **backfilled** |
| test-ecb.R | 15 | 0 | 15 | algorithmic |
| test-guardian.R | 11 | 0 | 11 | algorithmic |
| test-hd_strat_keff_vertox.R | 16 | 5 | 11 | compliant |
| test-jst.R | 27 | 0 | 27 | algorithmic |
| test-mom-prepeak-ff-join.R | 3 | 0 | 3 | algorithmic |
| test-mom-prepeak-metrics.R | 38 | 1 | 37 | mixed |
| test-mom-prepeak-portfolio.R | 19 | 1 | 18 | mixed |
| test-mom-prepeak-random-peak.R | 4 | 0 | 4 | algorithmic |
| test-mom-prepeak.R | 24 | 4 | 20 | compliant |
| test-olmar.R | 33 | 0 | 33 | algorithmic |
| test-pit-guard.R | 7 | 0 | 7 | algorithmic |
| test-query.R | 30 | 4 | 26 | compliant |
| test-registry-artefacts.R | 19 | 1 | 18 | mixed |
| test-registry-db.R | 12 | 0 | 12 | algorithmic |
| test-registry-metrics.R | 16 | 0 | 16 | algorithmic |
| test-registry-upsert.R | 11 | 0 | 11 | algorithmic |
| test-registry-writers.R | 12 | 0 | 12 | algorithmic |
| test-registry.R | 14 | 1 | 13 | mixed |
| test-research_log.R | 36 | 0 | 36 | algorithmic |
| test-risk-metrics.R | 27 | 0 | 27 | algorithmic |
| test-survivorship-bias.R | 8 | 0 | 8 | algorithmic |
| test-topological-risk-parity.R | 28 | 0 | 28 | algorithmic |
| test-vintages.R | 3 | 0 | 3 | algorithmic |
| test-wf-correlation.R | 34 | 0 | 34 | algorithmic |

### tests/testthat/ (root-level)

| File | Total | Snap | Non-snap | Verdict |
|------|-------|------|----------|---------|
| test-cpcv-integration.R | 16 | 0 | 16 | algorithmic |
| test-drif.R | 17→18 | **0→1** | 17 | **backfilled** |
| test-momentum-decomposition.R | 12 | 3 | 9 | compliant |
| test-pairwise-alignment.R | 27 | 3 | 24 | compliant |
| test-plan-factormax.R | 5 | 0 | 5 | algorithmic |
| test-plan-portfolio-opt.R | 8 | 0 | 8 | algorithmic |
| test-qa-look-ahead-bias.R | 17 | 0 | 17 | algorithmic |
| test-qa-summary-deps.R | 5 | 0 | 5 | algorithmic |
| test-stock-backtest.R | 21 | 0 | 21 | mixed — warning msgs snapshottable |
| test-utils_align.R | 33 | 4 | 29 | compliant |
| test-utils_dates.R | 11 | 2 | 9 | compliant |
| test-utils_rolling.R | 16 | 3 | 13 | compliant |
| test-utils_validation.R | 49 | 3 | 46 | mixed |
| test-utils-metrics.R | 27 | 0 | 27 | algorithmic |
| test-vignette-utils.R | 32 | 0 | 32 | algorithmic |
| test-volatility-spike-na-alignment.R | 5 | 0 | 5 | algorithmic |

**Corrected finding vs issue #340:** 7 files already had snapshot tests before this PR (hd_strat_keff_vertox, mom-prepeak*, query, registry, registry-artefacts, plus momentum-decomposition, pairwise-alignment, utils_align, utils_dates, utils_rolling, utils_validation). Issue #340's "0 snapshot tests" was specific to the DRIF test files — confirmed.

---

## Backfill details

### File 1: `test-drif-selection.R` (+4 snapshots)

For the 3 input-validation `test_that` blocks that test `cli_abort` error messages:
- Added `expect_snapshot(error = TRUE, ...)` **alongside** the existing `expect_error(..., class = "rlang_error")` guard
- No existing assertions deleted

Added a 4th block for API stability:
- `expect_snapshot(args(hd_drif_select_topn))` — catches param renames/additions

Second run: `FAIL 0 | WARN 0 | SKIP 0 | PASS 27`

### File 2: `test-drif.R` (+1 snapshot + edition declaration)

For the caption assembly test (`drif_multiverse_caption is a non-empty string`):
- Added `expect_snapshot(cat(caption))` **alongside** existing `expect_type` / `expect_gt` / `expect_true` guards
- Added `testthat::local_edition(3)` at file top (root-level tests outside a package need explicit edition declaration)

Second run: `FAIL 0 | WARN 0 | SKIP 0 | PASS 18`

---

## Cross-project follow-ups

None required. The global rule `snapshot-tests-mandatory.md` already exists in `~/docs_gh/llm/.claude/rules/`. No `llm` issues filed for this PR.

## Test plan

- [x] `test-drif-selection.R` second run: FAIL 0 | WARN 0 | SKIP 0 | PASS 27
- [x] `test-drif.R` second run: FAIL 0 | WARN 0 | SKIP 0 | PASS 18
- [x] Both `_snaps/*.md` files committed alongside test changes
- [x] No existing assertions deleted (ADD pattern, not REPLACE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
