### PR TITLE
feat(register_runs): auto-record SSR + top5pct — PR 5/6 for #400

### DIFF
--- a/R/plan_commodities_mean_reversion.R
+++ b/R/plan_commodities_mean_reversion.R
@@ -149,17 +149,23 @@ plan_commodities_mean_reversion <- function() {
     }),
 
 
-    # ── Registry sentinel (#347 PR 2/4) ───────────────────────────────────
+    # ── Registry sentinel (#347 PR 2/4; stability metrics #400 PR 5/6) ──────
     # First strategy to write into the bt.* registry. One bt.strategy row
     # + three bt.run rows (one per lookback partition: 1m, 3m, 6m). The
     # registry path is overridable via HD_REGISTRY_PATH so CI / tests can
     # point it at a tempfile. Returns a tibble of the run_uuids for
     # inspection via tar_read(cmr_registry_run).
+    # Also records SSR + top5pct stability metrics via hd_record_stability_metrics().
 
     targets::tar_target(cmr_registry_run, {
       .cmr_register_runs(
         strategy_names = strategy_names,
-        cmr_summary    = cmr_summary
+        cmr_summary    = cmr_summary,
+        portfolio_list = list(
+          `1m` = cmr_portfolio_1m,
+          `3m` = cmr_portfolio_3m,
+          `6m` = cmr_portfolio_6m
+        )
       )
     })
 
@@ -214,10 +220,13 @@ plan_commodities_mean_reversion <- function() {
 }
 
 
-# ── Registry sentinel helper (#347 PR 2/4) ────────────────────────────────
+# ── Registry sentinel helper (#347 PR 2/4; stability metrics #400 PR 5/6) ──
 # Initialises (idempotent) + upserts CMR strategy + records one bt.run
-# row per lookback partition. Returns a tibble of (partition, run_uuid).
-.cmr_register_runs <- function(strategy_names, cmr_summary) {
+# row per lookback partition. Also records SSR + top5pct stability metrics
+# via hd_record_stability_metrics() when portfolio_list is supplied.
+# Returns a tibble of (partition, run_uuid).
+.cmr_register_runs <- function(strategy_names, cmr_summary,
+                               portfolio_list = list()) {
   if (!requireNamespace("DBI", quietly = TRUE) ||
       !requireNamespace("duckdb", quietly = TRUE)) {
     return(tibble::tibble(
@@ -268,6 +277,22 @@ plan_commodities_mean_reversion <- function() {
       metric_cols <- setdiff(names(row), "lookback")
       wide <- row[, metric_cols, drop = FALSE]
       historicaldata::hd_metric_record(con, uu, wide)
+    }
+
+    # Record SSR + top5pct stability metrics (#400 PR 5/6).
+    # Monthly series: w = 36 rolling windows, ann_factor = 12.
+    port <- portfolio_list[[p]]
+    if (!is.null(port) && is.data.frame(port) && "net_ret" %in% names(port)) {
+      rets <- port$net_ret
+      if (length(rets) > 0L) {
+        historicaldata::hd_record_stability_metrics(
+          con        = con,
+          run_uuid   = uu,
+          returns    = rets,
+          w          = 36L,
+          ann_factor = 12L
+        )
+      }
     }
   }
 

--- a/R/plan_mom_prepeak.R
+++ b/R/plan_mom_prepeak.R
@@ -153,15 +153,21 @@ plan_mom_prepeak <- function() {
     }),
 
 
-    # ── Registry sentinel (#365 PR 2/4) ─────────────────────────────────────
+    # ── Registry sentinel (#365 PR 2/4; stability metrics #400 PR 5/6) ──────
     # Mirrors .cmr_register_runs() from plan_commodities_mean_reversion.R.
     # Upserts 3 strategy rows + records one bt.run + bt.metric row each.
+    # Also records SSR + top5pct stability metrics via hd_record_stability_metrics().
     # Guard: returns empty tibble if DBI / duckdb are unavailable.
 
     targets::tar_target(mom_prepeak_register_runs, {
       .mom_prepeak_register_runs(
-        strategy_names    = strategy_names,
-        mom_prepeak_summary = mom_prepeak_summary
+        strategy_names      = strategy_names,
+        mom_prepeak_summary = mom_prepeak_summary,
+        returns_list        = list(
+          mom_prepeak  = mom_prepeak_returns$ret_ls,
+          mom_postpeak = mom_postpeak_returns$ret_ls,
+          mom_combined = mom_combined_returns$ret_ls
+        )
       )
     })
 
@@ -346,14 +352,22 @@ plan_mom_prepeak <- function() {
 #' Registry sentinel: upsert 3 sibling strategies + record runs + metrics
 #'
 #' Mirrors .cmr_register_runs() from plan_commodities_mean_reversion.R.
+#' Also records SSR + top-5pct stability metrics via
+#' [historicaldata::hd_record_stability_metrics()] for each sibling.
 #' Returns empty tibble if DBI / duckdb are unavailable.
 #'
 #' @param strategy_names Tibble from the strategy_names target.
 #' @param mom_prepeak_summary Tibble from the mom_prepeak_summary target.
+#' @param returns_list Named list of numeric vectors keyed by strategy
+#'   code_name (`mom_prepeak`, `mom_postpeak`, `mom_combined`). Each
+#'   vector should be the `ret_ls` column from the corresponding
+#'   `*_returns` target. May be `NULL` or missing entries — stability
+#'   metrics are skipped for that strategy.
 #'
 #' @return Tibble with columns: strategy_id, run_uuid.
 #' @noRd
-.mom_prepeak_register_runs <- function(strategy_names, mom_prepeak_summary) {
+.mom_prepeak_register_runs <- function(strategy_names, mom_prepeak_summary,
+                                       returns_list = list()) {
   if (!requireNamespace("DBI", quietly = TRUE) ||
       !requireNamespace("duckdb", quietly = TRUE)) {
     return(tibble::tibble(
@@ -406,6 +420,19 @@ plan_mom_prepeak <- function() {
       metric_cols <- setdiff(names(metrics_row), "strategy")
       wide <- metrics_row[, metric_cols, drop = FALSE]
       historicaldata::hd_metric_record(con, uu, wide)
+    }
+
+    # Record SSR + top5pct stability metrics (#400 PR 5/6).
+    # Monthly series: w = 36 rolling windows, ann_factor = 12.
+    rets <- returns_list[[cn]]
+    if (!is.null(rets) && length(rets) > 0L) {
+      historicaldata::hd_record_stability_metrics(
+        con        = con,
+        run_uuid   = uu,
+        returns    = rets,
+        w          = 36L,
+        ann_factor = 12L
+      )
     }
 
     strategy_ids[[i]] <- cn

--- a/packages/historicaldata/tests/testthat/test-register-runs-stability.R
+++ b/packages/historicaldata/tests/testthat/test-register-runs-stability.R
@@ -1,0 +1,369 @@
+# Tests for stability-metric registration in *_register_runs helpers (#400 PR 5/6)
+#
+# Covers:
+#   1. .mom_prepeak_register_runs() writes SSR + top5pct rows for each sibling
+#   2. Idempotency: calling register_runs twice leaves 8 stability rows per run
+#   3. .mom_prepeak_register_runs() with returns_list = list() skips stability rows
+#   4. .cmr_register_runs() writes SSR + top5pct rows for each lookback partition
+#   5. .cmr_register_runs() with portfolio_list = list() skips stability rows
+#
+# NOTE: These tests source R/plan_mom_prepeak.R and
+# R/plan_commodities_mean_reversion.R to pull in the private helpers
+# (.mom_prepeak_register_runs, .cmr_register_runs).  If the plan files cannot
+# be sourced the tests are skipped gracefully — same pattern as
+# test-mom-prepeak-random-peak.R.
+
+# ── helper loaders ────────────────────────────────────────────────────────────
+
+.load_mom_prepeak_plan <- function() {
+  plan_path <- here::here("R/plan_mom_prepeak.R")
+  if (!file.exists(plan_path)) return(invisible(FALSE))
+  tryCatch(
+    { source(plan_path, local = FALSE); invisible(TRUE) },
+    error = function(e) invisible(FALSE)
+  )
+}
+
+.load_cmr_plan <- function() {
+  plan_path <- here::here("R/plan_commodities_mean_reversion.R")
+  if (!file.exists(plan_path)) return(invisible(FALSE))
+  tryCatch(
+    { source(plan_path, local = FALSE); invisible(TRUE) },
+    error = function(e) invisible(FALSE)
+  )
+}
+
+# ── shared registry fixture ───────────────────────────────────────────────────
+
+.init_registry_tmp <- function() {
+  tmp <- tempfile(fileext = ".duckdb")
+  hd_registry_init(tmp)
+  con <- hd_registry_open(tmp, read_only = FALSE)
+  list(tmp = tmp, con = con)
+}
+
+# ── shared strategy_names fixture ────────────────────────────────────────────
+# Minimal tibble: only the columns referenced by .mom_prepeak_register_runs()
+# and .cmr_register_runs() via dplyr::transmute().
+
+.make_strategy_names_mom <- function() {
+  code_names <- c("mom_prepeak", "mom_postpeak", "mom_combined")
+  tibble::tibble(
+    code_name               = code_names,
+    short_name              = c("Mom Pre", "Mom Post", "Mom 12-2"),
+    long_name               = c("Pre-Peak Momentum", "Post-Peak Momentum",
+                                "Standard 12-2 Momentum"),
+    asset_class             = rep("equity", 3L),
+    frequency               = rep("monthly", 3L),
+    ann_factor              = rep(12L, 3L),
+    directionality          = factor(rep("long_short", 3L),
+                               levels = c("long_only", "long_short",
+                                          "market_neutral", "overlay")),
+    liquidity_tier          = factor(rep("med", 3L),
+                               levels = c("high", "med", "low")),
+    time_horizon_days_avg   = rep(21L, 3L),
+    trades_per_year_avg     = rep(12, 3L),
+    turnover_pct_per_period_avg = rep(100, 3L),
+    tags                    = rep('["momentum"]', 3L),
+    research_paper_doi      = rep("10.2139/ssrn.4298538", 3L)
+  )
+}
+
+.make_strategy_names_cmr <- function() {
+  tibble::tibble(
+    code_name               = "cmr",
+    short_name              = "CMR",
+    long_name               = "Commodities Mean Reversion",
+    asset_class             = "commodities",
+    frequency               = "monthly",
+    ann_factor              = 12L,
+    directionality          = factor("long_short",
+                               levels = c("long_only", "long_short",
+                                          "market_neutral", "overlay")),
+    liquidity_tier          = factor("med",
+                               levels = c("high", "med", "low")),
+    time_horizon_days_avg   = 21L,
+    trades_per_year_avg     = 12,
+    turnover_pct_per_period_avg = 100,
+    tags                    = '["mean_reversion","commodities"]',
+    research_paper_doi      = NA_character_
+  )
+}
+
+# ── synthetic returns and summaries ──────────────────────────────────────────
+
+.make_mom_prepeak_summary <- function() {
+  code_names <- c("mom_prepeak", "mom_postpeak", "mom_combined")
+  tibble::tibble(
+    strategy   = code_names,
+    sharpe     = c(0.42, 0.31, 0.38),
+    cagr       = c(4.1,  2.8,  3.5),
+    vol        = c(10.0, 9.5,  9.8),
+    max_dd     = c(-22,  -20,  -21),
+    n_months   = rep(120L, 3L)
+  )
+}
+
+.make_mom_returns_vec <- function(n = 120L) {
+  set.seed(42L)
+  rnorm(n, mean = 0.003, sd = 0.04)
+}
+
+.make_cmr_summary <- function() {
+  tibble::tibble(
+    lookback        = c("1m", "3m", "6m"),
+    n_months        = c(100L, 98L, 95L),
+    sharpe          = c(-0.21, -0.18, -0.15),
+    cagr            = c(-2.1, -1.8, -1.5),
+    vol             = c(12.0, 11.5, 11.0),
+    max_dd          = c(-30, -28, -26),
+    avg_dd_duration = c(6L, 5L, 5L),
+    max_dd_duration = c(18L, 16L, 15L)
+  )
+}
+
+.make_cmr_portfolio <- function(n = 100L) {
+  set.seed(7L)
+  gross <- rnorm(n, 0, 0.04)
+  cost  <- rep(0.002, n)
+  tibble::tibble(
+    date      = seq.Date(as.Date("2015-01-31"), by = "month", length.out = n),
+    gross_ret = gross,
+    cost      = cost,
+    net_ret   = gross - cost,
+    n_long    = rep(10L, n),
+    n_short   = rep(10L, n),
+    turnover  = rep(0.5, n)
+  )
+}
+
+# ── query helpers ─────────────────────────────────────────────────────────────
+
+.stability_metric_names <- c(
+  "ssr", "ssr_mean_sharpe", "ssr_se", "ssr_n_windows", "ssr_lag_nw",
+  "top_share", "top_n_top", "top_n_total"
+)
+
+.count_stability_rows <- function(con, run_uuid) {
+  DBI::dbGetQuery(
+    con,
+    sprintf(
+      "SELECT COUNT(*) AS n FROM bt.metric
+       WHERE run_uuid = ? AND metric_name IN (%s)",
+      paste(rep("?", length(.stability_metric_names)), collapse = ", ")
+    ),
+    params = c(list(run_uuid), as.list(.stability_metric_names))
+  )$n
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests 1–3: .mom_prepeak_register_runs()
+# ─────────────────────────────────────────────────────────────────────────────
+
+test_that("mom_prepeak_register_runs writes 8 stability rows per sibling strategy", {
+  skip_if_not_installed("DBI")
+  skip_if_not_installed("duckdb")
+  skip_if_not(
+    .load_mom_prepeak_plan(),
+    "R/plan_mom_prepeak.R not loadable — skipping"
+  )
+  skip_if_not(
+    exists(".mom_prepeak_register_runs"),
+    ".mom_prepeak_register_runs not found after source()"
+  )
+
+  s <- .init_registry_tmp()
+  withr::defer({
+    DBI::dbDisconnect(s$con, shutdown = TRUE)
+    unlink(s$tmp)
+  })
+
+  withr::with_envvar(c(HD_REGISTRY_PATH = s$tmp), {
+    rvec  <- .make_mom_returns_vec()
+    out   <- .mom_prepeak_register_runs(
+      strategy_names      = .make_strategy_names_mom(),
+      mom_prepeak_summary = .make_mom_prepeak_summary(),
+      returns_list        = list(
+        mom_prepeak  = rvec,
+        mom_postpeak = rvec,
+        mom_combined = rvec
+      )
+    )
+  })
+
+  expect_equal(nrow(out), 3L)
+  expect_setequal(out$strategy_id, c("mom_prepeak", "mom_postpeak", "mom_combined"))
+
+  for (uuid in out$run_uuid) {
+    n <- .count_stability_rows(s$con, uuid)
+    expect_equal(n, 8L,
+      info = paste("strategy run_uuid:", uuid,
+                   "expected 8 stability rows, got", n))
+  }
+})
+
+
+test_that("mom_prepeak_register_runs idempotent: 8 stability rows after 2 calls", {
+  skip_if_not_installed("DBI")
+  skip_if_not_installed("duckdb")
+  skip_if_not(
+    .load_mom_prepeak_plan(),
+    "R/plan_mom_prepeak.R not loadable — skipping"
+  )
+  skip_if_not(
+    exists(".mom_prepeak_register_runs"),
+    ".mom_prepeak_register_runs not found after source()"
+  )
+
+  s <- .init_registry_tmp()
+  withr::defer({
+    DBI::dbDisconnect(s$con, shutdown = TRUE)
+    unlink(s$tmp)
+  })
+
+  rvec <- .make_mom_returns_vec()
+  rl   <- list(
+    mom_prepeak  = rvec,
+    mom_postpeak = rvec,
+    mom_combined = rvec
+  )
+
+  out1 <- NULL
+  withr::with_envvar(c(HD_REGISTRY_PATH = s$tmp), {
+    out1 <- .mom_prepeak_register_runs(
+      strategy_names      = .make_strategy_names_mom(),
+      mom_prepeak_summary = .make_mom_prepeak_summary(),
+      returns_list        = rl
+    )
+    .mom_prepeak_register_runs(
+      strategy_names      = .make_strategy_names_mom(),
+      mom_prepeak_summary = .make_mom_prepeak_summary(),
+      returns_list        = rl
+    )
+  })
+
+  # hd_run_upsert is idempotent: same uuid on second call.
+  # hd_metric_record DELETE-then-INSERTs, so still exactly 8 rows.
+  for (uuid in out1$run_uuid) {
+    n <- .count_stability_rows(s$con, uuid)
+    expect_equal(n, 8L,
+      info = paste("after 2 calls, run_uuid:", uuid, "has", n, "stability rows"))
+  }
+})
+
+
+test_that("mom_prepeak_register_runs with empty returns_list writes 0 stability rows", {
+  skip_if_not_installed("DBI")
+  skip_if_not_installed("duckdb")
+  skip_if_not(
+    .load_mom_prepeak_plan(),
+    "R/plan_mom_prepeak.R not loadable — skipping"
+  )
+  skip_if_not(
+    exists(".mom_prepeak_register_runs"),
+    ".mom_prepeak_register_runs not found after source()"
+  )
+
+  s <- .init_registry_tmp()
+  withr::defer({
+    DBI::dbDisconnect(s$con, shutdown = TRUE)
+    unlink(s$tmp)
+  })
+
+  out <- NULL
+  withr::with_envvar(c(HD_REGISTRY_PATH = s$tmp), {
+    out <- .mom_prepeak_register_runs(
+      strategy_names      = .make_strategy_names_mom(),
+      mom_prepeak_summary = .make_mom_prepeak_summary(),
+      returns_list        = list()
+    )
+  })
+
+  for (uuid in out$run_uuid) {
+    n <- .count_stability_rows(s$con, uuid)
+    expect_equal(n, 0L,
+      info = paste("no returns supplied; run_uuid:", uuid, "should have 0 stability rows"))
+  }
+})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests 4–5: .cmr_register_runs()
+# ─────────────────────────────────────────────────────────────────────────────
+
+test_that("cmr_register_runs writes 8 stability rows per lookback partition", {
+  skip_if_not_installed("DBI")
+  skip_if_not_installed("duckdb")
+  skip_if_not(
+    .load_cmr_plan(),
+    "R/plan_commodities_mean_reversion.R not loadable — skipping"
+  )
+  skip_if_not(
+    exists(".cmr_register_runs"),
+    ".cmr_register_runs not found after source()"
+  )
+
+  s <- .init_registry_tmp()
+  withr::defer({
+    DBI::dbDisconnect(s$con, shutdown = TRUE)
+    unlink(s$tmp)
+  })
+
+  port <- .make_cmr_portfolio()
+  pl   <- list(`1m` = port, `3m` = port, `6m` = port)
+
+  out <- NULL
+  withr::with_envvar(c(HD_REGISTRY_PATH = s$tmp), {
+    out <- .cmr_register_runs(
+      strategy_names = .make_strategy_names_cmr(),
+      cmr_summary    = .make_cmr_summary(),
+      portfolio_list = pl
+    )
+  })
+
+  expect_equal(nrow(out), 3L)
+  expect_setequal(out$partition, c("1m", "3m", "6m"))
+
+  for (uuid in out$run_uuid) {
+    n <- .count_stability_rows(s$con, uuid)
+    expect_equal(n, 8L,
+      info = paste("cmr run_uuid:", uuid,
+                   "expected 8 stability rows, got", n))
+  }
+})
+
+
+test_that("cmr_register_runs with empty portfolio_list writes 0 stability rows", {
+  skip_if_not_installed("DBI")
+  skip_if_not_installed("duckdb")
+  skip_if_not(
+    .load_cmr_plan(),
+    "R/plan_commodities_mean_reversion.R not loadable — skipping"
+  )
+  skip_if_not(
+    exists(".cmr_register_runs"),
+    ".cmr_register_runs not found after source()"
+  )
+
+  s <- .init_registry_tmp()
+  withr::defer({
+    DBI::dbDisconnect(s$con, shutdown = TRUE)
+    unlink(s$tmp)
+  })
+
+  out <- NULL
+  withr::with_envvar(c(HD_REGISTRY_PATH = s$tmp), {
+    out <- .cmr_register_runs(
+      strategy_names = .make_strategy_names_cmr(),
+      cmr_summary    = .make_cmr_summary(),
+      portfolio_list = list()
+    )
+  })
+
+  for (uuid in out$run_uuid) {
+    n <- .count_stability_rows(s$con, uuid)
+    expect_equal(n, 0L,
+      info = paste("no portfolio supplied; run_uuid:", uuid,
+                   "should have 0 stability rows"))
+  }
+})


### PR DESCRIPTION
## Summary

PR 5/6 for #400 SSR rollout — auto-records SSR + top-5% stability metrics from `*_register_runs` helpers.

Threads strategy returns into the existing registry sentinels and calls `hd_record_stability_metrics()` (added in #410) per sibling/partition:

- `.mom_prepeak_register_runs()` — 3 sibling strategies (prepeak/postpeak/combined), `w=36`, `ann_factor=12` (monthly).
- `.cmr_register_runs()` — 3 lookback partitions (1m/3m/6m), same monthly params.

Missing returns/portfolio → stability metrics skipped for that run (graceful no-op).

## Tests

5 new tests in `test-register-runs-stability.R` covering positive paths, idempotency (DELETE-then-INSERT keeps 8 rows per run), and empty-input edge cases. Tests skip gracefully when plan files cannot be sourced from package root, matching `test-mom-prepeak-random-peak.R`.

- `devtools::test(filter = "registry")`: **137 PASS / 0 FAIL** (1 skip unrelated).

## History

Supersedes closed #412 (which was stacked on #410's branch and auto-closed when GitHub deleted that branch on merge). Rebased the three PR 5 commits directly onto main; PR 3 commits dropped (already in main as squash 84aeb34).

Refs #400 (PR 5/6).
