### PR TITLE
fix(bdbb-sol): guard targets-store path (#530)

### DIFF
--- a/docs/bdbb-sol.qmd
+++ b/docs/bdbb-sol.qmd
@@ -10,7 +10,9 @@ date: "`r Sys.Date()`"
 library(targets)
 library(dplyr)
 library(ggplot2)
-tar_config_set(store = here::here("docs/_targets"))
+store_path <- if (dir.exists("_targets")) "_targets" else
+  file.path(here::here(), "docs/_targets")
+tar_config_set(store = store_path)
 ```
 
 ## Overview


### PR DESCRIPTION
## Summary

- `docs/bdbb-sol.qmd` failed to render because the setup chunk called `tar_config_set(store = here::here("docs/_targets"))`. Under Quarto's `docs/` execute-dir, `here::here()` resolves to the project root, so the store path became `<root>/docs/docs/_targets` — doubled — and `tar_read()` aborted with "targets data store not found".
- Fix: copy the working two-line guard from `docs/falsification.qmd:85-87` (same pattern in `docs/leaderboard.qmd:29-31`): check `dir.exists("_targets")` first (TRUE when Quarto renders from `docs/`), fall back to `file.path(here::here(), "docs/_targets")` for `tar_make()` at the project root.
- Render + deploy of `bdbb-sol.html` is handled by the orchestrator post-merge.

## Test plan

- [ ] Confirm diff is limited to the two-line store-path guard in `docs/bdbb-sol.qmd`
- [ ] Confirm the new guard matches `docs/falsification.qmd:85-87` idiom exactly
- [ ] Orchestrator renders `docs/bdbb-sol.qmd` post-merge and verifies `tar_read(bdbb_sol_dv)` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
