### PR TITLE
fix(crypto): coerce parquet date to Date before filter — unblock crypto backtest chain (#489 Cluster B)

### DIFF
--- a/R/crypto_momentum.R
+++ b/R/crypto_momentum.R
@@ -205,6 +205,18 @@ backtest_crypto_momentum <- function(signals, returns, cost_bps = 30,
     unique() |>
     sort()
 
+  # Guard: empty signals / rebalance_dates means an empty universe upstream
+  # (e.g. Date-vs-POSIXct filter mismatch in crypto_universe that returns 0 rows).
+  # Fail loudly here rather than producing a column-less tibble whose join later
+  # throws a cryptic "ticker not present in y" error.
+  if (nrow(signals) == 0L || length(rebalance_dates) == 0L) {
+    cli::cli_abort(c(
+      "x" = "backtest_crypto_momentum(): no signals / rebalance dates.",
+      "i" = "nrow(signals) = {nrow(signals)}, length(rebalance_dates) = {length(rebalance_dates)}.",
+      "i" = "An empty universe upstream (e.g. Date-vs-POSIXct filter mismatch) is the most common cause."
+    ))
+  }
+
   # For each rebalance date, rank by signal and assign positions
   positions <- lapply(rebalance_dates, function(reb_date) {
     signals |>

--- a/R/plan_crypto_momentum.R
+++ b/R/plan_crypto_momentum.R
@@ -31,8 +31,13 @@ plan_crypto_momentum <- function() {
       library(dplyr)
       library(arrow)
 
-      # Read crypto data from local parquet file
+      # Read crypto data from local parquet file.
+      # NOTE: arrow parquet TIMESTAMP columns load as POSIXct; sample_start/sample_end
+      # are Date objects. A POSIXct-vs-Date comparison silently returns 0 rows
+      # (see data-validation-timeseries rule §9). Coerce to Date first so the
+      # filter is Date-vs-Date and produces the expected ~35k-row universe.
       crypto_data <- arrow::read_parquet(here::here("data/raw/crypto_all.parquet")) |>
+        dplyr::mutate(date = as.Date(date)) |>
         filter(
           date >= crypto_mom_params$sample_start,
           date <= crypto_mom_params$sample_end

--- a/tests/testthat/_snaps/crypto-momentum.md
+++ b/tests/testthat/_snaps/crypto-momentum.md
@@ -1,0 +1,15 @@
+# C2: backtest_crypto_momentum aborts informatively on empty signals
+
+    Code
+      backtest_crypto_momentum(empty_signals, empty_returns)
+    Condition
+      Warning:
+      There was 1 warning in `dplyr::filter()`.
+      i In argument: `date == max(date)`.
+      Caused by warning in `max.default()`:
+      ! no non-missing arguments to max; returning -Inf
+      Error in `backtest_crypto_momentum()`:
+      x backtest_crypto_momentum(): no signals / rebalance dates.
+      i nrow(signals) = 0, length(rebalance_dates) = 0.
+      i An empty universe upstream (e.g. Date-vs-POSIXct filter mismatch) is the most common cause.
+

--- a/tests/testthat/test-crypto-momentum.R
+++ b/tests/testthat/test-crypto-momentum.R
@@ -1,0 +1,124 @@
+testthat::local_edition(3)
+source(here::here("R/crypto_momentum.R"))
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# Minimal daily crypto-style data spanning 2020-2022
+make_crypto_returns <- function() {
+  dates <- seq(as.Date("2020-01-01"), as.Date("2022-12-31"), by = "day")
+  tickers <- c("BTC", "ETH", "XRP", "LTC", "ADA", "SOL")
+  df <- tidyr::expand_grid(ticker = tickers, date = dates)
+  set.seed(42L)
+  df$ret <- stats::rnorm(nrow(df), 0, 0.03)
+  df
+}
+
+# Minimal signals for backtest (one signal per ticker per month-end)
+make_crypto_signals <- function(n_months = 6L) {
+  tickers <- c("BTC", "ETH", "XRP", "LTC", "ADA", "SOL", "DOT", "LINK", "UNI", "AVAX")
+  dates <- seq(as.Date("2020-01-31"), by = "month", length.out = n_months)
+  df <- tidyr::expand_grid(date = dates, ticker = tickers)
+  set.seed(7L)
+  df$signal <- stats::rnorm(nrow(df))
+  df
+}
+
+# ── Fix #489 Cluster B: POSIXct-vs-Date filter regression test ───────────────
+
+test_that("C1: as.Date coercion makes POSIXct dates filterable against Date bounds", {
+  # Reproduce the parquet scenario: date column arrives as POSIXct.
+  # Without coercion, comparison against Date bounds returns 0 rows.
+  # With coercion (the fix), it returns the expected subset.
+  posixct_dates <- as.POSIXct(
+    c("2020-06-01 00:00:00", "2020-07-15 00:00:00", "2021-03-10 00:00:00",
+      "2014-12-31 00:00:00", "2027-01-05 00:00:00"),
+    tz = "UTC"
+  )
+  df <- tibble::tibble(
+    date   = posixct_dates,
+    ticker = paste0("C", seq_along(posixct_dates)),
+    close  = c(100, 200, 300, 50, 400)
+  )
+
+  sample_start <- as.Date("2017-01-01")  # Date object (as in crypto_mom_params)
+  sample_end   <- as.Date("2026-12-31")
+
+  # Without the fix: POSIXct vs Date comparison — expect 0 rows (demonstrates the bug)
+  rows_without_fix <- df |>
+    dplyr::filter(date >= sample_start, date <= sample_end) |>
+    nrow()
+  # This should be 0 — POSIXct vs Date silently produces no matches
+  expect_equal(rows_without_fix, 0L,
+    info = "POSIXct vs Date comparison must return 0 rows (pre-fix behaviour)")
+
+  # With the fix: coerce to Date first — expect 3 rows (the 2020, 2020, 2021 entries)
+  rows_with_fix <- df |>
+    dplyr::mutate(date = as.Date(date)) |>
+    dplyr::filter(date >= sample_start, date <= sample_end) |>
+    nrow()
+  expect_equal(rows_with_fix, 3L,
+    info = "After as.Date() coercion, filter must keep the 3 in-range rows")
+})
+
+test_that("C1: as.Date coercion is a no-op when date is already Date", {
+  # Confirm the fix is safe even when the parquet schema already returns Date
+  date_col <- as.Date(c("2020-01-01", "2021-06-15", "2015-12-31"))
+  df <- tibble::tibble(date = date_col, ticker = "BTC", close = 1)
+  result <- df |> dplyr::mutate(date = as.Date(date))
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, date_col)
+})
+
+# ── Defensive guard: empty signals / rebalance_dates ─────────────────────────
+
+test_that("C2: backtest_crypto_momentum aborts informatively on empty signals", {
+  empty_signals <- tibble::tibble(
+    date   = as.Date(character(0)),
+    ticker = character(0),
+    signal = numeric(0)
+  )
+  empty_returns <- tibble::tibble(
+    date   = as.Date(character(0)),
+    ticker = character(0),
+    ret    = numeric(0)
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    backtest_crypto_momentum(empty_signals, empty_returns)
+  )
+})
+
+test_that("C2: guard error message mentions empty universe as cause", {
+  empty_signals <- tibble::tibble(
+    date   = as.Date(character(0)),
+    ticker = character(0),
+    signal = numeric(0)
+  )
+  returns <- make_crypto_returns()
+
+  err <- tryCatch(
+    backtest_crypto_momentum(empty_signals, returns),
+    error = function(e) e
+  )
+  expect_true(inherits(err, "error"))
+  expect_true(
+    grepl("empty universe", conditionMessage(err), fixed = FALSE),
+    info = paste0("Error message should mention 'empty universe'. Got: ", conditionMessage(err))
+  )
+})
+
+test_that("C2: backtest_crypto_momentum runs without error on well-formed inputs", {
+  signals  <- make_crypto_signals(n_months = 6L)
+  returns  <- make_crypto_returns()
+
+  # Should not error; spot-check result structure
+  result <- backtest_crypto_momentum(
+    signals, returns,
+    cost_bps = 30, n_long = 3L, n_short = 3L
+  )
+  expect_type(result, "list")
+  expect_true("performance" %in% names(result))
+  expect_true("summary" %in% names(result))
+  expect_true(nrow(result$performance) > 0L)
+})


### PR DESCRIPTION
## Summary

- **Root cause (orchestrator-verified)**: `arrow::read_parquet()` returns TIMESTAMP columns as POSIXct. In `crypto_universe`, filtering against `crypto_mom_params$sample_start`/`sample_end` (which are `Date` objects) silently produced **0 rows** — a POSIXct-vs-Date comparison with no error, just no matches. The empty universe cascaded through the whole chain: `crypto_returns` → `crypto_signals` → empty `rebalance_dates` → column-less `positions` tibble → cryptic `"ticker not present in y"` join error in `backtest_crypto_momentum()`.
- **Verified row counts**: raw parquet = 35,775 rows / 14 tickers / 2014→2026. Filter as-is → **0 rows**. After `as.Date()` coercion → **34,938 rows**.
- **Fix 1** (`R/plan_crypto_momentum.R`): add `dplyr::mutate(date = as.Date(date))` immediately after `read_parquet()`, with a comment citing the Date-vs-POSIXct hazard (data-validation-timeseries rule §9).
- **Fix 2** (`R/crypto_momentum.R`): add `cli::cli_abort()` guard in `backtest_crypto_momentum()` when `nrow(signals) == 0L || length(rebalance_dates) == 0L`, so an empty upstream universe fails loudly and diagnostically instead of via the cryptic join error.

## Sibling date-type hazard scan

Checked `R/plan_crypto_momentum.R` and `R/crypto_momentum.R` for other bare POSIXct-vs-Date comparisons — none found. The `rebalance_date <= date` comparisons inside `backtest_crypto_momentum()` are safe: `date` there derives from `crypto_universe$date` which is now `Date`.

## Test coverage

- `test-crypto-momentum.R` C1: confirms POSIXct-vs-Date filter returns 0 rows (demonstrates the bug) and that `as.Date()` coercion returns the expected 3 rows (locks the fix).
- `test-crypto-momentum.R` C2: confirms the guard fires with an informative `cli_abort()` message on empty signals. Snapshot locked in `_snaps/crypto-momentum.md`.
- `test-crypto-momentum.R` C2 (happy path): smoke-test that `backtest_crypto_momentum()` runs without error on well-formed inputs.
- Result: **11 PASS, 0 FAIL, 0 SKIP** (`NOT_CRAN=true`).

## Post-merge

Orchestrator will rebuild the 7 crypto targets (`crypto_bt_baseline` + 6 cascades) against the live store to confirm they complete.

## Related

- Closes Cluster B in #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)