### PR TITLE
fix(ci): harden lychee against transient GitHub 500/429 (#473)

### DIFF
--- a/.github/workflows/link-audit.yml
+++ b/.github/workflows/link-audit.yml
@@ -29,6 +29,12 @@ jobs:
   link-audit:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # lychee auto-detects GITHUB_TOKEN and checks github.com links via the
+    # GitHub API instead of scraping HTML blob/ pages. This avoids the
+    # intermittent 500/429 responses GitHub returns on HTML endpoints under
+    # load, which previously failed the whole audit on a valid link (#473).
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -47,6 +53,8 @@ jobs:
             --verbose \
             --max-redirects 5 \
             --max-concurrency 8 \
+            --max-retries 3 \
+            --retry-wait-time 2 \
             --accept 200,206,403,429 \
             --output ./lychee-out.md \
             --format markdown \
@@ -62,6 +70,8 @@ jobs:
             --verbose \
             --max-redirects 5 \
             --max-concurrency 8 \
+            --max-retries 3 \
+            --retry-wait-time 2 \
             --accept 200,206,403,429 \
             --output ./lychee-out.md \
             --format markdown \


### PR DESCRIPTION
## Problem

The scheduled **Link audit (lychee)** run failed on 2026-06-21 (run 27900970329) and auto-filed #473. The sole reported failure:

```
[500] https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/falsification.R
      | Rejected status code: 500 Internal Server Error
```

This link is **not broken** — the file exists in the repo and the URL returns HTTP 200. GitHub intermittently returns 500/429 on HTML `blob/` endpoints under load. lychee scrapes those pages as plain HTML, and `--accept 200,206,403,429` does not tolerate 5xx, so one flaky response failed the whole audit.

## Fix

- **Job-level `GITHUB_TOKEN`** — lychee auto-detects it and checks `github.com` links via the **GitHub API** instead of scraping HTML. Reliable and rate-limit-friendly; does **not** mask genuine 404s.
- **`--max-retries 3 --retry-wait-time 2`** on both lychee invocations — belt-and-braces for any remaining transient network errors.

## Verification

- File exists in repo + URL returns 200 (confirmed locally — transient failure)
- `python3 -c "yaml.safe_load(...)"` → YAML OK

Closes #473 (false positive — transient server error, link is valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)