### PR TITLE
test: fix remaining adjusted→adjusted_close test failures (#397)

### DIFF
--- a/packages/historicaldata/tests/testthat/_snaps/query.md
+++ b/packages/historicaldata/tests/testthat/_snaps/query.md
@@ -4,17 +4,17 @@
       str(result)
     Output
       tibble [3 x 11] (S3: tbl_df/tbl/data.frame)
-       $ date       : POSIXct[1:3], format: "2026-04-07" "2026-04-08" ...
-       $ open       : num [1:3] 256 258 259
-       $ high       : num [1:3] 256 260 261
-       $ low        : num [1:3] 246 257 256
-       $ close      : num [1:3] 254 259 260
-       $ adjusted   : num [1:3] 254 259 260
-       $ volume     : num [1:3] 62148000 41032800 28121600
-       $ ticker     : chr [1:3] "AAPL" "AAPL" "AAPL"
-       $ source     : chr [1:3] "yahoo" "yahoo" "yahoo"
-       $ asset_class: chr [1:3] "equity" "equity" "equity"
-       $ updated_at : POSIXct[1:3], format: "2026-04-12 18:55:57" "2026-04-12 18:55:57" ...
+       $ date          : POSIXct[1:3], format: "2026-04-07" "2026-04-08" ...
+       $ open          : num [1:3] 256 258 259
+       $ high          : num [1:3] 256 260 261
+       $ low           : num [1:3] 246 257 256
+       $ close         : num [1:3] 254 259 260
+       $ adjusted_close: num [1:3] 254 259 260
+       $ volume        : num [1:3] 62148000 41032800 28121600
+       $ ticker        : chr [1:3] "AAPL" "AAPL" "AAPL"
+       $ source        : chr [1:3] "yahoo" "yahoo" "yahoo"
+       $ asset_class   : chr [1:3] "equity" "equity" "equity"
+       $ updated_at    : POSIXct[1:3], format: "2026-04-12 18:55:57" "2026-04-12 18:55:57" ...
 
 # hd_datasets snapshot
 

--- a/packages/historicaldata/tests/testthat/test-query.R
+++ b/packages/historicaldata/tests/testthat/test-query.R
@@ -91,11 +91,11 @@ test_that("hd_ohlcv split-and-bind: mixed equity + crypto batch", {
   expect_true("AAPL" %in% result$ticker)
   expect_true("BTC" %in% result$ticker)
   # Union of schemas: equity-only columns are NA for crypto rows
-  expect_true("adjusted" %in% names(result))     # equity-only column
+  expect_true("adjusted_close" %in% names(result))     # equity-only column (#397)
   aapl_rows <- result[result$ticker == "AAPL", ]
   btc_rows  <- result[result$ticker == "BTC",  ]
-  expect_true(all(!is.na(aapl_rows$adjusted)))   # AAPL has adjusted prices
-  expect_true(all(is.na(btc_rows$adjusted)))     # BTC rows get NA for equity-only col
+  expect_true(all(!is.na(aapl_rows$adjusted_close)))   # AAPL has adjusted prices
+  expect_true(all(is.na(btc_rows$adjusted_close)))     # BTC rows get NA for equity-only col
 })
 
 test_that("hd_ohlcv split-and-bind: collect=FALSE informs user", {

--- a/packages/historicaldata/tests/testthat/test-registry.R
+++ b/packages/historicaldata/tests/testthat/test-registry.R
@@ -49,6 +49,14 @@ test_that("registry schema matches actual parquet columns for all datasets", {
       }
     )
     if (!length(actual_cols)) next
+    # Apply the same backward-compat alias that hd_lazy()/hd_ohlcv_single()
+    # applies at read time (#325 / #397): parquets written before the rename
+    # still contain 'adjusted'; the schema declares the post-alias canonical
+    # name 'adjusted_close'.  Normalise before comparing so this test checks
+    # the caller-visible schema, not the raw parquet column names.
+    if ("adjusted" %in% actual_cols && !("adjusted_close" %in% actual_cols)) {
+      actual_cols[actual_cols == "adjusted"] <- "adjusted_close"
+    }
     missing_from_parquet <- setdiff(ds$schema, actual_cols)
     extra_in_parquet     <- setdiff(actual_cols, ds$schema)
     msg <- paste0(


### PR DESCRIPTION
## Summary

Fixes the remaining two `adjusted` → `adjusted_close` test failures from #397
(after PR #401 fixed `R/plan_turn_of_month.R`).

### Before

```
[ FAIL 1 | WARN 9 | SKIP 16 | PASS 794 ]
```

Failure:
```
FAILURE: 'test-registry.R:59:5'
Expected dataset 'equity_daily': in schema not in parquet: adjusted_close
                                  in parquet not in schema: adjusted to be TRUE.
```

### After

```
[ FAIL 0 | WARN 9 | SKIP 16 | PASS 795 ]
```

## What was fixed

### `test-query.R` lines 94-98 (commit `df57026`)

Three `expect_true`/`expect_false` assertions used the old bare `adjusted` column
name. The read-time shim in `query.R:187-188` transparently renames `adjusted` →
`adjusted_close` for all callers. Updated the three assertions to use
`adjusted_close` to match the canonical post-shim name.

### `test-registry.R` lines 51-63 (commit `f8ed4a1`)

The `registry schema matches actual parquet columns` test calls `setequal(actual_cols, ds$schema)`
where `ds$schema` correctly declares `adjusted_close` (the canonical caller-visible
name, per `test-column-naming.R` which enforces this). However, the actual
`equity_daily` parquet on HuggingFace was written before #325 and still contains
the old `adjusted` column.

Applied the same backward-compat alias inside the test (`adjusted` → `adjusted_close`
when reading `actual_cols`) so the comparison validates the post-shim schema that
callers observe, not the raw parquet column names. This mirrors the logic in
`query.R:187-188` and is consistent with the design intent documented in the
`registry.R` docstring (lines 18-21).

### `_snaps/query.md` (commit `f8ed4a1`)

Updated the `hd_ohlcv snapshot of AAPL structure` snapshot entry from `adjusted`
to `adjusted_close` with correct `str()` column-name padding (longest field is now
14 chars, so all names are right-padded to 14). This snapshot is only exercised
when `skip_if_no_remote_data()` passes (remote data available).

## What was deferred

None. All three failures are fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
