### PR TITLE
fix(falsification): compute true running peak instead of final value (#569)

### DIFF
--- a/R/plan_falsification.R
+++ b/R/plan_falsification.R
@@ -1164,11 +1164,19 @@ plan_falsification <- function() {
                       max_dd_duration_days = NA_integer_,
                       avg_dd_duration_obs  = NA_real_,
                       n_drawdowns = NA_integer_,
-                      recovery_days = NA_integer_))
+                      recovery_days = NA_integer_,
+                      peak_value = NA_real_))
         }
         cum  <- cumprod(1 + ret)
         peak <- cummax(cum)
         dd   <- (cum - peak) / peak
+
+        # True running high-water mark of the equity curve (start_value = 1).
+        # peak is non-decreasing, so its final element is the overall max —
+        # equivalent to max(cum). This replaces the prior approximation that
+        # set peak_value == final_value (wrong for any strategy in a
+        # drawdown at the end of the sample; #569).
+        peak_value <- peak[length(peak)]
 
         max_dd <- min(dd, na.rm = TRUE)
 
@@ -1199,7 +1207,8 @@ plan_falsification <- function() {
           max_dd_duration_obs  = max_dd_duration,
           avg_dd_duration_obs  = avg_dd_duration,
           n_drawdowns          = as.integer(n_drawdowns),
-          recovery_obs         = recovery_obs
+          recovery_obs         = recovery_obs,
+          peak_value           = peak_value
         )
       }
 
@@ -1214,6 +1223,7 @@ plan_falsification <- function() {
           return(list(
             start_date = NA, end_date = NA, duration_days = NA_integer_,
             exposure_time_pct = NA_real_, total_return_pct = NA_real_,
+            peak_value = NA_real_,
             cagr = NA_real_, vol = NA_real_, sharpe_naive = NA_real_,
             sortino = NA_real_, calmar = NA_real_,
             correlation_benchmark = NA_real_,
@@ -1335,6 +1345,7 @@ plan_falsification <- function() {
           duration_days         = duration_days,
           exposure_time_pct     = exposure_time_pct,
           total_return_pct      = total_return_pct,
+          peak_value            = dd_list$peak_value,
           cagr                  = cagr,
           vol                   = vol,
           sharpe_naive          = sharpe_naive,
@@ -1523,9 +1534,11 @@ plan_falsification <- function() {
       rows$final_value <- vapply(metrics_list, function(m) {
         1 + m$total_return_pct / 100
       }, double(1L))
-      rows$peak_value <- vapply(metrics_list, function(m) {
-        1 + m$total_return_pct / 100  # approximate
-      }, double(1L))
+      # True running high-water mark of the equity curve (start_value = 1),
+      # computed from the return series in compute_drawdowns(). Fixes #569:
+      # peak_value was previously set equal to final_value, which understates
+      # the true peak for any strategy in a drawdown at the end of the sample.
+      rows$peak_value <- vapply(metrics_list, function(m) m$peak_value, double(1L))
       rows$exposure_adj_return <- rows$cagr  # fully invested = cagr
       rows$n_drawdowns_per_year <- vapply(seq_along(metrics_list), function(i) {
         nd <- metrics_list[[i]]$n_drawdowns

--- a/tests/testthat/test-falsification-peak-value.R
+++ b/tests/testthat/test-falsification-peak-value.R
@@ -1,0 +1,122 @@
+testthat::local_edition(3)
+
+# Regression tests for #569: peak_value was set equal to final_value in
+# R/plan_falsification.R's fals_results_db target, which understates the
+# true historical high-water mark for any strategy in a drawdown at the end
+# of the sample.
+#
+# The fix computes peak_value from the return series inside the local
+# compute_drawdowns() closure (peak <- cummax(cumprod(1 + ret)); the last
+# element of peak is the overall running maximum, i.e. max(cum)).
+#
+# compute_drawdowns() is an inline closure defined inside a tar_target()
+# body (R/plan_falsification.R), not an exported function. Following the
+# pattern used in test-plan-factormax.R, we reproduce the fixed logic here
+# to regression-test the guarantee.
+
+# ── Helper: compute_drawdowns (extracted from plan_falsification.R,
+#    fals_results_db target, post-#569 fix) ─────────────────────────────
+
+compute_drawdowns_extracted <- function(ret) {
+  ret <- ret[!is.na(ret)]
+  if (length(ret) == 0L) {
+    return(list(max_dd = NA_real_, avg_dd = NA_real_,
+                max_dd_duration_days = NA_integer_,
+                avg_dd_duration_obs  = NA_real_,
+                n_drawdowns = NA_integer_,
+                recovery_days = NA_integer_,
+                peak_value = NA_real_))
+  }
+  cum  <- cumprod(1 + ret)
+  peak <- cummax(cum)
+  dd   <- (cum - peak) / peak
+
+  peak_value <- peak[length(peak)]
+
+  max_dd <- min(dd, na.rm = TRUE)
+
+  in_dd  <- dd < -0.01
+  rle_dd  <- rle(in_dd)
+  dd_runs <- rle_dd$lengths[rle_dd$values]
+  n_drawdowns <- length(dd_runs)
+  avg_dd <- if (any(in_dd)) mean(dd[in_dd], na.rm = TRUE) else NA_real_
+
+  max_dd_duration <- if (n_drawdowns > 0L) as.integer(max(dd_runs)) else NA_integer_
+  avg_dd_duration <- if (n_drawdowns > 0L) mean(dd_runs) else NA_real_
+
+  trough_idx <- which.min(dd)
+  recovery_obs <- NA_integer_
+  if (!is.na(trough_idx) && trough_idx < length(dd)) {
+    post_trough <- dd[(trough_idx + 1L):length(dd)]
+    rec_rel <- which(post_trough >= -0.001)[1L]
+    if (!is.na(rec_rel)) recovery_obs <- as.integer(rec_rel)
+  }
+
+  list(
+    max_dd               = max_dd,
+    avg_dd               = avg_dd,
+    max_dd_duration_obs  = max_dd_duration,
+    avg_dd_duration_obs  = avg_dd_duration,
+    n_drawdowns          = as.integer(n_drawdowns),
+    recovery_obs         = recovery_obs,
+    peak_value           = peak_value
+  )
+}
+
+# ── F1: peak_value differs from final_value when the curve peaked and
+#    then declined before the end of the sample (the bug this fixes) ─────
+
+test_that("peak_value: exceeds final_value for a strategy in a drawdown at period end (regression #569)", {
+  # Equity rises 20%, then gives back half of it, ending in a drawdown.
+  ret <- c(0.05, 0.05, 0.05, 0.05, -0.03, -0.03, -0.03, -0.03, -0.02, -0.02)
+  dd <- compute_drawdowns_extracted(ret)
+
+  final_value <- prod(1 + ret)
+  expect_gt(dd$peak_value, final_value)
+
+  # The buggy code set peak_value <- final_value exactly. Confirm the fixed
+  # value is materially different (not just floating point noise).
+  expect_gt(dd$peak_value - final_value, 1e-6)
+})
+
+# ── F2: peak_value equals final_value when the curve never draws down
+#    (monotonically increasing equity — the one case where the old
+#    approximation was accidentally correct) ──────────────────────────
+
+test_that("peak_value: equals final_value for a monotonically increasing equity curve", {
+  ret <- rep(0.01, 10L)
+  dd <- compute_drawdowns_extracted(ret)
+
+  final_value <- prod(1 + ret)
+  expect_equal(dd$peak_value, final_value, tolerance = 1e-10)
+})
+
+# ── F3: peak_value is always >= final_value (running high-water mark is
+#    never below the final value; property test across random series) ───
+
+test_that("peak_value: is always >= final_value (running max property)", {
+  set.seed(569)
+  for (i in 1:20) {
+    ret <- rnorm(50, mean = 0, sd = 0.02)
+    dd <- compute_drawdowns_extracted(ret)
+    final_value <- prod(1 + ret)
+    expect_gte(dd$peak_value, final_value - 1e-10)
+  }
+})
+
+# ── F4: peak_value matches an independently computed max(cummax(cumprod)) ─
+
+test_that("peak_value: matches max(cummax(cumprod(1 + ret))) independently", {
+  ret <- c(0.02, -0.01, 0.03, -0.05, 0.01, 0.04, -0.02, 0.01, -0.03, 0.02)
+  dd <- compute_drawdowns_extracted(ret)
+
+  expected <- max(cummax(cumprod(1 + ret)))
+  expect_equal(dd$peak_value, expected, tolerance = 1e-10)
+})
+
+# ── F5: empty return series yields NA peak_value (consumers must tolerate) ─
+
+test_that("peak_value: NA for empty return series", {
+  dd <- compute_drawdowns_extracted(numeric(0))
+  expect_true(is.na(dd$peak_value))
+})


### PR DESCRIPTION
Closes the `peak_value` P1 from [#569](https://github.com/JohnGavin/historical/issues/569) (cross-project audit [JohnGavin/llm#792](https://github.com/JohnGavin/llm/issues/792)).

## Problem

`R/plan_falsification.R:1526-1528` set `peak_value` to exactly `final_value`:

```r
rows$peak_value <- vapply(metrics_list, function(m) {
  1 + m$total_return_pct / 100  # approximate
}, double(1L))
```

Identical to the `final_value` computation three lines above. Correct only for a strategy that ends at its all-time high; wrong for **any strategy in a drawdown at the end of the sample**, which is the common case. Every drawdown-adjacent metric derived from `peak_value` was distorted accordingly.

## Fix

The audit expected this might be unfixable in place — if only scalar summaries were available, the honest fix would have been `NA_real_`, matching `up_capture` / `down_capture` / `turnover_annual` immediately below.

It turned out better than that: `compute_drawdowns()` **already** computes the running high-water mark as a `cummax` of the equity curve. The true peak was there and simply not threaded through. It is now returned alongside the other drawdown outputs and consumed directly.

Both early-return branches of `compute_drawdowns()` and the short-series guard return `peak_value = NA_real_`, so the honest-NA pattern still holds where the curve genuinely isn't available.

## Verification

Run via `nix develop` against the project flake (no R on the plain PATH; this project uses `flake.nix`, not `default.nix`):

| Check | Result |
|---|---|
| `parse("_targets.R")` | OK |
| `parse("R/plan_falsification.R")` | OK |
| `test-falsification-peak-value.R` | `[ FAIL 0 \| WARN 0 \| SKIP 0 \| PASS 25 ]` |
| Full root suite, changed tree | `[ FAIL 3 \| WARN 7 \| SKIP 41 \| PASS 771 ]` |
| Full root suite, **baseline** | `[ FAIL 3 \| WARN 7 \| SKIP 41 \| PASS 746 ]` |

The three failures are **pre-existing and unrelated** — `test-crypto-momentum.R:51`, `test-qa-summary-deps.R:196`, `test-stock-backtest.R:161` — and are present in a baseline run of a tree with no R changes. The `+25` delta is exactly the new test file.

Worth stating plainly: **there were no falsification tests before this change.** A filtered run looks reassuring but proves nothing, which is why the full suite plus an explicit baseline is quoted above.

## Note for reviewers

`scripts/` and root `R/` are outside the `packages/historicaldata/**` path filter, so **this PR gets no CI**. The local verification above is the only gate. That gap is itself tracked in #569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
