### PR TITLE
feat(falsification): surface weight-stability diagnostic (#507 Phase 4b)

### DIFF
--- a/R/plan_weight_stability_vignette.R
+++ b/R/plan_weight_stability_vignette.R
@@ -1,0 +1,220 @@
+# Plan: Weight-Stability Vignette Targets (issue #507 Phase 4b)
+#
+# Pre-computed plot, table, and caption for the "Weight-Stability Diagnostic
+# (MVO breakdown)" section in docs/falsification.qmd. Consumes
+# asset_monthly_returns_wide from plan_returns.R — the same 4-asset
+# (SPY/TLT/GLD/DBC) universe and train_window = 60L used by cov_diag_4asset
+# in plan_cov_diagnostic.R, giving consistent cross-section comparisons.
+#
+# Targets produced:
+#   ws_diag_raw         — raw tibble from hd_weight_stability_diagnostic()
+#   ws_diag_vig_table   — tidy data.frame for fals_dt() (Method / Avg Turnover
+#                         / Max |w| / OOS Sharpe / Eff N / Failed)
+#   ws_diag_vig_plot    — Cleveland dot plot of OOS Sharpe by method (dark bg)
+#   ws_diag_vig_caption — dynamic caption string (>=3 sentences, data-driven)
+#
+# Template: mirrors R/plan_cov_diagnostic_vignette.R (#498 Phase 3b).
+# All plots match the dark-background theme (black panel, #e0e0e0 text).
+# BL-no-views caveat: with w_mkt = 1/p and no views, BL posterior collapses
+# to equal-weight tangency — documented in hd_black_litterman() and #513.
+
+plan_weight_stability_vignette <- function() {
+
+  list(
+
+    # ── Raw diagnostic compute ─────────────────────────────────────────────
+    # Walk-forward OOS weight-stability diagnostic on the 4-asset universe.
+    # asset_monthly_returns_wide is a wide tibble (date col + 4 ticker cols);
+    # hd_weight_stability_diagnostic() silently drops the date column.
+    # cov_method defaults to "ledoit_wolf" — regularised Sigma for gmv,
+    # shrunk_mu, black_litterman, hrp.
+    targets::tar_target(ws_diag_raw, {
+      hd_weight_stability_diagnostic(
+        returns      = asset_monthly_returns_wide,
+        methods      = c(
+          "raw_mvo", "gmv", "shrunk_mu", "black_litterman",
+          "equal_weight", "hrp"
+        ),
+        train_window = 60L
+      )
+    }),
+
+
+    # ── Display table ──────────────────────────────────────────────────────
+    # Five core columns per task specification, plus Failed (n_failed) which
+    # is essential for interpreting raw_mvo (singular sample Sigma windows).
+    # Arranged descending by OOS Sharpe: best method at top of the table.
+    targets::tar_target(ws_diag_vig_table, {
+      library(dplyr)
+
+      ws_diag_raw |>
+        dplyr::mutate(
+          Method = dplyr::case_when(
+            method == "raw_mvo"         ~ "Raw MVO",
+            method == "gmv"             ~ "GMV (Global Min-Var)",
+            method == "shrunk_mu"       ~ "Shrunk-μ (James-Stein)",
+            method == "black_litterman" ~ "Black-Litterman (no views)†",
+            method == "equal_weight"    ~ "Equal-Weight (1/N)",
+            method == "hrp"             ~ "HRP (Hierarchical RP)",
+            .default = method
+          ),
+          `Avg Turnover` = round(avg_turnover,   3L),
+          `Max |w|`      = round(max_abs_weight, 3L),
+          `OOS Sharpe`   = round(oos_sharpe,     2L),
+          `Eff N`        = round(mean_eff_n,      1L),
+          Failed         = as.integer(n_failed)
+        ) |>
+        dplyr::arrange(dplyr::desc(oos_sharpe)) |>
+        dplyr::select(
+          Method, `Avg Turnover`, `Max |w|`, `OOS Sharpe`, `Eff N`, Failed
+        )
+    }),
+
+
+    # ── OOS Sharpe Cleveland dot plot ──────────────────────────────────────
+    # Horizontal dotchart (Cleveland convention, per visualization-standards):
+    # one point per method, sorted ascending so the worst Sharpe is at the
+    # bottom, best at the top. Raw MVO is coloured orange-red to flag it as
+    # the error-maximiser. Dashed zero line for reference.
+    # No legend: colours are self-labelled by the y-axis tick labels.
+    targets::tar_target(ws_diag_vig_plot, {
+      library(ggplot2)
+
+      method_colours <- c(
+        "Raw MVO"                          = "#e07b54",
+        "GMV (Global Min-Var)"             = "#4a90d9",
+        "Shrunk-μ (James-Stein)"      = "#69d4a0",
+        "Black-Litterman (no views)†" = "#a8d4b0",
+        "Equal-Weight (1/N)"               = "#c9b7e8",
+        "HRP (Hierarchical RP)"            = "#f0c040"
+      )
+
+      s <- ws_diag_raw
+
+      s$label <- dplyr::case_when(
+        s$method == "raw_mvo"         ~ "Raw MVO",
+        s$method == "gmv"             ~ "GMV (Global Min-Var)",
+        s$method == "shrunk_mu"       ~ "Shrunk-μ (James-Stein)",
+        s$method == "black_litterman" ~ "Black-Litterman (no views)†",
+        s$method == "equal_weight"    ~ "Equal-Weight (1/N)",
+        s$method == "hrp"             ~ "HRP (Hierarchical RP)",
+        .default = s$method
+      )
+
+      # Sort ascending (lowest Sharpe at bottom); NA goes first (bottom).
+      sort_idx <- order(s$oos_sharpe, na.last = FALSE)
+      s$label  <- factor(s$label, levels = s$label[sort_idx])
+
+      ggplot(s, aes(x = oos_sharpe, y = label, colour = label)) +
+        geom_vline(
+          xintercept = 0, colour = "#666", linetype = "dashed", linewidth = 0.6
+        ) +
+        geom_point(size = 5L) +
+        scale_colour_manual(values = method_colours, guide = "none") +
+        labs(
+          title    = "Out-of-Sample (OOS) Sharpe by Portfolio Construction Method",
+          subtitle = paste0(
+            "4-asset universe (SPY/TLT/GLD/DBC). ",
+            "Raw MVO = error maximiser. †BL shown at no-views equilibrium prior."
+          ),
+          x = "Annualised OOS Sharpe ratio",
+          y = NULL
+        ) +
+        theme_minimal(base_size = 14L) +
+        theme(
+          plot.background    = element_rect(fill = "black", color = NA),
+          panel.background   = element_rect(fill = "black", color = NA),
+          text               = element_text(color = "#e0e0e0"),
+          axis.text          = element_text(color = "#e0e0e0", size = 13L),
+          legend.position    = "none",
+          panel.grid.major.x = element_line(color = "#333"),
+          panel.grid.minor   = element_blank(),
+          panel.grid.major.y = element_line(color = "#222")
+        )
+    }),
+
+
+    # ── Dynamic caption ────────────────────────────────────────────────────
+    # >=3 sentences. All numbers computed from ws_diag_raw at build time.
+    # Includes the BL-no-views caveat (#513 invariant) so readers do not read
+    # the coincidence of BL == Equal-Weight as a bug in the implementation.
+    targets::tar_target(ws_diag_vig_caption, {
+      gh_base <- "https://github.com/JohnGavin/historical/blob/main"
+
+      s <- ws_diag_raw
+
+      get_val <- function(meth, col) {
+        val <- s[[col]][s$method == meth]
+        if (length(val) == 0L) NA_real_ else val[[1L]]
+      }
+
+      mvo_turnover   <- get_val("raw_mvo",        "avg_turnover")
+      ew_turnover    <- get_val("equal_weight",    "avg_turnover")
+      gmv_turnover   <- get_val("gmv",             "avg_turnover")
+      hrp_turnover   <- get_val("hrp",             "avg_turnover")
+
+      mvo_maxw       <- get_val("raw_mvo",         "max_abs_weight")
+      ew_maxw        <- get_val("equal_weight",     "max_abs_weight")
+
+      mvo_sharpe     <- get_val("raw_mvo",         "oos_sharpe")
+      gmv_sharpe     <- get_val("gmv",             "oos_sharpe")
+      hrp_sharpe     <- get_val("hrp",             "oos_sharpe")
+      ew_sharpe      <- get_val("equal_weight",    "oos_sharpe")
+      shrunk_sharpe  <- get_val("shrunk_mu",       "oos_sharpe")
+      bl_sharpe      <- get_val("black_litterman", "oos_sharpe")
+
+      mvo_failed     <- as.integer(get_val("raw_mvo", "n_failed"))
+
+      n_assets  <- attr(s, "n_assets")
+      train_win <- attr(s, "train_window")
+      n_per     <- attr(s, "n_periods")
+
+      fail_note <- if (!is.na(mvo_failed) && mvo_failed > 0L) {
+        paste0(
+          " (", mvo_failed, " window",
+          if (mvo_failed != 1L) "s" else "",
+          " with singular sample covariance, counted as failed)"
+        )
+      } else {
+        ""
+      }
+
+      paste0(
+        "Walk-forward weight-stability diagnostic across six portfolio construction ",
+        "methods on the 4-asset universe (SPY/TLT/GLD/DBC; p = ", n_assets,
+        ", T = ", n_per, " months, training window = ", train_win, " months). ",
+
+        "Raw MVO (plug-in tangency; sample Σ and μ, no regularisation) ",
+        "is the literature’s error maximiser: ",
+        "avg turnover = ", round(mvo_turnover, 3),
+        " vs GMV = ", round(gmv_turnover, 3),
+        ", Equal-Weight = ", round(ew_turnover, 3),
+        ", HRP = ", round(hrp_turnover, 3),
+        "; max |w| = ", round(mvo_maxw, 3),
+        " vs Equal-Weight = ", round(ew_maxw, 3),
+        "; OOS Sharpe = ", round(mvo_sharpe, 2), fail_note, ". ",
+
+        "Stable alternatives cluster rightward: ",
+        "GMV = ", round(gmv_sharpe, 2),
+        ", HRP = ", round(hrp_sharpe, 2),
+        ", Equal-Weight = ", round(ew_sharpe, 2),
+        "; expected-return regularisation: ",
+        "Shrunk-μ (James-Stein) = ", round(shrunk_sharpe, 2),
+        ", Black-Litterman (no views)† = ", round(bl_sharpe, 2), ". ",
+
+        "† Black-Litterman is shown at the no-views equilibrium prior ",
+        "(w_mkt = 1/p equal-weight, risk_aversion = 2.5), ",
+        "the #513 invariant; with no investor views the BL posterior mu-hat ",
+        "collapses to Pi = lambda*Sigma*w_mkt, so BL tangency weights ",
+        "are approximately equal-weight (by construction, not a bug). ",
+
+        "Source: ",
+        "[hd_weight_stability_diagnostic()](", gh_base,
+        "/packages/historicaldata/R/weight_stability.R#L130), ",
+        "[R/plan_weight_stability_vignette.R](", gh_base,
+        "/R/plan_weight_stability_vignette.R), issue #507."
+      )
+    })
+
+  )
+}

--- a/docs/_targets.R
+++ b/docs/_targets.R
@@ -151,6 +151,8 @@ source(here::here("R/plan_cross_asset_corr.R"))
 source(here::here("R/plan_cov_diagnostic.R"))
 # Phase 3b of #498: covariance diagnostic vignette targets (falsification.qmd section)
 source(here::here("R/plan_cov_diagnostic_vignette.R"))
+# Phase 4b of #507: weight-stability vignette targets (falsification.qmd #wstab section)
+source(here::here("R/plan_weight_stability_vignette.R"))
 # #482 Slice 1: strategy digest (leaderboard deltas + blastula email-to-file)
 source(here::here("R/plan_strategy_digest.R"))
 
@@ -217,6 +219,8 @@ c(plan_strategy_names(),
   plan_cov_diagnostic(),
   # Phase 3b of #498: vignette targets for falsification.qmd covariance section
   plan_cov_diagnostic_vignette(),
+  # Phase 4b of #507: weight-stability vignette targets for falsification.qmd #wstab
+  plan_weight_stability_vignette(),
 
   # Phase 1 of #149: date-type consistency across all registered datasets.
   # tar_target_raw + explicit deps so targets schedules dv_join_key_types

--- a/docs/falsification.qmd
+++ b/docs/falsification.qmd
@@ -469,6 +469,64 @@ The deployed strategy universes (4–6 assets) operate at p/n ≪ 0.1, where the
 **References:** Raviv (2026), *WIREs Computational Statistics*, [doi:10.1002/wics.70068](https://doi.org/10.1002/wics.70068). Full digest: [`knowledge/wiki/covariance-estimation-wide-data.md`](https://github.com/JohnGavin/historical/blob/main/knowledge/wiki/covariance-estimation-wide-data.md){target="_blank" rel="noopener noreferrer"}. Issue [#498](https://github.com/JohnGavin/historical/issues/498){target="_blank" rel="noopener noreferrer"}.
 
 
+# Weight-Stability Diagnostic (MVO breakdown) {#wstab}
+
+Does the choice of portfolio construction method affect weight stability and out-of-sample (OOS) performance? This section presents a walk-forward diagnostic on the 4-asset universe (SPY/TLT/GLD/DBC) comparing six methods: plug-in MVO, GMV, Shrunk-μ, Black-Litterman, Equal-Weight (1/N), and HRP. The central claim of the MVO-breakdown literature (Michaud 1989): plug-in mean-variance is an *error maximiser* — amplifying estimation noise in expected returns into high turnover, extreme weights, and poor OOS Sharpe. Regularised alternatives are more stable.
+
+## Row
+
+### {.tabset}
+
+#### OOS Diagnostic
+
+```{r}
+#| label: wstab-table
+wstab <- safe_tar_read("ws_diag_vig_table")
+wscap <- safe_tar_read("ws_diag_vig_caption")
+if (!is.null(wstab)) fals_dt(wstab, wscap)
+```
+
+#### OOS Sharpe
+
+```{r}
+#| label: wstab-plot
+#| fig-height: 6
+#| fig-width: 10
+#| fig-alt: "Cleveland dot plot of annualised OOS Sharpe ratio for six portfolio construction methods on the 4-asset universe (SPY/TLT/GLD/DBC). Raw MVO (plug-in tangency) has the lowest Sharpe and is coloured orange-red. GMV, HRP, Equal-Weight, Shrunk-mu, and Black-Litterman (no-views prior) cluster rightward, demonstrating that avoiding unconstrained expected-return estimation reduces OOS performance variance. A dashed vertical line marks Sharpe = 0."
+p <- safe_tar_read("ws_diag_vig_plot")
+if (!is.null(p)) p
+```
+
+`r { cap <- safe_tar_read("ws_diag_vig_caption"); if (!is.null(cap)) paste0("*", cap, "*") else "" }`
+
+#### How to Read This
+
+**What is tested:**
+
+A 60-month rolling walk-forward backtest estimates portfolio weights using each construction method from the training window (no look-ahead). The next-period (t+1) return is applied to the estimated weights — strictly no look-ahead per the `alpha-decay-min-t+1` rule. Six methods are compared:
+
+- **Raw MVO** — Plug-in tangency portfolio w ∝ Σ⁻¹μ using the *sample* covariance and *sample* mean. This is the article's error maximiser: small changes in μ produce large changes in w, especially when Σ is ill-conditioned. Fails (singular sample Σ) whenever the number of assets approaches the training window.
+- **GMV (Global Min-Var)** — `w ∝ Σ⁻¹1` via a regularised (Ledoit-Wolf) covariance. No expected-return input. Implemented in [`hd_min_var_weights()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/min_var_weights.R#L65){target="_blank" rel="noopener noreferrer"}.
+- **Shrunk-μ (James-Stein)** — Tangency portfolio using Bayes-Stein (Jorion 1986) shrinkage on μ toward the grand mean, with a regularised Σ. Implemented in [`hd_returns_shrink(method = "james_stein")`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/returns_shrink.R){target="_blank" rel="noopener noreferrer"}.
+- **Black-Litterman (no views)** — Tangency portfolio from the BL (1992) posterior μ̂ and Σ_BL using [`hd_black_litterman()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/black_litterman.R){target="_blank" rel="noopener noreferrer"}. Shown at the no-views equilibrium prior (P = NULL, w_mkt = 1/p, risk_aversion = 2.5). **Important:** with no investor views, the BL posterior collapses to Π = λΣw_mkt, so tangency weights are approximately equal-weight — this is the #513 invariant, not a bug (see caption).
+- **Equal-Weight (1/N)** — The robust benchmark. Zero turnover by construction.
+- **HRP (Hierarchical Risk Parity)** — Lopez de Prado (2016) hierarchical diversification using a regularised Σ. Implemented in [`hrp_weights()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/hrp_weights.R){target="_blank" rel="noopener noreferrer"}.
+
+**Metrics explained:**
+
+- **Avg Turnover** — Mean L₁ weight change between consecutive OOS windows: mean(‖w_t − w_{t−1}‖₁). Higher = more rebalancing cost. Equal-Weight = 0 by construction.
+- **Max |w|** — Mean across windows of the largest absolute weight. Equal-Weight → 1/p = 0.25 for 4 assets. Raw MVO → values often > 1 (short positions).
+- **OOS Sharpe** — Annualised Sharpe ratio of OOS portfolio returns (mean/sd × √12) over non-failed windows.
+- **Eff N** — Mean effective number of holdings (1/Σw_j²; Herfindahl measure). Equal-Weight → p = 4; concentrated raw MVO → near 1.
+- **Failed** — Windows where weight construction failed (e.g. singular sample Σ for raw MVO). Counted but excluded from all performance metrics.
+
+**Honest interpretation:**
+
+The diagnostic is designed to confirm, not discover. The Michaud (1989) error-maximiser result is well-established theory: raw MVO's turnover and concentration metrics should exceed those of stable alternatives on any reasonably short training window. The 4-asset universe (p = 4, n = 60 months) gives p/n = 0.07 — the sample covariance is well-conditioned here, so raw_mvo rarely fails; the instability is in the *μ* estimation channel, not Σ. That is why Shrunk-μ and BL (expected-return regularisers) show a different benefit than GMV (a Σ-only regulariser).
+
+**References:** Michaud, R. O. (1989). "The Markowitz optimization enigma: Is 'optimized' optimal?" *Financial Analysts Journal*, 45(1), 31–42. Jorion, P. (1986). "Bayes-Stein Estimation for Portfolio Analysis." *JFQA*, 21(3), 279–292. Black, F. & Litterman, R. (1992). "Global Portfolio Optimization." *FAJ*, 48(5), 28–43. Lopez de Prado, M. (2016). "Building diversified portfolios that outperform out-of-sample." *JPM*, 42(4), 59–69. Implemented in [`hd_weight_stability_diagnostic()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/weight_stability.R#L130){target="_blank" rel="noopener noreferrer"}. Issue [#507](https://github.com/JohnGavin/historical/issues/507){target="_blank" rel="noopener noreferrer"}.
+
+
 # Walk-Forward Correlation {#wfc}
 
 ## Row


### PR DESCRIPTION
## Summary

- **New file** `R/plan_weight_stability_vignette.R` — mirrors `R/plan_cov_diagnostic_vignette.R` (#503 template). Adds four targets: `ws_diag_raw` (calls `hd_weight_stability_diagnostic()` on `asset_monthly_returns_wide`, train_window = 60L), `ws_diag_vig_table` (Method / Avg Turnover / Max|w| / OOS Sharpe / Eff N / Failed), `ws_diag_vig_plot` (Cleveland dot plot of OOS Sharpe by method, dark theme), and `ws_diag_vig_caption` (dynamic caption with all numbers from `ws_diag_raw`)
- **`docs/_targets.R`** — `source()` + `plan_weight_stability_vignette()` registered immediately after the cov-diag equivalents (lines 155 and 223)
- **`docs/falsification.qmd`** — new `# Weight-Stability Diagnostic (MVO breakdown) {#wstab}` section inserted between `#covreg` and `#wfc`; three tabs: OOS Diagnostic (fals_dt table), OOS Sharpe (dot plot + inline caption), How to Read This (methodology + references)

## BL-no-views caveat (#513 invariant)

Black-Litterman is shown at the no-views equilibrium prior (`w_mkt = 1/p`, `risk_aversion = 2.5`). With no investor views the BL posterior collapses to `Π = λΣw_mkt`, making BL tangency weights approximately equal-weight by construction — not a bug. The caption and How-to-Read tab explain this explicitly.

## Parse checks (both passed in nix dev shell)

```
nix develop #default -- Rscript -e 'invisible(parse("R/plan_weight_stability_vignette.R")); cat("plan parse OK\n")'
# plan parse OK

nix develop #default -- Rscript -e 'invisible(parse("docs/_targets.R")); cat("targets parse OK\n")'
# targets parse OK
```

## Test plan

- [ ] Visual verification via deploy pipeline (`tar_make()` + quarto render) — deferred because targets store is not built in-agent
- [ ] Confirm `ws_diag_vig_table` rows ordered descending by OOS Sharpe (raw_mvo at bottom, best method at top)
- [ ] Confirm Cleveland dot plot renders dark background with raw_mvo in orange-red
- [ ] Confirm caption values are data-driven (no hardcoded numbers)
- [ ] Confirm BL row in table coincides with Equal-Weight row (expected; caption explains)
- [ ] Confirm new `#wstab` nav item appears in falsification dashboard between Covariance Regularisation and Walk-Forward Correlation

Dispatch-Id: 30fc7a0f
Agent-Type: fixer

🤖 Generated with [Claude Code](https://claude.com/claude-code)