### PR TITLE
feat(vignette): structural-break summary section on leaderboard (#484)

### DIFF
--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -548,6 +548,11 @@ if (!is.null(sb_sum) && !is.null(snames)) {
 #| label: sb-dotplot
 #| fig-height: 7
 #| fig-width: 9
+# Path-checked pkgload (cwd-trap fix: here::here() returns docs/ under quarto render)
+pkg_path <- if (dir.exists("packages/historicaldata")) "packages/historicaldata" else
+  file.path(dirname(here::here()), "packages/historicaldata")
+pkgload::load_all(pkg_path, quiet = TRUE)
+
 sb_sum <- safe_tar_read("structural_breaks_summary")
 snames  <- safe_tar_read("strategy_names")
 

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -450,6 +450,187 @@ if (!is.null(kelly_t)) {
 }
 ```
 
+# Structural Breaks
+
+## Row {height=100%}
+
+### {.tabset}
+
+#### Interpretation
+
+A **structural break** at date *T* means the returns process appears to have changed before and after that date — the distribution of vol-normalised returns differs significantly on each side. This is **evidence worth investigating**, not an automatic allocation trigger.
+
+The `resulting-prohibition` rule applies directly here: a detected break does not justify revising strategy weights without identifying new *structural* evidence for why the change occurred. Past underperformance alone is not such evidence — Swedroe documents 12–39-year underperformance episodes for well-established risk premia (`underperformance-prior`). Conflating a drawdown with a structural change risks abandoning a strategy at exactly the wrong time.
+
+Rob Carver's empirical finding (2026) is the calibrating prior: across instrument/forecast pairs, only ~13% show breaks at the 1% level, and whole-history estimation often beats break-adjusted estimation out-of-sample. **Break-splitting is a guard against over-splitting, not an always-on re-estimator.**
+
+For the full framework context see the [market-behavior gap analysis](https://github.com/JohnGavin/historical/blob/main/knowledge/wiki/market-behavior-gap-analysis.md) (§ Structural Stability), which this section closes (gap now ✅).
+
+#### Summary Table
+
+```{r}
+#| label: sb-table
+sb_sum <- safe_tar_read("structural_breaks_summary")
+sb_cap <- safe_tar_read("structural_breaks_caption")
+snames  <- safe_tar_read("strategy_names")
+
+if (!is.null(sb_sum) && !is.null(snames)) {
+  # strategy_names join: structural_breaks_summary uses short_name labels
+  sb_disp <- sb_sum |>
+    left_join(
+      snames |> select(short_name, long_name),
+      by = c("strategy" = "short_name")
+    ) |>
+    mutate(Strategy = dplyr::coalesce(long_name, strategy)) |>
+    transmute(
+      Strategy,
+      `Break Date(s)`     = break_dates,
+      `N Breaks`          = ifelse(is.na(n_breaks), "—", as.character(n_breaks)),
+      `Whole Sharpe`      = ifelse(
+        is.na(whole_sharpe), "—",
+        format(round(whole_sharpe,      3L), nsmall = 3L)
+      ),
+      `Post-Break Sharpe` = ifelse(
+        is.na(post_break_sharpe), "—",
+        format(round(post_break_sharpe, 3L), nsmall = 3L)
+      ),
+      `Divergence %`      = ifelse(
+        is.na(sharpe_divergence_pct), "—",
+        paste0(sharpe_divergence_pct, "%")
+      ),
+      Material            = ifelse(
+        is.na(material_divergence), "—",
+        ifelse(material_divergence, "YES", "no")
+      ),
+      Note                = ifelse(is.na(note), "", note)
+    )
+
+  cap_text <- if (!is.null(sb_cap)) sb_cap else
+    "Structural break analysis — run tar_make() to populate."
+
+  DT::datatable(
+    sb_disp,
+    caption  = htmltools::tags$caption(
+      style = "caption-side: top; text-align: left; font-weight: bold;",
+      class = "dt-caption",
+      cap_text
+    ),
+    rownames = FALSE,
+    filter   = "top",
+    options  = list(
+      pageLength   = 20L,
+      scrollX      = TRUE,
+      dom          = "frtip",
+      initComplete = DT::JS(
+        "function(settings, json) {",
+        "  var isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark'",
+        "    || document.body.classList.contains('dark-mode');",
+        "  if (isDark) {",
+        "    $(this.api().table().container()).css({'color': '#ddd', 'background-color': '#1a1a1a'});",
+        "    $(this.api().table().header()).css({'color': '#ddd', 'background-color': '#222'});",
+        "    $('input', this.api().table().container()).css({'color': '#ddd', 'background-color': '#333', 'border-color': '#555'});",
+        "  }",
+        "}"
+      )
+    )
+  ) |>
+    DT::formatStyle(
+      "Material",
+      target          = "row",
+      backgroundColor = DT::styleEqual("YES", "rgba(255, 99, 71, 0.18)")
+    )
+}
+```
+
+#### Sharpe Comparison
+
+```{r}
+#| label: sb-dotplot
+#| fig-height: 7
+#| fig-width: 9
+sb_sum <- safe_tar_read("structural_breaks_summary")
+snames  <- safe_tar_read("strategy_names")
+
+if (!is.null(sb_sum) && !is.null(snames)) {
+  plot_df <- sb_sum |>
+    filter(!is.na(whole_sharpe)) |>
+    left_join(
+      snames |> select(short_name, long_name),
+      by = c("strategy" = "short_name")
+    ) |>
+    mutate(
+      label     = dplyr::coalesce(long_name, strategy),
+      has_break = factor(
+        ifelse(!is.na(n_breaks) & n_breaks > 0L, "Break at 1%", "No break"),
+        levels = c("No break", "Break at 1%")
+      )
+    )
+
+  strat_order <- plot_df |>
+    arrange(whole_sharpe) |>
+    pull(label)
+
+  long_df <- plot_df |>
+    select(label, has_break,
+           `Whole History` = whole_sharpe,
+           `Post-Break`    = post_break_sharpe) |>
+    tidyr::pivot_longer(
+      c(`Whole History`, `Post-Break`),
+      names_to  = "Period",
+      values_to = "Sharpe"
+    ) |>
+    filter(!is.na(Sharpe)) |>
+    mutate(
+      label  = factor(label,  levels = strat_order),
+      Period = factor(Period, levels = c("Whole History", "Post-Break"))
+    )
+
+  ggplot(long_df, aes(x = Sharpe, y = label, colour = Period, shape = has_break)) +
+    geom_vline(xintercept = 0, linetype = "dotted",
+               colour = "grey50", linewidth = 0.4) +
+    geom_point(size = 3.5, alpha = 0.9) +
+    scale_colour_manual(
+      values = hd_palette(2),
+      name   = "Estimate period"
+    ) +
+    scale_shape_manual(
+      values = c("No break" = 16L, "Break at 1%" = 17L),
+      name   = "Break status"
+    ) +
+    labs(
+      x     = "Annualised Sharpe Ratio",
+      y     = NULL,
+      title = "Whole-history vs post-break Sharpe"
+    ) +
+    hd_theme()
+}
+```
+
+```{r}
+#| label: sb-dotplot-caption
+#| results: asis
+sb_cap <- safe_tar_read("structural_breaks_caption")
+fig_cap <- paste0(
+  "**Figure — Cleveland dot plot:** whole-history Sharpe (circle) vs ",
+  "post-break Sharpe (where a break was detected) for all leaderboard strategies. ",
+  "**Data:** return series pre-computed in the docs targets pipeline; see ",
+  "[plan_structural_breaks.R](https://github.com/JohnGavin/historical/blob/main/R/plan_structural_breaks.R). ",
+  "**Variables:** annualised Sharpe ratio; Whole History = full return series, ",
+  "Post-Break = segment after the first detected break (triangle shape). ",
+  "**Labels:** `long_name` from the `strategy_names` target ",
+  "([plan_strategy_names.R](https://github.com/JohnGavin/historical/blob/main/R/plan_strategy_names.R)), ",
+  "ordered by whole-history Sharpe ascending. ",
+  "**Methodology:** iterative forward-split t-test at 1% level with 5-year minimum segment; see ",
+  "[hd_structural_breaks()](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/structural_breaks.R). ",
+  "**Caveats:** scanning all candidate split dates inflates false-break rate above the nominal 1% level; ",
+  "a detected break is evidence to investigate, not an allocation trigger (`resulting-prohibition`); ",
+  "whole-history estimation often beats break-adjusted OOS (Carver 2026). ",
+  "**Chart type:** Cleveland dot plot per visualization-standards (dotchart first choice). ",
+  if (!is.null(sb_cap)) paste0("Dynamic summary: ", sb_cap) else ""
+)
+cat(paste0("\n*", fig_cap, "*\n"))
+```
+
 # Details
 
 ## Row

--- a/knowledge/wiki/market-behavior-gap-analysis.md
+++ b/knowledge/wiki/market-behavior-gap-analysis.md
@@ -208,21 +208,20 @@ Audit of the comprehensive market behavior definition (from #105 comment) agains
 | Strategy decay (#73) | ✅ | `plan_strategy_decay.R` (Factor MAX decay >50%) |
 | Bootstrap CI (parameter stability) | ✅ | `plan_bootstrap_ci.R` |
 | Regime-split performance | ✅ | Causal graph HML-VIX by period (pre/post 2010) |
-| Formal structural break tests | ❌ | Regime detection exists but no Chow/CUSUM tests |
+| Formal structural break tests | ✅ | `hd_structural_breaks()` via `plan_structural_breaks.R`; displayed in the [Structural Breaks](https://johngavin.github.io/historical/leaderboard.html) page of the leaderboard (#484) |
 
 **Vignettes displaying:**
-- Leaderboard: By Partition tab, Alpha Decay tab, Bootstrap CI tab
+- Leaderboard: By Partition tab, Alpha Decay tab, Bootstrap CI tab, Structural Breaks page
 - Falsification: Causal graph implication split tests
 
 ### Gaps: ⚠️ **MINOR (20%)**
 
 | Missing | Priority | Reason |
 |---------|----------|--------|
-| Chow test (structural break) | Medium | Formal test for parameter change at known date |
-| CUSUM (rolling break detection) | Medium | Detect breaks at unknown dates |
+| CUSUM (rolling break detection) | Low | `hd_structural_breaks()` uses iterative forward-split t-test; CUSUM is an alternative method not yet implemented |
 | Rolling window Sharpe | Low | Already have partition-based + bootstrap |
 
-**Recommendation:** Add Chow test for strategies with suspected decay (e.g., Factor MAX at 2010 split). Low priority — partition-based analysis and causal graph splits already cover this ground.
+**Recommendation:** Structural break detection is now covered by `hd_structural_breaks()` (iterative forward-split t-test, 1% level, 5-year minimum segment). The Chow test for a *known* break date and CUSUM for rolling monitoring are lower-priority alternatives if the current iterative method proves insufficient.
 
 ---
 


### PR DESCRIPTION
## Summary

- Closes #484; closes the final open checkbox of #477
- Adds a new **Structural Breaks** page to `docs/leaderboard.qmd` (between Robustness and Details)
- Flips `knowledge/wiki/market-behavior-gap-analysis.md:211` from ❌ to ✅

## What was added (leaderboard.qmd)

New page `# Structural Breaks` with three tabs:

**Interpretation tab** — prose: break is evidence to investigate not an allocation trigger (`resulting-prohibition`); multi-year underperformance is normal (`underperformance-prior`); Carver's ~13% break-rate calibrating prior; link to gap-analysis wiki.

**Summary Table tab** — DT table using:
- `tar_read(structural_breaks_summary)` via `safe_tar_read()`
- `tar_read(structural_breaks_caption)` — used as DT caption (dynamic; contains "4 of 14" count)
- `tar_read(strategy_names)` — joined on `short_name` → `long_name` per `strategy-name-consistency`
- Columns: Strategy (long_name), Break Date(s), N Breaks, Whole Sharpe (3 dp), Post-Break Sharpe (3 dp), Divergence %, Material, Note
- Row highlight for `material_divergence == YES` via `DT::formatStyle` with `rgba(255, 99, 71, 0.18)` (dark-mode-safe semi-transparent)
- Dark-mode JS callback matching the existing `hd_dt()` pattern

**Sharpe Comparison tab** — Cleveland dot plot using:
- `tar_read(structural_breaks_summary)` + `tar_read(strategy_names)`
- `hd_palette(2)` + `hd_theme()` (legend already at bottom per theme)
- Circle = no break, triangle = break at 1%; strategies ordered by whole-history Sharpe ascending
- 7-item figure caption chunk (`results: asis`) with source links to `plan_structural_breaks.R` and `hd_structural_breaks()`; embeds `structural_breaks_caption` dynamically at end

## tar_read calls

```r
safe_tar_read("structural_breaks_summary")   # tidy tibble, 14 rows
safe_tar_read("structural_breaks_caption")   # dynamic narrative string
safe_tar_read("strategy_names")              # for long_name labels
```

## Wiki change

`knowledge/wiki/market-behavior-gap-analysis.md:211` updated:
- Was: `| Formal structural break tests | ❌ | Regime detection exists but no Chow/CUSUM tests |`
- Now: `| Formal structural break tests | ✅ | hd_structural_breaks() via plan_structural_breaks.R; displayed in the [Structural Breaks](https://johngavin.github.io/historical/leaderboard.html) page (#484) |`
- Gaps table updated: Chow test row removed (the iterative forward-split t-test covers it); CUSUM downgraded to Low
- `## Sources` section intact

## Chunk parse results

All three new R chunks parse successfully via `nix develop --command Rscript`:
- `sb-table`: PASS
- `sb-dotplot`: PASS
- `sb-dotplot-caption`: PASS

## Orchestrator must render

**This PR cannot be self-verified in-worktree** — the worktree has no populated `_targets` store.
The orchestrator must render `docs/leaderboard.qmd` against the live store after merging to verify:
1. The new "Structural Breaks" nav item appears
2. The DT table shows 14 rows with material rows highlighted
3. The Cleveland dot plot renders with correct labels
4. The dynamic caption shows the correct strategy/break counts

## Rules applied

- `strategy-name-consistency` — long_name labels via strategy_names target
- `dynamic-captions-always` — structural_breaks_caption target for DT caption; no hardcoded counts
- `visualization-standards` — Cleveland dot plot (dotchart first choice)
- `resulting-prohibition` — framing prose in Interpretation tab
- `underperformance-prior` — framing prose in Interpretation tab
- `dark-mode-completeness` — rgba semi-transparent highlight, existing dark JS callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)