### PR TITLE
fix(plan_returns): replace native-pipe dot placeholder in asset_monthly_returns_wide

### DIFF
--- a/R/plan_returns.R
+++ b/R/plan_returns.R
@@ -73,15 +73,22 @@ plan_returns <- function() {
     # Inner-joins all assets on date so every row has a complete observation.
     # This is the canonical feed for plan_cross_asset_corr.R's multi_asset_returns.
     targets::tar_target(asset_monthly_returns_wide, {
-      library(dplyr)
+      wide <- asset_monthly_returns |>
+        tidyr::pivot_wider(names_from = ticker, values_from = ret)
 
-      asset_monthly_returns |>
-        tidyr::pivot_wider(names_from = ticker, values_from = ret) |>
-        # Drop any row where ANY asset is NA (ensures cov() gets complete cases)
-        dplyr::filter(if (ncol(dplyr::select(., -date)) > 0)
-          rowSums(is.na(dplyr::select(., -date))) == 0
-          else TRUE) |>
-        dplyr::arrange(date)
+      asset_cols <- setdiff(colnames(wide), "date")
+
+      # Drop any row where ANY asset is NA (ensures cov() gets complete cases).
+      # NOTE: native pipe |> does not bind `.`, so the previous dplyr::select(., -date)
+      # pattern caused "object '.' not found" at runtime (#471 sibling).
+      if (length(asset_cols) > 0) {
+        wide <- dplyr::filter(
+          wide,
+          !dplyr::if_any(dplyr::all_of(asset_cols), is.na)
+        )
+      }
+
+      dplyr::arrange(wide, date)
     }),
 
     # ── Full-sample annualised covariance matrix ──────────────────────────────

--- a/tests/testthat/test-plan-returns.R
+++ b/tests/testthat/test-plan-returns.R
@@ -238,6 +238,73 @@ test_that("plan_returns: function signature is stable (API drift guard)", {
   expect_snapshot(args(plan_returns))
 })
 
+# ============================================================================
+# Regression: asset_monthly_returns_wide NA-drop (native pipe `.` bug, #471 sibling)
+# ============================================================================
+#
+# Before the fix, dplyr::select(., -date) inside a native-pipe |> chain threw
+# "object '.' not found" because |> does not bind `.` (only magrittr %>% does).
+# These tests replicate the pivot_wider + NA-drop logic on toy data to confirm:
+#   (a) rows with NA in any asset column are dropped
+#   (b) rows with all non-NA asset values are kept
+#   (c) zero-asset-column edge case keeps all rows (no error)
+
+# Helper: replicate the fixed asset_monthly_returns_wide logic
+wide_na_drop <- function(long_tbl) {
+  wide <- tidyr::pivot_wider(long_tbl, names_from = ticker, values_from = ret)
+  asset_cols <- setdiff(colnames(wide), "date")
+  if (length(asset_cols) > 0) {
+    wide <- dplyr::filter(
+      wide,
+      !dplyr::if_any(dplyr::all_of(asset_cols), is.na)
+    )
+  }
+  dplyr::arrange(wide, date)
+}
+
+test_that("wide_na_drop: rows with NA in any asset column are dropped", {
+  long <- tibble::tibble(
+    date   = as.Date(c("2020-01-31", "2020-01-31",
+                       "2020-02-29", "2020-02-29",
+                       "2020-03-31", "2020-03-31")),
+    ticker = c("SPY", "TLT",   "SPY", "TLT",   "SPY", "TLT"),
+    ret    = c(0.01,   0.02,    NA,    0.03,    0.04,   0.05)
+  )
+  result <- wide_na_drop(long)
+  # 2020-02-29 has NA for SPY -> should be dropped; other two months kept
+  expect_equal(nrow(result), 2L,
+    info = "Row with NA in any asset must be dropped")
+  expect_false(any(as.character(result$date) == "2020-02-29"),
+    info = "The NA-containing month (2020-02-29) must not appear in output")
+})
+
+test_that("wide_na_drop: rows with all non-NA asset values are kept", {
+  long <- tibble::tibble(
+    date   = as.Date(c("2020-01-31", "2020-01-31",
+                       "2020-02-29", "2020-02-29")),
+    ticker = c("SPY", "TLT", "SPY", "TLT"),
+    ret    = c(0.01,   0.02,  0.03,  0.04)
+  )
+  result <- wide_na_drop(long)
+  expect_equal(nrow(result), 2L,
+    info = "All complete rows should be retained")
+  expect_equal(sort(as.character(result$date)),
+               c("2020-01-31", "2020-02-29"))
+})
+
+test_that("wide_na_drop: zero-asset edge case keeps all rows without error", {
+  # pivot_wider on a zero-row long tibble produces a date-only wide tibble
+  long_zero <- tibble::tibble(
+    date   = as.Date(character(0)),
+    ticker = character(0),
+    ret    = numeric(0)
+  )
+  # Should not error and return an empty tibble
+  expect_no_error(wide_na_drop(long_zero))
+  result <- wide_na_drop(long_zero)
+  expect_equal(nrow(result), 0L)
+})
+
 test_that("cov_annual: structure snapshot with canonical 4-asset universe", {
   assets <- c("SPY", "TLT", "GLD", "DBC")
   wide   <- make_wide_returns(n_months = 120L, assets = assets, seed = 7L)


### PR DESCRIPTION
## Root cause

`R/plan_returns.R`, target `asset_monthly_returns_wide`, used `dplyr::select(., -date)` inside a native-pipe `|>` chain. The native pipe does NOT bind `.` (only magrittr `%>%` does), so this threw `object '.' not found` at runtime. This cascaded to block `add_crowding`, `mf_portfolios`, and the `leaderboard` target, causing the live leaderboard page to render stale data. Sibling of the #471 tidy-eval fix merged last session.

## The fix

- Remove the `dplyr::select(., -date)` pattern entirely.
- Pivot into a named variable `wide` first, then compute `asset_cols <- setdiff(colnames(wide), "date")`.
- Replace the `rowSums(is.na(...)) == 0` filter with `dplyr::filter(!dplyr::if_any(dplyr::all_of(asset_cols), is.na))` — native-pipe safe, idiomatic dplyr 1.1+, same behaviour.
- Drop the `library(dplyr)` call from this target body (body already uses `dplyr::` qualification throughout; namespace-discipline rule).

Behaviour is identical: rows where ANY asset column is NA are dropped; if there are zero asset columns, all rows are kept.

## Verification

**1. Parse check (ran in worktree):**
```
PARSE OK
```

**2. Unit tests (ran in worktree — `testthat::test_file()`):**
```
[ FAIL 0 | WARN 0 | SKIP 2 | PASS 99 ]
```
The 2 SKIPs are the existing snapshot tests that use `here::here()` (correctly skipped outside the package root/CRAN context). All 99 assertions pass, including 3 new regression tests.

**3. New regression tests** added to `tests/testthat/test-plan-returns.R`:
- `wide_na_drop: rows with NA in any asset column are dropped` — asserts the bug row (NA in SPY for one month) is dropped, other months kept.
- `wide_na_drop: rows with all non-NA asset values are kept` — asserts complete rows are retained unchanged.
- `wide_na_drop: zero-asset edge case keeps all rows without error` — zero-length `asset_cols` path does not error and returns empty tibble.

**4. DAG construction check (`source("docs/_targets.R")`):** Could NOT be run in the worktree's outer shell — requires the full project Nix environment (flake.nix) to load `duckplyr` and other project-specific packages. The check fails at `pkgload::load_all()` before it ever reaches target expression evaluation. Full leaderboard verification (`tar_make` in the main store) is a follow-up for the orchestrator.

## Not fixed in this PR (out of scope)

- Other `library(dplyr)` calls in `asset_monthly_returns` and `cov_rolling_60m` targets — same namespace-discipline issue but not part of the identified bug cascade; flagged for a separate cleanup PR.

## References

- Sibling fix: #471 (`.data[[col]]` tidy-eval bug in `add_crowding`)
- CHANGELOG session-19 Known Limitations

🤖 Generated with [Claude Code](https://claude.com/claude-code)