### PR TITLE
fix(cmr): store cagr/vol/max_dd as decimal canonical (#336)

### DIFF
--- a/R/plan_commodities_mean_reversion.R
+++ b/R/plan_commodities_mean_reversion.R
@@ -207,13 +207,18 @@ plan_commodities_mean_reversion <- function() {
 
   dd_stats   <- hd_dd_duration(r)
 
+  # Unit convention (#336): cagr, vol, max_dd are stored as DECIMAL fractions
+  # (e.g., -0.21 = -21% drawdown), matching the canonical convention used by
+  # plan_factormax.R, plan_drif.R, commodities_momentum.R, and the leaderboard
+  # normalizers in plan_leaderboard.R. Display-time formatting (× 100, "%")
+  # belongs to the consumer (DT::datatable, plot label), not the producer.
   tibble::tibble(
     lookback        = lookback,
     n_months        = n,
     sharpe          = round(sharpe, 3),
-    cagr            = round(cagr * 100, 1),
-    vol             = round(vol * 100, 1),
-    max_dd          = round(max_dd * 100, 1),
+    cagr            = round(cagr, 4),
+    vol             = round(vol, 4),
+    max_dd          = round(max_dd, 4),
     avg_dd_duration = dd_stats$avg_dd_duration,
     max_dd_duration = dd_stats$max_dd_duration
   )

--- a/docs/avoid-worst-days.qmd
+++ b/docs/avoid-worst-days.qmd
@@ -327,7 +327,6 @@ if (!is.null(mi)) {
 The asymmetry table on the **S&P 500 Analysis** tab includes Mkt-RF rows (Fama-French market factor, 1926+). The same pattern holds over nearly a century: the asymmetry ratio exceeds 1 at every N, confirming this is not a recent or data-period-specific phenomenon.
 
 Mkt-RF is not identical to the S&P 500 — it is the value-weighted CRSP market return minus the risk-free rate. The longer history (1926 vs 1993 for SPY) provides stronger evidence that return asymmetry is a persistent structural feature of equity markets.
-```
 
 # Practical Implementation
 

--- a/tests/testthat/test-cmr-units.R
+++ b/tests/testthat/test-cmr-units.R
@@ -1,0 +1,58 @@
+# Tests for cmr_summary unit convention — #336
+#
+# .compute_cmr_metrics() in R/plan_commodities_mean_reversion.R produces
+# the per-lookback metric row that flows into the cmr_summary target and
+# from there to the leaderboard, cmr_vs_mom_compare, and bt.run registry.
+#
+# Before #336: cagr, vol, max_dd were stored as percent (e.g., -100 = -100%).
+# After  #336: stored as decimal fractions (e.g., -1.0 = -100%), matching
+# plan_factormax.R, plan_drif.R, commodities_momentum.R, and the leaderboard
+# normalizers.
+
+# Path-checked pkgload — .compute_cmr_metrics() calls hd_dd_duration() from
+# the historicaldata package, so the package must be loaded before sourcing
+# the plan file. Mirrors the pattern used in vignette setup chunks.
+pkg_path <- if (dir.exists(here::here("packages/historicaldata"))) {
+  here::here("packages/historicaldata")
+} else {
+  file.path(dirname(here::here()), "packages/historicaldata")
+}
+suppressMessages(pkgload::load_all(pkg_path, quiet = TRUE))
+
+source(here::here("R/plan_commodities_mean_reversion.R"))
+
+# Minimal toy portfolio: 24 monthly net returns in a tibble shape that
+# .compute_cmr_metrics() consumes. Returns drawn so that max_dd lands well
+# inside the (-1, 0] decimal band — under the old percent convention this
+# would be ~−45 instead of ~−0.45.
+toy_portfolio <- tibble::tibble(
+  date    = seq.Date(as.Date("2020-01-31"), by = "month", length.out = 24L),
+  net_ret = c(rep(-0.05, 12L), rep(0.02, 12L))  # 12mo drawdown then recovery
+)
+
+test_that(".compute_cmr_metrics returns max_dd as decimal fraction (#336)", {
+  metrics <- .compute_cmr_metrics(toy_portfolio, lookback = "test", ann_factor = 12L)
+  expect_true(is.finite(metrics$max_dd))
+  expect_gte(metrics$max_dd, -1)    # canonical decimal: in [-1, 0]
+  expect_lte(metrics$max_dd, 0)
+})
+
+test_that(".compute_cmr_metrics returns cagr/vol as decimal fractions (#336)", {
+  metrics <- .compute_cmr_metrics(toy_portfolio, lookback = "test", ann_factor = 12L)
+  # Decimal CAGR for monthly returns near ±5% sits in (-1, 1); under the old
+  # percent convention this would land in the (-100, 100) band.
+  expect_gt(metrics$cagr, -1)
+  expect_lt(metrics$cagr,  1)
+  # Annualised vol of a 5% / 2% monthly series is well below 1 in decimal.
+  expect_gt(metrics$vol, 0)
+  expect_lt(metrics$vol, 1)
+})
+
+test_that(".compute_cmr_metrics never returns the old percent magnitude (#336 regression)", {
+  metrics <- .compute_cmr_metrics(toy_portfolio, lookback = "test", ann_factor = 12L)
+  # Specific anti-regression: -100 was the old percent output for this kind
+  # of monotone-loss path; the decimal equivalent is around -0.45.
+  expect_false(metrics$max_dd < -1.0)
+  expect_false(abs(metrics$cagr) > 1.0)
+  expect_false(metrics$vol > 1.0)
+})


### PR DESCRIPTION
## Summary

Switches `cmr_summary` (and `cmr_metrics_*` partitions) from **percent** to **decimal** unit convention for `cagr`, `vol`, and `max_dd` — matching the rest of the package and resolving the -100 vs -0.81 confusion in `cmr_vs_mom_compare` flagged by #336.

## Root cause

`R/plan_commodities_mean_reversion.R:214-216` multiplied by 100:

```r
cagr   = round(cagr * 100, 1),    # percent  (non-canonical)
vol    = round(vol * 100, 1),     # percent  (non-canonical)
max_dd = round(max_dd * 100, 1),  # percent  (non-canonical)
```

Every other strategy stores `max_dd` as decimal:

| File | Line | Pattern |
|------|------|---------|
| `R/plan_factormax.R` | 154-165 | `max_dd = max_dd` (raw decimal) |
| `R/plan_drif.R` | 262-272 | `max_dd = min(cum/cummax(cum) - 1)` |
| `R/commodities_momentum.R` | 281 | `max_dd = map_dbl(...{ min(dd) })` |
| Deployed `leaderboard.html` | — | shows -0.35, -0.15, -0.08 |

## Fix

Removed the `* 100` from the 3 lines, rounded to 4 dp for display precision, and added a 5-line comment documenting the unit convention.

## Downstream impact

| Consumer | Status |
|---|---|
| `.norm_cmr()` → leaderboard | ✅ Now consistent (passes through verbatim) |
| `cmr_vs_mom_compare` | ✅ Both sides decimal — #336 symptom gone |
| `.cmr_register_runs()` → `bt.run` registry | ⚠️ Forward-only; pre-existing rows (if any) need one-off SQL update |
| `fals_cmr_summary` | ✅ Separate target with different columns — unaffected |

## Test plan

- [x] New: `tests/testthat/test-cmr-units.R` — 3 test_that blocks asserting decimal range invariants. Toy 24-month portfolio with 12mo loss + 12mo recovery. Local run: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 10 ]`
- [x] `parse("R/plan_commodities_mean_reversion.R")` succeeds
- [ ] CI runs full test suite
- [ ] Manual: `tar_make(c("cmr_summary", "cmr_vs_mom_compare"))` from main checkout to confirm registry stays clean

Closes #336.
