### PR TITLE
feat(leaderboard): ADD crowding column for all strategies (#430)

### DIFF
--- a/R/plan_add_crowding.R
+++ b/R/plan_add_crowding.R
@@ -1,0 +1,179 @@
+# Plan: Anomaly-Driven Demand (ADD) Crowding Column — #430
+#
+# Kjær & Posselt (2025) show that mechanically rebalancing published anomaly
+# portfolios creates coordinated flow in the first ~6 trading days of each
+# month. Strategies whose returns are correlated with this SPY month-start
+# return are partially riding crowding flow, not pure mispricing.
+#
+# This plan computes an ADD loading for each strategy in the leaderboard:
+#   add_corr: Pearson correlation between strategy's monthly return and
+#             SPY's first-N-trading-day return in the same month.
+#   add_beta: OLS slope (strategy_ret ~ spy_start_ret).
+#   add_flag: TRUE when add_corr > crowd_corr_threshold.
+#
+# The correlation is a PROXY for the direct ADD measurement (which requires
+# daily portfolio returns). For monthly strategies, SPY month-start return
+# is the best available crowding-flow signal.
+#
+# See wiki: knowledge/wiki/anomaly-driven-demand.md
+# Applicable rules:
+#   priced-in-prohibition  — ADD clause already present; this operationalises it
+#   backtest-robustness    — threshold and month_start_days are sensitivity levers
+#   resulting-prohibition  — ADD loading is evidence about the mechanism, not
+#                           a signal to abandon a strategy automatically
+#
+# Naming: add_*
+# Total targets: 4
+
+plan_add_crowding <- function() {
+  list(
+
+    # ── Parameters ─────────────────────────────────────────────────────────────
+    targets::tar_target(add_params, {
+      list(
+        # Number of trading days at month-start to use for the SPY signal.
+        # 6 is the canonical ADD rebalancing window (Kjær & Posselt 2025).
+        # Sensitivity lever: sweep 4, 6, 8 in v1.
+        month_start_days     = 6L,
+
+        # Correlation threshold above which a strategy is flagged as ADD-crowded.
+        # 0.40 = moderate-to-strong linear association.
+        # Sensitivity lever: sweep 0.30 / 0.40 / 0.50 in v1.
+        crowd_corr_threshold = 0.40,
+
+        # Minimum matched months required to compute a meaningful correlation.
+        min_months           = 24L
+      )
+    }),
+
+
+    # ── SPY daily returns: build once, reuse for all month-start windows ──────
+    # Per look-ahead-bias-prevention: we are computing an ex-post diagnostic
+    # statistic (ADD loading), NOT a forward-looking signal. The daily SPY
+    # returns are used purely to characterise PAST return distributions.
+    # No future data leaks into strategy returns (which are already fixed).
+    targets::tar_target(add_spy_daily, {
+      library(dplyr)
+
+      hd_ohlcv("SPY", collect = TRUE) |>
+        dplyr::arrange(.data$date) |>
+        dplyr::mutate(
+          date      = as.Date(.data$date),
+          daily_ret = .data$adjusted_close / dplyr::lag(.data$adjusted_close) - 1,
+          ym        = format(.data$date, "%Y-%m")
+        ) |>
+        dplyr::filter(!is.na(.data$daily_ret)) |>
+        dplyr::select("date", "ym", "adjusted_close", "daily_ret")
+    }),
+
+
+    # ── SPY first-N-trading-days return per calendar month ────────────────────
+    # spy_start_ret = compounded return over the first N trading days of each month.
+    # spy_rest_ret  = compounded return over the remaining days.
+    # Both are informational; only spy_start_ret enters the correlation.
+    targets::tar_target(add_spy_month_start, {
+      library(dplyr)
+
+      n_start <- add_params$month_start_days
+
+      add_spy_daily |>
+        dplyr::group_by(.data$ym) |>
+        dplyr::arrange(.data$date, .by_group = TRUE) |>
+        dplyr::summarise(
+          n_days       = dplyr::n(),
+          spy_start_ret = prod(1 + head(.data$daily_ret, n_start)) - 1,
+          spy_full_ret  = prod(1 + .data$daily_ret) - 1,
+          spy_rest_ret  = (1 + .data$spy_full_ret) /
+                          (1 + .data$spy_start_ret) - 1,
+          .groups = "drop"
+        ) |>
+        dplyr::filter(.data$n_days >= n_start)
+    }),
+
+
+    # ── ADD crowding per strategy ─────────────────────────────────────────────
+    # Collects monthly return vectors from all accessible strategy portfolios,
+    # joins them with spy_start_ret by year-month, then computes:
+    #   add_corr — Pearson r between strategy return and SPY month-start return
+    #   add_beta — OLS beta (strategy_ret ~ spy_start_ret), annualised units
+    #   add_flag — TRUE if add_corr > threshold
+    #
+    # Coverage: strategies with accessible monthly return vectors and a
+    # date / exec_date column for ym construction. Strategies without a
+    # supported return column receive NA for all three ADD columns.
+    #
+    # Interpretability:
+    #   add_corr > 0.40  → mild ADD exposure
+    #   add_corr > 0.60  → strong ADD exposure (returns partly driven by flow)
+    #   add_corr ~ 0     → no rebalancing-flow signature
+    #   add_corr < 0     → counter-cyclical to month-start flow (unusual)
+    targets::tar_target(add_crowding, {
+      library(dplyr)
+
+      threshold  <- add_params$crowd_corr_threshold
+      min_mo     <- add_params$min_months
+      spy_ms     <- add_spy_month_start |> dplyr::select("ym", "spy_start_ret")
+
+      # Helper: safely extract ym + ret from a portfolio tibble
+      .to_ym_ret <- function(df, date_col, ret_col) {
+        if (is.null(df) || !all(c(date_col, ret_col) %in% names(df))) return(NULL)
+        df |>
+          dplyr::transmute(
+            ym  = format(as.Date(.data[[date_col]]), "%Y-%m"),
+            ret = .data[[ret_col]]
+          )
+      }
+
+      strat_rets <- list(
+        # Factor-level strategies (monthly, portfolio_ret column)
+        "Factor MAX"      = .to_ym_ret(fm_portfolio,       "date", "portfolio_ret"),
+        "Factor DRIF"     = .to_ym_ret(drif_portfolio,     "date", "portfolio_ret"),
+        # Stock-level strategies (monthly, port_ret column)
+        "Stock MAX"       = .to_ym_ret(stk_max_portfolio,  "date", "port_ret"),
+        "Stock DRIF"      = .to_ym_ret(stk_drif_portfolio, "date", "port_ret"),
+        "XGB DRIF"        = .to_ym_ret(xgb_drif_portfolio, "date", "port_ret"),
+        # LTR (monthly, port_ret)
+        "LTR"             = .to_ym_ret(ltr_portfolio,      "date", "port_ret"),
+        # Mom siblings (exec_date column, ret_ls column)
+        "Mom Pre-Peak"    = .to_ym_ret(mom_prepeak_returns,  "exec_date", "ret_ls"),
+        "Mom Post-Peak"   = .to_ym_ret(mom_postpeak_returns, "exec_date", "ret_ls"),
+        "Mom 12-2"        = .to_ym_ret(mom_combined_returns, "exec_date", "ret_ls"),
+        # FIP-screened momentum (exec_date, ret_ls)
+        "Mom FIP Screen"  = .to_ym_ret(fip_returns,          "exec_date", "ret_ls"),
+        # Managed futures (date, ret_ls)
+        "Managed Futures" = .to_ym_ret(mf_portfolios, "date", "ret_ls")
+      )
+
+      # Remove strategies with no data
+      strat_rets <- Filter(Negate(is.null), strat_rets)
+
+      dplyr::bind_rows(lapply(names(strat_rets), function(nm) {
+        df <- dplyr::inner_join(strat_rets[[nm]], spy_ms, by = "ym") |>
+          dplyr::filter(!is.na(.data$ret), !is.na(.data$spy_start_ret))
+
+        if (nrow(df) < min_mo) {
+          return(tibble::tibble(
+            strategy         = nm,
+            n_months_matched = nrow(df),
+            add_corr         = NA_real_,
+            add_beta         = NA_real_,
+            add_flag         = NA
+          ))
+        }
+
+        corr <- cor(df$ret, df$spy_start_ret, use = "complete.obs")
+        fit  <- lm(ret ~ spy_start_ret, data = df)
+        beta <- unname(stats::coef(fit)[2])
+
+        tibble::tibble(
+          strategy         = nm,
+          n_months_matched = nrow(df),
+          add_corr         = round(corr, 3),
+          add_beta         = round(beta, 3),
+          add_flag         = !is.na(corr) && corr > threshold
+        )
+      }))
+    })
+
+  )
+}

--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -392,6 +392,28 @@ plan_leaderboard <- function() {
         }
       }
 
+      # ── ADD (Anomaly-Driven Demand) crowding columns (#430) ──────────────────
+      # add_corr: Pearson correlation between strategy monthly return and
+      #   SPY's first-6-trading-day return in the same month.
+      #   High positive correlation = returns concentrated in month-start
+      #   rebalancing window → ADD crowding signature.
+      # add_flag: TRUE if add_corr > add_params$crowd_corr_threshold (0.40).
+      # add_beta: OLS slope; one-unit increase in SPY month-start return maps
+      #   to add_beta units change in strategy return.
+      # Only "Full Period" rows carry meaningful values; sub-period rows receive NA.
+      # Reference: Kjær & Posselt (2025); wiki: anomaly-driven-demand.md
+      if (!is.null(add_crowding) && nrow(add_crowding) > 0) {
+        add_join <- add_crowding |>
+          dplyr::select("strategy", "add_corr", "add_beta", "add_flag")
+        all_metrics <- all_metrics |>
+          dplyr::left_join(add_join, by = "strategy") |>
+          dplyr::mutate(
+            add_corr = ifelse(period == "Full Period", add_corr, NA_real_),
+            add_beta = ifelse(period == "Full Period", add_beta, NA_real_),
+            add_flag = ifelse(period == "Full Period", add_flag, NA)
+          )
+      }
+
       # ── Pillar 8: risk-architecture columns (#269, #331) ─────────────────────
       # Join avg_dd_days, max_dd_days, loss_clustered, max_cons_losses from
       # fals_results_db. fals_results_db uses strategy_id (internal code); map

--- a/docs/_targets.R
+++ b/docs/_targets.R
@@ -128,6 +128,7 @@ source(here::here("R/plan_commodities_mean_reversion.R"))
 source(here::here("R/plan_mom_prepeak.R"))
 source(here::here("R/plan_mom_prepeak_gauntlet.R"))
 source(here::here("R/plan_fip_screen.R"))
+source(here::here("R/plan_add_crowding.R"))
 source(here::here("R/plan_crypto_momentum.R"))
 source(here::here("R/plan_solana_momentum.R"))
 source(here::here("R/plan_olmar.R"))
@@ -184,6 +185,7 @@ c(plan_strategy_names(),
   plan_mom_prepeak(),
   plan_mom_prepeak_gauntlet(),
   plan_fip_screen(),
+  plan_add_crowding(),
   plan_crypto_momentum(),
   plan_solana_momentum(),
   plan_olmar(),


### PR DESCRIPTION
## Summary

- Adds `R/plan_add_crowding.R` with 4 targets computing Anomaly-Driven Demand (ADD) crowding metrics per leaderboard strategy
- Joins `add_corr`, `add_beta`, `add_flag` into the existing `leaderboard` target in `plan_leaderboard.R`
- Wires `plan_add_crowding()` into `docs/_targets.R` (after `plan_fip_screen`, before `plan_leaderboard`)

**ADD crowding metric (Kjær & Posselt 2025):** strategies that mechanically rebalance published anomaly portfolios create coordinated buying flow in the first ~6 trading days of each month. A strategy whose monthly returns correlate strongly with SPY's month-start return is partly riding this flow, not pure alpha.

**What's computed:**
- `add_spy_month_start` — SPY compounded first-6-trading-day return per calendar month
- `add_corr` — Pearson correlation between strategy monthly return and `spy_start_ret` (higher = more crowded)
- `add_beta` — OLS slope (strategy ~ spy_start_ret)
- `add_flag` — TRUE when `add_corr > 0.40`

**Strategies covered (11):** Factor MAX, Factor DRIF, Stock MAX, Stock DRIF, XGB DRIF, LTR, Mom Pre-Peak, Mom Post-Peak, Mom 12-2, Mom FIP Screen, Managed Futures.

**Rules compliance:**
- `priced-in-prohibition` — ADD clause is already in the rule; this plan operationalises it as a leaderboard column
- `resulting-prohibition` — `add_flag = TRUE` is a crowding diagnostic, not an automatic abandon signal
- `backtest-robustness` — `month_start_days=6` and `crowd_corr_threshold=0.40` are the main sensitivity levers; sweep deferred to v1

## Test plan

- [x] `parse("R/plan_add_crowding.R")` — OK
- [x] `parse("R/plan_leaderboard.R")` — OK
- [x] `parse("docs/_targets.R")` — OK
- [x] `r_code_check.sh R/plan_add_crowding.R` — no violations
- [ ] `tar_make()` completes `add_crowding` target with ≥ 8 strategies having non-NA `add_corr`
- [ ] `leaderboard` target has `add_corr`, `add_beta`, `add_flag` columns for Full-Period rows
- [ ] Sub-period rows have NA for all three ADD columns

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)