### PR TITLE
fix(index.qmd): apply path-checked pkgload pattern (#387)

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -66,8 +66,10 @@ execute:
 # succeeds even when HuggingFace is offline.
 
 local({
-  # Load the package from the project tree
-  suppressMessages(pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE))
+  # Path-checked pkgload (cwd-trap fix: here::here() returns docs/ under quarto render) — #387
+  pkg_path <- if (dir.exists("packages/historicaldata")) "packages/historicaldata" else
+    file.path(dirname(here::here()), "packages/historicaldata")
+  suppressMessages(pkgload::load_all(pkg_path, quiet = TRUE))
 
   n_tickers <- tryCatch({
     tickers_equity <- hd_tickers("equity_daily")


### PR DESCRIPTION
## Summary

- `docs/index.qmd` was the last of 4 vignettes still using `pkgload::load_all(here::here("packages/historicaldata"))` — broken under `quarto render` (cwd-trap: `here::here()` resolves to `docs/`).
- The other 3 (`avoid-worst-days.qmd`, `european-overlay.qmd`, `macro-defense-rotation.qmd`) were fixed in earlier PRs.
- Applies the canonical path-checked pattern.

## Diff

```r
# Before
suppressMessages(pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE))

# After
pkg_path <- if (dir.exists("packages/historicaldata")) "packages/historicaldata" else
  file.path(dirname(here::here()), "packages/historicaldata")
suppressMessages(pkgload::load_all(pkg_path, quiet = TRUE))
```

Pattern mirrors `docs/avoid-worst-days.qmd:8-11` exactly.

## Test plan

- [x] Grep confirms no remaining `pkgload::load_all(here::here(` calls in `docs/*.qmd`
- [ ] `quarto render docs/index.qmd` succeeds locally (deferred — committed HTML still works; bug was latent)
- [ ] Pages build green after merge

Closes #387.
