### PR TITLE
refactor(dashboards): merge negative-results into falsification (#514 consolidation 3/3)

### DIFF
--- a/docs/DASHBOARDS.md
+++ b/docs/DASHBOARDS.md
@@ -7,8 +7,7 @@
 > updates the relevant row here, and every feature proposes at least one
 > consolidation against this list.
 
-**Current count: 12 standalone dashboards.** Consolidation target: **11** (see
-§ Consolidation Proposal). The causal-DAG is an embedded surface inside
+**Current count: 11 standalone dashboards.** Consolidation target reached. The causal-DAG is an embedded surface inside
 `falsification.qmd`, not a standalone dashboard.
 
 ## Inventory
@@ -17,7 +16,7 @@
 |---|---|---|---|
 | `index.qmd` | Portal + dataset catalogue | Headline stat block (tickers/rows/datasets/years/functions); 4 dataset cards; card grid → downstream dashboards | `hd_datasets()`, `hd_tickers()`, `hd_factors()` |
 | `leaderboard.qmd` | Rank all strategies by risk-adjusted return; central output | Ranking table (Sharpe/CAGR/MaxDD/CVaR95/Vol/SSR/Top5%/Credible); partition table; equity-curve plotly (range slider); monthly-returns heatmap; bootstrap-CI table; deflated-Sharpe table; alpha-decay; regime-adjusted Sharpe; Kelly table; structural-breaks dot plot; correlation matrix | `tar_read(leaderboard)`, `boot_ci_summary`, `structural_breaks_summary`, `strategy_correlation` |
-| `falsification.qmd` | Test causal integrity / robustness gauntlet | Scorecard (Verdict/HAC t/Sharpe/Alpha/R²); null-rejection heatmap (6 envs × strats); FF5+Mom alpha scatter; HAC t comparison; multiplicity K_eff table; WFC 2×2; **covariance regularisation table + conditioning/OOS dot plots (#498)**; causal DAG (Mermaid/D3, tabbed); implication tests; risk-architecture table | `fals_vig_*`, `wfc_all_summary`, `cov_diag_vig_table`, `cg_dag`, `cg_test_implications` |
+| `falsification.qmd` | Test causal integrity / robustness gauntlet + **Failed Strategies section (#514 merge 3/3)** | Scorecard (Verdict/HAC t/Sharpe/Alpha/R²); null-rejection heatmap (6 envs × strats); FF5+Mom alpha scatter; HAC t comparison; multiplicity K_eff table; WFC 2×2; **covariance regularisation table + conditioning/OOS dot plots (#498)**; causal DAG (Mermaid/D3, tabbed); implication tests; risk-architecture table; **failed-strategy filtered scorecard + pattern table + portfolio implications** | `fals_vig_*`, `wfc_all_summary`, `cov_diag_vig_table`, `cg_dag`, `cg_test_implications`, `fals_summary`, `fals_vig_names` |
 | `evidence.qmd` | Negative results + 155-yr pervasiveness | Failed-strategies scorecard; pattern-analysis table; negative-result cards; JST pervasiveness table (18 countries); equity-premium heatmap; crisis timeline; crisis-frequency table | `fals_summary`, `jst_equity_premium`, `jst_pervasiveness`, `jst_crises` |
 | ~~`factor-max.qmd`~~ | ~~MAX signal at factor level~~ | ~~Cumulative-return plotly (log); metrics table (IS/OOS/Full); factor-selection bar chart; MAX-signal heatmap; ETF comparison~~ | ~~`fm_cumret_plot`, `fm_metrics`, `fm_selection_freq`, `fm_heatmap`~~ **→ merged into `stock-backtest.qmd#factor-level-deep-dive` (#514 merge 2/3)** |
 | ~~`drif.qmd`~~ | ~~DRIF elastic-net signal at factor level~~ | ~~Cumulative-return plotly; metrics table (seal warning on Validation); selection-frequency table; DRIF-vs-MAX comparison; parameters table~~ | ~~`drif_cumret_plot`, `drif_metrics`, `drif_params`, `drif_selection_freq`, `drif_vs_max_plot`~~ **→ merged into `stock-backtest.qmd#factor-level-deep-dive` (#514 merge 2/3)** |
@@ -28,7 +27,7 @@
 | `macro-defense-rotation.qmd` | Macro hedge rotation (TLT/GLD/DBC/UUP vs SPY) | Normalised price chart; performance-metrics table (by partition); regime overlay; win-rate table; allocation table | `bt_prices`, inline backtest |
 | `momentum-prepeak.qmd` | Büsing (2022) pre-peak vs post-peak 12-2 momentum | Equity-curve comparison (pre/post/combined); summary metrics; bankruptcy-events table; signal-decomposition explanation | `mom_prepeak_*`, `mom_postpeak_returns`, `mom_combined_returns`, `strategy_names` |
 | `bdbb-sol.qmd` | M/G/∞ queueing model (Varma 2026) on SOL/USD | Data-coverage table; rolling-diagnostics table; regime-distribution bar chart; tail-risk predictivity table | `bdbb_sol_dv`, `bdbb_sol_fit`, `bdbb_sol_metrics` |
-| `negative-results.qmd` | Archive of failed strategies (detailed) | Failed-strategies scorecard; detailed failure cards; lessons-learned callouts; portfolio implications | `fals_summary` filtered Alpha t < 2.0 |
+| ~~`negative-results.qmd`~~ | ~~Archive of failed strategies (detailed)~~ | ~~Failed-strategies scorecard; detailed failure cards; lessons-learned callouts; portfolio implications~~ | ~~`fals_summary` filtered Alpha t < 2.0~~ **→ merged into `falsification.qmd#failed-strategies` (#514 merge 3/3)** |
 | `quiz.qmd` | Educational: real vs synthetic equity curves | Quiz interface (side-by-side plotly); difficulty badges; results card; explanation panels | `quiz_json`, quiz-logic.js |
 
 ## Overlap Clusters
@@ -36,7 +35,7 @@
 1. **Strategy performance** — `index` → `leaderboard` → `falsification`: ranking, equity curves, and verdicts that reference each other.
 2. ~~**Per-strategy deep dives** — `factor-max`, `drif`, `stock-backtest`, `macro-defense-rotation`, `momentum-prepeak`: all show definition + cumulative-return plotly + metrics table + signal analysis. `stock-backtest` already subsumes `factor-max`/`drif` as a 2×2.~~ Resolved: `factor-max` and `drif` merged into `stock-backtest.qmd#factor-level-deep-dive` (#514 merge 2/3).
 3. **Long-run evidence** — ~~`evidence` and `jst-dashboard` render the **same** JST pervasiveness table, heatmap, and crisis timeline.~~ Resolved: `jst-dashboard` merged into `evidence.qmd#historical-evidence` (#514 merge 1/3).
-4. **Robustness & falsification** — `leaderboard`, `falsification`, `negative-results`: overlapping robustness metrics; `negative-results` is a subset of the `falsification` scorecard.
+4. ~~**Robustness & falsification** — `leaderboard`, `falsification`, `negative-results`: overlapping robustness metrics; `negative-results` is a subset of the `falsification` scorecard.~~ Resolved: `negative-results` merged into `falsification.qmd#failed-strategies` (#514 merge 3/3).
 
 ## Consolidation Proposal (15 → 11)
 
@@ -44,10 +43,10 @@
 |---|---|---|---|
 | 1 | ~~**Merge `jst-dashboard` → `evidence`** (tabset)~~ **DONE** (#514 consolidation 1/3) | Identical JST outputs; no new information | All data kept; redirect stub replaces standalone page; `evidence.qmd#historical-evidence` is the new anchor |
 | 2 | ~~**Merge `factor-max` + `drif` → `stock-backtest`** (Factor-Level tabset)~~ **DONE** (#514 consolidation 2/3) | `stock-backtest` already shows the 2×2 (Stock/Factor × MAX/DRIF) | All data kept as Factor-Level Deep Dive tabset; redirect stubs replace standalone pages; index links to `stock-backtest#factor-level-deep-dive` |
-| 3 | **Merge `negative-results` → `falsification`** (final "Failed Strategies" tab) | `negative-results` copies the falsification scorecard + failure cards | Falsification becomes passing→failing narrative; redirect old page |
+| 3 | ~~**Merge `negative-results` → `falsification`** (final "Failed Strategies" tab)~~ **DONE** (#514 consolidation 3/3) | `negative-results` copies the falsification scorecard + failure cards; detail cards already in `evidence.qmd` | Filtered scorecard + patterns + implications in `falsification.qmd#failed-strategies`; per-strategy failure cards remain in `evidence.qmd#negative-results`; redirect stub replaces standalone page |
 | 4 | **Keep** `index`, `leaderboard`, `falsification`, `evidence`, `stock-backtest`, `macro-defense-rotation`, `momentum-prepeak`, `european-overlay`, `bdbb-sol`, `avoid-worst-days`, `quiz` | Distinct objective/audience each | — |
 
-**Resulting 11-dashboard architecture:** Portal (`index`) · Core (`leaderboard` → `falsification` → `evidence`) · Signals (`stock-backtest`) · Exploratory (`macro-defense-rotation`, `momentum-prepeak`, `european-overlay`, `bdbb-sol`, `avoid-worst-days`) · Interactive (`quiz`). Each merge is its own follow-up PR through the Phase 0 workflow.
+**Resulting 11-dashboard architecture (target reached, #514 consolidation complete):** Portal (`index`) · Core (`leaderboard` → `falsification` → `evidence`) · Signals (`stock-backtest`) · Exploratory (`macro-defense-rotation`, `momentum-prepeak`, `european-overlay`, `bdbb-sol`, `avoid-worst-days`) · Interactive (`quiz`).
 
 ## Template Recipe
 

--- a/docs/falsification.qmd
+++ b/docs/falsification.qmd
@@ -986,6 +986,88 @@ Issue [#269](https://github.com/JohnGavin/historical/issues/269).
 #### Related Vignettes
 
 - **[Strategy Leaderboard](leaderboard.html)** — displays the falsification scorecard verdicts alongside performance rankings; leaderboard surfaces what this page proves
-- **[Evidence & Context](evidence.html)** — catalogues strategies that failed the falsification gauntlet; companion document to this page's verdicts
+- **[Evidence & Context](evidence.html)** — per-strategy failure cards, lessons learned, and 155 years of equity premium across 18 countries; companion document to this page's verdicts
 - **[Momentum Pre-Peak](momentum-prepeak.html)** — the most recent gauntlet run; applies HAC, FF5, CPCV PBO, and Walk-Forward Correlation from this framework
+
+
+# Failed Strategies {#failed-strategies}
+
+Strategies that fail the falsification gauntlet (Alpha t < 2.0) reveal where market intuition breaks down. Their returns are explained by known factor exposure (beta) or statistical noise — not genuine alpha. Publication bias in finance means failed strategies are rarely documented; this section corrects that.
+
+## Row
+
+### {.tabset}
+
+#### Filtered Scorecard
+
+```{r}
+#| label: neg-scorecard-fals
+summary_tbl <- safe_tar_read("fals_summary")
+nms_tbl     <- safe_tar_read("fals_vig_names")
+if (!is.null(summary_tbl) && !is.null(nms_tbl)) {
+  neg <- summary_tbl |>
+    dplyr::filter(ff_alpha_tstat < 2.0) |>
+    dplyr::mutate(
+      Strategy   = nms_tbl$long_name[match(strategy, nms_tbl$code_name)],
+      `HAC t`    = round(hac_tstat, 2),
+      `Alpha t`  = round(ff_alpha_tstat, 2),
+      `R2 (%)`   = round(ff_r_squared * 100, 1),
+      `Alpha (%)` = round(ff_alpha_annual * 100, 0),
+      Diagnosis  = dplyr::case_when(
+        ff_r_squared > 0.50 ~ "Pure market beta",
+        ff_r_squared > 0.15 ~ "Significant factor exposure",
+        TRUE                ~ "Noise — neither alpha nor beta"
+      )
+    ) |>
+    dplyr::select(Strategy, `HAC t`, `Alpha t`, `R2 (%)`, `Alpha (%)`, Diagnosis) |>
+    dplyr::arrange(`Alpha t`)
+
+  hd_dt(neg, paste0(
+    nrow(neg), " of ", nrow(summary_tbl),
+    " strategies failed the falsification framework (Alpha t < 2.0). ",
+    "These strategies' returns are explained by known factor exposure or noise."
+  ))
+} else {
+  cat("*Falsification summary not yet built. Run `tar_make()`.*")
+}
+```
+
+#### Failure Patterns
+
+```{r}
+#| label: neg-pattern-fals
+summary_tbl <- safe_tar_read("fals_summary")
+nms_tbl     <- safe_tar_read("fals_vig_names")
+if (!is.null(summary_tbl) && !is.null(nms_tbl)) {
+  pattern <- summary_tbl |>
+    dplyr::mutate(
+      Strategy      = nms_tbl$long_name[match(strategy, nms_tbl$code_name)],
+      `Asset Class` = nms_tbl$asset_class[match(strategy, nms_tbl$code_name)],
+      Frequency     = nms_tbl$frequency[match(strategy, nms_tbl$code_name)],
+      `R2 (%)`      = round(ff_r_squared * 100, 1),
+      `Alpha t`     = round(ff_alpha_tstat, 2),
+      Verdict       = ifelse(ff_alpha_tstat > 2.0, "Alpha", "No alpha")
+    ) |>
+    dplyr::select(Strategy, `Asset Class`, Frequency, `R2 (%)`, `Alpha t`, Verdict) |>
+    dplyr::arrange(dplyr::desc(`Alpha t`))
+
+  hd_dt(pattern, paste0(
+    "All strategies sorted by Alpha t. ",
+    "The two overlay strategies (daily, VIX-based) both fail. ",
+    "The two factor strategies (monthly, momentum-based) both pass. ",
+    "Pattern: daily VIX-based overlays = beta; monthly factor rotation = alpha."
+  ))
+} else {
+  cat("*Falsification summary not yet built.*")
+}
+```
+
+#### Portfolio Implications
+
+1. **Do not include** Avoid Worst Days or Risk State Classification in the multi-strategy portfolio (see issue [#52](https://github.com/JohnGavin/historical/issues/52)).
+2. **VIX-based overlays** add cost and complexity without alpha — use passive SPY instead.
+3. **Factor rotation** ([DRIF](stock-backtest.html#factor-level-deep-dive), Factor MAX) is where the genuine alpha lives.
+4. **Cross-sectional momentum** (LTR) needs scaling before inclusion — promising but unconfirmed at production scale.
+
+For per-strategy failure cards and lessons learned, see [**Evidence & Context → Negative Results tab**](evidence.html#negative-results).
 

--- a/docs/negative-results.qmd
+++ b/docs/negative-results.qmd
@@ -1,206 +1,26 @@
 ---
 title: "Negative Results"
+subtitle: "Moved to Strategy Falsification"
 format:
   html:
-    embed-resources: false
     theme:
       dark: darkly
       light: cosmo
-    toc: true
-    toc-depth: 2
-    code-fold: true
-    include-in-header:
-      - text: |
-          <style>
-          body { font-size: 1.3em; }
-          caption, figcaption, .figure-caption { color: #fff !important; }
-          .negative-card {
-            background: #1a1a2e; border: 1px solid #d73027; border-radius: 8px;
-            padding: 16px; margin: 16px 0;
-          }
-          .negative-card h3 { color: #d73027; margin-top: 0; }
-          .lesson { background: #111; border-left: 4px solid #e6a817; padding: 12px 16px; margin: 12px 0; }
-          </style>
-          <script>
-          if (!localStorage.getItem('quarto-color-scheme'))
-            document.documentElement.setAttribute('data-bs-theme', 'dark');
-          </script>
+    embed-resources: false
 execute:
   echo: false
-  warning: false
-  message: false
 ---
 
-```{r}
-#| label: setup
-#| include: false
-library(targets)
-library(dplyr)
+> **This page has moved.**
+>
+> The failed-strategies scorecard, failure patterns, and portfolio implications
+> are now part of the [**Strategy Falsification**](falsification.html#failed-strategies)
+> vignette — select the **Failed Strategies** section.
+>
+> Per-strategy failure cards and lessons learned remain in
+> [**Evidence & Context → Negative Results tab**](evidence.html#negative-results).
 
-store_path <- if (dir.exists("_targets")) "_targets" else
-  file.path(here::here(), "docs/_targets")
-tar_config_set(store = store_path)
+Redirecting automatically…
 
-utils_path <- if (file.exists("vignette_utils.R")) "vignette_utils.R" else
-  file.path(here::here(), "docs/vignette_utils.R")
-source(utils_path)
-```
-
-## Why Document Negative Results?
-
-Negative results are as valuable as positive ones. A strategy that fails the falsification framework teaches us:
-
-- Which signals are **disguised beta** (market exposure dressed up as alpha)
-- Which intuitions about markets are **wrong** (or at least not tradeable)
-- Where the **boundary** lies between genuine alpha and noise
-
-Publication bias in finance means failed strategies are rarely documented. This page corrects that.
-
-## Failed Strategies
-
-```{r}
-#| label: neg-scorecard
-summary <- safe_tar_read("fals_summary")
-nms <- safe_tar_read("fals_vig_names")
-if (!is.null(summary) && !is.null(nms)) {
-  neg <- summary |>
-    filter(ff_alpha_tstat < 2.0) |>
-    mutate(
-      Strategy = nms$long_name[match(strategy, nms$code_name)],
-      `HAC t` = round(hac_tstat, 2),
-      `Alpha t` = round(ff_alpha_tstat, 2),
-      `R² (%)` = round(ff_r_squared * 100, 1),
-      `Alpha (%)` = round(ff_alpha_annual * 100, 0),
-      Diagnosis = case_when(
-        ff_r_squared > 0.50 ~ "Pure market beta",
-        ff_r_squared > 0.15 ~ "Significant factor exposure",
-        TRUE ~ "Noise — neither alpha nor beta"
-      )
-    ) |>
-    select(Strategy, `HAC t`, `Alpha t`, `R² (%)`, `Alpha (%)`, Diagnosis) |>
-    arrange(`Alpha t`)
-
-  hd_dt(neg, paste0(
-    nrow(neg), " of ", nrow(summary),
-    " strategies failed the falsification framework (Alpha t < 2.0). ",
-    "These strategies' returns are explained by known factor exposure or noise."
-  ))
-}
-```
-
-## Avoid Worst Days (VIX Protection) {#avoid-worst}
-
-::: {.negative-card}
-### Verdict: Pure market beta (R² = 41%)
-
-**What it does:** Exit to cash when yesterday's <abbr title="CBOE Volatility Index — implied volatility of S&P 500 options">VIX</abbr> > 30 or yesterday's absolute return > 3%. Re-enter when VIX < 25 and 5-day cooloff expires. All signals use t-1 (previous day) values.
-
-**Why it fails:**
-
-- The strategy is essentially a crude vol-timing filter on SPY
-- When VIX is high, you're out of the market — but so is the VIX signal embedded in the market itself
-- The 41% R² means the strategy's returns are 41% explained by Mkt-RF (market factor alone)
-- Alpha = -1% per year: the strategy **destroys** value relative to just holding the market
-- The t+1 execution constraint is critical: the pre-fix version (using same-day VIX) showed 18.4% CAGR; honest t+1 execution drops it to 5.3%
-
-**Key lesson:** VIX is not a leading indicator — it's a concurrent indicator. By the time VIX > 30, the worst days have already happened.
-:::
-
-::: {.lesson}
-**What we learned:** Any strategy that triggers on elevated VIX is timing exits AFTER the crash, not before it. The worst days and best days cluster together (median 5 calendar days apart). You cannot avoid one without missing the other. See the [temporal clustering analysis](avoid-worst-days.html).
-:::
-
-## Risk State Classification (VIX Overlay) {#risk-state}
-
-::: {.negative-card}
-### Verdict: Pure market beta (R² = 88%)
-
-**What it does:** Three-signal design: VVIX (vol-of-vol) as early warning, VIX term structure 5-day change, VIX term structure level. Market-specific percentile thresholds from training data only. Overlay on SPY: reduce exposure when signals are elevated.
-
-**Why it fails:**
-
-- 88% R² — this is almost entirely market beta
-- Alpha = -1% per year (negative): the overlay HURTS performance
-- Despite using VVIX (which IS an early warning — it rises before VIX spikes), the signal doesn't translate into tradeable alpha
-- The 5-day change in term structure adds noise, not signal
-- Percentile thresholds from training data don't generalise: crisis regimes are structurally different from calm regimes
-
-**Key lesson:** Adding more VIX-derived signals doesn't help. VVIX, term structure, and VIX level are all highly correlated. Three correlated signals ≈ one signal with more noise.
-:::
-
-::: {.lesson}
-**What we learned:** Implied volatility signals (VIX, VVIX, term structure) are priced in. The market already incorporates this information. A strategy based on these signals is, by construction, replicating what the market already does — hence the 88% R² with the market factor.
-:::
-
-## LTR Cross-Sectional Momentum (Borderline) {#ltr}
-
-::: {.negative-card}
-### Verdict: Borderline (Alpha t = 1.99, R² = 7%)
-
-**What it does:** XGBoost LambdaMART ranks ~500 US stocks monthly using 21 momentum/volatility features. Long top decile, short bottom decile.
-
-**Why it's borderline:**
-
-- Alpha t = 1.99 — just below the 2.0 threshold
-- R² = 7% — low factor exposure, which is good
-- Alpha = 166% per year — suspiciously high
-- The demo uses ~51 stocks (not the full US universe) which inflates returns
-- Walk-forward from 2005 with annual retraining — but limited out-of-sample validation
-
-**Key lesson:** The signal may be genuine but the implementation is too small-scale to confirm. Needs: full US universe (3000+ stocks), transaction costs for monthly L/S rebalancing, and multi-market replication.
-:::
-
-::: {.lesson}
-**What we learned:** Cross-sectional momentum is well-documented academically. Our implementation is a proof-of-concept, not a production signal. The 166% annual alpha is an artifact of the small universe, not evidence of a genuine edge.
-:::
-
-## Pattern: What Predicts Failure?
-
-```{r}
-#| label: neg-pattern
-if (!is.null(summary) && !is.null(nms)) {
-  pattern <- summary |>
-    mutate(
-      Strategy = nms$long_name[match(strategy, nms$code_name)],
-      `Asset Class` = nms$asset_class[match(strategy, nms$code_name)],
-      `Frequency` = nms$frequency[match(strategy, nms$code_name)],
-      `R² (%)` = round(ff_r_squared * 100, 1),
-      `Alpha t` = round(ff_alpha_tstat, 2),
-      Verdict = ifelse(ff_alpha_tstat > 2.0, "Alpha", "No alpha")
-    ) |>
-    select(Strategy, `Asset Class`, Frequency, `R² (%)`, `Alpha t`, Verdict) |>
-    arrange(desc(`Alpha t`))
-
-  hd_dt(pattern, paste0(
-    "All 5 strategies sorted by Alpha t. ",
-    "The two overlay strategies (daily, VIX-based) both fail. ",
-    "The two factor strategies (monthly, momentum-based) both pass. ",
-    "Pattern: daily VIX-based overlays = beta; monthly factor rotation = alpha."
-  ))
-}
-```
-
-## Implications for Portfolio Construction
-
-1. **Do not include** Avoid Worst Days or Risk State in the multi-strategy portfolio (#52)
-2. **VIX-based overlays** add cost and complexity without alpha — use passive SPY instead
-3. **Factor rotation** (<abbr title="Dynamic Rotation Into Factors — selects best-performing FF factor each month">DRIF</abbr>, Factor MAX) is where the genuine alpha lives
-4. **Cross-sectional momentum** (LTR) needs scaling before inclusion — promising but unconfirmed at production scale
-
-## References
-
-- Full falsification methodology: [Strategy Falsification](falsification.html)
-- Avoid Worst Days analysis: [avoid-worst-days.html](avoid-worst-days.html)
-- Strategy leaderboard: [leaderboard.html](leaderboard.html)
-- Harvey, Liu & Zhu (2016). "...and the Cross-Section of Expected Returns"
-
-## Related Vignettes
-
-- **[Strategy Falsification](falsification.html)** — the full statistical framework that produced these negative results: HAC t-stats, null rejection rates, and FF5 alpha
-- **[Strategy Leaderboard](leaderboard.html)** — ranks the strategies that passed falsification alongside those catalogued here as failures
-
-```{r}
-#| label: build-info
-#| results: asis
-build_info()
-```
+<meta http-equiv="refresh" content="0; url=falsification.html#failed-strategies">
+<script>window.location.href = "falsification.html#failed-strategies";</script>


### PR DESCRIPTION
## Summary

- Added `# Failed Strategies {#failed-strategies}` section to `docs/falsification.qmd`: filtered scorecard (Alpha t < 2.0), failure patterns table, portfolio implications. Reuses existing pipeline targets `fals_summary` + `fals_vig_names` — no new targets introduced.
- Replaced `docs/negative-results.qmd` body with a `<meta http-equiv="refresh">` + JS redirect stub → `falsification.html#failed-strategies` (mirrors jst-dashboard.qmd pattern). File retained, not deleted.
- Updated `docs/DASHBOARDS.md`: count 12 → 11 (consolidation target reached), `negative-results` row struck through, consolidation row #3 marked DONE, overlap cluster #4 marked Resolved.

## Dedup vs evidence.qmd

`evidence.qmd` already contains all of `negative-results.qmd`'s content (identical code, same targets, same per-strategy failure cards). The new section in `falsification.qmd` adds only the compact dashboard view (filtered scorecard + patterns + implications) and cross-references `evidence.html#negative-results` for the per-strategy detail. Nothing is triplicated.

## Redirect approach

`negative-results.qmd` follows the `jst-dashboard.qmd` stub pattern: prose fallback + `<meta http-equiv="refresh">` + JS redirect. Remaining links in `bdbb-sol.qmd` and `evidence.qmd` to `negative-results.html` continue to work through the redirect.

## DASHBOARDS count: 11 (target reached — #514 consolidation complete)

Portal (`index`) · Core (`leaderboard` → `falsification` → `evidence`) · Signals (`stock-backtest`) · Exploratory (`macro-defense-rotation`, `momentum-prepeak`, `european-overlay`, `bdbb-sol`, `avoid-worst-days`) · Interactive (`quiz`)

## Test plan

- [ ] `docs/falsification.qmd`: YAML intact, 54 fences (even), `#wstab` and covariance block at lines 472/400 — untouched
- [ ] `docs/negative-results.qmd`: redirect stub only (no R chunks, no targets)
- [ ] `git grep -n "negative-results" -- docs/` clean — all remaining references intentional (DASHBOARDS notes, redirect stub itself, evidence.qmd/bdbb-sol.qmd redirect targets)
- [ ] Visual verify: `falsification.html#failed-strategies` nav tab loads, `negative-results.html` redirects — deferred to deploy (no built _targets store)

🤖 Generated with [Claude Code](https://claude.com/claude-code)