### PR TITLE
chore(scripts): add verify.sh single-entry-point verification tool (#569)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,3 +5,18 @@
 **API doc regen:** when `packages/historicaldata/R/*` exports change, run `scripts/regen_api_context.sh` before committing. The deployed link from `docs/index.qmd` → `docs/api-historicaldata.md` depends on it. The "functions" stat on the landing page is counted dynamically from `kind: function` lines in that file.
 
 **Automation (issue #438):** A project-local Stop hook (`.claude/hooks/pkgctx_regen_on_stop.sh`) runs automatically at session end. If `packages/historicaldata/R/` was touched during the session it invokes `scripts/regen_api_context.sh`; otherwise it exits silently. The hook is fail-open — a regen failure prints a warning but never blocks the session. A CI check (`.github/workflows/pkgctx-check.yml`) catches any stale doc on PRs that touch `packages/historicaldata/R/` or `docs/api-historicaldata.md`.
+
+## Verifying a change (issue #569)
+
+**Run `scripts/verify.sh` — it is the one command to run before claiming a change is verified.** `scripts/verify.sh --quick` does a fast parse-only check; plain `scripts/verify.sh` runs the full suite. Do not hand-roll a verification sequence — every fact below was learned the slow way by agents that got it wrong.
+
+| Fact | Detail |
+|------|--------|
+| Build system | This project uses **`flake.nix`**, not `default.nix`. Most global tooling assumes `default.nix` — it does not apply here. |
+| Getting R | There is **no R on the bare PATH** (`$IN_NIX_SHELL` is unset in a normal session). Always `nix develop <repo-root> --command Rscript -e '...'`. |
+| Shell entry cost | **Warm ~13s. Cold build 10+ minutes** (compiles dozens of R packages). Run verification in the background and wait for it — do not sit blocked on a cold build, and do not report "waiting on the build" as a result. |
+| Root test suite | `testthat::test_local()` **fails at repo root** (`Could not find a root 'DESCRIPTION' file`) — the package lives at `packages/historicaldata/`. Use `testthat::test_dir("tests/testthat")` for the root suite instead. |
+| Root suite baseline | **3 pre-existing failures** as of 2026-07-19: `test-crypto-momentum.R:51`, `test-qa-summary-deps.R:196`, `test-stock-backtest.R:161`. Not regressions — an agent unaware of this will misread them as its own breakage. `scripts/verify.sh` compares against this baseline by exact signature and only fails on a *different* set. |
+| Snapshot tests need `NOT_CRAN=true` | Plain `Rscript -e 'testthat::test_dir(...)'` leaves `NOT_CRAN` **unset**, so every `skip_on_cran()`-gated test — including this repo's mandated snapshot tests (`snapshot-test-policy` rule: error messages, captions, function signatures, target schemas) — is silently skipped and never executed. Confirmed empirically 2026-07-19 on the unmodified root suite: `NOT_CRAN` unset → `failed=3 skipped=41 passed=746`; `NOT_CRAN=true` → `failed=3 skipped=0 passed=800` (same 3 baseline failures either way). `scripts/verify.sh` sets `NOT_CRAN=true` before running either suite and prints the SKIP count in its summary. |
+| Pipeline check | `parse("_targets.R")` MUST succeed before every commit (global rule). `scripts/verify.sh` runs this first, always. |
+| CI coverage gap | `r-tests`/`pkgctx` CI only fire on `packages/historicaldata/**`. Changes to root `R/`, `scripts/`, and `tests/` get **no CI at all** — local `scripts/verify.sh` is the only gate for those paths. |

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# scripts/verify.sh — single entry point to verify a change to this repo.
+#
+# This project uses flake.nix (NOT default.nix) and has no R on the bare
+# PATH. This script wraps everything in `nix develop --command` so it works
+# the same for a human or an agent, and runs (full mode) with NOT_CRAN=true
+# set — WITHOUT it, testthat silently skips every skip_on_cran()-gated test,
+# which includes this repo's mandated snapshot tests:
+#   1. parse("_targets.R")                                  (always)
+#   2. root testthat suite  (tests/testthat/)                (full mode only)
+#   3. package testthat suite (packages/historicaldata/)      (full mode only)
+#
+# Both suites carry a small number of known pre-existing failures (see the
+# BASELINE_* arrays below, issue #569) that predate this script and are NOT
+# regressions. verify.sh exits 0 only if a suite's failing-test signatures
+# are EXACTLY its baseline set — any addition, removal, or substitution is
+# treated as a change worth a human's attention. A NEW failure that testthat
+# reports as snapshot-related is called out as [NEW-SNAPSHOT] rather than
+# [NEW] — it means a snapshot is missing or stale, not that behaviour
+# regressed. SKIP counts are always printed alongside PASS/FAIL; a jump in
+# SKIP without a code change is itself a signal worth investigating.
+#
+# Usage:
+#   scripts/verify.sh            # full verification (can take a few minutes)
+#   scripts/verify.sh --quick    # parse-only, fast pre-commit check
+#
+# Exit codes:
+#   0  verified: parse OK, both suites' failures == their baseline exactly
+#   1  verification RAN and found a problem (new/missing failure, parse error)
+#   2  verification did NOT run at all (nix develop / Rscript unavailable or
+#      crashed) — this is NOT a pass, never treat it as one
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Known pre-existing failures in the ROOT testthat suite (tests/testthat/),
+# confirmed 2026-07-19 (issue #569). These predate this script and are
+# tracked here deliberately so an agent doesn't misread them as its own
+# regression. Format: one line per failure, "<file>::<test description>".
+# Do NOT add an entry here to silence a new failure; fix it, or get explicit
+# sign-off and update this list on purpose.
+# ---------------------------------------------------------------------------
+BASELINE_ROOT_FAILURES=(
+  "test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds"
+  "test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files"
+  "test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)"
+)
+
+# ---------------------------------------------------------------------------
+# Known pre-existing failures in the packages/historicaldata testthat suite,
+# confirmed 2026-07-19 (issue #569). Same rules as BASELINE_ROOT_FAILURES.
+# ---------------------------------------------------------------------------
+BASELINE_PKG_FAILURES=(
+  "test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%"
+)
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+QUICK=0
+if [[ "${1:-}" == "--quick" ]]; then
+  QUICK=1
+fi
+
+echo "=== scripts/verify.sh ==="
+echo "Repo root: $REPO_ROOT"
+if [[ "$QUICK" -eq 1 ]]; then
+  echo "Mode: --quick (parse only)"
+else
+  echo "Mode: full (parse + root suite + package suite)"
+fi
+echo ""
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+R_OUT="$WORK_DIR/r_out.txt"
+
+if [[ "$QUICK" -eq 1 ]]; then
+  R_SCRIPT='
+    parse_ok <- tryCatch({
+      parse(file.path("_targets.R"))
+      TRUE
+    }, error = function(e) {
+      message("PARSE_ERROR: ", conditionMessage(e))
+      FALSE
+    })
+    if (!isTRUE(parse_ok)) quit(status = 1, save = "no")
+    cat("::VERIFY:PARSE_OK::\n")
+  '
+else
+  R_SCRIPT='
+    pkg_path <- file.path("packages", "historicaldata")
+
+    parse_ok <- tryCatch({
+      parse(file.path("_targets.R"))
+      TRUE
+    }, error = function(e) {
+      message("PARSE_ERROR: ", conditionMessage(e))
+      FALSE
+    })
+    if (!isTRUE(parse_ok)) quit(status = 1, save = "no")
+    cat("::VERIFY:PARSE_OK::\n")
+
+    # NOT_CRAN=true — WITHOUT this, testthat silently SKIPS every
+    # skip_on_cran()-gated test, and that gate is what this project uses to
+    # guard its mandated snapshot tests (error messages, captions, function
+    # signatures, target schemas — see the snapshot-test-policy rule). A
+    # plain `Rscript -e test_dir(...)` run leaves NOT_CRAN unset, so those
+    # snapshot tests never execute at all — they get written, committed, and
+    # then never checked again. Confirmed empirically 2026-07-19 (#569
+    # follow-up) on this exact root suite: NOT_CRAN unset -> 41 skipped;
+    # NOT_CRAN=true -> 0 skipped, same 3 baseline failures either way.
+    Sys.setenv(NOT_CRAN = "true")
+
+    suppressPackageStartupMessages(library(testthat))
+
+    # Pull the failure message out of a test_dir() result row so we can tell
+    # a snapshot mismatch/missing-snapshot failure (testthat mentions
+    # "snapshot" in the condition message) apart from an ordinary assertion
+    # failure. Heuristic, based on testthat'"'"'s documented expect_snapshot()
+    # message format — a missing/stale snapshot means the test never ran
+    # under the old NOT_CRAN-unset regime, not that behaviour regressed.
+    extract_fail_msg <- function(result_list) {
+      msgs <- vapply(result_list, function(cond) {
+        if (inherits(cond, "expectation") && !inherits(cond, "expectation_success")) {
+          tryCatch(conditionMessage(cond), error = function(e) "<no message>")
+        } else {
+          NA_character_
+        }
+      }, character(1))
+      paste(msgs[!is.na(msgs)], collapse = " ||| ")
+    }
+
+    report_suite <- function(res) {
+      df <- as.data.frame(res)
+      fail_idx <- which((df$failed > 0) | (df$error > 0))
+      sig <- sort(paste0(df$file[fail_idx], "::", df$test[fail_idx]))
+      snap_sig <- character(0)
+      for (i in fail_idx) {
+        msg <- extract_fail_msg(df$result[[i]])
+        if (grepl("snapshot", msg, ignore.case = TRUE)) {
+          snap_sig <- c(snap_sig, paste0(df$file[i], "::", df$test[i]))
+        }
+      }
+      list(total = nrow(df), failed = length(sig), skipped = sum(df$skipped),
+           sig = sig, snap_sig = sort(snap_sig))
+    }
+
+    # Root suite: tests/testthat/ exercises repo-root R/ scripts that are
+    # NOT part of packages/historicaldata (see tests/testthat.R). Note this
+    # is test_dir(), not test_local() — test_local() fails at repo root
+    # because there is no DESCRIPTION file here.
+    root_res <- test_dir("tests/testthat", stop_on_failure = FALSE, reporter = "silent")
+    root <- report_suite(root_res)
+    cat("::VERIFY:ROOT_SIGNATURES_START::\n")
+    if (length(root$sig) > 0) cat(paste(root$sig, collapse = "\n"), "\n", sep = "")
+    cat("::VERIFY:ROOT_SIGNATURES_END::\n")
+    cat("::VERIFY:ROOT_SNAPSHOT_FAILS_START::\n")
+    if (length(root$snap_sig) > 0) cat(paste(root$snap_sig, collapse = "\n"), "\n", sep = "")
+    cat("::VERIFY:ROOT_SNAPSHOT_FAILS_END::\n")
+    cat(sprintf("::VERIFY:ROOT_SUMMARY:: total=%d failed=%d skipped=%d\n", root$total, root$failed, root$skipped))
+
+    # Package suite: packages/historicaldata — load_all() first so the
+    # package tests see the current source, not an installed copy.
+    suppressPackageStartupMessages(library(pkgload))
+    load_all(pkg_path, quiet = TRUE)
+    pkg_res <- test_dir(file.path(pkg_path, "tests", "testthat"),
+                         package = "historicaldata", stop_on_failure = FALSE, reporter = "silent")
+    pkg <- report_suite(pkg_res)
+    cat("::VERIFY:PKG_SIGNATURES_START::\n")
+    if (length(pkg$sig) > 0) cat(paste(pkg$sig, collapse = "\n"), "\n", sep = "")
+    cat("::VERIFY:PKG_SIGNATURES_END::\n")
+    cat("::VERIFY:PKG_SNAPSHOT_FAILS_START::\n")
+    if (length(pkg$snap_sig) > 0) cat(paste(pkg$snap_sig, collapse = "\n"), "\n", sep = "")
+    cat("::VERIFY:PKG_SNAPSHOT_FAILS_END::\n")
+    cat(sprintf("::VERIFY:PKG_SUMMARY:: total=%d failed=%d skipped=%d\n", pkg$total, pkg$failed, pkg$skipped))
+
+    cat("::VERIFY:DONE::\n")
+  '
+fi
+
+echo "--- entering nix develop (warm: ~13s, cold build: 10+ min compiling R packages) ---"
+set +e
+nix develop "$REPO_ROOT" --command Rscript -e "$R_SCRIPT" 2>&1 | tee "$R_OUT"
+NIX_STATUS=${PIPESTATUS[0]}
+set -e
+echo "--- nix develop exited $NIX_STATUS ---"
+echo ""
+
+if [[ "$NIX_STATUS" -ne 0 ]] || ! grep -q "::VERIFY:PARSE_OK::" "$R_OUT"; then
+  echo "!!! VERIFICATION DID NOT RUN — nix develop / Rscript failed or exited early !!!"
+  echo "!!! This is NOT a pass. Do not report this as verified-clean.             !!!"
+  exit 2
+fi
+echo "PASS: _targets.R parses"
+
+if [[ "$QUICK" -eq 1 ]]; then
+  echo ""
+  echo "=== scripts/verify.sh: PASS (--quick, parse only) ==="
+  exit 0
+fi
+
+if ! grep -q "::VERIFY:DONE::" "$R_OUT"; then
+  echo "!!! VERIFICATION DID NOT COMPLETE — R script did not reach the end !!!"
+  echo "!!! This is NOT a pass. Do not report this as verified-clean.     !!!"
+  exit 2
+fi
+
+# compare_failure_set LABEL BASELINE_NL CURRENT_NL SNAPSHOT_CURRENT_NL SUMMARY_LINE
+# Prints a PASS/FAIL block (with SKIP count) for one suite and returns 0
+# (match) or 1 (differs). NEW failures that testthat flagged as
+# snapshot-related (SNAPSHOT_CURRENT_NL) are called out distinctly — a
+# missing/stale snapshot means the test never ran before, not a regression.
+compare_failure_set() {
+  local label="$1"
+  local baseline="$2"
+  local current="$3"
+  local snapshot_current="$4"
+  local summary_line="$5"
+  local baseline_sorted current_sorted snapshot_sorted new_failures resolved_failures skipped_n line
+
+  baseline_sorted="$(printf '%s\n' "$baseline" | sed '/^[[:space:]]*$/d' | sort)"
+  current_sorted="$(printf '%s\n' "$current" | sed '/^[[:space:]]*$/d' | sort)"
+  snapshot_sorted="$(printf '%s\n' "$snapshot_current" | sed '/^[[:space:]]*$/d' | sort)"
+  skipped_n="$(printf '%s\n' "$summary_line" | grep -oE 'skipped=[0-9]+' | grep -oE '[0-9]+' || echo '?')"
+
+  echo ""
+  echo "=== $label ==="
+  echo "SKIP count this run: $skipped_n"
+  if [[ "$current_sorted" == "$baseline_sorted" ]]; then
+    if [[ -z "$baseline_sorted" ]]; then
+      echo "PASS: no failures (fully green)"
+    else
+      echo "PASS: failures match the known baseline exactly:"
+      echo "$baseline_sorted" | sed 's/^/  [baseline, expected] /'
+    fi
+    return 0
+  fi
+
+  echo "FAIL: failures differ from the known baseline."
+  new_failures="$(comm -13 <(echo "$baseline_sorted") <(echo "$current_sorted") | sed '/^[[:space:]]*$/d' || true)"
+  resolved_failures="$(comm -23 <(echo "$baseline_sorted") <(echo "$current_sorted") | sed '/^[[:space:]]*$/d' || true)"
+  if [[ -n "$new_failures" ]]; then
+    echo "  NEW failures (not in baseline — investigate, these may be your regression):"
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      if printf '%s\n' "$snapshot_sorted" | grep -qxF "$line"; then
+        echo "    [NEW-SNAPSHOT] $line"
+        echo "        -> missing/stale snapshot, NOT necessarily a behaviour regression."
+        echo "           Review with testthat::snapshot_review()/snapshot_accept(), then commit the _snaps/ file."
+      else
+        echo "    [NEW] $line"
+      fi
+    done <<< "$new_failures"
+  fi
+  if [[ -n "$resolved_failures" ]]; then
+    echo "  Baseline failures NOT seen this run (may be fixed — update the baseline deliberately if confirmed):"
+    echo "$resolved_failures" | sed 's/^/    [RESOLVED?] /'
+  fi
+  return 1
+}
+
+OVERALL_STATUS=0
+
+CURRENT_ROOT_SIGNATURES="$(awk '/::VERIFY:ROOT_SIGNATURES_START::/{flag=1; next} /::VERIFY:ROOT_SIGNATURES_END::/{flag=0} flag' "$R_OUT")"
+CURRENT_ROOT_SNAPSHOT="$(awk '/::VERIFY:ROOT_SNAPSHOT_FAILS_START::/{flag=1; next} /::VERIFY:ROOT_SNAPSHOT_FAILS_END::/{flag=0} flag' "$R_OUT")"
+ROOT_SUMMARY_LINE="$(grep '::VERIFY:ROOT_SUMMARY::' "$R_OUT" || true)"
+BASELINE_ROOT_STR="$(printf '%s\n' "${BASELINE_ROOT_FAILURES[@]+"${BASELINE_ROOT_FAILURES[@]}"}")"
+if ! compare_failure_set "root suite (tests/testthat/, ${#BASELINE_ROOT_FAILURES[@]} known baseline failure(s), issue #569)" \
+     "$BASELINE_ROOT_STR" "$CURRENT_ROOT_SIGNATURES" "$CURRENT_ROOT_SNAPSHOT" "$ROOT_SUMMARY_LINE"; then
+  OVERALL_STATUS=1
+fi
+
+CURRENT_PKG_SIGNATURES="$(awk '/::VERIFY:PKG_SIGNATURES_START::/{flag=1; next} /::VERIFY:PKG_SIGNATURES_END::/{flag=0} flag' "$R_OUT")"
+CURRENT_PKG_SNAPSHOT="$(awk '/::VERIFY:PKG_SNAPSHOT_FAILS_START::/{flag=1; next} /::VERIFY:PKG_SNAPSHOT_FAILS_END::/{flag=0} flag' "$R_OUT")"
+PKG_SUMMARY_LINE="$(grep '::VERIFY:PKG_SUMMARY::' "$R_OUT" || true)"
+BASELINE_PKG_STR="$(printf '%s\n' "${BASELINE_PKG_FAILURES[@]+"${BASELINE_PKG_FAILURES[@]}"}")"
+if ! compare_failure_set "package suite (packages/historicaldata/, ${#BASELINE_PKG_FAILURES[@]} known baseline failure(s), issue #569)" \
+     "$BASELINE_PKG_STR" "$CURRENT_PKG_SIGNATURES" "$CURRENT_PKG_SNAPSHOT" "$PKG_SUMMARY_LINE"; then
+  OVERALL_STATUS=1
+fi
+
+echo ""
+if [[ "$OVERALL_STATUS" -eq 0 ]]; then
+  echo "=== scripts/verify.sh: PASS ==="
+else
+  echo "=== scripts/verify.sh: FAIL ==="
+fi
+exit "$OVERALL_STATUS"


### PR DESCRIPTION
## Summary

Two agents recently burned 8-15 minutes each parked on a cold nix build and returned non-answers ("I'll wait for the background build to finish") instead of verification results. The environment knowledge needed to verify a change here is undocumented, so every agent rediscovered it the slow way.

- `scripts/verify.sh` — a single entry point that wraps `nix develop` (this repo uses `flake.nix`, not `default.nix`) and runs, in order: `parse("_targets.R")`, the root `testthat` suite (`test_dir()`, not `test_local()` — the latter fails at repo root with no `DESCRIPTION`), and the `packages/historicaldata` suite. `--quick` runs the parse-only fast path.
- `.claude/CLAUDE.md` — documents the facts an agent needs before touching this repo: flake.nix not default.nix, no R on the bare PATH, ~13s warm vs 10+ min cold shell entry, `test_dir()` vs `test_local()`, the baseline failures, the `NOT_CRAN` snapshot-skip gotcha, and the CI path-filter gap.

### Baseline comparison

Both suites carry a small number of known pre-existing failures, tracked in named `BASELINE_ROOT_FAILURES` / `BASELINE_PKG_FAILURES` arrays with a comment pointing at #569 (not scattered). `verify.sh` exits 0 only when a suite's failing-test signatures match its baseline exactly by signature (`file::test description`), and prints `[NEW]` vs `[RESOLVED?]` for any drift so a human/agent can update the baseline deliberately rather than by accident.

### NOT_CRAN discovery (verified empirically this session)

While building this I found that a plain `Rscript -e testthat::test_dir(...)` leaves `NOT_CRAN` unset, so every `skip_on_cran()`-gated test is silently skipped — and this repo's mandated snapshot tests (`snapshot-test-policy` rule) are gated that way. Confirmed on the unmodified root suite:

| `NOT_CRAN` | failed | skipped | passed |
|---|---|---|---|
| unset | 3 | 41 | 746 |
| `true` | 3 | 0 | 800 |

Same 3 baseline failures either way — enabling `NOT_CRAN=true` does not introduce new failures, it just makes the previously-skipped tests actually run. `verify.sh` sets `NOT_CRAN=true` before both suites, reports the SKIP count in its summary, and flags any *new* failure that testthat reports as snapshot-related as `[NEW-SNAPSHOT]` (missing/stale snapshot — review with `snapshot_review()`/`snapshot_accept()`) rather than `[NEW]` (ordinary regression).

### Known follow-up (not fixed in this PR — out of scope)

Running the package suite with `NOT_CRAN=true` for the first time caused testthat to auto-create `tests/testthat/_snaps/momentum-decomposition.md` (a previously-uncommitted snapshot for `test-momentum-decomposition.R`'s `expect_snapshot(error = TRUE, ...)` tests, which had never actually executed before this PR). Left untracked/uncommitted here since it's outside this PR's write scope — worth its own issue to review and commit deliberately.

## Verification

Ran `scripts/verify.sh` and `scripts/verify.sh --quick` directly (not simulated). Verbatim output:

**`--quick`:**
```
=== scripts/verify.sh ===
Mode: --quick (parse only)
--- entering nix develop (warm: ~13s, cold build: 10+ min compiling R packages) ---
::VERIFY:PARSE_OK::
--- nix develop exited 0 ---
PASS: _targets.R parses
=== scripts/verify.sh: PASS (--quick, parse only) ===
QUICK_EXIT=0
```

**Full run** (also confirms the baseline comparison logic: exits 0 with exactly the 3 known root failures + 1 known package failure present):
```
::VERIFY:ROOT_SUMMARY:: total=269 failed=3 skipped=0
::VERIFY:PKG_SUMMARY:: total=571 failed=1 skipped=5

=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 5
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

=== scripts/verify.sh: PASS ===
FULL_EXIT=0
```

- `bash -n scripts/verify.sh` — clean, no syntax errors.
- Executable bit confirmed staged: `git ls-files -s scripts/verify.sh` → `100755`.

### Test plan

- [x] `scripts/verify.sh --quick` exits 0
- [x] `scripts/verify.sh` (full) exits 0 with baseline failures matching exactly
- [x] `bash -n scripts/verify.sh` passes
- [x] Executable bit set (`100755`)
- [ ] Human review of the `NOT_CRAN=true` behavior change and the newly-surfaced `tests/testthat/_snaps/momentum-decomposition.md` follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
