### PR TITLE
refactor(cov): replace deprecated case_match with portable case_when (#498)

### DIFF
--- a/R/plan_cov_diagnostic_vignette.R
+++ b/R/plan_cov_diagnostic_vignette.R
@@ -26,17 +26,15 @@ plan_cov_diagnostic_vignette <- function() {
 
       cov_diag_summary |>
         dplyr::mutate(
-          Universe     = dplyr::case_match(
-            universe,
-            "4-asset" ~ "4-asset (SPY/TLT/GLD/DBC)",
-            "wide"    ~ "Wide (~30 large-cap equities)",
+          Universe     = dplyr::case_when(
+            universe == "4-asset" ~ "4-asset (SPY/TLT/GLD/DBC)",
+            universe == "wide"    ~ "Wide (~30 large-cap equities)",
             .default  = universe
           ),
-          Method       = dplyr::case_match(
-            method,
-            "sample"      ~ "Sample",
-            "ledoit_wolf" ~ "Ledoit-Wolf",
-            "rmt_denoise" ~ "RMT-denoise",
+          Method       = dplyr::case_when(
+            method == "sample"      ~ "Sample",
+            method == "ledoit_wolf" ~ "Ledoit-Wolf",
+            method == "rmt_denoise" ~ "RMT-denoise",
             .default      = method
           ),
           `OOS Sharpe` = round(oos_sharpe,  2),
@@ -65,21 +63,19 @@ plan_cov_diagnostic_vignette <- function() {
       s <- cov_diag_summary
 
       s$method_label <- factor(
-        dplyr::case_match(
-          s$method,
-          "sample"      ~ "Sample",
-          "ledoit_wolf" ~ "Ledoit-Wolf",
-          "rmt_denoise" ~ "RMT-denoise",
+        dplyr::case_when(
+          s$method == "sample"      ~ "Sample",
+          s$method == "ledoit_wolf" ~ "Ledoit-Wolf",
+          s$method == "rmt_denoise" ~ "RMT-denoise",
           .default      = s$method
         ),
         levels = c("Sample", "Ledoit-Wolf", "RMT-denoise")
       )
 
       s$universe_label <- factor(
-        dplyr::case_match(
-          s$universe,
-          "4-asset" ~ "4-asset (SPY/TLT/GLD/DBC)",
-          "wide"    ~ "Wide (~30 equities)",
+        dplyr::case_when(
+          s$universe == "4-asset" ~ "4-asset (SPY/TLT/GLD/DBC)",
+          s$universe == "wide"    ~ "Wide (~30 equities)",
           .default  = s$universe
         )
       )
@@ -137,21 +133,19 @@ plan_cov_diagnostic_vignette <- function() {
       s <- cov_diag_summary
 
       s$method_label <- factor(
-        dplyr::case_match(
-          s$method,
-          "sample"      ~ "Sample",
-          "ledoit_wolf" ~ "Ledoit-Wolf",
-          "rmt_denoise" ~ "RMT-denoise",
+        dplyr::case_when(
+          s$method == "sample"      ~ "Sample",
+          s$method == "ledoit_wolf" ~ "Ledoit-Wolf",
+          s$method == "rmt_denoise" ~ "RMT-denoise",
           .default      = s$method
         ),
         levels = c("Sample", "Ledoit-Wolf", "RMT-denoise")
       )
 
       s$universe_label <- factor(
-        dplyr::case_match(
-          s$universe,
-          "4-asset" ~ "4-asset (SPY/TLT/GLD/DBC)",
-          "wide"    ~ "Wide (~30 equities, survivorship-biased)",
+        dplyr::case_when(
+          s$universe == "4-asset" ~ "4-asset (SPY/TLT/GLD/DBC)",
+          s$universe == "wide"    ~ "Wide (~30 equities, survivorship-biased)",
           .default  = s$universe
         )
       )

--- a/R/plan_vignette.R
+++ b/R/plan_vignette.R
@@ -253,9 +253,8 @@ p
 # Batch query: 2 credit spread series in one request
 spreads <- hd_macro(c("BAMLH0A0HYM2", "BAMLC0A4CBBB"), from = "2020-01-01") |>
   filter(!is.na(value)) |>
-  mutate(series_id = case_match(series_id,
-    "BAMLH0A0HYM2" ~ "HY Spread",
-    "BAMLC0A4CBBB" ~ "BBB Spread",
+  mutate(series_id = case_when(series_id == "BAMLH0A0HYM2" ~ "HY Spread",
+    series_id == "BAMLC0A4CBBB" ~ "BBB Spread",
     .default = series_id))
 
 ggplot(spreads, aes(date, value, colour = series_id)) +


### PR DESCRIPTION
## Summary

- `case_match()` is deprecated in the project's pinned dplyr 1.2.1 (CI/Nix env); `recode_values()` is absent in the global shell's dplyr 1.1.4
- Switched to `case_when()` which is non-deprecated and semantically identical across both versions: each bare LHS literal `"v"` becomes `COL == "v"`; `.default` preserved unchanged
- No DESCRIPTION change, no compat narrowing; no behaviour change; surfaced during the #498 Phase 3b build

## Call sites changed

| File | Lines | First arg |
|------|-------|-----------|
| `R/plan_cov_diagnostic_vignette.R` | 29, 35 | `universe`, `method` (in `cov_diag_vig_table` mutate) |
| `R/plan_cov_diagnostic_vignette.R` | 68, 79 | `s$method`, `s$universe` (in `cov_diag_vig_cond_plot`) |
| `R/plan_cov_diagnostic_vignette.R` | 140, 151 | `s$method`, `s$universe` (in `cov_diag_vig_sharpe_plot`) |
| `R/plan_vignette.R` | 256 | `series_id` (in `vig_ma_spreads`) |

## Test plan

- [x] `grep -rn "case_match" R/` → empty (zero remaining calls)
- [x] `grep -rn "case_when" R/ | wc -l` → 57 (7 new + 50 pre-existing)
- [x] `parse("R/plan_cov_diagnostic_vignette.R")` + `parse("R/plan_vignette.R")` → `PARSE_OK`
- [x] Smoke test: `case_when(m=="sample"~"Sample", m=="ledoit_wolf"~"Ledoit-Wolf", .default=m)` → `"Sample" "Ledoit-Wolf" "z"` (identical to `case_match` output)
- [x] `r_code_check.sh` → `All checks passed!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)