### PR TITLE
fix(verify): cd into REPO_ROOT — verify.sh was silently testing the caller's tree

### DIFF
--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -56,6 +56,23 @@ BASELINE_PKG_FAILURES=(
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# CRITICAL: cd into the repo this script belongs to.
+# `nix develop "$REPO_ROOT"` only selects which flake provides the shell — the
+# Rscript process it launches INHERITS THE CALLER'S CWD. Without this cd, running
+# e.g. /path/to/worktree-A/scripts/verify.sh from inside worktree-B silently
+# verifies worktree-B while reporting worktree-A's path in its header. That is a
+# false PASS: it tests a tree the caller never asked about.
+# Symptom to watch for: the suite's total test count differs between runs that
+# should be identical. See #575.
+cd "$REPO_ROOT"
+
+# Fail loudly if this is not actually a checkout of this repo.
+if [[ ! -f "$REPO_ROOT/_targets.R" ]]; then
+  echo "!!! $REPO_ROOT does not contain _targets.R — not a valid checkout !!!"
+  echo "!!! VERIFICATION DID NOT RUN. This is NOT a pass.                 !!!"
+  exit 2
+fi
+
 QUICK=0
 if [[ "${1:-}" == "--quick" ]]; then
   QUICK=1
@@ -76,6 +93,7 @@ R_OUT="$WORK_DIR/r_out.txt"
 
 if [[ "$QUICK" -eq 1 ]]; then
   R_SCRIPT='
+    cat("::VERIFY:CWD::", getwd(), "\n")
     parse_ok <- tryCatch({
       parse(file.path("_targets.R"))
       TRUE
@@ -88,6 +106,7 @@ if [[ "$QUICK" -eq 1 ]]; then
   '
 else
   R_SCRIPT='
+    cat("::VERIFY:CWD::", getwd(), "\n")
     pkg_path <- file.path("packages", "historicaldata")
 
     parse_ok <- tryCatch({
@@ -191,7 +210,17 @@ if [[ "$NIX_STATUS" -ne 0 ]] || ! grep -q "::VERIFY:PARSE_OK::" "$R_OUT"; then
   echo "!!! This is NOT a pass. Do not report this as verified-clean.             !!!"
   exit 2
 fi
-echo "PASS: _targets.R parses"
+
+# Guard against the #575 class of bug: confirm R actually ran in REPO_ROOT and
+# not in some inherited cwd. If these ever diverge the results describe a
+# different tree than the one this script claims to be verifying.
+R_CWD="$(grep '::VERIFY:CWD::' "$R_OUT" | head -1 | sed 's/.*::VERIFY:CWD:: *//' | sed 's/[[:space:]]*$//' | tr -d '\r')"
+if [[ "$(cd "$R_CWD" 2>/dev/null && pwd -P)" != "$(cd "$REPO_ROOT" && pwd -P)" ]]; then
+  echo "!!! CWD MISMATCH — R ran in '$R_CWD' but this script targets '$REPO_ROOT' !!!"
+  echo "!!! Results would describe the WRONG TREE. This is NOT a pass.           !!!"
+  exit 2
+fi
+echo "PASS: _targets.R parses (verified tree: $R_CWD)"
 
 if [[ "$QUICK" -eq 1 ]]; then
   echo ""


### PR DESCRIPTION
Hotfix to `scripts/verify.sh` from [#573](https://github.com/JohnGavin/historical/pull/573). **The tool was producing false PASSes.**

## The bug

`verify.sh` resolved `REPO_ROOT` from its own location but never `cd`'d there. `nix develop "$REPO_ROOT"` only selects *which flake provides the shell* — the `Rscript` process it launches **inherits the caller's cwd**.

So invoking `/path/to/tree-A/scripts/verify.sh` while sitting in tree-B verified **tree-B**, while printing tree-A's path in its header. Every relative path in the R script — `parse("_targets.R")`, `test_dir("tests/testthat")`, `packages/historicaldata` — resolved against the wrong tree.

## How it surfaced

While deliberately corrupting a snapshot to exercise the `[NEW-SNAPSHOT]` path, the corruption **did not fail the run**. `test_file()` caught it; `verify.sh` did not.

The tell was the suite total:

| Invocation | root total |
|---|---|
| From another worktree (broken) | **269** |
| From the repo root (correct) | **282** |

Same script, same branch, different tree. 269 was a stale checkout that happened to be the caller's cwd.

This is insidious precisely because the output looks right — correct-looking header, plausible counts, baseline matched — while describing a tree nobody asked about.

## Fix

- `cd "$REPO_ROOT"` immediately after resolving it.
- Exit 2 if `_targets.R` is absent — not a valid checkout.
- R emits `::VERIFY:CWD::`; the shell compares it against `REPO_ROOT` and exits 2 on divergence. **This class of bug can no longer fail silently**, only loudly.
- The success line now names the tree actually verified.

## Verification

From a *foreign* cwd (the exact condition that broke it):

```
PASS: _targets.R parses (verified tree: .../verify-main)
::VERIFY:ROOT_SUMMARY:: total=282 failed=3 skipped=0
::VERIFY:PKG_SUMMARY:: total=571 failed=1 skipped=5
=== scripts/verify.sh: PASS ===   (exit 0)
```

Before the fix, that same invocation reported `total=269`.

**The `[NEW-SNAPSHOT]` path is now confirmed working** — the one thing #573 shipped untested. With a corrupted snapshot the run exits 1 and reports:

```
FAIL: failures differ from the known baseline.
    [NEW-SNAPSHOT] test-drif.R::drif_multiverse_caption is a non-empty string
        -> missing/stale snapshot, NOT necessarily a behaviour regression.
```

correctly distinguished from an ordinary `[NEW]` failure. The corrupted snapshot was restored afterwards; `_snaps/drif.md` is untouched by this PR.

## Consequence for already-merged work

The re-verification runs I posted on [#570](https://github.com/JohnGavin/historical/pull/570), [#571](https://github.com/JohnGavin/historical/pull/571) and [#572](https://github.com/JohnGavin/historical/pull/572) used the broken invocation and therefore **did not verify those branches**. Correction comments posted on each.

Those merges are not invalidated — each had earlier *direct* `nix develop … Rscript -e "setwd(...)"` runs which were correct, and #570 additionally passed CI — but the specific claim "re-verified with NOT_CRAN=true" was false for all three, and their snapshot assertions remain unverified. Re-check against `main` once this lands.

## Related

[#573](https://github.com/JohnGavin/historical/pull/573) (introduced it) · [#574](https://github.com/JohnGavin/historical/issues/574) (snapshot tests never running) · [#569](https://github.com/JohnGavin/historical/issues/569)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
