### PR TITLE
Wire R/plan_liquidity.R into root pipeline (#569)

### DIFF
--- a/R/liquidity.R
+++ b/R/liquidity.R
@@ -87,7 +87,11 @@ liquidity_summary <- function(df) {
 
 #' Calculate realized turnover for a strategy
 #'
-#' Compares actual position changes to assumed 80% monthly turnover
+#' Compares actual position changes to assumed 80% monthly turnover.
+#'
+#' NOT wired into any targets pipeline (#569). The `assumed_turnover = 0.80`
+#' constant below is itself under review in #567 — do not wire this function
+#' in until that issue resolves the constant, to avoid a collision.
 #'
 #' @param positions Tibble with columns: date, ticker, weight (target weights)
 #' @return Monthly turnover summary

--- a/R/plan_liquidity.R
+++ b/R/plan_liquidity.R
@@ -1,57 +1,54 @@
 # Liquidity metrics targets
 # Addresses gap from #105: volume data not used for liquidity analysis
+#
+# Wired into the root pipeline (#569): consolidated_equity (_targets.R) carries
+# date, close, volume, ticker — the schema calculate_adv() expects.
+#
+# calculate_turnover() (R/liquidity.R) is intentionally NOT wired here. It
+# compares realized turnover to a hardcoded 0.80 assumption that is itself
+# under review in #567 — wiring it in this PR would collide with that fix.
 
-library(targets)
-library(dplyr)
+plan_liquidity <- function() {
+  list(
+    # === Liquidity metrics for equity data ===
+    targets::tar_target(
+      equity_with_adv,
+      {
+        consolidated_equity |>
+          calculate_adv(window_days = 20)
+      }
+    ),
 
-list(
-  # === Liquidity metrics for equity data ===
-  tar_target(
-    equity_with_adv,
-    {
-      # Load consolidated equity (assumes this exists from main pipeline)
-      # For now, use placeholder - will integrate with actual consolidated_equity
-      consolidated_equity |>
-        calculate_adv(window_days = 20)
-    }
-  ),
+    targets::tar_target(
+      equity_liquidity_filtered,
+      {
+        equity_with_adv |>
+          filter_liquidity(min_adv_usd = 1e6, filter_mode = "warn")
+      }
+    ),
 
-  tar_target(
-    equity_liquidity_filtered,
-    {
-      equity_with_adv |>
-        filter_liquidity(min_adv_usd = 1e6, filter_mode = "warn")
-    }
-  ),
+    targets::tar_target(
+      liquidity_summary_tbl,
+      {
+        equity_liquidity_filtered |>
+          liquidity_summary()
+      }
+    ),
 
-  tar_target(
-    liquidity_summary_table,
-    {
-      equity_liquidity_filtered |>
-        liquidity_summary() |>
-        DT::datatable(
-          caption = "Liquidity Summary by Ticker",
-          options = list(pageLength = 20),
-          rownames = FALSE
-        ) |>
-        DT::formatRound(columns = c("median_volume", "median_adv_usd"), digits = 0) |>
-        DT::formatRound(columns = c("median_price", "pct_illiquid"), digits = 2)
-    }
-  ),
-
-  # === Volume statistics for vignettes ===
-  tar_target(
-    volume_stats,
-    {
-      equity_with_adv |>
-        dplyr::summarise(
-          total_tickers = dplyr::n_distinct(ticker),
-          total_observations = dplyr::n(),
-          median_adv_all = median(adv_usd, na.rm = TRUE),
-          pct_liquid = 100 * mean(liquidity_flag == "liquid", na.rm = TRUE),
-          pct_illiquid = 100 * mean(liquidity_flag == "illiquid", na.rm = TRUE),
-          min_adv_threshold = 1e6
-        )
-    }
+    # === Volume statistics for vignettes ===
+    targets::tar_target(
+      volume_stats,
+      {
+        equity_liquidity_filtered |>
+          dplyr::summarise(
+            total_tickers = dplyr::n_distinct(ticker),
+            total_observations = dplyr::n(),
+            median_adv_all = median(adv_usd, na.rm = TRUE),
+            pct_liquid = 100 * mean(liquidity_flag == "liquid", na.rm = TRUE),
+            pct_illiquid = 100 * mean(liquidity_flag == "illiquid", na.rm = TRUE),
+            min_adv_threshold = 1e6
+          )
+      }
+    )
   )
-)
+}

--- a/_targets.R
+++ b/_targets.R
@@ -26,6 +26,8 @@ tar_source("R/consolidate.R")
 tar_source("R/validate_macro.R")
 tar_source("R/validate_factors.R")
 tar_source("R/plan_qa_gates.R")
+tar_source("R/liquidity.R")
+tar_source("R/plan_liquidity.R")
 
 list(
   # === QA GATES (run first — abort on look-ahead bias or other violations) ===
@@ -54,6 +56,9 @@ list(
   tar_target(equity_clean, clean_equity(equity_api_valid, equity_static_valid)),
 
   tar_target(consolidated_equity, consolidate_parquet(equity_clean, "equity")),
+
+  # === LIQUIDITY (ADV / illiquidity filtering on consolidated_equity, #569) ===
+  plan_liquidity(),
 
   # === CRYPTO (14 tokens from Yahoo + BTC backfill for cross-ref) ===
   tar_target(crypto_api_file,    "tmp_crypto_api.parquet",    format = "file"),

--- a/tests/testthat/test-liquidity.R
+++ b/tests/testthat/test-liquidity.R
@@ -1,0 +1,116 @@
+testthat::local_edition(3)
+source(here::here("R/liquidity.R"))
+
+# ── calculate_adv() ───────────────────────────────────────────────────────
+
+test_that("calculate_adv computes correct rolling dollar-volume mean", {
+  df <- tibble::tibble(
+    ticker = rep("AAA", 5),
+    date = as.Date("2024-01-01") + 0:4,
+    close = rep(10, 5),
+    volume = rep(1e6, 5)
+  )
+  result <- calculate_adv(df, window_days = 3)
+
+  # window_days = 3 -> .before = 2, .complete = TRUE: first 2 rows have no
+  # complete window and must be NA; from row 3 onward dollar_volume is
+  # constant (10 * 1e6 = 1e7) so the rolling mean is also 1e7.
+  expect_equal(result$adv_usd, c(NA_real_, NA_real_, 1e7, 1e7, 1e7))
+  # dollar_volume is an intermediate column and must not leak into the output
+  expect_false("dollar_volume" %in% names(result))
+})
+
+test_that("calculate_adv computes each ticker's rolling window independently", {
+  df <- tibble::tibble(
+    ticker = c(rep("AAA", 3), rep("BBB", 3)),
+    date = rep(as.Date("2024-01-01") + 0:2, 2),
+    close = c(10, 10, 10, 100, 100, 100),
+    volume = c(1e6, 1e6, 1e6, 1e6, 1e6, 1e6)
+  )
+  result <- calculate_adv(df, window_days = 3)
+
+  aaa_last <- result$adv_usd[result$ticker == "AAA"][3]
+  bbb_last <- result$adv_usd[result$ticker == "BBB"][3]
+  expect_equal(aaa_last, 1e7)
+  expect_equal(bbb_last, 1e8)
+})
+
+test_that("calculate_adv returns all NA when window_days exceeds available history (edge case)", {
+  df <- tibble::tibble(
+    ticker = rep("AAA", 2),
+    date = as.Date("2024-01-01") + 0:1,
+    close = c(10, 10),
+    volume = c(1e6, 1e6)
+  )
+  result <- calculate_adv(df, window_days = 5)
+  expect_true(all(is.na(result$adv_usd)))
+  expect_length(result$adv_usd, 2L)
+})
+
+# ── filter_liquidity() ────────────────────────────────────────────────────
+
+test_that("filter_liquidity flags liquid/illiquid/insufficient_data correctly (warn mode)", {
+  df <- tibble::tibble(
+    ticker = c("AAA", "AAA", "BBB"),
+    adv_usd = c(NA_real_, 5e6, 1e5)
+  )
+  expect_warning(
+    result <- filter_liquidity(df, min_adv_usd = 1e6, filter_mode = "warn"),
+    "illiquid"
+  )
+  expect_equal(result$liquidity_flag, c("insufficient_data", "liquid", "illiquid"))
+  # warn mode never drops rows
+  expect_equal(nrow(result), 3L)
+})
+
+test_that("filter_liquidity removes illiquid rows in remove mode", {
+  df <- tibble::tibble(
+    ticker = c("AAA", "AAA", "BBB"),
+    adv_usd = c(NA_real_, 5e6, 1e5)
+  )
+  result <- suppressWarnings(filter_liquidity(df, min_adv_usd = 1e6, filter_mode = "remove"))
+  expect_equal(nrow(result), 1L)
+  expect_equal(result$ticker, "AAA")
+  expect_false("illiquid" %in% result$liquidity_flag)
+})
+
+test_that("filter_liquidity aborts with an informative error when adv_usd is missing", {
+  expect_snapshot(
+    error = TRUE,
+    filter_liquidity(tibble::tibble(ticker = "AAA"))
+  )
+})
+
+# ── liquidity_summary() ───────────────────────────────────────────────────
+
+test_that("liquidity_summary computes correct per-ticker medians and orders by median_adv_usd desc", {
+  df <- tibble::tibble(
+    ticker = c("AAA", "AAA", "BBB", "BBB"),
+    volume = c(100, 200, 10, 20),
+    close = c(10, 12, 5, 6),
+    adv_usd = c(1000, 1200, 50, 60),
+    liquidity_flag = c("liquid", "liquid", "illiquid", "illiquid")
+  )
+  result <- liquidity_summary(df)
+
+  # AAA has the higher median_adv_usd (1100 vs 55) -> arrange(desc()) puts it first
+  expect_equal(result$ticker, c("AAA", "BBB"))
+  expect_equal(result$n_obs, c(2L, 2L))
+
+  aaa <- result[result$ticker == "AAA", ]
+  expect_equal(aaa$median_volume, 150)
+  expect_equal(aaa$median_price, 11)
+  expect_equal(aaa$median_adv_usd, 1100)
+  expect_equal(aaa$pct_illiquid, 0)
+
+  bbb <- result[result$ticker == "BBB", ]
+  expect_equal(bbb$pct_illiquid, 100)
+})
+
+# ── API stability ──────────────────────────────────────────────────────────
+
+test_that("liquidity function signatures are stable (catches API drift)", {
+  expect_snapshot(args(calculate_adv))
+  expect_snapshot(args(filter_liquidity))
+  expect_snapshot(args(liquidity_summary))
+})


### PR DESCRIPTION
## Summary

- Fixes #569. `R/plan_liquidity.R` was dead code — referenced by neither `_targets.R` nor `docs/_targets.R` — so `R/liquidity.R`'s functions had no callers.
- Converts `plan_liquidity.R` from a bare top-level `list(...)` to the project's plan-function pattern: `plan_liquidity <- function() { list(...) }`, matching how `plan_qa_gates()` is spliced into root `_targets.R`.
- Removes `library(targets)`/`library(dplyr)` from the sourced file; uses `targets::tar_target()` and `dplyr::` prefixes throughout (namespace-discipline rule).
- Deletes the stale placeholder comment — `consolidated_equity` is now wired directly.
- **DT violation fixed:** `liquidity_summary_table` renamed to `liquidity_summary_tbl` and now returns the plain summary `data.frame` instead of a `DT::datatable()` widget (table targets must not embed Nix store paths into the target store; presentation belongs in a vignette/dashboard chunk).
- **Bug fix while wiring:** `volume_stats` originally piped `equity_with_adv` into a `summarise()` that referenced `liquidity_flag` — a column only added by `filter_liquidity()`, i.e. present on `equity_liquidity_filtered`, not on `equity_with_adv`. This would have errored at `tar_make()` time. Changed the upstream dependency to `equity_liquidity_filtered` so the target is actually correct once wired.
- Wired in: `tar_source("R/liquidity.R")` + `tar_source("R/plan_liquidity.R")` added to root `_targets.R`; `plan_liquidity()` spliced into the top-level list immediately after `consolidated_equity`, which supplies the `date, close, volume, ticker` schema `calculate_adv()` expects.
- **Intentionally NOT wired:** `calculate_turnover()` (`R/liquidity.R:88-119`) hardcodes the same `assumed_turnover = 0.80` it purports to measure against — that constant is owned by #567. Left unwired with a comment pointing at #567; did not touch the 0.80 value.

## New targets in root `_targets.R`

`equity_with_adv`, `equity_liquidity_filtered`, `liquidity_summary_tbl`, `volume_stats` (all confirmed present via `tar_manifest()`).

## Tests

Added `tests/testthat/test-liquidity.R` — hand-built fixtures with known answers for `calculate_adv()` (including an NA/short-window edge case where `window_days` exceeds available history), `filter_liquidity()` (both `warn` and `remove` modes), and `liquidity_summary()`. Includes error-message and function-signature snapshots per `snapshot-test-policy`.

## Verification

- `parse("_targets.R")` — **PARSE OK**
- `targets::tar_manifest()` — 36 targets total, including the 4 new liquidity targets, DAG well-formed
- `testthat::test_dir('tests/testthat', filter='liquidity')` — all liquidity tests pass (2 snapshot tests skip under plain `Rscript`, same as every other snapshot test in the suite without `NOT_CRAN` set — confirmed identical behavior on `test-utils_rolling.R` as a baseline check)
- Full root suite `testthat::test_dir('tests/testthat')` — **765 passed, 3 failed, 4 warnings, 43 skipped**. The 3 failures are exactly the pre-existing baseline (`test-crypto-momentum.R:51`, `test-qa-summary-deps.R:196`, `test-stock-backtest.R:161`) — unrelated to this change. No fourth failure introduced.

## Test plan

- [x] `parse("_targets.R")` succeeds
- [x] `tar_manifest()` shows the 4 new liquidity targets with no DAG errors
- [x] Liquidity-filtered test run passes
- [x] Full root test suite shows unchanged pre-existing failure set (3/3, no new failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)