### PR TITLE
fix(add_crowding): replace .data[[col]] with df[[col]] in .to_ym_ret — unblocks tar_make()

### DIFF
--- a/R/plan_add_crowding.R
+++ b/R/plan_add_crowding.R
@@ -114,14 +114,17 @@ plan_add_crowding <- function() {
       min_mo     <- add_params$min_months
       spy_ms     <- add_spy_month_start |> dplyr::select("ym", "spy_start_ret")
 
-      # Helper: safely extract ym + ret from a portfolio tibble
+      # Helper: safely extract ym + ret from a portfolio tibble.
+      # Uses df[[col]] not .data[[col]] — targets tidy_eval wraps the body in
+      # rlang::expr() which treats .data[[col]] as a quosure reference and
+      # looks col up in envir (not the function's local scope), causing
+      # "object 'date_col' not found" at tar_target() construction time.
       .to_ym_ret <- function(df, date_col, ret_col) {
         if (is.null(df) || !all(c(date_col, ret_col) %in% names(df))) return(NULL)
-        df |>
-          dplyr::transmute(
-            ym  = format(as.Date(.data[[date_col]]), "%Y-%m"),
-            ret = .data[[ret_col]]
-          )
+        tibble::tibble(
+          ym  = format(as.Date(df[[date_col]]), "%Y-%m"),
+          ret = df[[ret_col]]
+        )
       }
 
       strat_rets <- list(


### PR DESCRIPTION
## Summary

- **Root cause**: `targets::tar_target()` with `tidy_eval=TRUE` wraps the command body in `rlang::expr()` and calls `quo_squash()` on the result. `.data[[date_col]]` inside an inner function's `dplyr::transmute()` is treated as a quosure reference — `date_col` is looked up in `tar_option_get("envir")` (not the function's local scope), causing `object 'date_col' not found` at `tar_target()` construction time, blocking all `tar_make()` / `tar_outdated()` calls.
- **Fix**: Replace `dplyr::transmute(.data[[col]])` with `tibble::tibble(col = df[[col]])` using base-R subsetting in the `.to_ym_ret` helper. Functionally identical.
- **Verified**: All 67 `plan_*()` calls succeed after the fix; `plan_add_crowding()` specifically no longer errors.

## Test plan

- [x] All plan functions call without error
- [x] `tar_outdated()` succeeds in the worktree after fix (requires full pipeline sourcing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)