### PR TITLE
fix(targets): Cluster D batch — forcats, adjusted_close, gh_base scope, month-complete, zak pronoun (#489 Cluster D)

### DIFF
--- a/R/plan_drif_v2.R
+++ b/R/plan_drif_v2.R
@@ -204,7 +204,7 @@ plan_drif_v2 <- function() {
                               " k=", nfolds,
                               " f=", feature_set,
                               " l=", sub("lambda\\.", "", lambda_rule), ")"),
-          spec_label = forcats::fct_inorder(spec_label),
+          spec_label = factor(spec_label, levels = unique(spec_label)),
           highlight  = is_current
         )
 

--- a/R/plan_falsification_vignette.R
+++ b/R/plan_falsification_vignette.R
@@ -541,6 +541,7 @@ plan_falsification_vignette <- function() {
     }),
 
     targets::tar_target(fals_vig_cmr_head_to_head_caption, {
+      gh_base <- "https://github.com/JohnGavin/historical/blob/main"
       mr_sharpes  <- fals_cmr_summary$hac_sharpe
       mom_sharpe  <- round(
         cmr_vs_mom_compare$sharpe[cmr_vs_mom_compare$type == "momentum"][1],

--- a/R/plan_mean_reversion.R
+++ b/R/plan_mean_reversion.R
@@ -54,11 +54,11 @@ plan_mean_reversion <- function() {
           hd_ohlcv(tkr, from = as.character(mr_params$start_date)) |>
             dplyr::arrange(date) |>
             dplyr::mutate(
-              ret = adjusted / dplyr::lag(adjusted) - 1,
+              ret = adjusted_close / dplyr::lag(adjusted_close) - 1,
               ticker = tkr
             ) |>
             dplyr::filter(!is.na(ret)) |>
-            dplyr::select(date, ticker, ret, adjusted, volume)
+            dplyr::select(date, ticker, ret, adjusted_close, volume)
         }, error = function(e) NULL)
       }) |>
         dplyr::mutate(date = as.Date(date, tz = "UTC"))
@@ -240,7 +240,7 @@ plan_mean_reversion <- function() {
       # SPY benchmark
       spy <- hd_ohlcv("SPY", from = as.character(mr_params$start_date)) |>
         arrange(date) |>
-        mutate(ret = adjusted / lag(adjusted) - 1) |>
+        mutate(ret = adjusted_close / lag(adjusted_close) - 1) |>
         filter(!is.na(ret)) |>
         mutate(cum_spy = cumprod(1 + ret)) |>
         select(date, cum_spy)

--- a/R/plan_portfolio_opt.R
+++ b/R/plan_portfolio_opt.R
@@ -268,10 +268,11 @@ plan_portfolio_opt <- function() {
           return_pct = optimal_ret * 100
         ) |>
         select(year, month, return_pct) |>
+        tidyr::complete(year, month = 1:12) |>
         pivot_wider(
           names_from = month,
           values_from = return_pct,
-          names_sort = FALSE
+          names_sort = TRUE
         ) |>
         arrange(year) |>
         mutate(across(-year, ~if_else(is.na(.), NA_real_, .))) |>

--- a/R/zakamulin_allocation.R
+++ b/R/zakamulin_allocation.R
@@ -333,20 +333,21 @@ summarize_regime_allocation <- function(backtest_results, annual_rf = 0.02) {
       .groups = "drop"
     ) |>
     mutate(
-      # Compute max drawdowns — use named-arg lambda + rlang::.env to avoid
-      # R parser warnings ("..1 may be used in an incorrect context") that
-      # purrr's `~{}` tilde-lambdas trigger when ..N refs sit inside dplyr's
-      # NSE-aware filter() — column-name vs iter-variable conflict requires
-      # .env$ to disambiguate. (#337)
+      # Compute max drawdowns — use DISTINCT lambda arg names (.scheme etc.)
+      # so there is no column-name vs. iterator-variable collision inside
+      # dplyr's data-mask filter(). The rlang::.env$ pronoun is NOT needed
+      # when the lambda args have names that don't shadow the column names.
+      # purrr::pmap_dbl() matches list keys to function arg names, so the
+      # list keys must also use the .prefixed names. (#337, #489 Cluster D)
       max_dd = purrr::pmap_dbl(
-        list(scheme = scheme, signal_type = signal_type, allocation_fn = allocation_fn),
-        function(scheme, signal_type, allocation_fn) {
+        list(.scheme = scheme, .signal_type = signal_type, .allocation_fn = allocation_fn),
+        function(.scheme, .signal_type, .allocation_fn) {
           rets <- backtest_results |>
-            filter(scheme == rlang::.env$scheme,
-                   signal_type == rlang::.env$signal_type,
-                   allocation_fn == rlang::.env$allocation_fn) |>
-            arrange(date) |>
-            pull(net_ret)
+            dplyr::filter(scheme == .scheme,
+                          signal_type == .signal_type,
+                          allocation_fn == .allocation_fn) |>
+            dplyr::arrange(date) |>
+            dplyr::pull(net_ret)
           if (length(rets) < 2) return(NA_real_)
           cumrets <- cumprod(1 + rets)
           cummax_vals <- cummax(cumrets)
@@ -355,14 +356,14 @@ summarize_regime_allocation <- function(backtest_results, annual_rf = 0.02) {
         }
       ),
       max_dd_allocated = purrr::pmap_dbl(
-        list(scheme = scheme, signal_type = signal_type, allocation_fn = allocation_fn),
-        function(scheme, signal_type, allocation_fn) {
+        list(.scheme = scheme, .signal_type = signal_type, .allocation_fn = allocation_fn),
+        function(.scheme, .signal_type, .allocation_fn) {
           rets <- backtest_results |>
-            filter(scheme == rlang::.env$scheme,
-                   signal_type == rlang::.env$signal_type,
-                   allocation_fn == rlang::.env$allocation_fn) |>
-            arrange(date) |>
-            pull(allocated_ret)
+            dplyr::filter(scheme == .scheme,
+                          signal_type == .signal_type,
+                          allocation_fn == .allocation_fn) |>
+            dplyr::arrange(date) |>
+            dplyr::pull(allocated_ret)
           if (length(rets) < 2) return(NA_real_)
           cumrets <- cumprod(1 + rets)
           cummax_vals <- cummax(cumrets)

--- a/packages/historicaldata/tests/testthat/test-column-naming.R
+++ b/packages/historicaldata/tests/testthat/test-column-naming.R
@@ -117,6 +117,62 @@ test_that("backward-compat alias is a no-op when adjusted_close already present"
   expect_equal(nrow(new_frame), 1L)
 })
 
+# ── Fix 1 (#489 Cluster D): mr_daily and mr_plot use adjusted_close ──────────
+# plan_mean_reversion.R previously referenced bare `adjusted` (→ "object not found").
+# Regression: the return-calc pattern used in both mr_daily and mr_plot targets
+# must work with adjusted_close, not adjusted.
+
+test_that("mr_daily return-calc pattern with adjusted_close (multi-ticker, #489 Cluster D)", {
+  # Simulate what hd_ohlcv() returns for two tickers: adjusted_close present
+  tickers <- c("AAPL", "MSFT")
+  make_ticker_frame <- function(tkr) {
+    tibble::tibble(
+      date           = as.Date(c("2024-01-02", "2024-01-03", "2024-01-04")),
+      adjusted_close = c(100.0, 105.0, 110.25),
+      volume         = c(1e6, 1.1e6, 1.2e6),
+      ticker         = tkr
+    )
+  }
+
+  result <- purrr::map_dfr(tickers, function(tkr) {
+    make_ticker_frame(tkr) |>
+      dplyr::arrange(date) |>
+      dplyr::mutate(
+        ret = adjusted_close / dplyr::lag(adjusted_close) - 1
+      ) |>
+      dplyr::filter(!is.na(ret)) |>
+      dplyr::select(date, ticker, ret, adjusted_close, volume)
+  })
+
+  # 2 tickers × 2 non-NA rows each = 4 rows
+  expect_equal(nrow(result), 4L)
+  # All returns should be approximately 5%
+  expect_true(all(abs(result$ret - 0.05) < 1e-8))
+  # adjusted_close column must be present (no bare 'adjusted')
+  expect_true("adjusted_close" %in% names(result))
+  expect_false("adjusted" %in% names(result))
+})
+
+test_that("mr_plot spy-benchmark return-calc uses adjusted_close (#489 Cluster D)", {
+  spy_frame <- tibble::tibble(
+    date           = as.Date(c("2024-01-02", "2024-01-03", "2024-01-04",
+                               "2024-01-05")),
+    adjusted_close = c(400.0, 404.0, 408.04, 412.12)
+  )
+
+  spy <- spy_frame |>
+    dplyr::arrange(date) |>
+    dplyr::mutate(ret = adjusted_close / dplyr::lag(adjusted_close) - 1) |>
+    dplyr::filter(!is.na(ret)) |>
+    dplyr::mutate(cum_spy = cumprod(1 + ret)) |>
+    dplyr::select(date, cum_spy)
+
+  expect_equal(nrow(spy), 3L)
+  # Cumulative value after 3 ~1% returns should be ~(1.01)^3 ≈ 1.0303
+  expect_equal(spy$cum_spy[3L], (404 / 400) * (408.04 / 404) * (412.12 / 408.04),
+               tolerance = 1e-8)
+})
+
 test_that("hd_alphavantage output uses adjusted_close", {
   skip_if_not_installed("alphavantager")
   mock_result <- tibble::tibble(

--- a/tests/testthat/test-plan-portfolio-opt.R
+++ b/tests/testthat/test-plan-portfolio-opt.R
@@ -1,5 +1,58 @@
 testthat::local_edition(3)
 
+# ── Fix 4 (#489 Cluster D): complete month grid before pivot_wider ────────────
+# When port_combined is missing a calendar month (e.g. month 3 = March) the
+# hardcoded rename(Mar = `3`, ...) used to fail with
+# "Column `3` doesn't exist".  The fix inserts tidyr::complete(year, month = 1:12)
+# before pivot_wider so all 12 month columns are always present.
+
+test_that("port_monthly_returns: missing month still yields all 12 renamed columns (#489 Cluster D)", {
+  # Synthetic data missing March (month 3) — mirrors the live failure
+  raw <- tibble::tibble(
+    year        = c(2020L, 2020L, 2020L, 2020L, 2020L,
+                    2020L, 2020L, 2020L, 2020L, 2020L, 2020L),   # 11 months
+    month       = c(1L, 2L,          4L, 5L, 6L,
+                    7L, 8L, 9L, 10L, 11L, 12L),                   # no 3
+    return_pct  = c(1.1, -0.5,       0.8, 1.2, -0.3,
+                    0.4,  0.7, -0.1,  0.9,  1.5, -0.2)
+  )
+
+  # Apply the fix: complete then pivot
+  wide <- raw |>
+    tidyr::complete(year, month = 1:12) |>
+    tidyr::pivot_wider(
+      names_from  = month,
+      values_from = return_pct,
+      names_sort  = TRUE
+    )
+
+  # All 12 month columns must exist (names are integers as characters)
+  month_cols <- as.character(1:12)
+  missing_cols <- setdiff(month_cols, names(wide))
+  expect_equal(
+    length(missing_cols), 0L,
+    info = paste("After complete(), these month columns are still absent:", paste(missing_cols, collapse = ", "))
+  )
+
+  # Month 3 column should be NA (completed but no data)
+  expect_true(is.na(wide[["3"]]),
+              info = "Completed month 3 must be NA when no data existed for it")
+
+  # The rename step that used to fail should now succeed
+  result <- wide |>
+    dplyr::rename(
+      Year = year,
+      Jan = `1`,  Feb = `2`,  Mar = `3`,  Apr = `4`,
+      May = `5`,  Jun = `6`,  Jul = `7`,  Aug = `8`,
+      Sep = `9`,  Oct = `10`, Nov = `11`, Dec = `12`
+    )
+
+  expect_true("Mar" %in% names(result),
+              info = "rename(Mar = `3`) must succeed after complete()")
+  expect_equal(ncol(result), 13L,  # year + 12 month columns
+               info = "Wide table should have exactly 13 columns (year + 12 months)")
+})
+
 # Regression test for fix in commit 159e3b9:
 # calc_port_metrics() was missing opt_vol column, causing NA in the PSO
 # Optimal leaderboard row. Test that the output tibble contains all four

--- a/tests/testthat/test-zakamulin-allocation.R
+++ b/tests/testthat/test-zakamulin-allocation.R
@@ -1,0 +1,100 @@
+# Regression tests for #489 Cluster D Fix 5:
+# summarize_regime_allocation() with distinct lambda arg names (no .env$ pronoun).
+#
+# Prior to the fix, rlang::.env$scheme inside dplyr filter() inside purrr::pmap_dbl()
+# threw "Can't subset .data outside of a data mask context".  The fix renames the
+# lambda args to .scheme / .signal_type / .allocation_fn so no pronoun is needed.
+testthat::local_edition(3)
+
+source(here::here("R/zakamulin_allocation.R"))
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+# Build a minimal backtest_results tibble: 2 schemes x 1 signal_type x 1 fn.
+.make_backtest_results <- function() {
+  # 12 monthly rows per scheme so summarize gets enough data
+  n_months <- 12L
+  dates_a  <- seq.Date(as.Date("2020-01-31"), by = "month", length.out = n_months)
+  dates_b  <- dates_a
+
+  rbind(
+    data.frame(
+      date          = dates_a,
+      scheme        = "scheme_A",
+      signal_type   = "MA",
+      allocation_fn = "linear",
+      net_ret       = c(0.05, -0.02, 0.03, 0.01, -0.01, 0.04,
+                        0.02, -0.03, 0.01, 0.05, -0.02, 0.03),
+      allocated_ret = c(0.04, -0.01, 0.02, 0.01, -0.01, 0.03,
+                        0.01, -0.02, 0.01, 0.04, -0.01, 0.02),
+      allocation    = rep(0.8, n_months),
+      stringsAsFactors = FALSE
+    ),
+    data.frame(
+      date          = dates_b,
+      scheme        = "scheme_B",
+      signal_type   = "MA",
+      allocation_fn = "linear",
+      net_ret       = c(-0.01, 0.02, 0.04, -0.03, 0.01, 0.02,
+                        0.03, 0.01, -0.01, 0.02, 0.04, -0.02),
+      allocated_ret = c(-0.01, 0.02, 0.03, -0.02, 0.01, 0.01,
+                        0.02, 0.01, -0.01, 0.02, 0.03, -0.01),
+      allocation    = rep(0.75, n_months),
+      stringsAsFactors = FALSE
+    )
+  )
+}
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+test_that(
+  "summarize_regime_allocation() returns one row per group without .env$ error (#489 Cluster D)",
+  {
+    br     <- .make_backtest_results()
+    result <- summarize_regime_allocation(br, annual_rf = 0.02)
+
+    # Should have exactly 2 rows (one per scheme)
+    expect_equal(nrow(result), 2L)
+
+    # Required columns present
+    expect_true("max_dd"           %in% names(result))
+    expect_true("max_dd_allocated" %in% names(result))
+
+    # max_dd and max_dd_allocated must be finite (not NA/NaN) for both schemes
+    expect_false(any(is.na(result$max_dd)),
+                 info = "max_dd must be finite for all groups (no .env$ pronoun error)")
+    expect_false(any(is.na(result$max_dd_allocated)),
+                 info = "max_dd_allocated must be finite for all groups")
+
+    # Drawdowns must be <= 0 by definition
+    expect_true(all(result$max_dd           <= 0),
+                info = "max_dd is a drawdown — must be non-positive")
+    expect_true(all(result$max_dd_allocated <= 0),
+                info = "max_dd_allocated must be non-positive")
+  }
+)
+
+test_that(
+  "summarize_regime_allocation() max_dd correct for known drawdown (#489 Cluster D)",
+  {
+    # scheme_C: starts high, then crashes hard so max_dd is easy to predict
+    # 1 -> 1.10 -> 1.10*0.80 = 0.88 → drawdown from peak = (0.88-1.10)/1.10 = -0.20
+    br_c <- data.frame(
+      date          = as.Date(c("2020-01-31", "2020-02-28", "2020-03-31")),
+      scheme        = "scheme_C",
+      signal_type   = "MA",
+      allocation_fn = "linear",
+      net_ret       = c(0.10, -0.20, 0.05),  # max drawdown: -0.20 from peak
+      allocated_ret = c(0.08, -0.16, 0.04),
+      allocation    = c(0.8, 0.8, 0.8),
+      stringsAsFactors = FALSE
+    )
+
+    result <- summarize_regime_allocation(br_c, annual_rf = 0.02)
+
+    expect_equal(nrow(result), 1L)
+    # Peak after month 1: 1.10; valley after month 2: 1.10*0.80 = 0.88
+    # max_dd = (0.88 - 1.10) / 1.10 = -0.20 exactly
+    expect_equal(result$max_dd, -0.20, tolerance = 1e-8)
+  }
+)


### PR DESCRIPTION
## Summary

Fixes #489 Cluster D — 5 independent broken targets, each with a distinct root cause:

| # | Target | File | Root cause | Fix |
|---|--------|------|-----------|-----|
| 1 | `mr_plot`, `mr_daily` | `R/plan_mean_reversion.R` | `hd_ohlcv()` returns `adjusted_close`; 3 sites used bare `adjusted` | Replaced all 3 bare `adjusted` price-column references with `adjusted_close` |
| 2 | `drif_multiverse_plot` | `R/plan_drif_v2.R` | `forcats::fct_inorder()` — `forcats` not installed | Replaced with base-R `factor(spec_label, levels = unique(spec_label))` |
| 3 | `fals_vig_cmr_head_to_head_caption` | `R/plan_falsification_vignette.R` | `gh_base` defined at outer-function scope (line 12), but targets execute in isolated envs | Added `gh_base <- "https://github.com/JohnGavin/historical/blob/main"` inside the target body. Only this one target needed it (grep confirmed). |
| 4 | `port_monthly_returns` | `R/plan_portfolio_opt.R` | Missing month 3 (March) in `port_combined` caused `rename(Mar = \`3\`)` to fail | Inserted `tidyr::complete(year, month = 1:12)` before `pivot_wider`; set `names_sort = TRUE` |
| 5 | `zak_performance_table`, `zak_summary` | `R/zakamulin_allocation.R` | `rlang::.env$scheme` inside `pmap_dbl` lambda fails outside data-mask context | Renamed lambda args to `.scheme`/`.signal_type`/`.allocation_fn` AND renamed pmap list keys to match (purrr passes by name; keys must align with param names) |

## Test coverage

- **Fix 5 (zak):** `tests/testthat/test-zakamulin-allocation.R` — 9 tests; covers no-`.env$`-pronoun-error regression, finite `max_dd`/`max_dd_allocated` for both schemes, exact drawdown value for a known crash sequence.
- **Fix 4 (port):** `tests/testthat/test-plan-portfolio-opt.R` — 4 new tests (13 total); verifies all 12 renamed columns present when month 3 is absent, and `Mar` rename succeeds.
- **Fix 1 (mr):** `packages/historicaldata/tests/testthat/test-column-naming.R` — 2 new tests; covers multi-ticker `mr_daily` return-calc pattern and SPY-benchmark `mr_plot` pattern with `adjusted_close`.
- Fixes 2 & 3 are trivial substitutions; covered by parse checks only.

## Test results

- `test-zakamulin-allocation.R`: FAIL 0 | PASS 9
- `test-plan-portfolio-opt.R`: FAIL 0 | PASS 13
- `test-column-naming.R`: FAIL 0 | PASS 18 (2 pre-existing failures need `hd_datasets()` from loaded package — not regressions)

## Post-merge orchestrator action

Orchestrator to rebuild these targets against the store: `drif_multiverse_plot`, `zak_performance_table`, `zak_summary`, `mr_plot`, `mr_daily`, `port_monthly_returns`, `fals_vig_cmr_head_to_head_caption`.

## Test plan

- [ ] Verify all 5 failing targets now succeed in `tar_make()` run post-merge
- [ ] Confirm `mr_daily` returns `adjusted_close` column (not bare `adjusted`)
- [ ] Confirm `drif_multiverse_plot` renders without `forcats` error
- [ ] Confirm `fals_vig_cmr_head_to_head_caption` value is a non-empty string
- [ ] Confirm `port_monthly_returns` has all 12 month columns even in early years
- [ ] Confirm `zak_performance_table` / `zak_summary` have finite `max_dd` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)