### PR TITLE
docs(process): dashboard-output-first workflow + dashboard inventory (#514)

### DIFF
--- a/.claude/rules/dashboard-output-first.md
+++ b/.claude/rules/dashboard-output-first.md
@@ -1,0 +1,121 @@
+# Rule: Output-First ("Dashboard-First") Planning — Phase 0
+
+## Source
+
+Issue #514. The dashboard output is the critical deliverable; it must be the
+*first* planning artifact, not the last. Paired with a mandatory relationship
+diagram and a consolidation review so the dashboard count trends **down** as
+features are added.
+
+## When This Applies
+
+Every major feature/issue whose work will (now or later) produce or change a
+**visible output** — a table, plot, metric block, or diagram — on any dashboard
+in `docs/`. Applies before any production code is written. Pure internal
+estimators with no eventual output (e.g. a numeric helper that only feeds
+another function) are exempt until the phase that surfaces them.
+
+## CRITICAL: No production code until Phase 0 is approved
+
+Plan-first failure mode this prevents: implement an estimator/strategy, then
+bolt a chart onto whatever dashboard is handy (or spawn a new one). The result
+is output that is inconsistent with — or duplicates — what already exists, and
+yet another standalone surface. Phase 0 forces the output, its relationships,
+and its home to be decided and **approved** before the code exists.
+
+## Phase 0 — Output & Relationship Design (6 steps)
+
+Phase 0 slots **ahead** of the normal R-package PR workflow
+(architecture → TDD → implement → render → QA).
+
+### 1. Diagram the relationship (start here)
+
+Build or **extend** a Mermaid graph locating the new feature in the existing web
+of strategies / diagnostics / data sources — what it depends on, what it feeds,
+what it resembles. This is the first artifact attached to the issue/PR.
+
+- If a relevant graph exists (the causal-DAG surface in `falsification.qmd`, or
+  the future `strategy_graph` of #481), **extend it** rather than start a new one.
+- Nodes MUST carry **clickable code anchors** to the implementing function/file
+  at the current commit (per `mermaid-click-anchors`).
+- Nodes MUST carry **hover popups**: a short explanation plus links to further
+  detail (vignette section, issue, wiki page).
+- "No diagram needed" is allowed only with a one-line justification.
+
+### 2. Locate the home
+
+Identify the **target dashboard + exact section** for the new output. Map the
+issue → `dashboard:section`. Adding a NEW dashboard is the exception and
+requires justifying why no existing surface fits. Default answer: an existing
+dashboard. Consult `docs/DASHBOARDS.md` for the current inventory and the
+best-template sources.
+
+### 3. Comparable-output audit
+
+List the existing outputs (tables/plots/captions) the new one will sit beside or
+resemble. The new output MUST be consistent with them:
+
+- naming per `strategy-name-consistency` (shared `strategy_names` target);
+- captions per `visualization-standards` (7-item caption, source links);
+- table styling per `dashboard-table-styling`; filters per
+  `dashboard-filter-placement`.
+
+### 4. Prototype for approval (Class C gate)
+
+Build a **throwaway prototype of just the visible output** (and the diagram
+change), leveraging an existing dashboard chunk as a template — copy the
+structure, swap the data with a stub/sample. Render it. Attach the rendered
+preview + the diagram to the issue/PR. **Implementation waits for an explicit
+"approved"** (a Class C cross-boundary gate per `human-in-the-loop-decision-points`).
+See `docs/DASHBOARDS.md` § Template Recipe for which chunk templates which
+output type.
+
+### 5. Consolidation review (mandatory)
+
+Re-read the full dashboard inventory (`docs/DASHBOARDS.md`) — each dashboard's
+functionality and objective — and the relationship diagram. Identify what the
+new feature makes redundant or mergeable, and **propose at least one concrete
+simplification**: drop / merge / fold-into-leaderboard / replace-with-diagram-node.
+"No change" is allowed only with a one-line justification. **Net dashboard count
+should trend down.**
+
+### 6. Then build
+
+Proceed to the normal architecture → TDD → implement → render → QA workflow,
+building the real output into the agreed dashboard section and wiring the
+diagram anchors to the shipped code.
+
+## Mermaid as the navigation + consolidation layer
+
+A single diagram-driven relationship map (with click-through to source and
+hover detail) can **replace several thin standalone dashboards**. Instead of one
+surface per strategy, the map shows all strategies and their relationships, with
+click-through to the (fewer) dashboards that hold the real output. Strengthening
+the diagram layer and reducing dashboard count are the same effort — see #481
+(`strategy_graph` backbone) for the canonical graph this layer should grow.
+
+## Forbidden Patterns
+
+| Pattern | Why wrong | Fix |
+|---|---|---|
+| Implement estimator/strategy, then decide where the chart goes | Output is an afterthought; lands inconsistent/duplicate | Run Phase 0 first |
+| Spin up a new dashboard for a new feature by default | Sprawl | Default to extending an existing dashboard (step 2) |
+| Ship visible output with no relationship diagram | Reader can't see how it connects; can't spot redundancy | Step 1 is mandatory |
+| Mermaid node with no code anchor / no hover detail | Diagram is decoration, not navigation | `mermaid-click-anchors` + hover popup |
+| Skip the consolidation review because "the feature is small" | Count never goes down | Step 5 is mandatory; "no change" needs a one-line reason |
+| Build production output before the prototype is approved | Bypasses the Class C sign-off | Prototype → approve → build |
+
+## Related
+
+- `docs/DASHBOARDS.md` — living inventory, overlap clusters, consolidation
+  proposal, and template recipe this rule reviews against
+- `mermaid-dashboard-pattern`, `mermaid-click-anchors` — Mermaid diagram +
+  clickable-anchor conventions (step 1)
+- `strategy-name-consistency` — single source of truth for strategy names (step 3)
+- `visualization-standards`, `dashboard-table-styling`, `dashboard-filter-placement`
+  — output consistency (step 3)
+- `human-in-the-loop-decision-points` — the prototype sign-off is a Class C gate
+- #481 — unified `strategy_graph` backbone (the relationship graph the Mermaid
+  layer renders and grows)
+- #507 — MVO remedy set; its weight-stability diagnostic is the first feature to
+  run through this workflow

--- a/docs/DASHBOARDS.md
+++ b/docs/DASHBOARDS.md
@@ -1,0 +1,74 @@
+# Dashboard Inventory & Objectives
+
+> Living inventory of every dashboard in `docs/`. This is the artifact the
+> **`dashboard-output-first` rule** (issue #514) reviews against in Phase 0
+> step 2 (locate the home), step 4 (template recipe), and step 5 (consolidation
+> review). Keep it current: every feature that adds/changes a dashboard output
+> updates the relevant row here, and every feature proposes at least one
+> consolidation against this list.
+
+**Current count: 15 standalone dashboards.** Consolidation target: **11** (see
+§ Consolidation Proposal). The causal-DAG is an embedded surface inside
+`falsification.qmd`, not a standalone dashboard.
+
+## Inventory
+
+| Dashboard | Objective | Primary visible outputs | Data source |
+|---|---|---|---|
+| `index.qmd` | Portal + dataset catalogue | Headline stat block (tickers/rows/datasets/years/functions); 4 dataset cards; card grid → downstream dashboards | `hd_datasets()`, `hd_tickers()`, `hd_factors()` |
+| `leaderboard.qmd` | Rank all strategies by risk-adjusted return; central output | Ranking table (Sharpe/CAGR/MaxDD/CVaR95/Vol/SSR/Top5%/Credible); partition table; equity-curve plotly (range slider); monthly-returns heatmap; bootstrap-CI table; deflated-Sharpe table; alpha-decay; regime-adjusted Sharpe; Kelly table; structural-breaks dot plot; correlation matrix | `tar_read(leaderboard)`, `boot_ci_summary`, `structural_breaks_summary`, `strategy_correlation` |
+| `falsification.qmd` | Test causal integrity / robustness gauntlet | Scorecard (Verdict/HAC t/Sharpe/Alpha/R²); null-rejection heatmap (6 envs × strats); FF5+Mom alpha scatter; HAC t comparison; multiplicity K_eff table; WFC 2×2; **covariance regularisation table + conditioning/OOS dot plots (#498)**; causal DAG (Mermaid/D3, tabbed); implication tests; risk-architecture table | `fals_vig_*`, `wfc_all_summary`, `cov_diag_vig_table`, `cg_dag`, `cg_test_implications` |
+| `evidence.qmd` | Negative results + 155-yr pervasiveness | Failed-strategies scorecard; pattern-analysis table; negative-result cards; JST pervasiveness table (18 countries); equity-premium heatmap; crisis timeline; crisis-frequency table | `fals_summary`, `jst_equity_premium`, `jst_pervasiveness`, `jst_crises` |
+| `factor-max.qmd` | MAX signal at factor level | Cumulative-return plotly (log); metrics table (IS/OOS/Full); factor-selection bar chart; MAX-signal heatmap; ETF comparison | `fm_cumret_plot`, `fm_metrics`, `fm_selection_freq`, `fm_heatmap` |
+| `drif.qmd` | DRIF elastic-net signal at factor level | Cumulative-return plotly; metrics table (seal warning on Validation); selection-frequency table; DRIF-vs-MAX comparison; parameters table | `drif_cumret_plot`, `drif_metrics`, `drif_params`, `drif_selection_freq`, `drif_vs_max_plot` |
+| `stock-backtest.qmd` | Cross-sectional: MAX/DRIF on 660 stocks vs 5 factors | 2×2 strategy matrix; equity curves (4 strats, range slider); metrics table; key-findings matrix; per-signal detail (plots, pros/cons, factor exposure); XGBoost DRIF section | `stk_max_metrics`, `stk_drif_metrics`, `fm_metrics`, `drif_metrics`, `stk_all_comparison_plot` |
+| `avoid-worst-days.qmd` | Thought experiment: return asymmetry | Conceptual $100→$165 vs $75 chart; temporal-clustering analysis; discussion (not tradeable) | Inline SPY daily returns |
+| `european-overlay.qmd` | VIX-style signals on European equities vs ECB CISS | CISS-vs-VIX correlation table; CISS sub-market breakdown; CISS time series plotly; regime-allocation table; performance comparison | `ecb_raw`, `aw_vix_daily`, `hd_ecb()` |
+| `jst-dashboard.qmd` | Interactive 155-yr equity premium, 18 countries | Pervasiveness table; decade×country heatmap; crisis timeline; crisis-frequency table; summary callouts | `jst_equity_premium`, `jst_pervasiveness`, `jst_crises` |
+| `macro-defense-rotation.qmd` | Macro hedge rotation (TLT/GLD/DBC/UUP vs SPY) | Normalised price chart; performance-metrics table (by partition); regime overlay; win-rate table; allocation table | `bt_prices`, inline backtest |
+| `momentum-prepeak.qmd` | Büsing (2022) pre-peak vs post-peak 12-2 momentum | Equity-curve comparison (pre/post/combined); summary metrics; bankruptcy-events table; signal-decomposition explanation | `mom_prepeak_*`, `mom_postpeak_returns`, `mom_combined_returns`, `strategy_names` |
+| `bdbb-sol.qmd` | M/G/∞ queueing model (Varma 2026) on SOL/USD | Data-coverage table; rolling-diagnostics table; regime-distribution bar chart; tail-risk predictivity table | `bdbb_sol_dv`, `bdbb_sol_fit`, `bdbb_sol_metrics` |
+| `negative-results.qmd` | Archive of failed strategies (detailed) | Failed-strategies scorecard; detailed failure cards; lessons-learned callouts; portfolio implications | `fals_summary` filtered Alpha t < 2.0 |
+| `quiz.qmd` | Educational: real vs synthetic equity curves | Quiz interface (side-by-side plotly); difficulty badges; results card; explanation panels | `quiz_json`, quiz-logic.js |
+
+## Overlap Clusters
+
+1. **Strategy performance** — `index` → `leaderboard` → `falsification`: ranking, equity curves, and verdicts that reference each other.
+2. **Per-strategy deep dives** — `factor-max`, `drif`, `stock-backtest`, `macro-defense-rotation`, `momentum-prepeak`: all show definition + cumulative-return plotly + metrics table + signal analysis. `stock-backtest` already subsumes `factor-max`/`drif` as a 2×2.
+3. **Long-run evidence** — `evidence` and `jst-dashboard` render the **same** JST pervasiveness table, heatmap, and crisis timeline.
+4. **Robustness & falsification** — `leaderboard`, `falsification`, `negative-results`: overlapping robustness metrics; `negative-results` is a subset of the `falsification` scorecard.
+
+## Consolidation Proposal (15 → 11)
+
+| # | Action | Rationale | Kept / lost |
+|---|---|---|---|
+| 1 | **Merge `jst-dashboard` → `evidence`** (tabset) | Identical JST outputs; no new information | All data kept; lose a standalone page |
+| 2 | **Merge `factor-max` + `drif` → `stock-backtest`** (Factor-Level tabset) | `stock-backtest` already shows the 2×2 (Stock/Factor × MAX/DRIF) | All metrics/charts kept as tabs; lose two isolated pages; index links to `stock-backtest#factor-deep-dive` |
+| 3 | **Merge `negative-results` → `falsification`** (final "Failed Strategies" tab) | `negative-results` copies the falsification scorecard + failure cards | Falsification becomes passing→failing narrative; redirect old page |
+| 4 | **Keep** `index`, `leaderboard`, `falsification`, `evidence`, `stock-backtest`, `macro-defense-rotation`, `momentum-prepeak`, `european-overlay`, `bdbb-sol`, `avoid-worst-days`, `quiz` | Distinct objective/audience each | — |
+
+**Resulting 11-dashboard architecture:** Portal (`index`) · Core (`leaderboard` → `falsification` → `evidence`) · Signals (`stock-backtest`) · Exploratory (`macro-defense-rotation`, `momentum-prepeak`, `european-overlay`, `bdbb-sol`, `avoid-worst-days`) · Interactive (`quiz`). Each merge is its own follow-up PR through the Phase 0 workflow.
+
+## Template Recipe
+
+Clone one of these chunks into a throwaway prototype (Phase 0 step 4), swap the
+data with a stub, render, attach for approval.
+
+| New output type | Template chunk | Why |
+|---|---|---|
+| Multi-strategy ranking table | `leaderboard.qmd` metrics table (~L115–158) | Generic `hd_dt()` ranking with colour bars; new strategy = new row |
+| Robustness / CI assessment table | `leaderboard.qmd` bootstrap-CI table (~L318–336) | Conditional styling (red if CI crosses zero) |
+| Multi-hypothesis comparison | `falsification.qmd` null-rejection heatmap (~L229–236) | `geom_tile` rejection-rate scale, facet by strategy |
+| Alpha vs factor-exposure diagnosis | `falsification.qmd` FF alpha scatter (~L194–200) | Standard alpha/R² placement |
+| Walk-forward estimator comparison | `falsification.qmd` covariance-regularisation block (~L410–468) | Comprehensive sample-vs-shrunk OOS template — **the model for #507's weight-stability diagnostic** |
+| Asset-rotation selection | `factor-max.qmd` selection-frequency (~L143–149) | `group_by + count` bar, facet by signal |
+| Causal-assumption documentation | `falsification.qmd` causal DAG + implications (~L581–737) | DAG + conditional-independence table with source links |
+
+## Maintenance
+
+- Update the relevant inventory row whenever a dashboard output changes.
+- Every Phase 0 run appends its consolidation decision (step 5) — even "no
+  change, because …".
+- When a merge from the Consolidation Proposal ships, move the merged dashboard
+  to a struck-through line with the absorbing target noted, and decrement the
+  count.


### PR DESCRIPTION
## Summary

Implements the planning workflow from #514: treat the **dashboard output as the critical deliverable and the first planning artifact**, with a Mermaid relationship diagram up front and a mandatory consolidation review so the dashboard count trends **down**.

Two prose deliverables (no code):

### 1. `.claude/rules/dashboard-output-first.md`
A **Phase 0 — Output & Relationship Design** that runs *before* the normal architecture → TDD → implement workflow. No production code until Phase 0 is approved.

1. **Diagram the relationship (start here)** — build/extend a Mermaid graph placing the feature in the existing web of strategies/diagnostics/data; nodes carry clickable code anchors (`mermaid-click-anchors`) + hover detail.
2. **Locate the home** — which existing dashboard + section (new dashboard is the exception).
3. **Comparable-output audit** — consistency with neighbours (`strategy-name-consistency`, `visualization-standards`).
4. **Prototype for approval** — throwaway preview by templating an existing chunk; Class C sign-off gate.
5. **Consolidation review (mandatory)** — propose ≥1 merge/drop; net count trends down.
6. **Then build.**

### 2. `docs/DASHBOARDS.md`
Living inventory of all **15 dashboards** (objective · primary visible outputs · data source), overlap clusters, a **15 → 11 consolidation proposal**, and a **template recipe** mapping new output types to existing template chunks.

## Consolidation proposal (15 → 11)
| Action | Rationale |
|---|---|
| Merge `jst-dashboard` → `evidence` | Identical JST tables |
| Merge `factor-max` + `drif` → `stock-backtest` | Already the 2×2 (Stock/Factor × MAX/DRIF) |
| Merge `negative-results` → `falsification` | Subset of the scorecard |

Each merge is its own follow-up PR through this workflow.

## First test case
#507's weight-stability diagnostic is the first feature to run through Phase 0 — its home is a new `falsification.qmd` section (templated on the #498 covariance-regularisation block), with a relationship diagram linking `hd_returns_shrink()` / `hd_black_litterman()` / `hd_min_var_weights()` / `hd_cov_estimate()`.

## Notes
- Inventory seeded from a read-only survey of all 15 `docs/*.qmd`.
- Follow-up (not in this PR): link `docs/DASHBOARDS.md` from `index.qmd`; grow the master relationship diagram into #481's `strategy_graph`.

Part of #514. Prose-only — no R/Quarto code changes, so no functional CI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
