### PR TITLE
fix(plan_returns): native-pipe-safe complete-case filter — unblock leaderboard rebuild (#487)

### DIFF
--- a/R/plan_returns.R
+++ b/R/plan_returns.R
@@ -40,6 +40,16 @@ RETURNS_ASSETS <- c("SPY", "TLT", "GLD", "DBC")
 # Monthly periods per year.
 PERIODS_PER_YEAR <- 12L
 
+# ── Pure helper: drop rows with any NA in non-date asset columns ─────────────
+#
+# Used by asset_monthly_returns_wide to ensure cov() gets complete cases.
+# Native |>-pipe-safe: no magrittr dot dependency.
+# Edge case: a date-only frame (zero non-date cols) passes all rows through
+# because if_all() over an empty column set returns TRUE for every row.
+.complete_case_wide <- function(df) {
+  dplyr::filter(df, dplyr::if_all(-date, ~ !is.na(.x)))
+}
+
 plan_returns <- function() {
   list(
 
@@ -78,9 +88,7 @@ plan_returns <- function() {
       asset_monthly_returns |>
         tidyr::pivot_wider(names_from = ticker, values_from = ret) |>
         # Drop any row where ANY asset is NA (ensures cov() gets complete cases)
-        dplyr::filter(if (ncol(dplyr::select(., -date)) > 0)
-          rowSums(is.na(dplyr::select(., -date))) == 0
-          else TRUE) |>
+        .complete_case_wide() |>
         dplyr::arrange(date)
     }),
 

--- a/tests/testthat/test-plan-returns.R
+++ b/tests/testthat/test-plan-returns.R
@@ -238,6 +238,67 @@ test_that("plan_returns: function signature is stable (API drift guard)", {
   expect_snapshot(args(plan_returns))
 })
 
+# ============================================================================
+# Tests: .complete_case_wide() — regression guard for #487
+#
+# Exercises the pure helper extracted from asset_monthly_returns_wide.
+# Source plan_returns.R once; the helper is available as .complete_case_wide().
+# ============================================================================
+
+test_that(".complete_case_wide: row with any NA asset column is dropped (#487)", {
+  # Source file in local env to get .complete_case_wide without side effects
+  env <- new.env()
+  source(here::here("R/plan_returns.R"), local = env)
+  ccw <- env$.complete_case_wide
+
+  wide <- tibble::tibble(
+    date = as.Date(c("2020-01-31", "2020-02-29", "2020-03-31")),
+    SPY  = c(0.01, NA_real_, 0.03),   # row 2 has NA
+    TLT  = c(0.02, 0.00,    0.01)
+  )
+
+  result <- ccw(wide)
+
+  expect_equal(nrow(result), 2L,
+               info = "Row with NA in asset column must be dropped")
+  expect_equal(result$date, as.Date(c("2020-01-31", "2020-03-31")),
+               info = "Remaining rows must be the complete-case rows")
+})
+
+test_that(".complete_case_wide: fully-populated frame is unchanged (#487)", {
+  env <- new.env()
+  source(here::here("R/plan_returns.R"), local = env)
+  ccw <- env$.complete_case_wide
+
+  wide <- tibble::tibble(
+    date = as.Date(c("2020-01-31", "2020-02-29")),
+    SPY  = c(0.01, 0.02),
+    TLT  = c(0.03, 0.04)
+  )
+
+  result <- ccw(wide)
+
+  expect_equal(nrow(result), 2L,
+               info = "No rows should be dropped from a fully-populated frame")
+  expect_equal(result, wide)
+})
+
+test_that(".complete_case_wide: date-only frame (no asset cols) is unchanged (#487)", {
+  # if_all(-date) over zero non-date columns returns TRUE → all rows kept.
+  # This guards the original 'else TRUE' edge case from the magrittr version.
+  env <- new.env()
+  source(here::here("R/plan_returns.R"), local = env)
+  ccw <- env$.complete_case_wide
+
+  wide <- tibble::tibble(date = as.Date(c("2020-01-31", "2020-02-29")))
+
+  result <- ccw(wide)
+
+  expect_equal(nrow(result), 2L,
+               info = "Date-only frame must pass all rows through (zero non-date cols)")
+  expect_equal(result, wide)
+})
+
 test_that("cov_annual: structure snapshot with canonical 4-asset universe", {
   assets <- c("SPY", "TLT", "GLD", "DBC")
   wide   <- make_wide_returns(n_months = 120L, assets = assets, seed = 7L)


### PR DESCRIPTION
## Summary

- **Closes #487.** `asset_monthly_returns_wide` used `dplyr::select(., -date)` inside a native `|>` pipe where `.` is not bound — causing `Error: object '.' not found` that cascaded through `cov_annual → mf_* → add_crowding → leaderboard` and blocked all rebuilds.

- **Fix:** extracted `.complete_case_wide(df)` helper using `dplyr::if_all(-date, ~ !is.na(.x))` — native-pipe-safe, preserves the original `else TRUE` edge case (zero non-date columns → all rows kept).

- **Sweep:** grepped `R/` and `packages/historicaldata/R/` for all bare-dot patterns under native pipes. Every hit is either a lambda placeholder (`.x` inside `~ !is.na(.x)`) or a ggplot2 formula data-transform (`data = ~dplyr::filter(., ...)`) — none are magrittr-dot-under-`|>` bugs.

## Changes

| File | What changed |
|---|---|
| `R/plan_returns.R` | Added `.complete_case_wide()` helper; replaced 3-line buggy filter with `.complete_case_wide()` call |
| `tests/testthat/test-plan-returns.R` | Added 3 regression tests for the helper (NA row dropped, full frame unchanged, date-only frame unchanged) |

## Sibling `.`-under-`|>` sweep results

All clear — no other genuine bugs found:

| File | Line | Pattern | Verdict |
|---|---|---|---|
| `R/plan_vvix.R` | 98 | `data = ~dplyr::filter(., ...)` | **Safe** — ggplot2 formula syntax, not a pipe dot |
| `R/plan_portfolio_opt.R` | 277 | `across(-year, ~if_else(is.na(.), ...))` | **Safe** — `.` bound by `~` lambda |
| `R/plan_causal_graph.R` | 250 | `if_all(..., ~ !is.na(.))` | **Safe** — `.` bound by `~` lambda |

## Test plan

- [x] `parse("R/plan_returns.R")` — OK
- [x] `parse("_targets.R")` — OK
- [x] `testthat::test_file("tests/testthat/test-plan-returns.R")` — `[ FAIL 0 | WARN 0 | SKIP 2 | PASS 99 ]`
- [x] `~/.claude/scripts/r_code_check.sh R/plan_returns.R` — no violations
- [ ] Post-merge: orchestrator to run `tar_make()` targeting `leaderboard` to confirm full rebuild produces current schema (with `add_*` crowding columns) — unblocks #482 digest snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)