### PR TITLE
feat(gauntlet): mom_prepeak SSR axis — PR 6/6 for #400

### DIFF
--- a/R/plan_mom_prepeak_gauntlet.R
+++ b/R/plan_mom_prepeak_gauntlet.R
@@ -372,11 +372,43 @@ plan_mom_prepeak_gauntlet <- function() {
 
 
     # ══════════════════════════════════════════════════════════════════════════
-    # B5 — Registry sentinel extension
+    # B5 — Sharpe Stability Ratio (SSR) + Top-5% share
+    #
+    # Complements the HAC Sharpe (B3) with a temporal-stability dimension:
+    # does the strategy earn its Sharpe consistently across rolling windows,
+    # or is it concentrated in a few episodes?
+    #
+    # SSR calibration anchors (Bajor Traver & Rodriguez Dominguez 2026;
+    # Brine & Sueppel 2026):
+    #   S&P 500 daily (1995-): naive Sharpe ~0.5, SSR ~5.3
+    #   Macro FX cross-asset: SSR ~4.4
+    #   Pure random walk: SSR near 0
+    #
+    # top5pct_share: fraction of total return contributed by the top 5% of months.
+    # Used jointly with SSR to distinguish benign seasonality (high SSR + high
+    # top5pct) from detrimental episodic spikes (low SSR + high top5pct).
+    # ══════════════════════════════════════════════════════════════════════════
+
+    targets::tar_target(mom_prepeak_ssr, {
+      hd_sharpe_stability_ratio(
+        mom_prepeak_returns$ret_ls,
+        w          = 36L,
+        ann_factor = 12L
+      )
+    }),
+
+    targets::tar_target(mom_prepeak_top5pct, {
+      hd_top5pct_share(mom_prepeak_returns$ret_ls)
+    }),
+
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # B6 — Registry sentinel extension
     #
     # Record gauntlet metrics (hac_sharpe, hac_pvalue, ff5_alpha, ff5_alpha_t,
-    # pbo, wfc_pearson, avg_dd_days, max_dd_days, max_cons_losses) into bt.metric
-    # under the existing mom_prepeak run_uuid from mom_prepeak_register_runs.
+    # pbo, wfc_pearson, avg_dd_days, max_dd_days, max_cons_losses, ssr,
+    # top5pct_share) into bt.metric under the existing mom_prepeak run_uuid
+    # from mom_prepeak_register_runs.
     #
     # NOTE: idempotency bug #375 is known — deterministic UUID re-running produces
     # duplicate rows.  This target writes correctly on the FIRST tar_make invocation.
@@ -390,7 +422,9 @@ plan_mom_prepeak_gauntlet <- function() {
         mom_prepeak_hac            = mom_prepeak_hac,
         mom_prepeak_ff_reg         = mom_prepeak_ff_reg,
         mom_prepeak_pbo            = mom_prepeak_pbo,
-        mom_prepeak_wfc_result     = mom_prepeak_wfc_result
+        mom_prepeak_wfc_result     = mom_prepeak_wfc_result,
+        mom_prepeak_ssr            = mom_prepeak_ssr,
+        mom_prepeak_top5pct        = mom_prepeak_top5pct
       )
     })
 
@@ -499,8 +533,8 @@ plan_mom_prepeak_gauntlet <- function() {
 
 #' Register gauntlet metrics into bt.metric for the mom_prepeak run
 #'
-#' Appends HAC, FF5, PBO, and WFC metrics to the bt.metric table for the
-#' mom_prepeak run_uuid established in mom_prepeak_register_runs.
+#' Appends HAC, FF5, PBO, WFC, SSR, and top5pct metrics to the bt.metric table
+#' for the mom_prepeak run_uuid established in mom_prepeak_register_runs.
 #' Returns an empty tibble if DBI / duckdb are unavailable.
 #'
 #' @noRd
@@ -509,7 +543,9 @@ plan_mom_prepeak_gauntlet <- function() {
                                             mom_prepeak_hac,
                                             mom_prepeak_ff_reg,
                                             mom_prepeak_pbo,
-                                            mom_prepeak_wfc_result) {
+                                            mom_prepeak_wfc_result,
+                                            mom_prepeak_ssr    = NULL,
+                                            mom_prepeak_top5pct = NULL) {
   if (!requireNamespace("DBI", quietly = TRUE) ||
       !requireNamespace("duckdb", quietly = TRUE)) {
     return(tibble::tibble(run_uuid = character(), metric_rows = integer()))
@@ -550,7 +586,15 @@ plan_mom_prepeak_gauntlet <- function() {
       mom_prepeak_wfc_result$classification else NA_character_,
     avg_dd_days    = mom_prepeak_metrics$avg_dd_days,
     max_dd_days    = mom_prepeak_metrics$max_dd_days,
-    max_cons_losses = mom_prepeak_metrics$max_cons_losses
+    max_cons_losses = mom_prepeak_metrics$max_cons_losses,
+    ssr            = if (!is.null(mom_prepeak_ssr) && !is.null(mom_prepeak_ssr$ssr))
+      mom_prepeak_ssr$ssr else NA_real_,
+    ssr_mean_sr    = if (!is.null(mom_prepeak_ssr) && !is.null(mom_prepeak_ssr$mean_sharpe))
+      mom_prepeak_ssr$mean_sharpe else NA_real_,
+    ssr_n_windows  = if (!is.null(mom_prepeak_ssr) && !is.null(mom_prepeak_ssr$n_windows))
+      as.integer(mom_prepeak_ssr$n_windows) else NA_integer_,
+    top5pct_share  = if (!is.null(mom_prepeak_top5pct) && !is.null(mom_prepeak_top5pct$top_share))
+      mom_prepeak_top5pct$top_share else NA_real_
   )
 
   historicaldata::hd_metric_record(con, uu, gauntlet_wide)

--- a/docs/momentum-prepeak.qmd
+++ b/docs/momentum-prepeak.qmd
@@ -1040,11 +1040,99 @@ DT::datatable(
 
 **CPCV PBO:** The Combinatorial Purged Cross-Validation Probability of Backtest Overfitting measures how often the IS-best configuration (n_quantiles value) underperforms the OOS median. PBO = **`r pbo_val`** (across `r pbo_paths` paths). PBO near 0 means the IS-best choice also tends to be OOS-best — little evidence of overfitting. PBO near 1 means IS selection is anti-predictive for OOS — strong evidence of overfitting. Since mom_prepeak is not a highly tuned strategy, this PBO is more of a sanity check than a critical test.
 
+# Sharpe Stability Ratio
+
+## Row
+
+### {.tabset}
+
+#### SSR Panel
+
+```{r}
+#| label: ssr-panel
+ssr_res    <- safe_tar_read("mom_prepeak_ssr")
+top5_res   <- safe_tar_read("mom_prepeak_top5pct")
+
+ssr_available  <- !is.null(ssr_res)
+top5_available <- !is.null(top5_res)
+
+# Dynamic values for prose (dynamic-prose-values rule)
+ssr_val       <- if (ssr_available && !is.null(ssr_res$ssr))
+  round(ssr_res$ssr, 3) else "N/A"
+ssr_mean_sr   <- if (ssr_available && !is.null(ssr_res$mean_sharpe))
+  round(ssr_res$mean_sharpe, 3) else "N/A"
+ssr_n_windows <- if (ssr_available && !is.null(ssr_res$n_windows))
+  ssr_res$n_windows else "N/A"
+top5_share    <- if (top5_available && !is.null(top5_res$top_share))
+  round(top5_res$top_share, 3) else "N/A"
+top5_n_top    <- if (top5_available) top5_res$n_top    else "N/A"
+top5_n_total  <- if (top5_available) top5_res$n_total  else "N/A"
+
+ssr_display <- tibble::tibble(
+  Metric = c(
+    "SSR",
+    "Mean rolling Sharpe",
+    "Rolling windows (36-month)",
+    "Top-5% share of total return",
+    "Top-5% period count"
+  ),
+  Value = c(
+    as.character(ssr_val),
+    as.character(ssr_mean_sr),
+    as.character(ssr_n_windows),
+    as.character(top5_share),
+    paste0(as.character(top5_n_top), " of ", as.character(top5_n_total))
+  ),
+  Interpretation = c(
+    "Sharpe Stability Ratio: mean rolling Sharpe / HAC SE. SSR > 1.96 → 95% confidence the strategy is persistently profitable across rolling windows.",
+    "Mean of 36-month rolling annualised Sharpe series (12× ann factor).",
+    "Number of complete 36-month rolling windows used to compute SSR.",
+    "Fraction of total compounded return contributed by the top 5% of months.",
+    "Count of top-5% months / total months."
+  )
+)
+
+DT::datatable(
+  ssr_display,
+  caption = htmltools::tags$caption(
+    style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+    paste0(
+      "Sharpe Stability Ratio (SSR) for mom_prepeak — 36-month rolling windows, ann_factor = 12. ",
+      "Calibration anchors: S\\u00B950 500 daily since 1995: SSR \\u224 5.3; macro FX cross-asset: SSR \\u224 4.4. ",
+      "SSR is computed via hd_sharpe_stability_ratio() in packages/historicaldata/R/stability.R ",
+      "using Newey-West HAC bandwidth (floor(4*(T/100)^(2/9))). ",
+      "Top-5% share is computed via hd_top5pct_share()."
+    )
+  ),
+  rownames = FALSE,
+  options  = list(pageLength = 6, scrollX = TRUE, dom = "t")
+)
+```
+
+#### Interpretation
+
+```{r}
+#| label: ssr-interpretation
+#| results: asis
+ssr_res    <- if (exists("ssr_res"))    ssr_res    else safe_tar_read("mom_prepeak_ssr")
+top5_res   <- if (exists("top5_res"))   top5_res   else safe_tar_read("mom_prepeak_top5pct")
+
+ssr_available  <- !is.null(ssr_res)
+top5_available <- !is.null(top5_res)
+
+ssr_val     <- if (ssr_available && !is.null(ssr_res$ssr))       round(ssr_res$ssr, 3)          else "N/A"
+top5_share  <- if (top5_available && !is.null(top5_res$top_share)) round(top5_res$top_share, 3) else "N/A"
+```
+
+**Sharpe Stability Ratio:** The SSR is the mean of a 36-month rolling annualised Sharpe series divided by its Newey-West HAC standard error. It is a t-statistic for the hypothesis that the strategy earns a consistently positive Sharpe across rolling windows, not just on average. SSR = **`r ssr_val`**. Calibration anchors from published research (Bajor Traver & Rodriguez Dominguez 2026; Brine & Sueppel 2026): S&P 500 daily returns since 1995 have a naive Sharpe of ~0.5 and SSR ~5.3; macro FX cross-asset strategies score SSR ~4.4. An SSR below 1.96 indicates that the strategy's Sharpe is not statistically stable across the rolling-window horizon — profits may be concentrated in a small number of windows rather than earned consistently.
+
+**Top-5% return share:** Top-5% share = **`r top5_share`**. This measures what fraction of total compounded return comes from the best 5% of months. A share near 1.0 indicates highly episodic returns (edge concentrated in a few exceptional periods); a share near 0.05 indicates uniformly distributed returns. Interpreted jointly with SSR: high SSR + high top-5% share indicates benign seasonality (the strategy consistently wins, but larger in favourable regimes — a desirable property). Low SSR + high top-5% share indicates detrimental episodic spikes (a few outlier months drive the full-sample Sharpe, masking instability).
+
 ## Methodology
 
 ### What this vignette computes
 
-This vignette reads pre-computed targets from the pipeline and builds eight sections: a peak-date distribution histogram (replicating paper Figure 1); a 84/16 decomposition table from `mom_prepeak_summary`; cumulative-return curves for all three strategies with bankruptcy annotation at month `r if (!is.na(bankrupt_mo)) bankrupt_mo else "N/A"`; a skewness comparison; Pillar-8 risk metrics (dd duration, consecutive losses, loss clustering) from the extended `mom_prepeak_summary`; a Walk-Forward Correlation grid over n_quantiles ∈ {5, 10, 20}; a random-day-as-peak null test; and a statistical hardening panel (HAC Sharpe, FF5+Momentum regression alpha, CPCV PBO).
+This vignette reads pre-computed targets from the pipeline and builds nine sections: a peak-date distribution histogram (replicating paper Figure 1); a 84/16 decomposition table from `mom_prepeak_summary`; cumulative-return curves for all three strategies with bankruptcy annotation at month `r if (!is.na(bankrupt_mo)) bankrupt_mo else "N/A"`; a skewness comparison; Pillar-8 risk metrics (dd duration, consecutive losses, loss clustering) from the extended `mom_prepeak_summary`; a Walk-Forward Correlation grid over n_quantiles ∈ {5, 10, 20}; a random-day-as-peak null test; a statistical hardening panel (HAC Sharpe, FF5+Momentum regression alpha, CPCV PBO); and a Sharpe Stability Ratio (SSR) panel quantifying temporal consistency of risk-adjusted returns.
 
 ### Data sources
 
@@ -1054,6 +1142,8 @@ This vignette reads pre-computed targets from the pipeline and builds eight sect
 - `mom_prepeak_random_peak_test`, `mom_prepeak_random_peak_metrics` — random-day-as-peak null from [`.mom_prepeak_random_peak_signal()`](https://github.com/JohnGavin/historical/blob/main/R/plan_mom_prepeak_gauntlet.R) in the gauntlet plan.
 - `mom_prepeak_hac`, `mom_prepeak_ff_reg` — HAC Sharpe and FF5+Momentum regression via [`hd_hac_sharpe()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/falsification.R#L80) and [`hd_factor_null_test()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/falsification.R#L738) on monthly Fama-French factors from `hd_factors(frequency="monthly")`.
 - `mom_prepeak_pbo` — CPCV Probability of Backtest Overfitting via [`hd_pbo()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/cpcv.R#L267) over n_quantiles ∈ {5, 10, 20}.
+- `mom_prepeak_ssr` — Sharpe Stability Ratio via [`hd_sharpe_stability_ratio()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/stability.R#L132) with w=36 months and ann_factor=12. Computed in [`R/plan_mom_prepeak_gauntlet.R`](https://github.com/JohnGavin/historical/blob/main/R/plan_mom_prepeak_gauntlet.R).
+- `mom_prepeak_top5pct` — Top-5% return share via [`hd_top5pct_share()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/stability.R#L238). Computed in [`R/plan_mom_prepeak_gauntlet.R`](https://github.com/JohnGavin/historical/blob/main/R/plan_mom_prepeak_gauntlet.R).
 - `strategy_names` — single source of truth for display names, defined in [`R/plan_strategy_names.R`](https://github.com/JohnGavin/historical/blob/main/R/plan_strategy_names.R).
 - Paper: Büsing, Mohrschladt & Siedhoff (2022), *Pre-peak and post-peak momentum*, [SSRN 4298538](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4298538).
 

--- a/packages/historicaldata/tests/testthat/test-mom-prepeak-gauntlet-ssr.R
+++ b/packages/historicaldata/tests/testthat/test-mom-prepeak-gauntlet-ssr.R
@@ -1,0 +1,159 @@
+# Tests for SSR and top5pct columns added to the mom_prepeak gauntlet (#400)
+#
+# These tests verify that hd_sharpe_stability_ratio() and hd_top5pct_share()
+# produce the expected list structure and numeric columns when called with a
+# synthetic monthly return series — the same signature used in the gauntlet
+# targets mom_prepeak_ssr and mom_prepeak_top5pct.
+#
+# All tests are self-contained and use set.seed() locally.
+
+testthat::local_edition(3)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# Synthetic monthly L/S return series (positive mean, realistic vol)
+make_monthly_returns <- function(n = 120L, mean_r = 0.005, sd_r = 0.04,
+                                 seed = 42L) {
+  set.seed(seed)
+  stats::rnorm(n, mean = mean_r, sd = sd_r)
+}
+
+
+# ── SSR column structure ───────────────────────────────────────────────────────
+
+test_that("G1: mom_prepeak_ssr target — hd_sharpe_stability_ratio returns expected names", {
+  r <- make_monthly_returns()
+  result <- hd_sharpe_stability_ratio(r, w = 36L, ann_factor = 12L)
+
+  expected_names <- c("ssr", "mean_sharpe", "se", "n_windows", "w",
+                       "lag_nw", "ann_factor")
+  expect_named(result, expected_names)
+})
+
+test_that("G2: mom_prepeak_ssr target — ssr is numeric scalar", {
+  r <- make_monthly_returns()
+  result <- hd_sharpe_stability_ratio(r, w = 36L, ann_factor = 12L)
+
+  expect_true(is.numeric(result$ssr))
+  expect_length(result$ssr, 1L)
+})
+
+test_that("G3: mom_prepeak_ssr target — n_windows is positive integer for n=120, w=36", {
+  r   <- make_monthly_returns(n = 120L)
+  res <- hd_sharpe_stability_ratio(r, w = 36L, ann_factor = 12L)
+
+  # Expect 120 - 36 + 1 = 85 complete windows
+  expect_equal(res$n_windows, 120L - 36L + 1L)
+})
+
+test_that("G4: mom_prepeak_ssr target — returns NA ssr when fewer than 2 complete windows", {
+  # n = 36 gives exactly 1 window, which is < 2 — SSR cannot be computed
+  r   <- make_monthly_returns(n = 36L)
+  res <- hd_sharpe_stability_ratio(r, w = 36L, ann_factor = 12L)
+
+  expect_true(is.na(res$ssr),
+    info = "SSR must be NA when n_windows < 2")
+})
+
+test_that("G5: mom_prepeak_ssr target — positive-mean series yields positive mean_sharpe", {
+  r   <- make_monthly_returns(n = 120L, mean_r = 0.01, sd_r = 0.02)
+  res <- hd_sharpe_stability_ratio(r, w = 36L, ann_factor = 12L)
+
+  expect_true(!is.na(res$mean_sharpe) && res$mean_sharpe > 0,
+    info = "Positive-mean return series should give positive mean_sharpe")
+})
+
+test_that("G6: mom_prepeak_ssr target — ann_factor=12 echoed in result", {
+  r   <- make_monthly_returns()
+  res <- hd_sharpe_stability_ratio(r, w = 36L, ann_factor = 12L)
+
+  expect_equal(res$ann_factor, 12)
+})
+
+
+# ── top5pct_share column structure ────────────────────────────────────────────
+
+test_that("G7: mom_prepeak_top5pct target — hd_top5pct_share returns expected names", {
+  r      <- make_monthly_returns()
+  result <- hd_top5pct_share(r)
+
+  expected_names <- c("top_share", "n_top", "n_total", "pct", "total_return")
+  expect_named(result, expected_names)
+})
+
+test_that("G8: mom_prepeak_top5pct target — top_share is numeric in (0, 1) for positive-mean series", {
+  r      <- make_monthly_returns(n = 120L, mean_r = 0.005)
+  result <- hd_top5pct_share(r)
+
+  expect_true(is.numeric(result$top_share))
+  expect_length(result$top_share, 1L)
+  # For a positive-mean series, top_share should be positive
+  expect_true(!is.na(result$top_share) && result$top_share > 0,
+    info = "Positive-mean series should have positive top_share")
+})
+
+test_that("G9: mom_prepeak_top5pct target — n_top is ceiling(n_total * 0.05)", {
+  n      <- 120L
+  r      <- make_monthly_returns(n = n)
+  result <- hd_top5pct_share(r)
+
+  expected_n_top <- as.integer(ceiling(n * 0.05))
+  expect_equal(result$n_top, expected_n_top)
+})
+
+test_that("G10: mom_prepeak_top5pct target — n_total matches length of non-NA returns", {
+  n   <- 120L
+  r   <- make_monthly_returns(n = n)
+  res <- hd_top5pct_share(r)
+
+  expect_equal(res$n_total, n)
+})
+
+test_that("G11: mom_prepeak_top5pct target — all-NA returns yields NA top_share", {
+  r   <- rep(NA_real_, 50L)
+  res <- hd_top5pct_share(r)
+
+  expect_true(is.na(res$top_share),
+    info = "All-NA input should yield NA top_share")
+  expect_equal(res$n_total, 0L)
+})
+
+
+# ── Integration: gauntlet workflow ────────────────────────────────────────────
+
+test_that("G12: gauntlet workflow — ssr and top5pct columns are numeric scalars", {
+  # Simulates the gauntlet target computation on a synthetic return vector
+  r <- make_monthly_returns(n = 120L)
+
+  ssr_res  <- hd_sharpe_stability_ratio(r, w = 36L, ann_factor = 12L)
+  top5_res <- hd_top5pct_share(r)
+
+  ssr_col        <- round(ssr_res$ssr,          3)
+  ssr_mean_sr    <- round(ssr_res$mean_sharpe,   3)
+  ssr_n_windows  <- ssr_res$n_windows
+  top5pct_share  <- round(top5_res$top_share,    3)
+
+  expect_true(is.numeric(ssr_col)        && length(ssr_col)       == 1L)
+  expect_true(is.numeric(ssr_mean_sr)    && length(ssr_mean_sr)   == 1L)
+  expect_true(is.integer(ssr_n_windows)  && length(ssr_n_windows) == 1L)
+  expect_true(is.numeric(top5pct_share)  && length(top5pct_share) == 1L)
+})
+
+test_that("G13: gauntlet workflow — tibble with all four new columns assembles cleanly", {
+  r <- make_monthly_returns(n = 120L)
+
+  ssr_res  <- hd_sharpe_stability_ratio(r, w = 36L, ann_factor = 12L)
+  top5_res <- hd_top5pct_share(r)
+
+  row <- tibble::tibble(
+    ssr           = round(ssr_res$ssr,          3),
+    ssr_mean_sr   = round(ssr_res$mean_sharpe,   3),
+    ssr_n_windows = as.integer(ssr_res$n_windows),
+    top5pct_share = round(top5_res$top_share,    3)
+  )
+
+  expect_equal(nrow(row), 1L)
+  expect_true(all(c("ssr", "ssr_mean_sr", "ssr_n_windows", "top5pct_share") %in% names(row)))
+  expect_true(all(vapply(row[c("ssr", "ssr_mean_sr", "top5pct_share")], is.numeric, logical(1L))))
+  expect_true(is.integer(row$ssr_n_windows))
+})


### PR DESCRIPTION
## Summary

- Adds `mom_prepeak_ssr` and `mom_prepeak_top5pct` targets to the mom_prepeak gauntlet (`R/plan_mom_prepeak_gauntlet.R`), calling `hd_sharpe_stability_ratio(ret_ls, w=36, ann_factor=12)` and `hd_top5pct_share(ret_ls)` respectively
- Extends `.mom_prepeak_gauntlet_register()` to write four new columns (`ssr`, `ssr_mean_sr`, `ssr_n_windows`, `top5pct_share`) into `bt.metric`
- Adds a **Sharpe Stability Ratio** section to `docs/momentum-prepeak.qmd` with a DT table and prose interpreting the result against published calibration anchors (S&P 500 SSR ~5.3, macro FX ~4.4)
- Adds 13 tests (`G1`–`G13`) in `packages/historicaldata/tests/testthat/test-mom-prepeak-gauntlet-ssr.R` covering return structure, NA handling, and integration workflow

## Changes

| File | Change |
|---|---|
| `R/plan_mom_prepeak_gauntlet.R` | New B5 section (SSR + top5pct targets); B5→B6 registry; register call + helper extended |
| `docs/momentum-prepeak.qmd` | New `# Sharpe Stability Ratio` dashboard section; Methodology updated (eight→nine sections) |
| `packages/historicaldata/tests/testthat/test-mom-prepeak-gauntlet-ssr.R` | 13 new tests, all passing |

## Test plan

- [x] `devtools::test(filter="gauntlet-ssr")` — 23 PASS, 0 FAIL, 0 SKIP
- [ ] `tar_make()` on mom_prepeak slice — `mom_prepeak_ssr` and `mom_prepeak_top5pct` compute successfully (requires project pipeline; deferred to deploy commit)
- [ ] Re-render `docs/momentum-prepeak.qmd` — SSR panel displays with dynamic values (deploy commit #4)

## Statistical reporting note

SSR is reported as a t-statistic analog: SSR = mean(rolling Sharpe) / HAC SE. The vignette prose states the 95% confidence threshold (SSR > 1.96) and references the calibration anchors, satisfying the `statistical-reporting` rule requirement for FPR/p-value framing.

## Related

- Closes PR 6/6 for issue #400 (mom_prepeak umbrella)
- Functions: `hd_sharpe_stability_ratio()` and `hd_top5pct_share()` in `packages/historicaldata/R/stability.R`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
