### PR TITLE
feat(data): Kraken OHLCVT majors fetch pipeline (#436 Phase A)

### DIFF
--- a/scripts/fetch_kraken_ohlcvt.R
+++ b/scripts/fetch_kraken_ohlcvt.R
@@ -1,0 +1,421 @@
+#!/usr/bin/env Rscript
+# fetch_kraken_ohlcvt.R
+#
+# Phase A (#436): Fetch hourly + daily OHLCVT for the 6 largest USD pairs on
+# Kraken by 24 h USD volume: BTC, ETH, SOL, XRP, ADA, LINK.
+#
+# DOWNLOAD MECHANICS (investigated 2026-06-12):
+#   Kraken hosts one full archive and quarterly update ZIPs on Google Drive:
+#     Full archive (7.3 GB):
+#       https://drive.google.com/file/d/1ptNqWYidLkhb2VAKuLCxmp2OXEfGO-AP/view
+#     Quarterly updates folder:
+#       https://drive.google.com/drive/folders/15RSlNuW_h0kVM8or8McOGOMfHeBFvFGI
+#
+#   Automated download is NOT possible without the manual "Download anyway"
+#   click-through: Google Drive serves a virus-scan warning HTML page for files
+#   > 25 MB and the confirm token is session-scoped. The script therefore
+#   reads the ZIP from a path the user supplies (or the env var
+#   KRAKEN_ZIP_PATH) after they have manually downloaded it.
+#
+#   Fallback: for the recent ~30-day window the script can also pull from the
+#   Kraken public REST API (max 720 candles per call; no API key required).
+#   Set KRAKEN_REST_FALLBACK=1 to enable this for development / smoke-testing.
+#
+# CSV LAYOUT INSIDE THE ZIP (confirmed from community source):
+#   No header row. Seven columns:
+#     timestamp (Unix epoch seconds, integer)
+#     open, high, low, close (numeric, as string)
+#     volume (numeric, as string)
+#     trades (integer)
+#   File names: {PAIR}_{interval_minutes}.csv
+#   e.g. XBTUSD_60.csv, ETHUSD_1440.csv
+#   ZIP internal path: either "Kraken_OHLCVT/{file}" (old layout)
+#     or "{file}" (new layout from ~2023 quarterly updates).
+#   Source: https://github.com/gwangjinkim/krakenohlcvt
+#
+# OUTPUT SCHEMA (data/raw/kraken_ohlcvt.parquet):
+#   ticker      chr   Short symbol — "BTC", "ETH", "SOL", "XRP", "ADA", "LINK"
+#   pair        chr   Kraken pair name — "XBTUSD", "ETHUSD", etc.
+#   interval_min int  60 or 1440
+#   time        POSIXct (UTC) — heed issue #453: stored as proper timestamp
+#   open        dbl
+#   high        dbl
+#   low         dbl
+#   close       dbl
+#   volume      dbl
+#   trades      int
+#
+# USAGE:
+#   # With a manually downloaded ZIP:
+#   KRAKEN_ZIP_PATH=~/Downloads/Kraken_OHLCVT.zip Rscript scripts/fetch_kraken_ohlcvt.R
+#
+#   # REST fallback (recent ~30 days only, for smoke-testing):
+#   KRAKEN_REST_FALLBACK=1 Rscript scripts/fetch_kraken_ohlcvt.R
+
+suppressPackageStartupMessages({
+  library(httr2)
+  library(tibble)
+  library(dplyr)
+  library(arrow)
+  library(cli)
+})
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# The 6 largest USD pairs on Kraken by 24 h USD volume (verified 2026-06-12).
+# Ranking source: Kraken public REST API /Ticker endpoint.
+# Kraken internal name → (ticker, CSV pair prefix, wsname)
+PAIRS <- list(
+  list(kraken_pair = "XXBTZUSD", ticker = "BTC",  csv_prefix = "XBTUSD",  wsname = "XBT/USD"),
+  list(kraken_pair = "XETHZUSD", ticker = "ETH",  csv_prefix = "ETHUSD",  wsname = "ETH/USD"),
+  list(kraken_pair = "SOLUSD",   ticker = "SOL",  csv_prefix = "SOLUSD",  wsname = "SOL/USD"),
+  list(kraken_pair = "XXRPZUSD", ticker = "XRP",  csv_prefix = "XRPUSD",  wsname = "XRP/USD"),
+  list(kraken_pair = "ADAUSD",   ticker = "ADA",  csv_prefix = "ADAUSD",  wsname = "ADA/USD"),
+  list(kraken_pair = "LINKUSD",  ticker = "LINK", csv_prefix = "LINKUSD", wsname = "LINK/USD")
+)
+
+# Intervals to extract (minutes)
+INTERVALS <- c(60L, 1440L)
+
+# ---------------------------------------------------------------------------
+# Helper: parse one pair+interval from an open zip connection
+# ---------------------------------------------------------------------------
+
+#' Parse Kraken OHLCVT CSV from a ZIP file
+#'
+#' @param zip_path Path to the downloaded ZIP archive.
+#' @param csv_prefix Pair prefix as used in the CSV file name (e.g. "XBTUSD").
+#' @param interval_min Interval in minutes (60 or 1440).
+#' @param ticker Short ticker label for the output (e.g. "BTC").
+#' @param kraken_pair Full Kraken pair identifier (e.g. "XXBTZUSD").
+#' @return Tibble with normalised schema, or NULL on failure.
+parse_ohlcvt_from_zip <- function(zip_path, csv_prefix, interval_min,
+                                   ticker, kraken_pair) {
+  # The CSV may be at the root of the ZIP (new layout) or under Kraken_OHLCVT/
+  # (old layout). Try both.
+  csv_name <- paste0(csv_prefix, "_", interval_min, ".csv")
+  candidates <- c(csv_name, paste0("Kraken_OHLCVT/", csv_name))
+
+  zip_contents <- tryCatch(unzip(zip_path, list = TRUE)$Name, error = function(e) character(0))
+  match_idx <- match(candidates, zip_contents)
+  match_idx <- match_idx[!is.na(match_idx)]
+
+  if (length(match_idx) == 0L) {
+    cli::cli_warn("  {ticker} {interval_min}min: {csv_name} not found in ZIP")
+    return(NULL)
+  }
+
+  matched_name <- zip_contents[match_idx[1L]]
+  tmp_dir <- tempdir()
+
+  tryCatch({
+    unzip(zip_path, files = matched_name, exdir = tmp_dir, overwrite = TRUE)
+    csv_path <- file.path(tmp_dir, matched_name)
+
+    # No header; 7 columns: timestamp, open, high, low, close, volume, trades
+    raw <- utils::read.csv(
+      csv_path,
+      header = FALSE,
+      col.names = c("timestamp_s", "open", "high", "low", "close", "volume", "trades"),
+      colClasses = c("integer", "double", "double", "double", "double", "double", "integer"),
+      stringsAsFactors = FALSE
+    )
+
+    tibble::as_tibble(raw) |>
+      dplyr::mutate(
+        ticker       = ticker,
+        pair         = csv_prefix,
+        interval_min = interval_min,
+        # Issue #453: write proper POSIXct, NOT character
+        time         = as.POSIXct(timestamp_s, origin = "1970-01-01", tz = "UTC")
+      ) |>
+      dplyr::select(ticker, pair, interval_min, time, open, high, low, close, volume, trades)
+  }, error = function(e) {
+    cli::cli_warn("  {ticker} {interval_min}min: parse failed — {conditionMessage(e)}")
+    NULL
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Helper: fetch recent candles from Kraken REST API (fallback only)
+# ---------------------------------------------------------------------------
+
+#' Fetch OHLC candles from the Kraken public REST API
+#'
+#' Maximum 720 candles per call (no authentication required).
+#' Use ONLY for smoke-testing. The full archive ZIP is required for
+#' production-quality history.
+#'
+#' @param kraken_pair Kraken pair string, e.g. "XXBTZUSD".
+#' @param interval_min Interval in minutes (must be one of Kraken's supported values).
+#' @param ticker Short ticker label.
+#' @param csv_prefix CSV pair prefix for the pair column.
+#' @return Tibble with normalised schema, or NULL on failure.
+fetch_ohlc_rest <- function(kraken_pair, interval_min, ticker, csv_prefix) {
+  url <- paste0(
+    "https://api.kraken.com/0/public/OHLC?pair=", kraken_pair,
+    "&interval=", interval_min
+  )
+  cli::cli_progress_step("  REST {ticker} {interval_min}min (last ~720 candles)")
+
+  tryCatch({
+    resp <- httr2::request(url) |>
+      httr2::req_timeout(30L) |>
+      httr2::req_perform()
+    body <- httr2::resp_body_json(resp, simplifyVector = FALSE)
+
+    if (length(body$error) > 0L) {
+      cli::cli_warn("  REST error for {ticker}: {paste(body$error, collapse=', ')}")
+      return(NULL)
+    }
+
+    # result has one key = the pair name, plus "last"
+    pair_data <- body$result[[kraken_pair]]
+    if (is.null(pair_data) || length(pair_data) == 0L) return(NULL)
+
+    # Each candle: [time, open, high, low, close, vwap, volume, count]
+    # Note: REST includes vwap (position 6); ZIP does not. We drop vwap.
+    rows <- lapply(pair_data, function(c) {
+      tibble::tibble(
+        ticker       = ticker,
+        pair         = csv_prefix,
+        interval_min = interval_min,
+        time         = as.POSIXct(as.integer(c[[1L]]), origin = "1970-01-01", tz = "UTC"),
+        open         = as.double(c[[2L]]),
+        high         = as.double(c[[3L]]),
+        low          = as.double(c[[4L]]),
+        close        = as.double(c[[5L]]),
+        # c[[6]] is vwap — skip
+        volume       = as.double(c[[7L]]),
+        trades       = as.integer(c[[8L]])
+      )
+    })
+    dplyr::bind_rows(rows)
+  }, error = function(e) {
+    cli::cli_warn("  REST fetch failed for {ticker}: {conditionMessage(e)}")
+    NULL
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+#' Validate a Kraken OHLCVT tibble
+#'
+#' Checks schema (column names and types), duplicate (pair, interval_min, time),
+#' value ranges (positive prices, high >= low), and hourly gap detection.
+#' Aborts with cli_abort on hard failures; warns on soft issues.
+#'
+#' @param df Tibble produced by the fetch pipeline.
+#' @param abort_on_failure If TRUE, call cli_abort on validation failures
+#'   (default). Set FALSE in tests to capture the errors.
+#' @return df invisibly, after validation.
+dv_kraken_ohlcvt <- function(df, abort_on_failure = TRUE) {
+  # ── 1. Schema ──────────────────────────────────────────────────────────────
+  required_cols <- c("ticker", "pair", "interval_min", "time",
+                     "open", "high", "low", "close", "volume", "trades")
+  missing_cols <- setdiff(required_cols, names(df))
+  if (length(missing_cols) > 0L) {
+    msg <- c(
+      "x" = "kraken_ohlcvt: missing columns: {paste(missing_cols, collapse=', ')}",
+      "i" = "Expected: {paste(required_cols, collapse=', ')}"
+    )
+    if (abort_on_failure) cli::cli_abort(msg) else { cli::cli_warn(msg); return(invisible(df)) }
+  }
+
+  wrong_type <- c(
+    if (!inherits(df$time, "POSIXct")) "`time` must be POSIXct (UTC)" else NULL,
+    if (!is.character(df$ticker))      "`ticker` must be character" else NULL,
+    if (!is.character(df$pair))        "`pair` must be character" else NULL,
+    if (!is.integer(df$interval_min))  "`interval_min` must be integer" else NULL,
+    if (!is.double(df$close))          "`close` must be double" else NULL
+  )
+  if (length(wrong_type) > 0L) {
+    msg <- c("x" = "kraken_ohlcvt: type mismatch", "i" = wrong_type)
+    if (abort_on_failure) cli::cli_abort(msg) else cli::cli_warn(msg)
+  }
+
+  # ── 2. Duplicates ──────────────────────────────────────────────────────────
+  n_dup <- sum(duplicated(df[c("pair", "interval_min", "time")]))
+  if (n_dup > 0L) {
+    msg <- c("x" = "kraken_ohlcvt: {n_dup} duplicate (pair, interval_min, time) rows")
+    if (abort_on_failure) cli::cli_abort(msg) else cli::cli_warn(msg)
+  }
+
+  # ── 3. Value ranges ────────────────────────────────────────────────────────
+  n_neg_close <- sum(df$close <= 0L, na.rm = TRUE)
+  if (n_neg_close > 0L) {
+    msg <- c("x" = "kraken_ohlcvt: {n_neg_close} rows with close <= 0")
+    if (abort_on_failure) cli::cli_abort(msg) else cli::cli_warn(msg)
+  }
+
+  n_high_lt_low <- sum(df$high < df$low, na.rm = TRUE)
+  if (n_high_lt_low > 0L) {
+    msg <- c("x" = "kraken_ohlcvt: {n_high_lt_low} rows where high < low")
+    if (abort_on_failure) cli::cli_abort(msg) else cli::cli_warn(msg)
+  }
+
+  # ── 4. Gap detection (hourly grain only, soft warning) ────────────────────
+  hourly <- df[df$interval_min == 60L, ]
+  if (nrow(hourly) > 0L) {
+    gap_report <- hourly |>
+      dplyr::arrange(pair, time) |>
+      dplyr::group_by(pair) |>
+      dplyr::mutate(
+        delta_h = as.double(difftime(time, dplyr::lag(time), units = "hours"))
+      ) |>
+      dplyr::filter(!is.na(delta_h) & delta_h > 2L) |>
+      dplyr::summarise(
+        n_gaps    = dplyr::n(),
+        max_gap_h = if (dplyr::n() > 0L) max(delta_h, na.rm = TRUE) else NA_real_,
+        .groups   = "drop"
+      ) |>
+      dplyr::filter(n_gaps > 0L)
+
+    if (nrow(gap_report) > 0L) {
+      cli::cli_warn(c(
+        "!" = "kraken_ohlcvt: gaps >2h detected in hourly data",
+        "i" = "This is expected — Kraken only records candles when trades occur",
+        "i" = "{paste(gap_report$pair, 'max_gap=', round(gap_report$max_gap_h, 1), 'h', collapse='; ')}"
+      ))
+    }
+  }
+
+  cli::cli_alert_success(
+    "kraken_ohlcvt validation passed: {nrow(df)} rows, {dplyr::n_distinct(df$ticker)} pairs, intervals {paste(sort(unique(df$interval_min)), collapse='/')} min"
+  )
+  invisible(df)
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+cli::cli_h1("Kraken OHLCVT Fetch — 6 majors, 60 + 1440 min (#436 Phase A)")
+
+zip_path <- Sys.getenv("KRAKEN_ZIP_PATH", unset = "")
+use_rest  <- nchar(Sys.getenv("KRAKEN_REST_FALLBACK", unset = "")) > 0L
+
+if (nchar(zip_path) == 0L && !use_rest) {
+  cli::cli_abort(c(
+    "x" = "No data source specified.",
+    "i" = "Option 1 (full history): set KRAKEN_ZIP_PATH to the manually downloaded ZIP path:",
+    "i" = "  Download from: https://drive.google.com/file/d/1ptNqWYidLkhb2VAKuLCxmp2OXEfGO-AP/view",
+    "i" = "  Then: KRAKEN_ZIP_PATH=~/Downloads/Kraken_OHLCVT.zip Rscript scripts/fetch_kraken_ohlcvt.R",
+    "i" = "Option 2 (recent ~30 days, smoke-test only): set KRAKEN_REST_FALLBACK=1",
+    "i" = "  KRAKEN_REST_FALLBACK=1 Rscript scripts/fetch_kraken_ohlcvt.R"
+  ))
+}
+
+if (nchar(zip_path) > 0L) {
+  zip_path <- path.expand(zip_path)
+  if (!file.exists(zip_path)) {
+    cli::cli_abort(c(
+      "x" = "ZIP not found at {.path {zip_path}}",
+      "i" = "Download manually from: https://drive.google.com/file/d/1ptNqWYidLkhb2VAKuLCxmp2OXEfGO-AP/view"
+    ))
+  }
+  cli::cli_alert_info("Source: ZIP archive at {.path {zip_path}}")
+} else {
+  cli::cli_alert_info("Source: Kraken REST API (recent ~720 candles only)")
+}
+
+all_results <- list()
+
+for (p in PAIRS) {
+  for (iv in INTERVALS) {
+    label <- paste0(p$ticker, "_", iv, "min")
+    cli::cli_progress_step("Fetching {label}")
+
+    if (nchar(zip_path) > 0L) {
+      df <- parse_ohlcvt_from_zip(
+        zip_path    = zip_path,
+        csv_prefix  = p$csv_prefix,
+        interval_min = iv,
+        ticker       = p$ticker,
+        kraken_pair  = p$kraken_pair
+      )
+    } else {
+      df <- fetch_ohlc_rest(
+        kraken_pair  = p$kraken_pair,
+        interval_min = iv,
+        ticker       = p$ticker,
+        csv_prefix   = p$csv_prefix
+      )
+      Sys.sleep(1L)  # REST rate limit courtesy
+    }
+
+    if (!is.null(df) && nrow(df) > 0L) {
+      cli::cli_alert_success(
+        "  {label}: {nrow(df)} rows ({format(min(df$time), '%Y-%m-%d')} to {format(max(df$time), '%Y-%m-%d')})"
+      )
+      all_results[[label]] <- df
+    } else {
+      cli::cli_warn("  {label}: no data")
+    }
+  }
+}
+
+if (length(all_results) == 0L) {
+  cli::cli_abort("x" = "No data fetched — cannot write parquet.")
+}
+
+combined <- dplyr::bind_rows(all_results) |>
+  # Enforce correct types for parquet serialisation (issue #453)
+  dplyr::mutate(
+    ticker       = as.character(ticker),
+    pair         = as.character(pair),
+    interval_min = as.integer(interval_min),
+    time         = as.POSIXct(time, tz = "UTC"),
+    open         = as.double(open),
+    high         = as.double(high),
+    low          = as.double(low),
+    close        = as.double(close),
+    volume       = as.double(volume),
+    trades       = as.integer(trades)
+  ) |>
+  dplyr::distinct(pair, interval_min, time, .keep_all = TRUE) |>
+  dplyr::arrange(pair, interval_min, time)
+
+# Validate before writing
+dv_kraken_ohlcvt(combined)
+
+# ---------------------------------------------------------------------------
+# Write to parquet
+# ---------------------------------------------------------------------------
+
+out_path <- here::here("data", "raw", "kraken_ohlcvt.parquet")
+dir.create(dirname(out_path), showWarnings = FALSE, recursive = TRUE)
+
+# Idempotent merge with existing data if it exists
+if (file.exists(out_path)) {
+  existing <- arrow::read_parquet(out_path)
+  # Coerce existing time to POSIXct in case it was stored differently
+  existing <- existing |>
+    dplyr::mutate(time = as.POSIXct(time, tz = "UTC"))
+  combined <- dplyr::bind_rows(existing, combined) |>
+    dplyr::distinct(pair, interval_min, time, .keep_all = TRUE) |>
+    dplyr::arrange(pair, interval_min, time)
+  cli::cli_alert_info("Merged with existing file; {nrow(combined)} total rows")
+}
+
+arrow::write_parquet(combined, out_path, compression = "zstd")
+
+size_kb <- round(file.info(out_path)$size / 1024L)
+cli::cli_alert_success(
+  "Written {nrow(combined)} rows to {.path {out_path}} ({size_kb} KB)"
+)
+
+cli::cli_h2("Summary")
+summary_tbl <- combined |>
+  dplyr::group_by(ticker, interval_min) |>
+  dplyr::summarise(
+    n        = dplyr::n(),
+    from     = format(min(time), "%Y-%m-%d"),
+    to       = format(max(time), "%Y-%m-%d"),
+    .groups  = "drop"
+  )
+print(summary_tbl, n = Inf)

--- a/tests/testthat/_snaps/kraken-ohlcvt.md
+++ b/tests/testthat/_snaps/kraken-ohlcvt.md
@@ -1,0 +1,23 @@
+# parse_ohlcvt_from_zip snapshot — column names and type summary
+
+    Code
+      cat(summary_str)
+    Output
+      ticker:character, pair:character, interval_min:integer, time:POSIXct, open:numeric, high:numeric, low:numeric, close:numeric, volume:numeric, trades:integer
+
+# dv_kraken_ohlcvt error message snapshot — missing column
+
+    Code
+      dv_kraken_ohlcvt(df_bad)
+    Condition
+      Error in `dv_kraken_ohlcvt()`:
+      x kraken_ohlcvt: missing columns: volume, trades
+      i Expected: ticker, pair, interval_min, time, open, high, low, close, volume, trades
+
+# PAIRS snapshot — ticker list is stable
+
+    Code
+      cat(paste(tickers, collapse = ", "))
+    Output
+      BTC, ETH, SOL, XRP, ADA, LINK
+

--- a/tests/testthat/test-kraken-ohlcvt.R
+++ b/tests/testthat/test-kraken-ohlcvt.R
@@ -1,0 +1,263 @@
+# Tests for the Kraken OHLCVT fetch pipeline (#436 Phase A)
+# Covers:
+#  - CSV parsing (7-column no-header Kraken format)
+#  - Timestamp conversion to POSIXct UTC (issue #453)
+#  - dv_kraken_ohlcvt() validation: schema, duplicates, value ranges, gaps
+#  - At least one expect_snapshot() per snapshot-test-policy
+testthat::local_edition(3)
+
+# ---------------------------------------------------------------------------
+# Helpers for synthetic fixtures
+# ---------------------------------------------------------------------------
+
+# Build a minimal in-memory Kraken OHLCVT CSV (no header, 7 cols)
+make_kraken_csv_lines <- function(pair = "XBTUSD", interval_min = 60L,
+                                  n_rows = 5L, start_ts = 1700000000L) {
+  timestamps <- start_ts + seq(0L, by = interval_min * 60L, length.out = n_rows)
+  opens  <- seq(30000, by = 10, length.out = n_rows)
+  highs  <- opens + 50
+  lows   <- opens - 30
+  closes <- opens + 20
+  vols   <- seq(0.5, by = 0.1, length.out = n_rows)
+  trades <- seq(100L, by = 10L, length.out = n_rows)
+  paste(timestamps, opens, highs, lows, closes, vols, trades, sep = ",")
+}
+
+# Write synthetic CSV to a temp file and zip it
+make_kraken_zip <- function(pairs_intervals = list(list("XBTUSD", 60L)),
+                             n_rows = 5L, layout = "new") {
+  zip_path <- tempfile(fileext = ".zip")
+  tmp_dir  <- tempdir()
+  csv_paths <- character(0L)
+
+  for (pi in pairs_intervals) {
+    pair <- pi[[1L]]
+    iv   <- pi[[2L]]
+    lines <- make_kraken_csv_lines(pair, iv, n_rows)
+    csv_name <- paste0(pair, "_", iv, ".csv")
+    if (layout == "old") {
+      dir.create(file.path(tmp_dir, "Kraken_OHLCVT"), showWarnings = FALSE)
+      csv_path <- file.path(tmp_dir, "Kraken_OHLCVT", csv_name)
+    } else {
+      csv_path <- file.path(tmp_dir, csv_name)
+    }
+    writeLines(lines, csv_path)
+    csv_paths <- c(csv_paths, csv_path)
+  }
+
+  # zip with relative names from tmp_dir
+  # utils::zip() requires R_ZIPCMD which is unset in the nix shell; use
+  # system2 with the known system zip binary instead.
+  old_wd <- setwd(tmp_dir)
+  on.exit(setwd(old_wd), add = TRUE)
+  rel_paths <- if (layout == "old") {
+    file.path("Kraken_OHLCVT", sapply(pairs_intervals, function(pi) paste0(pi[[1L]], "_", pi[[2L]], ".csv")))
+  } else {
+    sapply(pairs_intervals, function(pi) paste0(pi[[1L]], "_", pi[[2L]], ".csv"))
+  }
+  zip_bin <- Sys.which("zip")
+  if (nchar(zip_bin) == 0L) zip_bin <- "/usr/bin/zip"
+  system2(zip_bin, args = c(zip_path, rel_paths), stdout = FALSE, stderr = FALSE)
+  zip_path
+}
+
+# Source the two key functions from the fetch script (without running main())
+source_fetch_fns <- function() {
+  script_path <- here::here("scripts", "fetch_kraken_ohlcvt.R")
+  if (!file.exists(script_path)) skip("fetch script not found")
+
+  lines  <- readLines(script_path)
+  # Find the line where main code starts (the cli::cli_h1 call at the top level)
+  # Everything after "# Main" comment block and up to the zip_path / use_rest checks
+  # is the interactive part; we want only the functions + PAIRS constant.
+  # Strategy: source only up to (but not including) "zip_path <-"
+  main_start <- grep("^zip_path\\s*<-", lines)[1L]
+  if (is.na(main_start)) stop("Could not find main block in fetch script")
+  fn_lines <- lines[seq_len(main_start - 1L)]
+  eval(parse(text = fn_lines), envir = parent.frame())
+}
+
+# ---------------------------------------------------------------------------
+# Tests: parse_ohlcvt_from_zip
+# ---------------------------------------------------------------------------
+
+test_that("parse_ohlcvt_from_zip returns correct schema from new-layout ZIP", {
+  suppressPackageStartupMessages({
+    library(tibble)
+    library(dplyr)
+  })
+  source_fetch_fns()
+
+  zip_path <- make_kraken_zip(list(list("XBTUSD", 60L)), n_rows = 5L, layout = "new")
+  on.exit(unlink(zip_path), add = TRUE)
+
+  result <- parse_ohlcvt_from_zip(zip_path, "XBTUSD", 60L, "BTC", "XXBTZUSD")
+
+  expect_s3_class(result, "tbl_df")
+  expect_named(result, c("ticker", "pair", "interval_min", "time", "open", "high", "low", "close", "volume", "trades"))
+  expect_equal(nrow(result), 5L)
+  expect_equal(unique(result$ticker), "BTC")
+  expect_equal(unique(result$pair), "XBTUSD")
+  expect_equal(unique(result$interval_min), 60L)
+  # Issue #453: time must be POSIXct, NOT character
+  expect_s3_class(result$time, "POSIXct")
+  expect_equal(attr(result$time, "tzone"), "UTC")
+})
+
+test_that("parse_ohlcvt_from_zip returns correct schema from old-layout ZIP (Kraken_OHLCVT/ prefix)", {
+  suppressPackageStartupMessages(library(tibble))
+  source_fetch_fns()
+
+  zip_path <- make_kraken_zip(list(list("ETHUSD", 1440L)), n_rows = 3L, layout = "old")
+  on.exit(unlink(zip_path), add = TRUE)
+
+  result <- parse_ohlcvt_from_zip(zip_path, "ETHUSD", 1440L, "ETH", "XETHZUSD")
+  expect_equal(nrow(result), 3L)
+  expect_equal(unique(result$ticker), "ETH")
+})
+
+test_that("parse_ohlcvt_from_zip returns NULL and warns when CSV not in ZIP", {
+  source_fetch_fns()
+  zip_path <- make_kraken_zip(list(list("XBTUSD", 60L)), layout = "new")
+  on.exit(unlink(zip_path), add = TRUE)
+
+  # Request a different pair that does not exist in the ZIP
+  # Use withCallingHandlers to capture the warning without affecting the return value
+  warned <- FALSE
+  result <- withCallingHandlers(
+    parse_ohlcvt_from_zip(zip_path, "SOLUSD", 60L, "SOL", "SOLUSD"),
+    warning = function(w) { warned <<- TRUE; invokeRestart("muffleWarning") }
+  )
+  expect_null(result)
+  expect_true(warned)
+})
+
+test_that("parsed timestamps match expected Unix epoch conversion", {
+  source_fetch_fns()
+
+  # ts 1700000000 = 2023-11-14 22:13:20 UTC
+  zip_path <- make_kraken_zip(list(list("XBTUSD", 60L)), n_rows = 1L, layout = "new")
+  on.exit(unlink(zip_path), add = TRUE)
+
+  result <- parse_ohlcvt_from_zip(zip_path, "XBTUSD", 60L, "BTC", "XXBTZUSD")
+  expected_time <- as.POSIXct(1700000000L, origin = "1970-01-01", tz = "UTC")
+  expect_equal(result$time[1L], expected_time)
+})
+
+test_that("parse_ohlcvt_from_zip snapshot — column names and type summary", {
+  source_fetch_fns()
+  zip_path <- make_kraken_zip(list(list("XBTUSD", 60L)), n_rows = 2L, layout = "new")
+  on.exit(unlink(zip_path), add = TRUE)
+
+  result <- parse_ohlcvt_from_zip(zip_path, "XBTUSD", 60L, "BTC", "XXBTZUSD")
+  summary_str <- paste(
+    names(result),
+    sapply(result, function(col) class(col)[[1L]]),
+    sep = ":", collapse = ", "
+  )
+  # Snapshot: catches column name or type drift
+  expect_snapshot(cat(summary_str))
+})
+
+# ---------------------------------------------------------------------------
+# Tests: dv_kraken_ohlcvt
+# ---------------------------------------------------------------------------
+
+make_valid_df <- function(n = 5L) {
+  tibble::tibble(
+    ticker       = rep("BTC", n),
+    pair         = rep("XBTUSD", n),
+    interval_min = rep(60L, n),
+    time         = as.POSIXct(
+      seq(1700000000L, by = 3600L, length.out = n),
+      origin = "1970-01-01", tz = "UTC"
+    ),
+    open         = seq(30000.0, by = 10.0, length.out = n),
+    high         = seq(30050.0, by = 10.0, length.out = n),
+    low          = seq(29970.0, by = 10.0, length.out = n),
+    close        = seq(30020.0, by = 10.0, length.out = n),
+    volume       = seq(0.5, by = 0.1, length.out = n),
+    trades       = seq(100L, by = 10L, length.out = n)
+  )
+}
+
+test_that("dv_kraken_ohlcvt passes on valid data", {
+  source_fetch_fns()
+  df <- make_valid_df()
+  expect_no_error(dv_kraken_ohlcvt(df))
+})
+
+test_that("dv_kraken_ohlcvt aborts on missing columns", {
+  source_fetch_fns()
+  df <- make_valid_df()
+  df_bad <- df[, setdiff(names(df), "volume")]
+  expect_error(dv_kraken_ohlcvt(df_bad), regexp = "volume")
+})
+
+test_that("dv_kraken_ohlcvt aborts on non-POSIXct time column", {
+  source_fetch_fns()
+  df <- make_valid_df()
+  df$time <- as.character(df$time)
+  expect_error(dv_kraken_ohlcvt(df), regexp = "POSIXct")
+})
+
+test_that("dv_kraken_ohlcvt aborts on duplicate (pair, interval_min, time)", {
+  source_fetch_fns()
+  df <- make_valid_df()
+  df_dup <- dplyr::bind_rows(df, df[1L, ])
+  expect_error(dv_kraken_ohlcvt(df_dup), regexp = "duplicate")
+})
+
+test_that("dv_kraken_ohlcvt aborts when close <= 0", {
+  source_fetch_fns()
+  df <- make_valid_df()
+  df$close[2L] <- -5.0
+  expect_error(dv_kraken_ohlcvt(df), regexp = "close <= 0")
+})
+
+test_that("dv_kraken_ohlcvt aborts when high < low", {
+  source_fetch_fns()
+  df <- make_valid_df()
+  df$high[3L] <- df$low[3L] - 1.0
+  expect_error(dv_kraken_ohlcvt(df), regexp = "high < low")
+})
+
+test_that("dv_kraken_ohlcvt warns on hourly gaps but does not abort", {
+  source_fetch_fns()
+  df <- make_valid_df(n = 5L)
+  # Introduce a 5-hour gap between rows 3 and 4
+  df$time[4L] <- df$time[3L] + 5L * 3600L
+  df$time[5L] <- df$time[4L] + 3600L
+  expect_warning(dv_kraken_ohlcvt(df), regexp = NULL)
+})
+
+test_that("dv_kraken_ohlcvt error message snapshot — missing column", {
+  source_fetch_fns()
+  df <- make_valid_df()
+  df_bad <- df[, setdiff(names(df), c("volume", "trades"))]
+  expect_snapshot(
+    error = TRUE,
+    dv_kraken_ohlcvt(df_bad)
+  )
+})
+
+# ---------------------------------------------------------------------------
+# Tests: PAIRS constant (pair list shape)
+# ---------------------------------------------------------------------------
+
+test_that("PAIRS constant has exactly 6 entries with required keys", {
+  source_fetch_fns()
+  expect_length(PAIRS, 6L)
+  for (p in PAIRS) {
+    expect_true(all(c("kraken_pair", "ticker", "csv_prefix", "wsname") %in% names(p)))
+    expect_type(p$ticker, "character")
+    expect_type(p$csv_prefix, "character")
+  }
+})
+
+test_that("PAIRS snapshot — ticker list is stable", {
+  source_fetch_fns()
+  tickers <- sapply(PAIRS, `[[`, "ticker")
+  # Snapshot: catches unintended pair substitutions (#436)
+  expect_snapshot(cat(paste(tickers, collapse = ", ")))
+})


### PR DESCRIPTION
## Summary

- **`scripts/fetch_kraken_ohlcvt.R`** — fetch hourly (60-min) and daily (1440-min) OHLCVT candles for the 6 largest Kraken USD pairs. Reads from a manually downloaded archive ZIP (`KRAKEN_ZIP_PATH`), with a REST-API fallback (`KRAKEN_REST_FALLBACK=1`) for recent ~720 candles per pair.
- **`tests/testthat/test-kraken-ohlcvt.R`** — 42 tests (FAIL 0) with 3 `expect_snapshot()` guards covering schema, column types, timestamp precision, validation errors, and pair list stability.
- **`tests/testthat/_snaps/kraken-ohlcvt.md`** — committed snapshot baselines.

## Download mechanics (investigated 2026-06-12)

The Kraken OHLCVT archive is hosted on Google Drive:

- **Full archive** (7.3 GB): https://drive.google.com/file/d/1ptNqWYidLkhb2VAKuLCxmp2OXEfGO-AP/view
- **Quarterly updates folder**: https://drive.google.com/drive/folders/15RSlNuW_h0kVM8or8McOGOMfHeBFvFGI

**Automated download is blocked.** Google Drive serves a virus-scan warning HTML page (not the file) for files over 25 MB. The `confirm=t` trick returns HTTP 200 with content-length 0. The script therefore requires the user to download manually and supply the path:

```bash
KRAKEN_ZIP_PATH=~/Downloads/Kraken_OHLCVT.zip Rscript scripts/fetch_kraken_ohlcvt.R
```

REST fallback (for development/smoke-testing — max 720 candles ≈ 30 days):

```bash
KRAKEN_REST_FALLBACK=1 Rscript scripts/fetch_kraken_ohlcvt.R
```

## CSV format inside the ZIP

No header row. Seven columns: `timestamp(Unix epoch s), open, high, low, close, volume, trades`. Note: the downloadable CSVs omit VWAP (the REST API returns 8 fields including VWAP, but the archive has 7). File names: `{PAIR}_{interval_minutes}.csv`, e.g. `XBTUSD_60.csv`. The script handles both the old layout (`Kraken_OHLCVT/{file}`) and the new flat layout (`{file}`).

## Pair selection — top 6 by 24h USD volume (Kraken Ticker API, 2026-06-12)

| Rank | Ticker | Kraken pair | CSV prefix | 24h USD vol |
|------|--------|-------------|------------|-------------|
| 1 | BTC | XXBTZUSD | XBTUSD | ~$99.9M |
| 2 | ETH | XETHZUSD | ETHUSD | ~$43.5M |
| 3 | SOL | SOLUSD | SOLUSD | ~$19.5M |
| 4 | XRP | XXRPZUSD | XRPUSD | ~$17.3M |
| 5 | ADA | ADAUSD | ADAUSD | ~$8.3M |
| 6 | LINK | LINKUSD | LINKUSD | ~$3.6M |

Ranking source: `https://api.kraken.com/0/public/Ticker?pair=...` (24h `v[1]` × last price).

## Output schema

`data/raw/kraken_ohlcvt.parquet` — columns: `ticker(chr), pair(chr), interval_min(int), time(POSIXct UTC), open(dbl), high(dbl), low(dbl), close(dbl), volume(dbl), trades(int)`. Timestamps stored as proper POSIXct (issue #453 discipline: never as character). Idempotent merge on `(pair, interval_min, time)`.

## Refresh cadence recommendation

Kraken releases quarterly OHLCVT update ZIPs. Until Phase B (HuggingFace upload + `hd_kraken_ohlcvt()` helper) ships, the suggested workflow is:

1. Quarterly: download the latest update ZIP from the Google Drive folder
2. Run `KRAKEN_ZIP_PATH=... Rscript scripts/fetch_kraken_ohlcvt.R` — idempotent merge adds new candles

For the most recent 30 days, `KRAKEN_REST_FALLBACK=1` can fill gaps between quarterly updates.

## Phase B gap

The following items are tracked in #436 and are **out of scope** for this PR:

- `hd_kraken_ohlcvt()` package helper in `packages/historicaldata/R/`
- HuggingFace upload via `hd_datasets` registry
- `hd_datasets` registry entry for the Kraken OHLCVT dataset
- `hd_kraken_trades()` tick-level helper

## Test plan

- [x] `NOT_CRAN=true Rscript -e 'testthat::test_file("tests/testthat/test-kraken-ohlcvt.R")'` — FAIL 0 | WARN 0 | SKIP 0 | PASS 42
- [x] 3 `expect_snapshot()` guards committed (schema types, error message, pair list)
- [x] Smoke-test with `KRAKEN_REST_FALLBACK=1` — REST API returns valid candles for all 6 pairs

Refs #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)
