### PR TITLE
fix(index): repair stats-row render regression from PR #437

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -102,9 +102,9 @@ body { font-size: 1.2em; }
              flex-wrap: nowrap !important; gap: 2.5em !important;
              justify-content: center !important; align-items: center !important;
              margin: 1em 0 !important; width: 100% !important; }
-.stat { text-align: center; flex-shrink: 0; }
-.stat .num { font-size: 1.8em; font-weight: bold; }
-.stat .label { font-size: 0.8em; opacity: 0.6; }
+.stat { text-align: center; flex-shrink: 0; display: inline-block; }
+.stat .num { font-size: 1.8em; font-weight: bold; display: block; }
+.stat .label { font-size: 0.8em; opacity: 0.6; display: block; }
 .badge { display: inline-block; padding: 0.2em 0.6em; border-radius: 4px;
          font-size: 0.8em; margin-right: 0.5em; }
 .badge-blue { background: #1a3a5c; color: #6B8DAE; }
@@ -323,52 +323,7 @@ grid-auto-rows: minmax(0, 1fr);">
 <p>Historical finance database for backtesting: equities, crypto, macro, and factors. Code-only R package — data hosted on <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer">Hugging Face</a>, queried via DuckDB <code>hf://</code> protocol with predicate pushdown.</p>
 <p><a href="https://github.com/JohnGavin/historical/tree/main/packages/historicaldata" target="_blank" rel="noopener noreferrer"><span class="badge badge-blue">R package</span></a> <a href="https://duckdb.org/docs/data/parquet/overview.html" target="_blank" rel="noopener noreferrer"><span class="badge badge-green">DuckDB + Parquet</span></a> <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer"><span class="badge badge-gold">Hugging Face</span></a></p>
 <div class="stats-row html-fill-item html-fill-container">
-<a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer" class="stat-link">
-<div class="stat html-fill-item html-fill-container">
-<div class="num html-fill-item html-fill-container">
-1,636
-</div>
-<div class="label html-fill-item html-fill-container">
-tickers
-</div>
-</div>
-</a> <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer" class="stat-link">
-<div class="stat html-fill-item html-fill-container">
-<div class="num html-fill-item html-fill-container">
-7.8M
-</div>
-<div class="label html-fill-item html-fill-container">
-rows
-</div>
-</div>
-</a> <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer" class="stat-link">
-<div class="stat html-fill-item html-fill-container">
-<div class="num html-fill-item html-fill-container">
-9
-</div>
-<div class="label html-fill-item html-fill-container">
-datasets
-</div>
-</div>
-</a> <a href="jst-dashboard.html" class="stat-link">
-<div class="stat html-fill-item html-fill-container">
-<div class="num html-fill-item html-fill-container">
-5553492yr
-</div>
-<div class="label html-fill-item html-fill-container">
-history
-</div>
-</div>
-</a> <a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/NAMESPACE" target="_blank" rel="noopener noreferrer" class="stat-link">
-<div class="stat html-fill-item html-fill-container">
-<div class="num html-fill-item html-fill-container">
-30
-</div>
-<div class="label html-fill-item html-fill-container">
-functions
-</div>
-</div>
-</a>
+<p><a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer" class="stat-link"><span class="stat"><span class="num">1,636</span><span class="label">tickers</span></span></a> <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer" class="stat-link"><span class="stat"><span class="num">7.8M</span><span class="label">rows</span></span></a> <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer" class="stat-link"><span class="stat"><span class="num">9</span><span class="label">datasets</span></span></a> <a href="jst-dashboard.html" class="stat-link"><span class="stat"><span class="num">100yr</span><span class="label">history</span></span></a> <a href="https://github.com/JohnGavin/historical/blob/main/docs/api-historicaldata.md" target="_blank" rel="noopener noreferrer" class="stat-link"><span class="stat"><span class="num">120</span><span class="label">functions</span></span></a></p>
 </div>
 </div>
 <bslib-tooltip placement="auto" bsoptions="[]" data-require-bs-version="5" data-require-bs-caller="tooltip()">
@@ -382,40 +337,85 @@ functions
 grid-auto-rows: minmax(0, 1fr);">
 <div class="card html-fill-item html-fill-container bslib-card" data-fill="false" data-bslib-card-init="" data-require-bs-caller="card()" data-full-screen="false">
 <div class="card-body html-fill-item html-fill-container">
-<div class="card-grid html-fill-item html-fill-container">
-<div class="info-card html-fill-item html-fill-container">
-<h4>
-Equity
-</h4>
-<p>
-1,022 tickers (51 US + 949 LSE ETFs + 13 macro ETFs + 9 factor ETFs). Daily OHLCV from 1980. Includes Vanguard, iShares, SPDR UCITS ETFs. 44 MB Parquet.
-</p>
-</div>
-<div class="info-card html-fill-item html-fill-container">
-<h4>
-Crypto
-</h4>
-<p>
-14 tokens (BTC, ETH, SOL, BNB, stablecoins, Solana DeFi). Daily from 2014. 1.1 MB.
-</p>
-</div>
-<div class="info-card html-fill-item html-fill-container">
-<h4>
-Macro
-</h4>
-<p>
-19 FRED series: SP500, <abbr title="CBOE Volatility Index — implied volatility of S&amp;P 500 options">VIX</abbr>, Treasury yields, credit spreads, GDP, CPI, oil, USD. From 1947.
-</p>
-</div>
-<div class="info-card html-fill-item html-fill-container">
-<h4>
-Factors
-</h4>
-<p>
-Fama-French FF3, <abbr title="Fama-French 5-Factor model (MktRF, SMB, HML, RMW, CMA)">FF5</abbr>, Momentum. Daily + monthly. Back to 1926. Ken French Data Library.
-</p>
-</div>
-</div>
+<details open="">
+<summary>
+<strong>Equity</strong> — 1,022 tickers · daily OHLCV from 1980 · 44 MB Parquet
+</summary>
+<ul>
+<li>
+<strong>US equities</strong> (51 tickers) — large-cap S&amp;P 500 sample from Yahoo Finance · <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer">HF dataset</a> · <a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/registry.R#L31" target="_blank" rel="noopener noreferrer"><code>hd_datasets()[[“equity_daily”]]</code></a>
+</li>
+<li>
+<strong>LSE ETFs</strong> (949 tickers) — UK-listed UCITS ETFs from iShares, Vanguard, SPDR · <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer">HF dataset</a> · <a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/registry.R#L31" target="_blank" rel="noopener noreferrer"><code>equity_daily</code></a>
+</li>
+<li>
+<strong>Macro ETFs</strong> (13 tickers) — TLT, GLD, DBC, UUP and extended macro hedge universe · <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer">HF dataset</a> · <a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/groups.R#L55" target="_blank" rel="noopener noreferrer"><code>hd_group(“Macro Hedge ETFs”)</code></a>
+</li>
+<li>
+<strong>Factor ETFs</strong> (9 tickers) — US index ETFs (SPY, QQQ, IWM, DIA) plus sector ETFs · <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer">HF dataset</a> · <a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/groups.R#L38" target="_blank" rel="noopener noreferrer"><code>hd_group(“US Index ETFs”)</code></a>
+</li>
+</ul>
+</details>
+<details>
+<summary>
+<strong>Crypto</strong> — 14 tokens · daily OHLCV from 2014 · 1.1 MB Parquet
+</summary>
+<ul>
+<li>
+<strong>Major crypto</strong> (4 tokens) — BTC, ETH, SOL, BNB · <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer">HF dataset</a> · <a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/registry.R#L47" target="_blank" rel="noopener noreferrer"><code>hd_datasets()[[“crypto_daily”]]</code></a>
+</li>
+<li>
+<strong>Stablecoins</strong> (2 tokens) — USDC, USDT · <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer">HF dataset</a> · <a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/groups.R#L45" target="_blank" rel="noopener noreferrer"><code>hd_group(“Stablecoins”)</code></a>
+</li>
+<li>
+<strong>Solana DeFi</strong> (5 tokens) — SOL, RAY, HNT, BONK, PYTH · <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer">HF dataset</a> · <a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/groups.R#L48" target="_blank" rel="noopener noreferrer"><code>hd_group(“Solana DeFi”)</code></a>
+</li>
+<li>
+<strong>DeFi altcoins</strong> (3 tokens) — XRP, ADA, DOGE, DOT · <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer">HF dataset</a> · <a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/groups.R#L50" target="_blank" rel="noopener noreferrer"><code>hd_group(“DeFi Altcoins”)</code></a>
+</li>
+</ul>
+</details>
+<details>
+<summary>
+<strong>Macro</strong> — 19 FRED series · mixed frequency · from 1947
+</summary>
+<ul>
+<li>
+<strong>Equity &amp; volatility</strong> — SP500, <abbr title="CBOE Volatility Index — implied volatility of S&amp;P 500 options">VIX</abbr> · <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer">HF dataset</a> · <a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/registry.R#L54" target="_blank" rel="noopener noreferrer"><code>hd_datasets()[[“macro_daily”]]</code></a>
+</li>
+<li>
+<strong>Interest rates</strong> — 2Y, 10Y, 30Y Treasury yields, Fed Funds rate · <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer">HF dataset</a> · <a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/query.R#L269" target="_blank" rel="noopener noreferrer"><code>hd_macro(c(“DGS2”,“DGS10”,“DGS30”))</code></a>
+</li>
+<li>
+<strong>Credit spreads</strong> — ICE BofA High Yield OAS, BBB corporate spread · <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer">HF dataset</a>
+</li>
+<li>
+<strong>Macro fundamentals</strong> — GDP (quarterly), CPI, PCE (monthly), unemployment · <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer">HF dataset</a>
+</li>
+<li>
+<strong>Commodities &amp; currency</strong> — WTI crude oil spot, trade-weighted USD index · <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer">HF dataset</a>
+</li>
+</ul>
+</details>
+<details>
+<summary>
+<strong>Factors</strong> — Fama-French FF3, FF5, Momentum · daily + monthly · from 1926
+</summary>
+<ul>
+<li>
+<strong>FF3</strong> — MktRF, SMB, HML plus risk-free rate · <a href="https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html" target="_blank" rel="noopener noreferrer">Ken French Data Library</a> · <a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/registry.R#L60" target="_blank" rel="noopener noreferrer"><code>hd_datasets()[[“factors”]]</code></a>
+</li>
+<li>
+<strong>FF5</strong> — adds <abbr title="Fama-French 5-Factor model adds Profitability (RMW) and Investment (CMA) to FF3">RMW, CMA</abbr> · <a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/query.R#L328" target="_blank" rel="noopener noreferrer"><code>hd_factors(“FF5”)</code></a>
+</li>
+<li>
+<strong>Momentum</strong> — prior-12-month return factor · <a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/query.R#L328" target="_blank" rel="noopener noreferrer"><code>hd_factors(“Mom”)</code></a>
+</li>
+<li>
+<strong>JST Macrohistory</strong> — 155 years, 18 countries (1870–2020) · <a href="https://www.macrohistory.net/database/" target="_blank" rel="noopener noreferrer">macrohistory.net</a> · <a href="https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/registry.R#L92" target="_blank" rel="noopener noreferrer"><code>hd_datasets()[[“jst_macrohistory”]]</code></a>
+</li>
+</ul>
+</details>
 </div>
 <bslib-tooltip placement="auto" bsoptions="[]" data-require-bs-version="5" data-require-bs-caller="tooltip()">
     <template>Expand</template>
@@ -571,7 +571,7 @@ grid-auto-rows: minmax(0, 1fr);">
 
 
 <div class="tab-content html-fill-item html-fill-container" data-tabset-id="card-tabset-6"><div class="tab-pane active show html-fill-item html-fill-container" role="tabpanel" id="card-tabset-6-1"><div class="card-body html-fill-item html-fill-container" data-title="R (pak)">
-<div class="html-fill-item html-fill-container bslib-grid" style="display: grid; grid-template-rows: minmax(3em, max-content); grid-auto-columns: minmax(0, 1fr);">
+<div class="html-fill-item html-fill-container bslib-grid" style="display: grid; grid-template-rows: minmax(3em, max-content) minmax(3em, 1fr); grid-auto-columns: minmax(0, 1fr);">
 <div class="card html-fill-item html-fill-container bslib-card" data-fill="false" data-bslib-card-init="" data-require-bs-caller="card()" data-full-screen="false">
 <div class="card-body html-fill-item html-fill-container">
 <div class="code-copy-outer-scaffold html-fill-item html-fill-container"><div class="sourceCode html-fill-item html-fill-container" id="cb1"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Install from GitHub</span></span>
@@ -590,21 +590,41 @@ grid-auto-rows: minmax(0, 1fr);">
         <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" style="height:1em;width:1em;" aria-hidden="true" role="img"><path d="M20 5C20 4.4 19.6 4 19 4H13C12.4 4 12 3.6 12 3C12 2.4 12.4 2 13 2H21C21.6 2 22 2.4 22 3V11C22 11.6 21.6 12 21 12C20.4 12 20 11.6 20 11V5ZM4 19C4 19.6 4.4 20 5 20H11C11.6 20 12 20.4 12 21C12 21.6 11.6 22 11 22H3C2.4 22 2 21.6 2 21V13C2 12.4 2.4 12 3 12C3.6 12 4 12.4 4 13V19Z"></path></svg>
     </span>
 </bslib-tooltip><script data-bslib-card-init="">bslib.Card.initializeAllCards();</script></div>
+<div class="card cell html-fill-item html-fill-container bslib-card" data-bslib-card-init="" data-require-bs-caller="card()" data-full-screen="false">
+<div class="card-body html-fill-item html-fill-container">
+<div class="cell-output cell-output-stdout html-fill-item html-fill-container">
+<pre><code># Live install check — re-runs on every page render</code></pre>
+</div>
+<div class="cell-output cell-output-stdout html-fill-item html-fill-container">
+<pre><code>List of 5
+ $ pkg_installed : logi TRUE
+ $ pkg_version   : chr "0.1.0"
+ $ n_exports     : int 120
+ $ r_version     : chr "4.5.3"
+ $ duckdb_version: chr "1.5.1"</code></pre>
+</div>
+</div>
+<bslib-tooltip placement="auto" bsoptions="[]" data-require-bs-version="5" data-require-bs-caller="tooltip()">
+    <template>Expand</template>
+    <span class="bslib-full-screen-enter badge rounded-pill">
+        <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" style="height:1em;width:1em;" aria-hidden="true" role="img"><path d="M20 5C20 4.4 19.6 4 19 4H13C12.4 4 12 3.6 12 3C12 2.4 12.4 2 13 2H21C21.6 2 22 2.4 22 3V11C22 11.6 21.6 12 21 12C20.4 12 20 11.6 20 11V5ZM4 19C4 19.6 4.4 20 5 20H11C11.6 20 12 20.4 12 21C12 21.6 11.6 22 11 22H3C2.4 22 2 21.6 2 21V13C2 12.4 2.4 12 3 12C3.6 12 4 12.4 4 13V19Z"></path></svg>
+    </span>
+</bslib-tooltip><script data-bslib-card-init="">bslib.Card.initializeAllCards();</script></div>
 </div>
 </div></div><div class="tab-pane html-fill-item html-fill-container" role="tabpanel" id="card-tabset-6-2"><div class="card-body html-fill-item html-fill-container" data-title="Python (DuckDB)">
 <div class="html-fill-item html-fill-container bslib-grid" style="display: grid; grid-template-rows: minmax(3em, max-content); grid-auto-columns: minmax(0, 1fr);">
 <div class="card html-fill-item html-fill-container bslib-card" data-fill="false" data-bslib-card-init="" data-require-bs-caller="card()" data-full-screen="false">
 <div class="card-body html-fill-item html-fill-container">
 <p>No R needed — query the same data directly from Python using DuckDB’s native <code>hf://</code> protocol:</p>
-<div class="code-copy-outer-scaffold html-fill-item html-fill-container"><div class="sourceCode html-fill-item html-fill-container" id="cb2"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="im">import</span> duckdb</span>
-<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>con <span class="op">=</span> duckdb.<span class="ex">connect</span>()</span>
-<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>df <span class="op">=</span> con.sql(<span class="st">"""</span></span>
-<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a><span class="st">    SELECT date, close, volume</span></span>
-<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a><span class="st">    FROM 'hf://datasets/JohnGavin/finance-data/equity_daily.parquet'</span></span>
-<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a><span class="st">    WHERE ticker = 'AAPL' AND date &gt;= '2024-01-01'</span></span>
-<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a><span class="st">    ORDER BY date</span></span>
-<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a><span class="st">"""</span>).df()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold html-fill-item html-fill-container"><div class="sourceCode html-fill-item html-fill-container" id="cb4"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="im">import</span> duckdb</span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>con <span class="op">=</span> duckdb.<span class="ex">connect</span>()</span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>df <span class="op">=</span> con.sql(<span class="st">"""</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a><span class="st">    SELECT date, close, volume</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a><span class="st">    FROM 'hf://datasets/JohnGavin/finance-data/equity_daily.parquet'</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a><span class="st">    WHERE ticker = 'AAPL' AND date &gt;= '2024-01-01'</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a><span class="st">    ORDER BY date</span></span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a><span class="st">"""</span>).df()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </div>
 <bslib-tooltip placement="auto" bsoptions="[]" data-require-bs-version="5" data-require-bs-caller="tooltip()">
     <template>Expand</template>
@@ -617,8 +637,8 @@ grid-auto-rows: minmax(0, 1fr);">
 <div class="html-fill-item html-fill-container bslib-grid" style="display: grid; grid-template-rows: minmax(3em, max-content); grid-auto-columns: minmax(0, 1fr);">
 <div class="card html-fill-item html-fill-container bslib-card" data-fill="false" data-bslib-card-init="" data-require-bs-caller="card()" data-full-screen="false">
 <div class="card-body html-fill-item html-fill-container">
-<div class="code-copy-outer-scaffold html-fill-item html-fill-container"><div class="sourceCode html-fill-item html-fill-container" id="cb3"><pre class="sourceCode bash code-with-copy"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Enter reproducible Nix shell (all R + Python packages included)</span></span>
-<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a><span class="ex">nix</span> develop github:JohnGavin/historical</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold html-fill-item html-fill-container"><div class="sourceCode html-fill-item html-fill-container" id="cb5"><pre class="sourceCode bash code-with-copy"><code class="sourceCode bash"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Enter reproducible Nix shell (all R + Python packages included)</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a><span class="ex">nix</span> develop github:JohnGavin/historical</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <p>Then start R and load the package. All dependencies (dplyr, ggplot2, scales, DT, arrow, duckdb) are pre-installed in the Nix shell.</p>
 </div>
 <bslib-tooltip placement="auto" bsoptions="[]" data-require-bs-version="5" data-require-bs-caller="tooltip()">
@@ -632,14 +652,14 @@ grid-auto-rows: minmax(0, 1fr);">
 <div class="html-fill-item html-fill-container bslib-grid" style="display: grid; grid-template-rows: minmax(3em, max-content); grid-auto-columns: minmax(0, 1fr);">
 <div class="card html-fill-item html-fill-container bslib-card" data-fill="false" data-bslib-card-init="" data-require-bs-caller="card()" data-full-screen="false">
 <div class="card-body html-fill-item html-fill-container">
-<div class="code-copy-outer-scaffold html-fill-item html-fill-container"><div class="sourceCode html-fill-item html-fill-container" id="cb4"><pre class="sourceCode bash code-with-copy"><code class="sourceCode bash"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Clone, enter Nix shell, fetch data, run pipeline</span></span>
-<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> clone https://github.com/JohnGavin/historical.git <span class="kw">&amp;&amp;</span> <span class="bu">cd</span> historical</span>
-<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a><span class="ex">nix</span> develop</span>
-<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a><span class="ex">python</span> scripts/fetch_equity.py     <span class="co"># 51 equity tickers</span></span>
-<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a><span class="ex">Rscript</span> scripts/fetch_crypto.R     <span class="co"># 14 crypto tokens</span></span>
-<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a><span class="ex">Rscript</span> scripts/fetch_macro.R      <span class="co"># 19 FRED series</span></span>
-<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a><span class="ex">Rscript</span> scripts/fetch_factors.R    <span class="co"># Fama-French factors</span></span>
-<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a><span class="ex">t</span> run src/pipeline.t               <span class="co"># T pipeline</span></span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold html-fill-item html-fill-container"><div class="sourceCode html-fill-item html-fill-container" id="cb6"><pre class="sourceCode bash code-with-copy"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Clone, enter Nix shell, fetch data, run pipeline</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> clone https://github.com/JohnGavin/historical.git <span class="kw">&amp;&amp;</span> <span class="bu">cd</span> historical</span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a><span class="ex">nix</span> develop</span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="ex">python</span> scripts/fetch_equity.py     <span class="co"># 51 equity tickers</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a><span class="ex">Rscript</span> scripts/fetch_crypto.R     <span class="co"># 14 crypto tokens</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a><span class="ex">Rscript</span> scripts/fetch_macro.R      <span class="co"># 19 FRED series</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a><span class="ex">Rscript</span> scripts/fetch_factors.R    <span class="co"># Fama-French factors</span></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a><span class="ex">t</span> run src/pipeline.t               <span class="co"># T pipeline</span></span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </div>
 <bslib-tooltip placement="auto" bsoptions="[]" data-require-bs-version="5" data-require-bs-caller="tooltip()">
     <template>Expand</template>
@@ -663,7 +683,7 @@ grid-auto-rows: minmax(0, 1fr);">
 grid-auto-rows: minmax(0, 1fr);">
 <div class="card html-fill-item html-fill-container bslib-card" data-fill="false" data-bslib-card-init="" data-require-bs-caller="card()" data-full-screen="false">
 <div class="card-body html-fill-item html-fill-container">
-<p>[1] “<strong>historicaldata</strong> <a href="https://github.com/JohnGavin/historical/releases/tag/v0.1.0">0.1.0</a> | <strong>Git</strong> <a href="https://github.com/JohnGavin/historical/commit/4e22ca94a8caea5df1387830444776eeb1a80054"><code>4e22ca9</code></a> | <strong>R</strong> <a href="https://cran.r-project.org/doc/manuals/r-release/NEWS.html">4.5.3</a> | <strong>Built</strong> 2026-06-05 15:59:21”</p>
+<p>[1] “<strong>historicaldata</strong> <a href="https://github.com/JohnGavin/historical/releases/tag/v0.1.0">0.1.0</a> | <strong>Git</strong> <a href="https://github.com/JohnGavin/historical/commit/236f865ba2e329149387966c5d8d77d4720f265d"><code>236f865</code></a> | <strong>R</strong> <a href="https://cran.r-project.org/doc/manuals/r-release/NEWS.html">4.5.3</a> | <strong>Built</strong> 2026-06-06 17:04:11”</p>
 </div>
 <bslib-tooltip placement="auto" bsoptions="[]" data-require-bs-version="5" data-require-bs-caller="tooltip()">
     <template>Expand</template>

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -32,9 +32,9 @@ format:
                        flex-wrap: nowrap !important; gap: 2.5em !important;
                        justify-content: center !important; align-items: center !important;
                        margin: 1em 0 !important; width: 100% !important; }
-          .stat { text-align: center; flex-shrink: 0; }
-          .stat .num { font-size: 1.8em; font-weight: bold; }
-          .stat .label { font-size: 0.8em; opacity: 0.6; }
+          .stat { text-align: center; flex-shrink: 0; display: inline-block; }
+          .stat .num { font-size: 1.8em; font-weight: bold; display: block; }
+          .stat .label { font-size: 0.8em; opacity: 0.6; display: block; }
           .badge { display: inline-block; padding: 0.2em 0.6em; border-radius: 4px;
                    font-size: 0.8em; margin-right: 0.5em; }
           .badge-blue { background: #1a3a5c; color: #6B8DAE; }
@@ -162,11 +162,11 @@ Historical finance database for backtesting: equities, crypto, macro, and factor
 <a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer"><span class="badge badge-gold">Hugging Face</span></a>
 
 <div class="stats-row">
-<a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer" class="stat-link"><div class="stat"><div class="num">`r stat_tickers`</div><div class="label">tickers</div></div></a>
-<a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer" class="stat-link"><div class="stat"><div class="num">`r stat_rows`</div><div class="label">rows</div></div></a>
-<a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer" class="stat-link"><div class="stat"><div class="num">`r stat_datasets`</div><div class="label">datasets</div></div></a>
-<a href="jst-dashboard.html" class="stat-link"><div class="stat"><div class="num">`r stat_yr`</div><div class="label">history</div></div></a>
-<a href="https://github.com/JohnGavin/historical/blob/main/docs/api-historicaldata.md" target="_blank" rel="noopener noreferrer" class="stat-link"><div class="stat"><div class="num">`r stat_functions`</div><div class="label">functions</div></div></a>
+<a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer" class="stat-link"><span class="stat"><span class="num">`r stat_tickers`</span><span class="label">tickers</span></span></a>
+<a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer" class="stat-link"><span class="stat"><span class="num">`r stat_rows`</span><span class="label">rows</span></span></a>
+<a href="https://huggingface.co/datasets/JohnGavin/finance-data" target="_blank" rel="noopener noreferrer" class="stat-link"><span class="stat"><span class="num">`r stat_datasets`</span><span class="label">datasets</span></span></a>
+<a href="jst-dashboard.html" class="stat-link"><span class="stat"><span class="num">`r stat_yr`</span><span class="label">history</span></span></a>
+<a href="https://github.com/JohnGavin/historical/blob/main/docs/api-historicaldata.md" target="_blank" rel="noopener noreferrer" class="stat-link"><span class="stat"><span class="num">`r stat_functions`</span><span class="label">functions</span></span></a>
 </div>
 
 ## Row


### PR DESCRIPTION
## Summary

- **Fix**: PR #437's `<details>` blocks changed pandoc's parsing context for the preceding stats-row, stripping nested `<div>` elements from inside `<a class="stat-link">` and leaving empty tags in the rendered HTML.
- **Solution**: Option A from the #437 follow-up plan — swap nested `<div>` for `<span>` (inline-in-inline is valid HTML). CSS `display: block` added to `.stat .num` and `.stat .label` to preserve vertical layout; `.stat` gets `display: inline-block`.
- **Re-rendered** `docs/index.html` against the fixed source.

## Verification

```
$ grep -oE 'class="num">[^<]{1,20}' docs/index.html
class="num">1,636          ← tickers
class="num">7.8M           ← rows
class="num">9              ← datasets
class="num">100yr          ← history (was bogus 5,553,492yr pre-#437)
class="num">120            ← functions (was hardcoded 30 pre-#437)
```

Dark-mode contrast audit: 1 file checked, 0 violations.

## What changes on https://johngavin.github.io/historical/ after merge

- Headline stats actually display values instead of empty cells
- "functions" stat now links to `docs/api-historicaldata.md` (pkgctx-generated, human-readable) instead of `NAMESPACE`
- Dataset descriptions remain in their collapsible `<details>` layout from #437

## Test plan

- [x] `quarto render docs/index.qmd` exit code 0
- [x] All 5 stat values present in `docs/index.html`
- [x] Dark-mode contrast clean
- [ ] **Reviewer**: visual spot-check the deployed page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)