### PR TITLE
feat(cov): route portfolio covariance through hd_cov_estimate (config default sample) (#498)

### DIFF
--- a/R/cov_config.R
+++ b/R/cov_config.R
@@ -1,0 +1,10 @@
+# Covariance-estimator configuration (issue #498).
+# Single source of truth for which estimator the portfolio-construction
+# pipeline uses. Routed through historicaldata::hd_cov_estimate().
+#
+# Default is "sample": bit-identical to stats::cov() (use = "complete.obs"),
+# so deployed numbers are unchanged by the Phase 2 routing. Phase 3 will flip
+# this to "ledoit_wolf" ONLY after the out-of-sample diagnostic (#498) shows
+# regularisation improves min-variance OOS Sharpe / conditioning.
+COV_METHOD    <- "sample"        # one of: sample, ledoit_wolf, rmt_denoise, threshold
+COV_LW_TARGET <- "const_cor"     # Ledoit-Wolf target; only used when COV_METHOD == "ledoit_wolf"

--- a/R/plan_portfolio_opt.R
+++ b/R/plan_portfolio_opt.R
@@ -135,7 +135,8 @@ plan_portfolio_opt <- function() {
         return(setNames(rep(0.25, 4), strat_cols))
       }
 
-      cov_mat <- cov(ret_matrix)
+      # ret_matrix is already complete-cased on the line above; no NA warning fires (#498).
+      cov_mat <- hd_cov_estimate(ret_matrix, method = COV_METHOD, lw_target = COV_LW_TARGET)
       # HRP_Portfolio returns a data.frame with a 'weights' column,
       # rownames match colnames of cov_mat.
       hrp_result <- HierPortfolios::HRP_Portfolio(cov_mat)

--- a/R/plan_returns.R
+++ b/R/plan_returns.R
@@ -112,7 +112,9 @@ plan_returns <- function() {
       ret_mat <- as.matrix(wide[, asset_cols])
 
       # Compute monthly covariance then annualise
-      Sigma_monthly <- stats::cov(ret_mat, use = "complete.obs")
+      # Routed through hd_cov_estimate() for configurable regularisation (#498).
+      # Default COV_METHOD = "sample" is bit-identical to stats::cov(use="complete.obs").
+      Sigma_monthly <- hd_cov_estimate(ret_mat, method = COV_METHOD, lw_target = COV_LW_TARGET)
 
       # Enforce symmetry numerically (floating-point drift)
       Sigma_annual  <- PERIODS_PER_YEAR * ((Sigma_monthly + t(Sigma_monthly)) / 2)
@@ -158,7 +160,8 @@ plan_returns <- function() {
 
           # Use complete-observation rows only
           window_cc  <- window[rowSums(is.na(window)) == 0L, , drop = FALSE]
-          Sigma_m    <- stats::cov(window_cc, use = "complete.obs")
+          # window_cc is already complete-cased; no NA warning fires (#498).
+          Sigma_m    <- hd_cov_estimate(window_cc, method = COV_METHOD, lw_target = COV_LW_TARGET)
           Sigma_ann  <- PERIODS_PER_YEAR * ((Sigma_m + t(Sigma_m)) / 2)
           rownames(Sigma_ann) <- asset_cols
           colnames(Sigma_ann) <- asset_cols

--- a/docs/_targets.R
+++ b/docs/_targets.R
@@ -71,6 +71,11 @@ source(here::here("R/commodities_momentum.R"))
 # Source crypto momentum functions (issue #135)
 source(here::here("R/crypto_momentum.R"))
 
+# Source covariance-estimator configuration (#498).
+# Constants (COV_METHOD, COV_LW_TARGET) are evaluated at source() time;
+# must precede any plan file that calls hd_cov_estimate().
+source(here::here("R/cov_config.R"))
+
 # Source plans (strategy_names FIRST — may be referenced by any plan)
 source(here::here("R/plan_strategy_names.R"))
 # Source plans (partitions FIRST — all backtests depend on it)

--- a/tests/testthat/test-cov-routing.R
+++ b/tests/testthat/test-cov-routing.R
@@ -1,0 +1,143 @@
+testthat::local_edition(3)
+
+# Tests for cov-routing (#498 Phase 2) — behaviour-preserving regression guards.
+#
+# These tests verify that:
+#   1. COV_METHOD defaults to "sample" and COV_LW_TARGET defaults to "const_cor"
+#      (guards against accidental flip of the default).
+#   2. hd_cov_estimate(X, method = "sample") produces values equal to
+#      stats::cov(X, use = "complete.obs") — i.e. the substitution is a no-op.
+#   3. The routed result is symmetric and matches the legacy expression on
+#      a representative complete frame.
+#
+# Per snapshot-test-policy: these are algorithmic tests (expected values can
+# be hand-derived or trivially computed from the same inputs). No snapshots
+# are needed or added here.
+#
+# hd_cov_estimate() is in the historicaldata package; the package is loaded
+# via pkgload::load_all() in this project's docs/_targets.R, but here we
+# load it directly.
+
+# ── Package setup ──────────────────────────────────────────────────────────────
+
+# Source hd_cov_estimate() directly from cov_estimate.R.
+# pkgload::load_all(historicaldata) fails in this test env because duckplyr
+# is not installed, but hd_cov_estimate() only depends on cli, rlang, and
+# stats — all of which are available. Sourcing the file directly avoids the
+# full-package import check while still exercising the exact function being routed.
+source(here::here("packages/historicaldata/R/cov_estimate.R"))
+
+# Source the config constants from R/cov_config.R.
+# (When running via test_dir() this file is not auto-sourced.)
+source(here::here("R/cov_config.R"))
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+make_complete_matrix <- function(n = 60L, p = 4L, seed = 42L) {
+  set.seed(seed)
+  m <- matrix(rnorm(n * p), nrow = n, ncol = p)
+  colnames(m) <- paste0("A", seq_len(p))
+  m
+}
+
+# ============================================================================
+# Guard 1: default constants
+# ============================================================================
+
+test_that("COV_METHOD is 'sample' (Phase 2 default; Phase 3 will flip to ledoit_wolf)", {
+  expect_equal(COV_METHOD, "sample",
+               info = paste0(
+                 "COV_METHOD must be 'sample' in Phase 2. ",
+                 "Changing it now would alter deployed numbers. ",
+                 "Phase 3 flip requires OOS diagnostic (#498)."
+               ))
+})
+
+test_that("COV_LW_TARGET is 'const_cor' (used only when COV_METHOD == 'ledoit_wolf')", {
+  expect_equal(COV_LW_TARGET, "const_cor",
+               info = "COV_LW_TARGET default is 'const_cor'; only active when COV_METHOD == 'ledoit_wolf'.")
+})
+
+# ============================================================================
+# Guard 2: numerical equivalence — hd_cov_estimate("sample") == stats::cov()
+# ============================================================================
+
+test_that("hd_cov_estimate(method='sample') values equal stats::cov(use='complete.obs')", {
+  X <- make_complete_matrix(n = 60L, p = 4L)
+
+  routed <- hd_cov_estimate(X, method = "sample", lw_target = "const_cor")
+  legacy <- stats::cov(X, use = "complete.obs")
+
+  # Values are bit-identical up to floating-point tolerance (ignore extra attrs)
+  expect_equal(routed, legacy,
+               ignore_attr = TRUE,
+               tolerance   = 1e-14,
+               info        = paste0(
+                 "hd_cov_estimate(method='sample') must be numerically ",
+                 "identical to stats::cov(use='complete.obs')."
+               ))
+})
+
+test_that("hd_cov_estimate(method='sample') values equal stats::cov() on larger matrix", {
+  X <- make_complete_matrix(n = 120L, p = 4L, seed = 99L)
+
+  routed <- hd_cov_estimate(X, method = "sample", lw_target = "const_cor")
+  legacy <- stats::cov(X, use = "complete.obs")
+
+  expect_equal(routed, legacy,
+               ignore_attr = TRUE,
+               tolerance   = 1e-14,
+               info        = "Equivalence must hold regardless of n.")
+})
+
+# ============================================================================
+# Guard 3: symmetry and regression guard for the routed result
+# ============================================================================
+
+test_that("hd_cov_estimate(method='sample') returns a symmetric matrix", {
+  X      <- make_complete_matrix(n = 80L, p = 4L)
+  routed <- hd_cov_estimate(X, method = "sample", lw_target = "const_cor")
+
+  expect_equal(routed, t(routed),
+               ignore_attr = TRUE,
+               tolerance   = 1e-12,
+               info        = "Routed covariance matrix must be symmetric.")
+})
+
+test_that("hd_cov_estimate(method='sample') matches legacy cov_annual expression (annualised)", {
+  # Reproduce the cov_annual target logic: Sigma_annual = 12 * (Sigma_m + t(Sigma_m)) / 2
+  X <- make_complete_matrix(n = 80L, p = 4L)
+
+  # Legacy path (what was in plan_returns.R before Phase 2)
+  Sigma_m_legacy   <- stats::cov(X, use = "complete.obs")
+  Sigma_ann_legacy <- 12L * ((Sigma_m_legacy + t(Sigma_m_legacy)) / 2)
+
+  # Routed path (Phase 2)
+  Sigma_m_routed   <- hd_cov_estimate(X, method = COV_METHOD, lw_target = COV_LW_TARGET)
+  Sigma_ann_routed <- 12L * ((Sigma_m_routed + t(Sigma_m_routed)) / 2)
+
+  expect_equal(Sigma_ann_routed, Sigma_ann_legacy,
+               ignore_attr = TRUE,
+               tolerance   = 1e-14,
+               info        = paste0(
+                 "Phase 2 routing must produce identical annualised covariance. ",
+                 "If this fails, COV_METHOD is not 'sample' or hd_cov_estimate ",
+                 "changed its 'sample' implementation."
+               ))
+})
+
+test_that("only changing COV_METHOD would alter deployed numbers (Phase 3 guard)", {
+  # When COV_METHOD != "sample", the routed result DIFFERS from the legacy path.
+  # This test documents (and tests) the change that Phase 3 will introduce.
+  X <- make_complete_matrix(n = 80L, p = 4L)
+
+  legacy <- stats::cov(X, use = "complete.obs")
+  lw     <- hd_cov_estimate(X, method = "ledoit_wolf", lw_target = "const_cor")
+
+  # ledoit_wolf != sample (shrinks off-diagonal elements)
+  expect_false(isTRUE(all.equal(lw, legacy, ignore_attr = TRUE, tolerance = 1e-10)),
+               info = paste0(
+                 "ledoit_wolf result must differ from sample result (Ledoit-Wolf shrinks). ",
+                 "Confirms that flipping COV_METHOD to 'ledoit_wolf' WILL change deployed numbers."
+               ))
+})


### PR DESCRIPTION
## Summary

Phase 2 of issue #498: wire all portfolio-construction covariance call sites through `hd_cov_estimate()` behind a single configurable constant (`COV_METHOD`, default `"sample"`). Deployed numbers are **unchanged** — the `"sample"` method is bit-identical to `stats::cov(use = "complete.obs")`.

### Routed sites (3)

| File | Target | Old call | New call |
|---|---|---|---|
| `R/plan_returns.R` | `cov_annual` | `stats::cov(ret_mat, use = "complete.obs")` | `hd_cov_estimate(ret_mat, method = COV_METHOD, lw_target = COV_LW_TARGET)` |
| `R/plan_returns.R` | `cov_rolling_60m` | `stats::cov(window_cc, use = "complete.obs")` | `hd_cov_estimate(window_cc, method = COV_METHOD, lw_target = COV_LW_TARGET)` |
| `R/plan_portfolio_opt.R` | `port_hrp_weights` | `cov(ret_matrix)` | `hd_cov_estimate(ret_matrix, method = COV_METHOD, lw_target = COV_LW_TARGET)` |

### Deferred sites (2 — NOT changed)

- `R/plan_stock_backtest.R` (~line 217): uses `pairwise.complete.obs` for a wide stock universe with staggered history. `hd_cov_estimate()` uses complete-cases (drops any-NA rows), which would materially change behaviour and may leave too few rows. Routing requires separate design (pairwise support or imputation).
- `packages/historicaldata/R/simulate_paths.R` (~line 142): covered by issue #463. Leave unchanged.

### New files

- `R/cov_config.R`: single source of truth for `COV_METHOD` (default `"sample"`) and `COV_LW_TARGET` (default `"const_cor"`). Registered in `docs/_targets.R` via `source(here::here("R/cov_config.R"))` before the plan files.
- `tests/testthat/test-cov-routing.R`: 7 algorithmic regression guards verifying: (1) default constants are unchanged, (2) `hd_cov_estimate(method="sample")` is numerically identical to `stats::cov()`, (3) symmetry, (4) full annualisation expression matches legacy path, (5) flipping `COV_METHOD` to `ledoit_wolf` WILL change numbers (documents Phase 3 intent).

### Phase 3 (deferred)

After the OOS diagnostic (#498) shows regularisation improves min-variance OOS Sharpe / conditioning, flip `COV_METHOD` in `R/cov_config.R` from `"sample"` to `"ledoit_wolf"`. That single-line change is the ONLY action needed to switch all routed sites simultaneously.

## Verification

```
# Parse gates
invisible(parse("_targets.R")); cat("PARSE_OK\n")   → PARSE_OK
invisible(parse("docs/_targets.R"))                  → PARSE_OK (docs targets)
invisible(parse("R/plan_returns.R")); invisible(parse("R/plan_portfolio_opt.R")); invisible(parse("R/cov_config.R")); cat("PLANS_PARSE_OK\n")   → PLANS_PARSE_OK

# Tests
testthat::test_dir("tests/testthat", filter = "cov-routing|plan-portfolio-opt|plan-returns")
→ [ FAIL 0 | WARN 0 | SKIP 2 | PASS 119 ]
# (2 SKIPs are CRAN-guard snapshot tests — expected in non-CRAN env)

# Code check: ast-grep + jarl
→ No violations found
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)