### PR TITLE
fix(plan_vignette): align adjusted_close column refs — unblock vig_eq_* / vig_cr_corr targets (#489 Cluster A)

### DIFF
--- a/R/plan_vignette.R
+++ b/R/plan_vignette.R
@@ -90,7 +90,7 @@ ggplot(aapl, aes(date)) +
 # Batch query: all FAANG tickers in one DuckDB request
 faang <- hd_ohlcv(hd_group("FAANG"), from = "2024-01-01") |>
   group_by(ticker) |>
-  mutate(cum_ret = adjusted / first(adjusted) - 1) |>
+  mutate(cum_ret = adjusted_close / first(adjusted_close) - 1) |>
   ungroup()
 
 ggplot(faang, aes(date, cum_ret, colour = ticker)) +
@@ -112,7 +112,7 @@ vol <- hd_ohlcv(vol_tickers, from = "2023-06-01") |>
   group_by(ticker) |>
   arrange(date) |>
   mutate(
-    log_ret = log(adjusted / lag(adjusted)),
+    log_ret = log(adjusted_close / lag(adjusted_close)),
     cum_sq = cumsum(if_else(is.na(log_ret), 0, log_ret^2)),
     vol_21d = sqrt(pmax((cum_sq - lag(cum_sq, 21, default = NA_real_)) / 21, 0)) * sqrt(252)
   ) |>

--- a/packages/historicaldata/tests/testthat/test-column-naming.R
+++ b/packages/historicaldata/tests/testthat/test-column-naming.R
@@ -1,4 +1,58 @@
 # Regression tests for #325: canonical adjusted_close column across datasets.
+# Regression tests for #489 Cluster A: vig_eq_faang / vig_eq_vol adjusted→adjusted_close.
+
+# ── Helpers used by vig_eq_faang and vig_eq_vol (inline in code-as-target strings) ──
+
+# Simulate what hd_ohlcv() returns for equity tickers after the #325/#397 rename:
+# a tibble with 'adjusted_close' (not bare 'adjusted').
+.ohlcv_frame <- function() {
+  tibble::tibble(
+    date           = as.Date(c("2024-01-02", "2024-01-03", "2024-01-04")),
+    close          = c(100.0, 110.0, 121.0),
+    adjusted_close = c(100.0, 110.0, 121.0),
+    ticker         = "AAPL"
+  )
+}
+
+test_that("return calc with adjusted_close gives expected values (#489 Cluster A regression)", {
+  # 3-row frame → ret = adjusted_close / lag(adjusted_close) - 1
+  df <- .ohlcv_frame() |>
+    dplyr::group_by(ticker) |>
+    dplyr::mutate(ret = adjusted_close / dplyr::lag(adjusted_close) - 1) |>
+    dplyr::ungroup()
+
+  # Row 1: NA (no lag)
+  expect_true(is.na(df$ret[1L]))
+  # Rows 2 and 3: exact 10% return each
+  expect_equal(df$ret[2L], 0.1, tolerance = 1e-10)
+  expect_equal(df$ret[3L], 0.1, tolerance = 1e-10)
+})
+
+test_that("cum-return calc with adjusted_close gives expected values (#489 Cluster A regression)", {
+  # Mirrors vig_eq_faang: cum_ret = adjusted_close / first(adjusted_close) - 1
+  df <- .ohlcv_frame() |>
+    dplyr::group_by(ticker) |>
+    dplyr::mutate(cum_ret = adjusted_close / dplyr::first(adjusted_close) - 1) |>
+    dplyr::ungroup()
+
+  expect_equal(df$cum_ret[1L], 0.0,  tolerance = 1e-10)
+  expect_equal(df$cum_ret[2L], 0.1,  tolerance = 1e-10)
+  expect_equal(df$cum_ret[3L], 0.21, tolerance = 1e-10)
+})
+
+test_that("bare 'adjusted' column on an adjusted_close frame gives a clear dplyr error (#489 regression)", {
+  # After #325/#397, hd_ohlcv() returns 'adjusted_close', not 'adjusted'.
+  # Code that uses 'adjusted' on such a frame must fail loudly, not silently return NA.
+  df <- .ohlcv_frame()   # has 'adjusted_close', NOT 'adjusted'
+
+  expect_error(
+    dplyr::mutate(df, ret = adjusted / dplyr::lag(adjusted) - 1),
+    regexp = "adjusted",
+    info   = "dplyr must error when bare 'adjusted' column is absent"
+  )
+})
+
+
 
 test_that("equity_daily schema uses adjusted_close, not adjusted", {
   ds <- hd_datasets()


### PR DESCRIPTION
## Summary

- Replaces bare `adjusted` price-column references with canonical `adjusted_close` in two code-as-target strings in `R/plan_vignette.R`
- Targets unblocked: `vig_eq_faang` (cum-ret calc), `vig_eq_vol` (log-ret calc)
- Adds 3 regression tests to `packages/historicaldata/tests/testthat/test-column-naming.R` covering the fixed arithmetic patterns and the "bare adjusted → clear error" guard

## Root cause

`hd_ohlcv()` returns `adjusted_close` (canonical, set by #325 / #397 / #453 with a backward-compat alias in `hd_lazy()` / `hd_ohlcv_single()`). The two vignette code-as-string targets still referenced the old bare `adjusted` column, causing dplyr to throw `Column 'adjusted' not found`.

## Files changed

| File | Change |
|---|---|
| `R/plan_vignette.R` line 93 | `adjusted / first(adjusted)` → `adjusted_close / first(adjusted_close)` |
| `R/plan_vignette.R` line 115 | `log(adjusted / lag(adjusted))` → `log(adjusted_close / lag(adjusted_close))` |
| `packages/historicaldata/tests/testthat/test-column-naming.R` | 3 new regression tests for #489 Cluster A |

## Verification

- `[ FAIL 0 | WARN 0 | SKIP 1 | PASS 16 ]` with `pkgload::load_all()` (SKIP = alphavantager optional)
- `parse("R/plan_vignette.R")`, `parse("_targets.R")`, `parse("docs/_targets.R")` all OK
- `r_code_check.sh` clean on both modified files

## Out of scope (for separate PRs)

- Other bare `adjusted` sites in `R/` outside `plan_vignette.R` (Clusters B/D of #489)
- `hd_most_volatile()` backward-compat SQL gap (DuckDB Binder Error on old local parquets)
- `vig_cr_corr` / `vig_meta_*` target failures (different root causes)

Closes #489 Cluster A only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)