### PR TITLE
fix(metadata): derive expected trading days from observed calendar (#569)

### DIFF
--- a/scripts/fetch_metadata.py
+++ b/scripts/fetch_metadata.py
@@ -30,7 +30,12 @@ _scripts_dir = str(Path(__file__).parent)
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
 
-from metadata_helpers import _yield_fields, first_present  # noqa: E402
+from metadata_helpers import (  # noqa: E402
+    _expected_trading_days,
+    _missing_pct,
+    _yield_fields,
+    first_present,
+)
 
 # US equity tickers
 # SYNC NOTE: when fetch_equity.py DEFAULT_TICKERS changes, update this list too.
@@ -149,7 +154,18 @@ def fetch_yahoo_info(yahoo_sym: str) -> dict:
 
 
 def compute_data_stats(ticker: str, dataset: str, data_dir: Path) -> dict:
-    """Compute start_date, end_date, total_obs, missing_pct from existing Parquet."""
+    """Compute start_date, end_date, total_obs, missing_pct from existing Parquet.
+
+    missing_pct means: "of the dates on which some ticker in this dataset has
+    an observation between this ticker's own start and end date, what
+    fraction is this ticker missing?" It is a data-derived proxy for the true
+    exchange trading calendar (see _expected_trading_days() in
+    metadata_helpers.py, historical#569), not a fixed 252/365 ratio.
+
+    LIMITATION: for a single-ticker dataset, missing_pct is 0 for every
+    ticker by construction (there is no other ticker's calendar to compare
+    against) — see _expected_trading_days() docstring.
+    """
     file_map = {
         "equity_daily": "yfinance_equity.parquet",
         "crypto_daily": "crypto_all.parquet",
@@ -158,6 +174,8 @@ def compute_data_stats(ticker: str, dataset: str, data_dir: Path) -> dict:
     if not fpath.exists():
         return {}
 
+    # Empty parquet (0 rows total) falls through to the len(sub) == 0 check
+    # below via an empty `sub`, same as a missing/unmatched ticker.
     df = pq.read_table(fpath, columns=["date", "ticker", "volume"]).to_pandas()
     sub = df[df["ticker"] == ticker]
     if len(sub) == 0:
@@ -166,21 +184,16 @@ def compute_data_stats(ticker: str, dataset: str, data_dir: Path) -> dict:
     start = sub["date"].min()
     end = sub["date"].max()
     total = len(sub)
+    days_span = (end - start).days  # may be 0 for a single-observation ticker
 
-    # Expected trading days (approximate: 252/year for equity, 365 for crypto)
-    days_span = (end - start).days
-    if dataset == "crypto_daily":
-        expected = days_span  # crypto trades every day
-    else:
-        expected = int(days_span * 252 / 365)  # approximate trading days
-
-    missing_pct = round(100 * (1 - total / max(expected, 1)), 1) if expected > 0 else 0.0
+    expected = _expected_trading_days(dataset, df["date"], start, end, days_span)
+    missing_pct = _missing_pct(total, expected)
 
     return {
         "start_date": start,
         "end_date": end,
         "total_obs": total,
-        "missing_pct": max(missing_pct, 0.0),
+        "missing_pct": missing_pct,
     }
 
 

--- a/scripts/metadata_helpers.py
+++ b/scripts/metadata_helpers.py
@@ -32,3 +32,49 @@ def _yield_fields(info: dict) -> dict:
         yield_type = "synthetic" if raw_yield > 0.20 else "reported"
         return {"yield_pct": raw_yield, "yield_type": yield_type}
     return {"yield_pct": None, "yield_type": None}
+
+
+def _expected_trading_days(dataset: str, all_dates, start, end, days_span: int) -> int:
+    """Estimate the number of expected trading days for one ticker's date range.
+
+    Historical#569: replaces the old fixed 252/365 ratio, which was a
+    hand-entered approximation feeding the published `missing_pct` metadata
+    field, with a calendar derived from the data itself.
+
+    - ``crypto_daily``: every calendar day counts, so ``days_span`` is
+      returned directly. Crypto genuinely trades daily, but this still
+      assumes no exchange/data-source outages.
+    - every other dataset: the number of *distinct* dates in ``all_dates``
+      (the date column of the FULL dataset, across every ticker — not just
+      this ticker) that fall within ``[start, end]``. Using the dataset's own
+      observed calendar as the trading-day estimate is more accurate than a
+      fixed ratio because it reflects the actual exchange holidays/outages
+      present in this data vintage, and it is directly verifiable (it comes
+      from data, not an assumption).
+
+      LIMITATION: for a single-ticker dataset, ``all_dates`` reduces to
+      exactly this ticker's own dates, so the returned count equals the
+      ticker's own observation count and ``missing_pct`` is 0 by
+      construction — the union-calendar approach cannot detect gaps for the
+      only ticker present in the dataset.
+
+    Raises nothing itself; if ``all_dates`` entries are not comparable to
+    ``start``/``end`` (e.g. wrong type), the comparison raises naturally
+    rather than silently falling back to any ratio-based estimate.
+    """
+    if dataset == "crypto_daily":
+        return days_span
+    return len({d for d in all_dates if start <= d <= end})
+
+
+def _missing_pct(total: int, expected: int) -> float:
+    """Percent of expected observations missing, floored at 0.0.
+
+    ``expected <= 0`` (e.g. a zero-length calendar, or a zero-day span with
+    no other ticker contributing a date) is treated as "cannot estimate" and
+    returns 0.0 rather than dividing by zero or reporting a nonsensical
+    negative/inf value.
+    """
+    if expected <= 0:
+        return 0.0
+    return max(round(100 * (1 - total / expected), 1), 0.0)

--- a/tests/test_fetch_metadata.py
+++ b/tests/test_fetch_metadata.py
@@ -1,12 +1,17 @@
-"""Regression tests for fetch_metadata._yield_fields().
+"""Regression tests for fetch_metadata._yield_fields() and related helpers.
 
 Covers the trailingAnnualDividendYield = 0.0 edge case (historical#233):
 truthiness checks (`if yield_value:`) treat 0.0 as absent; the fix requires
 `is not None` so that a genuine zero trailing yield is preserved and tagged
 correctly as "trailing" rather than falling through to the raw `yield` field.
+
+Also covers _expected_trading_days() / _missing_pct() (historical#569): the
+old missing_pct calculation used a hand-entered 252/365 ratio to approximate
+trading days; the fix derives the expected calendar from the dataset itself.
 """
 
 import sys
+from datetime import date
 from pathlib import Path
 
 # Allow running from repo root or from tests/
@@ -15,7 +20,7 @@ from pathlib import Path
 # effect that lives at the top level of fetch_metadata.py.
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from metadata_helpers import _yield_fields
+from metadata_helpers import _expected_trading_days, _missing_pct, _yield_fields
 
 
 class TestYieldFields:
@@ -89,3 +94,92 @@ class TestYieldFields:
         })
         assert result["yield_pct"] == 0.03
         assert result["yield_type"] == "reported"
+
+
+class TestExpectedTradingDays:
+    """Regression tests for _expected_trading_days() (historical#569).
+
+    Replaces the old hand-entered 252/365 ratio with a calendar derived from
+    the dataset's own observed dates.
+    """
+
+    def test_multi_ticker_uses_union_calendar(self):
+        """Expected days = distinct dates across ALL tickers within [start, end].
+
+        Ticker A trades Jan 2-4; ticker B additionally trades Jan 5. The
+        union calendar for the window Jan2-Jan5 is 4 distinct days, even
+        though any single ticker only contributes 3 observations.
+        """
+        all_dates = [
+            date(2024, 1, 2), date(2024, 1, 3), date(2024, 1, 4),  # ticker A
+            date(2024, 1, 2), date(2024, 1, 3), date(2024, 1, 4), date(2024, 1, 5),  # ticker B
+        ]
+        result = _expected_trading_days(
+            "equity_daily", all_dates, date(2024, 1, 2), date(2024, 1, 5), days_span=3
+        )
+        assert result == 4
+
+    def test_single_ticker_dataset_equals_own_dates(self):
+        """LIMITATION: with only one ticker in the dataset, the union calendar
+        reduces to that ticker's own dates, so missing_pct is 0 by
+        construction — a real gap (Jan 4 missing here) is invisible.
+        """
+        own_dates = [date(2024, 1, 2), date(2024, 1, 3), date(2024, 1, 5)]  # gap on Jan 4
+        result = _expected_trading_days(
+            "equity_daily", own_dates, date(2024, 1, 2), date(2024, 1, 5), days_span=3
+        )
+        assert result == len(own_dates) == 3
+
+    def test_empty_calendar_returns_zero(self):
+        """No dates at all (e.g. empty dataset) yields an expected count of 0."""
+        result = _expected_trading_days(
+            "equity_daily", [], date(2024, 1, 2), date(2024, 1, 5), days_span=3
+        )
+        assert result == 0
+
+    def test_zero_span_single_observation(self):
+        """A single-observation ticker (start == end, days_span == 0) still
+        counts its own date within the window."""
+        all_dates = [date(2024, 1, 2)]
+        result = _expected_trading_days(
+            "equity_daily", all_dates, date(2024, 1, 2), date(2024, 1, 2), days_span=0
+        )
+        assert result == 1
+
+    def test_crypto_branch_uses_days_span_ignoring_calendar(self):
+        """Crypto trades every calendar day: expected == days_span regardless
+        of what all_dates contains (deliberately mismatched here)."""
+        result = _expected_trading_days(
+            "crypto_daily", [], date(2024, 1, 1), date(2024, 1, 11), days_span=10
+        )
+        assert result == 10
+
+    def test_crypto_zero_span_returns_zero(self):
+        """Crypto with a zero-day span returns 0 (single observation)."""
+        result = _expected_trading_days(
+            "crypto_daily", [], date(2024, 1, 2), date(2024, 1, 2), days_span=0
+        )
+        assert result == 0
+
+
+class TestMissingPct:
+    """Regression tests for _missing_pct() (historical#569)."""
+
+    def test_normal_case(self):
+        assert _missing_pct(total=18, expected=20) == 10.0
+
+    def test_no_missing_days(self):
+        assert _missing_pct(total=20, expected=20) == 0.0
+
+    def test_zero_expected_returns_zero_not_error(self):
+        """expected <= 0 (e.g. zero-length calendar) must not raise
+        ZeroDivisionError; it is treated as 'cannot estimate' → 0.0."""
+        assert _missing_pct(total=5, expected=0) == 0.0
+
+    def test_negative_expected_returns_zero(self):
+        assert _missing_pct(total=5, expected=-1) == 0.0
+
+    def test_floors_at_zero_when_total_exceeds_expected(self):
+        """A ticker cannot have negative missing_pct even if its own total
+        exceeds the union-calendar expected count (e.g. duplicate rows)."""
+        assert _missing_pct(total=25, expected=20) == 0.0


### PR DESCRIPTION
## Summary

Fixes the P1 finding in [#569](https://github.com/JohnGavin/historical/issues/569): `scripts/fetch_metadata.py:175` used a hand-entered `int(days_span * 252 / 365)` ratio to approximate trading days, driving the published `missing_pct` coverage metadata. The observed exchange calendar is available in the same dataframe, so the ratio is replaced with a data-derived calendar.

- For non-crypto datasets, `expected` is now the count of **distinct dates on which any ticker in the dataset has an observation**, restricted to this ticker's own `[start, end]` window — a verifiable, data-derived proxy for the exchange trading calendar rather than a fixed assumption.
- Crypto branch is unchanged (`expected = days_span`) — crypto genuinely trades daily; comment now notes this still assumes no exchange/data-source outages.
- New `_expected_trading_days()` / `_missing_pct()` helpers added to `scripts/metadata_helpers.py`, kept pure-stdlib (consistent with the existing `_yield_fields()` pattern) so they're testable without pandas/pyarrow/yfinance.
- No silent fallback: the old ratio no longer exists as a backstop, so any calendar-derivation problem (e.g. bad column type) surfaces as a natural exception rather than being masked.

## What `missing_pct` means now

"Of the dates on which some ticker in this dataset has an observation between this ticker's own start and end date, what fraction is this ticker missing?"

**Limitation (documented in both docstrings):** for a single-ticker dataset, the union calendar reduces to exactly that ticker's own dates, so `missing_pct` is 0 by construction — it cannot detect gaps for the only ticker present in the dataset. This is inherent to any within-dataset comparison and is called out explicitly rather than silently accepted.

## Edge cases covered (19 unit tests + integration smoke test)

| Case | Handling |
|---|---|
| Multi-ticker, some missing days | Union calendar counts each date once; verified `missing_pct` matches expected fraction |
| Single-ticker dataset | Documented limitation — `missing_pct == 0` by construction |
| Empty/missing parquet file | Falls through existing `fpath.exists()` / `len(sub) == 0` guards → `{}` |
| Zero-day span (single observation) | `days_span == 0`; equity branch still counts the ticker's own date; crypto branch returns 0 → `missing_pct == 0.0` |
| Crypto branch | Uses `days_span` directly, ignores the calendar entirely (verified deliberately mismatched calendar data has no effect) |
| `expected <= 0` | `_missing_pct()` returns 0.0 rather than raising `ZeroDivisionError` |
| `total > expected` (e.g. duplicate rows) | Floored at 0.0, never negative |

## Test plan

- [x] `python3 -m pytest tests/test_fetch_metadata.py -v` inside `nix develop` — **19 passed**
- [x] Integration smoke test exercising `compute_data_stats()` end-to-end against real parquet files (multi-ticker gap detection, missing ticker, missing file, crypto gap detection via days_span, single-observation ticker) — all assertions passed
- [x] `python3 -m py_compile` on all three changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)