### PR TITLE
fix(zakamulin): silence ..1/..2/..3 parser warnings (#337)

### DIFF
--- a/R/zakamulin_allocation.R
+++ b/R/zakamulin_allocation.R
@@ -333,28 +333,42 @@ summarize_regime_allocation <- function(backtest_results, annual_rf = 0.02) {
       .groups = "drop"
     ) |>
     mutate(
-      # Compute max drawdowns
-      max_dd = purrr::pmap_dbl(list(scheme, signal_type, allocation_fn), ~{
-        rets <- backtest_results |>
-          filter(scheme == ..1, signal_type == ..2, allocation_fn == ..3) |>
-          arrange(date) |>
-          pull(net_ret)
-        if (length(rets) < 2) return(NA_real_)
-        cumrets <- cumprod(1 + rets)
-        cummax_vals <- cummax(cumrets)
-        dd <- (cumrets - cummax_vals) / cummax_vals
-        min(dd, na.rm = TRUE)
-      }),
-      max_dd_allocated = purrr::pmap_dbl(list(scheme, signal_type, allocation_fn), ~{
-        rets <- backtest_results |>
-          filter(scheme == ..1, signal_type == ..2, allocation_fn == ..3) |>
-          arrange(date) |>
-          pull(allocated_ret)
-        if (length(rets) < 2) return(NA_real_)
-        cumrets <- cumprod(1 + rets)
-        cummax_vals <- cummax(cumrets)
-        dd <- (cumrets - cummax_vals) / cummax_vals
-        min(dd, na.rm = TRUE)
-      })
+      # Compute max drawdowns — use named-arg lambda + rlang::.env to avoid
+      # R parser warnings ("..1 may be used in an incorrect context") that
+      # purrr's `~{}` tilde-lambdas trigger when ..N refs sit inside dplyr's
+      # NSE-aware filter() — column-name vs iter-variable conflict requires
+      # .env$ to disambiguate. (#337)
+      max_dd = purrr::pmap_dbl(
+        list(scheme = scheme, signal_type = signal_type, allocation_fn = allocation_fn),
+        function(scheme, signal_type, allocation_fn) {
+          rets <- backtest_results |>
+            filter(scheme == rlang::.env$scheme,
+                   signal_type == rlang::.env$signal_type,
+                   allocation_fn == rlang::.env$allocation_fn) |>
+            arrange(date) |>
+            pull(net_ret)
+          if (length(rets) < 2) return(NA_real_)
+          cumrets <- cumprod(1 + rets)
+          cummax_vals <- cummax(cumrets)
+          dd <- (cumrets - cummax_vals) / cummax_vals
+          min(dd, na.rm = TRUE)
+        }
+      ),
+      max_dd_allocated = purrr::pmap_dbl(
+        list(scheme = scheme, signal_type = signal_type, allocation_fn = allocation_fn),
+        function(scheme, signal_type, allocation_fn) {
+          rets <- backtest_results |>
+            filter(scheme == rlang::.env$scheme,
+                   signal_type == rlang::.env$signal_type,
+                   allocation_fn == rlang::.env$allocation_fn) |>
+            arrange(date) |>
+            pull(allocated_ret)
+          if (length(rets) < 2) return(NA_real_)
+          cumrets <- cumprod(1 + rets)
+          cummax_vals <- cummax(cumrets)
+          dd <- (cumrets - cummax_vals) / cummax_vals
+          min(dd, na.rm = TRUE)
+        }
+      )
     )
 }


### PR DESCRIPTION
## Summary

`tar_make(c("cmr_vs_mom_compare"))` emitted 6 warnings:

```
1: <anonymous>: ..1 may be used in an incorrect context
2: <anonymous>: ..2 may be used in an incorrect context
3: <anonymous>: ..3 may be used in an incorrect context
4: <anonymous>: ..1 may be used in an incorrect context
5: <anonymous>: ..2 may be used in an incorrect context
6: <anonymous>: ..3 may be used in an incorrect context
```

Source: `R/zakamulin_allocation.R` (sourced via `docs/_targets.R:65`). Both `max_dd` and `max_dd_allocated` `purrr::pmap_dbl(..., ~{...})` calls referenced `..1`/`..2`/`..3` inside `filter()`. R's parser flags these as ambiguous because the iterator names and column names collide (`scheme`, `signal_type`, `allocation_fn`).

## Fix

Replace tilde-lambda with named-arg `function(...)` and use `rlang::.env$<name>` inside `filter()` to disambiguate iterator variable from column name. Same computation, no warnings.

## Test plan

- [x] R parses cleanly (`Rscript -e 'parse("R/zakamulin_allocation.R")'`)
- [ ] CI test suite passes
- [ ] Manual: `tar_make(c("cmr_vs_mom_compare"))` should emit 0 warnings (deferred — needs warm `_targets/`)

Closes #337.
