### PR TITLE
docs(links): repoint internal links to consolidated dashboards (#514 follow-up)

### DIFF
--- a/.github/workflows/link-audit.yml
+++ b/.github/workflows/link-audit.yml
@@ -79,13 +79,10 @@ jobs:
             'https://johngavin.github.io/historical/' \
             'https://johngavin.github.io/historical/leaderboard.html' \
             'https://johngavin.github.io/historical/falsification.html' \
-            'https://johngavin.github.io/historical/factor-max.html' \
-            'https://johngavin.github.io/historical/drif.html' \
             'https://johngavin.github.io/historical/stock-backtest.html' \
             'https://johngavin.github.io/historical/avoid-worst-days.html' \
             'https://johngavin.github.io/historical/macro-defense-rotation.html' \
-            'https://johngavin.github.io/historical/jst-dashboard.html' \
-            'https://johngavin.github.io/historical/negative-results.html' \
+            'https://johngavin.github.io/historical/evidence.html' \
             'https://johngavin.github.io/historical/quiz.html' \
             'https://johngavin.github.io/historical/european-overlay.html'
 

--- a/docs/bdbb-sol.qmd
+++ b/docs/bdbb-sol.qmd
@@ -77,5 +77,5 @@ knitr::kable(
 ## Related vignettes
 
 - **[Falsification](falsification.html)** — statistical testing framework applied to all systematic strategies; the same hypothesis-testing approach used to evaluate the BDBB diagnostics
-- **[Negative Results](negative-results.html)** — documents approaches that failed empirical scrutiny; the BDBB mean-reversion findings sit alongside these investigations
+- **[Negative Results](falsification.html#failed-strategies)** — documents approaches that failed empirical scrutiny; the BDBB mean-reversion findings sit alongside these investigations
 - **[Strategy Leaderboard](leaderboard.html)** — performance comparison across all strategies; provides context for the SOL/USD queueing model relative to other systematic approaches

--- a/docs/evidence.qmd
+++ b/docs/evidence.qmd
@@ -450,5 +450,5 @@ build_info()
 
 - **[Falsification](falsification.html)** — applies formal hypothesis testing to each strategy's conditional independence claims; the long-run JST evidence is a key input to those priors
 - **[Strategy Leaderboard](leaderboard.html)** — ranks all strategies on risk-adjusted return; the equity premium evidence here contextualises what "good" looks like across 100+ years
-- **[Factor MAX](factor-max.html)** — applies cross-sectional factor rotation to the same academic factors whose long-run premia are documented in the JST data
-- **[Negative Results](negative-results.html)** — strategies that failed to survive empirical scrutiny; the historical evidence framework here explains why they were rejected
+- **[Factor MAX](stock-backtest.html#factor-level-deep-dive)** — applies cross-sectional factor rotation to the same academic factors whose long-run premia are documented in the JST data
+- **[Negative Results](falsification.html#failed-strategies)** — strategies that failed to survive empirical scrutiny; the historical evidence framework here explains why they were rejected

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -201,8 +201,8 @@ Each strategy links to its full definition, implementation, and backtest:
 
 | Strategy | Level | Signal | Definition |
 |----------|-------|--------|------------|
-| [Factor MAX](factor-max.html) | Factor (5 FF) | Max daily return in prior month | Ranks factors by single-day extreme |
-| [Factor <abbr title="Dynamic Rotation Into Factors — selects best-performing FF factor each month">DRIF</abbr>](drif.html) | Factor (5 FF) | Elastic net on 42 daily return features | Full daily return distribution |
+| [Factor MAX](stock-backtest.html#factor-level-deep-dive) | Factor (5 FF) | Max daily return in prior month | Ranks factors by single-day extreme |
+| [Factor <abbr title="Dynamic Rotation Into Factors — selects best-performing FF factor each month">DRIF</abbr>](stock-backtest.html#factor-level-deep-dive) | Factor (5 FF) | Elastic net on 42 daily return features | Full daily return distribution |
 | [Stock MAX](stock-backtest.html#stock-max) | Stock (660) | Max daily return, D1-D10 decile spread | Cross-sectional stock sorting |
 | [Stock DRIF](stock-backtest.html#stock-drif) | Stock (660) | Elastic net, D1-D10 decile spread | Pooled cross-sectional elastic net |
 | [XGB DRIF](stock-backtest.html#stock-drif) | Stock (660) | XGBoost monotonic on 42 features | Non-linear signal with monotonic constraints |
@@ -694,7 +694,7 @@ if (!is.null(params)) {
 
 - **[Strategy Falsification](falsification.html)** — provides the statistical survival verdict (HAC t-stat, null rejection rate, FF5 alpha) underlying the leaderboard scorecard
 - **[Stock Backtest](stock-backtest.html)** — per-asset equity-level view of Factor MAX and DRIF strategies ranked here
-- **[Factor MAX](factor-max.html)** — detailed breakdown of the top-ranked factor rotation strategy
+- **[Factor MAX](stock-backtest.html#factor-level-deep-dive)** — detailed breakdown of the top-ranked factor rotation strategy
 
 #### Build Info
 

--- a/docs/momentum-prepeak.qmd
+++ b/docs/momentum-prepeak.qmd
@@ -1151,7 +1151,7 @@ This vignette was developed with assistance from Anthropic's Claude (model: Opus
 
 - **[Strategy Falsification](falsification.html)** — the full gauntlet framework (HAC, FF5, null environments, Walk-Forward Correlation) that the momentum pre-peak strategy runs through
 - **[Strategy Leaderboard](leaderboard.html)** — ranks momentum pre-peak alongside all other strategies on risk-adjusted return and falsification scorecard
-- **[Factor MAX](factor-max.html)** — factor-level momentum rotation strategy; shares the momentum family with pre-peak decomposition
+- **[Factor MAX](stock-backtest.html#factor-level-deep-dive)** — factor-level momentum rotation strategy; shares the momentum family with pre-peak decomposition
 
 ## Row
 


### PR DESCRIPTION
## Summary

- Repoints all internal `.qmd` source links from the four retired dashboard pages to their new canonical locations
- Updates `link-audit.yml` to audit the new canonical pages, deduplicating where the canonical is already listed

## Link Mapping

| Old page | New canonical |
|---|---|
| `factor-max.html` | `stock-backtest.html#factor-level-deep-dive` |
| `drif.html` | `stock-backtest.html#factor-level-deep-dive` |
| `jst-dashboard.html` | `evidence.html#historical-evidence` |
| `negative-results.html` | `falsification.html#failed-strategies` |

## Files Touched

- `docs/bdbb-sol.qmd` — 1 link repointed (`negative-results` → `falsification#failed-strategies`)
- `docs/evidence.qmd` — 2 links repointed (`factor-max` → `stock-backtest#...`, `negative-results` → `falsification#...`)
- `docs/leaderboard.qmd` — 3 links repointed (`factor-max` ×2, `drif` → `stock-backtest#factor-level-deep-dive`)
- `docs/momentum-prepeak.qmd` — 1 link repointed (`factor-max` → `stock-backtest#factor-level-deep-dive`)
- `.github/workflows/link-audit.yml` — removed `factor-max.html` + `drif.html` (dupes of existing `stock-backtest.html`); replaced `jst-dashboard.html` with `evidence.html`; removed `negative-results.html` (dupe of existing `falsification.html`)

## Intentionally Excluded

- Redirect stub `.qmd` files (`docs/jst-dashboard.qmd`, `docs/factor-max.qmd`, `docs/drif.qmd`, `docs/negative-results.qmd`) — their redirect targets must stay pointing at the new canonical pages
- `docs/DASHBOARDS.md` — struck-through historical rows intentionally name the old pages
- All `.html` build artifacts — will be regenerated on next Quarto render

## Grep-Clean Confirmation

After all edits, `git grep -nE "factor-max\.html|drif\.html|jst-dashboard\.html|negative-results\.html" -- docs/ .github/` returns only occurrences in `.html` build artifacts (no `.qmd` sources, no workflow yml). Zero occurrences in editable source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)