### PR TITLE
feat(leaderboard): surface SSR + top5pct columns — PR 4/6 for #400

### DIFF
--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -302,6 +302,96 @@ plan_leaderboard <- function() {
           )
       }
 
+      # ── SSR + top5pct columns (#400) ─────────────────────────────────────────
+      # Sharpe Stability Ratio (SSR) and top-5% share for each strategy.
+      # Window w = 36 months (3 years) for all monthly strategies; ann_factor = 12.
+      # Strategies without an accessible return vector receive NA for both columns.
+      # SSR and top5pct_share are full-sample statistics: broadcast to all period
+      # rows (the vignette shows them only in the Full-Period view).
+      {
+        # Build a named list: strategy label -> full-period return vector
+        # Each return vector must be numeric, already NA-stripped by the helpers.
+        ssr_map <- list()
+
+        safe_ssr <- function(r) {
+          r <- r[!is.na(r)]
+          if (length(r) < 38L) return(NA_real_)
+          tryCatch(
+            historicaldata::hd_sharpe_stability_ratio(r, w = 36L, ann_factor = 12L)$ssr,
+            error = function(e) NA_real_
+          )
+        }
+
+        safe_top5 <- function(r) {
+          r <- r[!is.na(r)]
+          if (length(r) == 0L) return(NA_real_)
+          tryCatch(
+            historicaldata::hd_top5pct_share(r)$top_share,
+            error = function(e) NA_real_
+          )
+        }
+
+        # Factor MAX and Factor DRIF: monthly portfolio_ret
+        if (!is.null(fm_portfolio) && "portfolio_ret" %in% names(fm_portfolio)) {
+          r <- fm_portfolio$portfolio_ret
+          ssr_map[["Factor MAX"]] <- list(ssr = safe_ssr(r), top5 = safe_top5(r))
+        }
+        if (!is.null(drif_portfolio) && "portfolio_ret" %in% names(drif_portfolio)) {
+          r <- drif_portfolio$portfolio_ret
+          ssr_map[["Factor DRIF"]] <- list(ssr = safe_ssr(r), top5 = safe_top5(r))
+        }
+
+        # Stock MAX, Stock DRIF, XGB DRIF: monthly port_ret
+        if (!is.null(stk_max_portfolio) && "port_ret" %in% names(stk_max_portfolio)) {
+          r <- stk_max_portfolio$port_ret
+          ssr_map[["Stock MAX"]] <- list(ssr = safe_ssr(r), top5 = safe_top5(r))
+        }
+        if (!is.null(stk_drif_portfolio) && "port_ret" %in% names(stk_drif_portfolio)) {
+          r <- stk_drif_portfolio$port_ret
+          ssr_map[["Stock DRIF"]] <- list(ssr = safe_ssr(r), top5 = safe_top5(r))
+        }
+        if (!is.null(xgb_drif_portfolio) && "port_ret" %in% names(xgb_drif_portfolio)) {
+          r <- xgb_drif_portfolio$port_ret
+          ssr_map[["XGB DRIF"]] <- list(ssr = safe_ssr(r), top5 = safe_top5(r))
+        }
+
+        # Mom Pre-Peak, Post-Peak, Combined: monthly ret_ls
+        if (!is.null(mom_prepeak_returns) && "ret_ls" %in% names(mom_prepeak_returns)) {
+          r <- mom_prepeak_returns$ret_ls
+          ssr_map[["Mom Pre-Peak"]] <- list(ssr = safe_ssr(r), top5 = safe_top5(r))
+        }
+        if (!is.null(mom_postpeak_returns) && "ret_ls" %in% names(mom_postpeak_returns)) {
+          r <- mom_postpeak_returns$ret_ls
+          ssr_map[["Mom Post-Peak"]] <- list(ssr = safe_ssr(r), top5 = safe_top5(r))
+        }
+        if (!is.null(mom_combined_returns) && "ret_ls" %in% names(mom_combined_returns)) {
+          r <- mom_combined_returns$ret_ls
+          ssr_map[["Mom 12-2"]] <- list(ssr = safe_ssr(r), top5 = safe_top5(r))
+        }
+
+        # LTR: monthly port_ret
+        if (!is.null(ltr_portfolio) && "port_ret" %in% names(ltr_portfolio)) {
+          r <- ltr_portfolio$port_ret
+          ssr_map[["LTR"]] <- list(ssr = safe_ssr(r), top5 = safe_top5(r))
+        }
+
+        # Build lookup tibble for joining
+        if (length(ssr_map) > 0L) {
+          ssr_tbl <- dplyr::bind_rows(lapply(names(ssr_map), function(nm) {
+            tibble::tibble(
+              strategy     = nm,
+              ssr          = ssr_map[[nm]]$ssr,
+              top5pct_share = ssr_map[[nm]]$top5
+            )
+          }))
+          all_metrics <- all_metrics |>
+            dplyr::left_join(ssr_tbl, by = "strategy")
+        } else {
+          all_metrics <- all_metrics |>
+            dplyr::mutate(ssr = NA_real_, top5pct_share = NA_real_)
+        }
+      }
+
       # ── Pillar 8: risk-architecture columns (#269, #331) ─────────────────────
       # Join avg_dd_days, max_dd_days, loss_clustered, max_cons_losses from
       # fals_results_db. fals_results_db uses strategy_id (internal code); map

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -195,6 +195,11 @@ check_anchor_in_range <- function(html_dir,
 #' running `tar_make()`.  The `qa_leaderboard_coverage` target calls this
 #' function directly.
 #'
+#' Also asserts that the `ssr` and `top5pct_share` columns are present in the
+#' leaderboard tibble and that at least one row has a non-NA value for each
+#' (i.e. the stability metrics were computed for at least one strategy).
+#' Added in #400 (PR 4/6).
+#'
 #' @param strategy_names Tibble with at least `short_name` and `code_name`
 #'   columns (the output of the `strategy_names` targets pipeline target).
 #' @param leaderboard Tibble with at least a `strategy` column (the output of
@@ -216,6 +221,34 @@ check_leaderboard_coverage <- function(strategy_names, leaderboard) {
         rep("i", length(missing))
       ),
       "i" = "Add the corresponding add_meta() calls in R/plan_leaderboard.R."
+    ))
+  }
+
+  # Assert SSR column present and populated (#400)
+  if (!"ssr" %in% names(leaderboard)) {
+    cli::cli_abort(c(
+      "x" = "Leaderboard is missing required column {.field ssr}.",
+      "i" = "Add the SSR computation block to R/plan_leaderboard.R (#400)."
+    ))
+  }
+  if (all(is.na(leaderboard$ssr))) {
+    cli::cli_abort(c(
+      "x" = "Leaderboard column {.field ssr} is entirely NA — no stability metrics were computed.",
+      "i" = "Check that portfolio return targets are available and have >= 38 months (#400)."
+    ))
+  }
+
+  # Assert top5pct_share column present and populated (#400)
+  if (!"top5pct_share" %in% names(leaderboard)) {
+    cli::cli_abort(c(
+      "x" = "Leaderboard is missing required column {.field top5pct_share}.",
+      "i" = "Add the top5pct computation block to R/plan_leaderboard.R (#400)."
+    ))
+  }
+  if (all(is.na(leaderboard$top5pct_share))) {
+    cli::cli_abort(c(
+      "x" = "Leaderboard column {.field top5pct_share} is entirely NA — no top-5% shares were computed.",
+      "i" = "Check that portfolio return targets are available (#400)."
     ))
   }
 

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -127,9 +127,18 @@ if (!is.null(lb)) {
       Vol = paste0(round(vol * 100, 1), "%"),
       `Net CAGR` = ifelse(is.na(net_cagr), "—", paste0(round(net_cagr * 100, 1), "%")),
       Sharpe = ifelse(is.na(sharpe), "—", as.character(round(sharpe, 2))),
-      Credible = ifelse(is.na(credible) | !credible, "NO", "yes")
+      Credible = ifelse(is.na(credible) | !credible, "NO", "yes"),
+      # SSR and top5pct_share added in #400
+      SSR = ifelse(
+        is.na(ssr), "—",
+        as.character(round(ssr, 2))
+      ),
+      `Top5% Share` = ifelse(
+        is.na(top5pct_share), "—",
+        paste0(round(top5pct_share * 100, 1), "%")
+      )
     ) |>
-    select(strategy, `Max DD`, `CVaR 95%`, Vol, `Net CAGR`, Sharpe, Credible) |>
+    select(strategy, `Max DD`, `CVaR 95%`, Vol, `Net CAGR`, Sharpe, SSR, `Top5% Share`, Credible) |>
     pivot_longer(-strategy, names_to = "Metric", values_to = "value") |>
     pivot_wider(names_from = strategy, values_from = value)
 
@@ -149,7 +158,13 @@ if (!is.null(lb)) {
            " — draw on `stk_universe` (see issue #150).")
   } else ""
 
-  hd_dt(metrics_long, paste0("Risk-first rankings (sorted by max drawdown). Risk: DD, CVaR, Vol. Return: Net CAGR (after 0.20% round-trip/month). Sharpe secondary.", flag_note, bias_note))
+  hd_dt(metrics_long, paste0(
+    "Risk-first rankings (sorted by max drawdown). ",
+    "Risk: DD, CVaR, Vol. Return: Net CAGR (after 0.20% round-trip/month). ",
+    "SSR = Sharpe Stability Ratio (HAC-corrected t-stat of rolling 36-month Sharpes; ≥2 = consistent). ",
+    "Top5% Share = fraction of total return from the best 5% of months.",
+    flag_note, bias_note
+  ))
 }
 ```
 

--- a/tests/testthat/test-leaderboard-coverage.R
+++ b/tests/testthat/test-leaderboard-coverage.R
@@ -1,0 +1,106 @@
+# Tests for check_leaderboard_coverage() — QA gate S7 (#345, extended in #400)
+#
+# The function is defined in R/plan_qa_gates.R.  Tests exercise it directly
+# without running tar_make().
+
+# Load the function under test directly.
+source(here::here("R/plan_qa_gates.R"))
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+# Minimal strategy_names tibble (only columns the function reads)
+minimal_strategy_names <- tibble::tibble(
+  short_name = c("Factor MAX", "Factor DRIF"),
+  code_name  = c("fac_max",   "fac_drif")
+)
+
+# Leaderboard WITH both strategies and both stability columns
+good_leaderboard <- tibble::tibble(
+  strategy      = c("Factor MAX", "Factor MAX", "Factor DRIF", "Factor DRIF"),
+  period        = c("Training",   "Full Period", "Training",    "Full Period"),
+  ssr           = c(NA_real_,     2.1,           NA_real_,      1.8),
+  top5pct_share = c(NA_real_,     0.32,          NA_real_,      0.28)
+)
+
+# Leaderboard missing one strategy
+missing_strategy_leaderboard <- tibble::tibble(
+  strategy      = c("Factor MAX", "Factor MAX"),
+  period        = c("Training",   "Full Period"),
+  ssr           = c(NA_real_,     2.1),
+  top5pct_share = c(NA_real_,     0.32)
+)
+
+# Leaderboard missing the ssr column entirely
+no_ssr_leaderboard <- tibble::tibble(
+  strategy      = c("Factor MAX", "Factor DRIF"),
+  period        = c("Full Period", "Full Period"),
+  top5pct_share = c(0.32, 0.28)
+)
+
+# Leaderboard with ssr column present but entirely NA
+all_na_ssr_leaderboard <- tibble::tibble(
+  strategy      = c("Factor MAX", "Factor DRIF"),
+  period        = c("Full Period", "Full Period"),
+  ssr           = c(NA_real_, NA_real_),
+  top5pct_share = c(0.32, 0.28)
+)
+
+# Leaderboard missing top5pct_share column
+no_top5_leaderboard <- tibble::tibble(
+  strategy = c("Factor MAX", "Factor DRIF"),
+  period   = c("Full Period", "Full Period"),
+  ssr      = c(2.1, 1.8)
+)
+
+# Leaderboard with top5pct_share entirely NA
+all_na_top5_leaderboard <- tibble::tibble(
+  strategy      = c("Factor MAX", "Factor DRIF"),
+  period        = c("Full Period", "Full Period"),
+  ssr           = c(2.1, 1.8),
+  top5pct_share = c(NA_real_, NA_real_)
+)
+
+# ── Tests: strategy coverage ─────────────────────────────────────────────────
+
+test_that("check_leaderboard_coverage passes when all strategies present with SSR columns", {
+  expect_true(check_leaderboard_coverage(minimal_strategy_names, good_leaderboard))
+})
+
+test_that("check_leaderboard_coverage throws when a strategy is missing", {
+  expect_error(
+    check_leaderboard_coverage(minimal_strategy_names, missing_strategy_leaderboard),
+    regexp = "Factor DRIF"
+  )
+})
+
+# ── Tests: SSR column (#400) ─────────────────────────────────────────────────
+
+test_that("check_leaderboard_coverage throws when ssr column absent", {
+  expect_error(
+    check_leaderboard_coverage(minimal_strategy_names, no_ssr_leaderboard),
+    regexp = "ssr"
+  )
+})
+
+test_that("check_leaderboard_coverage throws when ssr column is entirely NA", {
+  expect_error(
+    check_leaderboard_coverage(minimal_strategy_names, all_na_ssr_leaderboard),
+    regexp = "entirely NA"
+  )
+})
+
+# ── Tests: top5pct_share column (#400) ───────────────────────────────────────
+
+test_that("check_leaderboard_coverage throws when top5pct_share column absent", {
+  expect_error(
+    check_leaderboard_coverage(minimal_strategy_names, no_top5_leaderboard),
+    regexp = "top5pct_share"
+  )
+})
+
+test_that("check_leaderboard_coverage throws when top5pct_share is entirely NA", {
+  expect_error(
+    check_leaderboard_coverage(minimal_strategy_names, all_na_top5_leaderboard),
+    regexp = "entirely NA"
+  )
+})


### PR DESCRIPTION
## Summary

- Adds `ssr` (Sharpe Stability Ratio) and `top5pct_share` columns to the `leaderboard` pipeline target in `R/plan_leaderboard.R`
- Extends `check_leaderboard_coverage()` QA gate to assert both columns are present and populated
- Adds `tests/testthat/test-leaderboard-coverage.R` with 6 tests covering the new assertions
- Surfaces SSR and Top5% Share in the Full Period tab of `docs/leaderboard.qmd` with descriptive caption

## Implementation details

**Window choice:** w=36 months (3 years) for all monthly strategies; ann_factor=12. Strategies with fewer than 38 observations receive NA (guarded by safe_ssr()).

**Strategies covered:** Factor MAX, Factor DRIF, Stock MAX, Stock DRIF, XGB DRIF, Mom Pre-Peak, Mom Post-Peak, Mom 12-2, LTR.

**Strategies with NA:** TOM, CMR, Avoid Worst, Risk State, OLMAR, PSO Optimal — no individual return vector is directly accessible as a target dependency.

**SSR broadcasting:** Both ssr and top5pct_share are full-sample statistics broadcast to all period rows via left join; the vignette displays them only in the Full Period view.

**Note on re-render:** HTML re-render deferred — tar_make() must rebuild leaderboard first. Consistent with PR sequence for #400.

## Test plan

- [x] parse(file = "R/plan_leaderboard.R") passes
- [x] parse(file = "R/plan_qa_gates.R") passes
- [x] parse(file = "tests/testthat/test-leaderboard-coverage.R") passes
- [ ] tar_make(leaderboard) — requires warm cache (deferred to deploy)
- [ ] devtools::test(filter = "leaderboard-coverage") — requires nix develop

PR 4/6 for issue #400.

Generated with [Claude Code](https://claude.com/claude-code)
