### PR TITLE
test(578): Tier A snapshots for 6 root suite files (batch 1)

### DIFF
--- a/tests/testthat/_snaps/falsification-peak-value.md
+++ b/tests/testthat/_snaps/falsification-peak-value.md
@@ -1,0 +1,17 @@
+# compute_drawdowns_extracted: function signature is stable (catches API drift)
+
+    Code
+      args(compute_drawdowns_extracted)
+    Output
+      function (ret) 
+      NULL
+
+# compute_drawdowns_extracted: return-value schema is stable (non-empty path)
+
+    Code
+      names(dd)
+    Output
+      [1] "max_dd"              "avg_dd"              "max_dd_duration_obs"
+      [4] "avg_dd_duration_obs" "n_drawdowns"         "recovery_obs"       
+      [7] "peak_value"         
+

--- a/tests/testthat/_snaps/leaderboard-coverage.md
+++ b/tests/testthat/_snaps/leaderboard-coverage.md
@@ -1,0 +1,28 @@
+# check_leaderboard_coverage throws when a strategy is missing
+
+    Code
+      check_leaderboard_coverage(minimal_strategy_names, missing_strategy_leaderboard)
+    Condition
+      Error in `check_leaderboard_coverage()`:
+      x Leaderboard missing 1/2 strategy/strategies:
+      i  Factor DRIF (code_name: fac_drif)
+      i Add the corresponding add_meta() calls in R/plan_leaderboard.R.
+
+# check_leaderboard_coverage throws when ssr column absent
+
+    Code
+      check_leaderboard_coverage(minimal_strategy_names, no_ssr_leaderboard)
+    Condition
+      Error in `check_leaderboard_coverage()`:
+      x Leaderboard is missing required column ssr.
+      i Add the SSR computation block to R/plan_leaderboard.R (#400).
+
+# check_leaderboard_coverage throws when ssr column is entirely NA
+
+    Code
+      check_leaderboard_coverage(minimal_strategy_names, all_na_ssr_leaderboard)
+    Condition
+      Error in `check_leaderboard_coverage()`:
+      x Leaderboard column ssr is entirely NA — no stability metrics were computed.
+      i Check that portfolio return targets are available and have >= 38 months (#400).
+

--- a/tests/testthat/_snaps/qa-look-ahead-bias.md
+++ b/tests/testthat/_snaps/qa-look-ahead-bias.md
@@ -1,0 +1,39 @@
+# check_no_lead_ym detects lead(ym) pattern
+
+    Code
+      names(hits)
+    Output
+      [1] "file" "line" "code"
+
+# qa look-ahead-bias scanner function signatures are stable (catches API drift)
+
+    Code
+      args(check_no_lead_ym)
+    Output
+      function (files) 
+      NULL
+
+---
+
+    Code
+      args(check_no_unleaded_slider)
+    Output
+      function (files) 
+      NULL
+
+---
+
+    Code
+      args(check_no_na_approx)
+    Output
+      function (files) 
+      NULL
+
+---
+
+    Code
+      args(check_no_forward_cumulative)
+    Output
+      function (files) 
+      NULL
+

--- a/tests/testthat/_snaps/stock-backtest.md
+++ b/tests/testthat/_snaps/stock-backtest.md
@@ -1,0 +1,17 @@
+# apply_adv_cap: function signature is stable (catches API drift)
+
+    Code
+      args(apply_adv_cap)
+    Output
+      function (w, adv_by_ticker, adv_pct_cap = 0.1) 
+      NULL
+
+# apply_adv_cap: uninvested-cash cli_warn wording is stable (#r2122)
+
+    Code
+      result <- apply_adv_cap(w, adv, adv_pct_cap = 0.3)
+    Condition
+      Warning:
+      ! apply_adv_cap: 10% of portfolio left as uninvested cash.
+      i ADV caps are too tight to fully invest. Increase `adv_pct_cap` or accept the cash drag.
+

--- a/tests/testthat/_snaps/utils-metrics.md
+++ b/tests/testthat/_snaps/utils-metrics.md
@@ -1,0 +1,26 @@
+# annualise_returns: non-numeric ret aborts with cli_abort
+
+    Code
+      annualise_returns(c("a", "b", "c"))
+    Condition
+      Error in `annualise_returns()`:
+      x `ret` must be a numeric vector.
+      i Got <character>.
+
+# annualise_returns: invalid periods_per_year aborts
+
+    Code
+      annualise_returns(c(0.01, 0.02), periods_per_year = -1)
+    Condition
+      Error in `annualise_returns()`:
+      x `periods_per_year` must be a single positive number.
+      i Got -1.
+
+# annualise_returns: function signature is stable (catches API drift)
+
+    Code
+      args(annualise_returns)
+    Output
+      function (ret, periods_per_year = 12L, na.rm = TRUE) 
+      NULL
+

--- a/tests/testthat/_snaps/vignette-utils.md
+++ b/tests/testthat/_snaps/vignette-utils.md
@@ -1,0 +1,80 @@
+# safe_tar_read: stops in strict mode when target is absent
+
+    Code
+      safe_tar_read("nonexistent_target_xyz_12345")
+    Condition
+      Error:
+      ! VIGNETTE_STRICT: Target 'nonexistent_target_xyz_12345' not found. Run tar_make() first.
+
+# safe_tar_read: VIGNETTE_STRICT=1 triggers strict error (issue #232 + #231 integration)
+
+    Code
+      safe_tar_read("nonexistent_target_xyz_12345")
+    Condition
+      Error:
+      ! VIGNETTE_STRICT: Target 'nonexistent_target_xyz_12345' not found. Run tar_make() first.
+
+# .parse_vignette_strict: VIGNETTE_STRICT=treu returns FALSE AND triggers cli_warn (typo guard, roborev T1)
+
+    Code
+      result <- .parse_vignette_strict()
+    Condition
+      Warning:
+      Unrecognised `VIGNETTE_STRICT` value "treu" — falling back to FALSE
+      i Accepted truthy: 1, yes, on, true, t (case-insensitive, whitespace-tolerant)
+      i Accepted falsy: 0, no, off, false, f, '' (empty)
+      This warning is displayed once per session.
+
+# .parse_vignette_strict: 'n' is unrecognised alias — warns and returns FALSE (safe default)
+
+    Code
+      result <- .parse_vignette_strict()
+    Condition
+      Warning:
+      Unrecognised `VIGNETTE_STRICT` value "n" — falling back to FALSE
+      i Accepted truthy: 1, yes, on, true, t (case-insensitive, whitespace-tolerant)
+      i Accepted falsy: 0, no, off, false, f, '' (empty)
+      This warning is displayed once per session.
+
+# .parse_vignette_strict: typo warning fires AT MOST ONCE across N calls (roborev #4263)
+
+    Code
+      cat(warnings_seen[[1]])
+    Output
+      Unrecognised `VIGNETTE_STRICT` value "yse" — falling back to FALSE
+      i Accepted truthy: 1, yes, on, true, t (case-insensitive, whitespace-tolerant)
+      i Accepted falsy: 0, no, off, false, f, '' (empty)
+      This warning is displayed once per session.
+
+# function signatures are stable (catches API drift)
+
+    Code
+      args(.parse_vignette_strict)
+    Output
+      function () 
+      NULL
+
+---
+
+    Code
+      args(safe_tar_read)
+    Output
+      function (name, strict = .parse_vignette_strict()) 
+      NULL
+
+---
+
+    Code
+      args(is_stale_marker)
+    Output
+      function (x) 
+      NULL
+
+---
+
+    Code
+      args(show_code)
+    Output
+      function (target_name) 
+      NULL
+

--- a/tests/testthat/test-falsification-peak-value.R
+++ b/tests/testthat/test-falsification-peak-value.R
@@ -66,6 +66,24 @@ compute_drawdowns_extracted <- function(ret) {
 # ── F1: peak_value differs from final_value when the curve peaked and
 #    then declined before the end of the sample (the bug this fixes) ─────
 
+test_that("compute_drawdowns_extracted: function signature is stable (catches API drift)", {
+  expect_snapshot(args(compute_drawdowns_extracted))
+})
+
+test_that("compute_drawdowns_extracted: return-value schema is stable (non-empty path)", {
+  # Schema snapshot for the normal (non-empty ret) branch only. NOTE: the
+  # empty-ret early-return branch (length(ret) == 0L, see lines 21-29 above)
+  # uses DIFFERENT field names for two elements
+  # (max_dd_duration_days/recovery_days) than this branch
+  # (max_dd_duration_obs/recovery_obs). That asymmetry is a latent schema bug
+  # in compute_drawdowns_extracted() / the R/plan_falsification.R original it
+  # mirrors -- flagged in the PR description rather than pinned here as a
+  # snapshot, since committing it would bless the mismatch as expected.
+  ret <- c(0.05, 0.05, 0.05, 0.05, -0.03, -0.03, -0.03, -0.03, -0.02, -0.02)
+  dd <- compute_drawdowns_extracted(ret)
+  expect_snapshot(names(dd))
+})
+
 test_that("peak_value: exceeds final_value for a strategy in a drawdown at period end (regression #569)", {
   # Equity rises 20%, then gives back half of it, ending in a drawdown.
   ret <- c(0.05, 0.05, 0.05, 0.05, -0.03, -0.03, -0.03, -0.03, -0.02, -0.02)

--- a/tests/testthat/test-leaderboard-coverage.R
+++ b/tests/testthat/test-leaderboard-coverage.R
@@ -1,3 +1,4 @@
+testthat::local_edition(3)
 # Tests for check_leaderboard_coverage() — QA gate S7 (#345, extended in #400)
 # Tests for .norm_mf / .norm_value normalizers — wiring fix for #489 Cluster C S7.
 #
@@ -159,6 +160,10 @@ test_that("check_leaderboard_coverage throws when a strategy is missing", {
     check_leaderboard_coverage(minimal_strategy_names, missing_strategy_leaderboard),
     regexp = "Factor DRIF"
   )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_coverage(minimal_strategy_names, missing_strategy_leaderboard)
+  )
 })
 
 # ── Tests: SSR column (#400) ─────────────────────────────────────────────────
@@ -168,12 +173,20 @@ test_that("check_leaderboard_coverage throws when ssr column absent", {
     check_leaderboard_coverage(minimal_strategy_names, no_ssr_leaderboard),
     regexp = "ssr"
   )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_coverage(minimal_strategy_names, no_ssr_leaderboard)
+  )
 })
 
 test_that("check_leaderboard_coverage throws when ssr column is entirely NA", {
   expect_error(
     check_leaderboard_coverage(minimal_strategy_names, all_na_ssr_leaderboard),
     regexp = "entirely NA"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_coverage(minimal_strategy_names, all_na_ssr_leaderboard)
   )
 })
 

--- a/tests/testthat/test-qa-look-ahead-bias.R
+++ b/tests/testthat/test-qa-look-ahead-bias.R
@@ -14,6 +14,8 @@ test_that("check_no_lead_ym detects lead(ym) pattern", {
   hits <- check_no_lead_ym(tmp)
   expect_equal(nrow(hits), 1L)
   expect_equal(hits$line, 2L)
+  # Schema snapshot: pins the returned tibble's column names (file/line/code).
+  expect_snapshot(names(hits))
 })
 
 test_that("check_no_lead_ym detects dplyr::lead(ym) pattern", {
@@ -153,6 +155,13 @@ test_that("check_no_forward_cumulative does not flag ordinary cumprod(1 + ret)",
 })
 
 # ── Live tripwire: current R/ tree must pass all 4 checks ────────────────────
+
+test_that("qa look-ahead-bias scanner function signatures are stable (catches API drift)", {
+  expect_snapshot(args(check_no_lead_ym))
+  expect_snapshot(args(check_no_unleaded_slider))
+  expect_snapshot(args(check_no_na_approx))
+  expect_snapshot(args(check_no_forward_cumulative))
+})
 
 test_that("qa_look_ahead_bias passes on current R/ tree", {
   files <- list.files(here::here("R"), pattern = "\\.R$",

--- a/tests/testthat/test-stock-backtest.R
+++ b/tests/testthat/test-stock-backtest.R
@@ -1,3 +1,4 @@
+testthat::local_edition(3)
 # Tests for plan_stock_backtest.R helpers
 # Sourced directly since these are non-exported helper functions
 
@@ -52,8 +53,15 @@ test_that("apply_adv_cap: all-capped names leave residual as cash, not over-cap 
   w <- c(a = 0.01, b = 0.01, c = 0.98)
   adv <- c(a = 1, b = 1, c = 1)
   # 10% residual cash → warns (10% > 5% threshold)
-  result <- expect_warning(
-    apply_adv_cap(w, adv, adv_pct_cap = 0.30),
+  # NOTE: the assignment MUST happen inside the expect_warning() expression.
+  # Under testthat edition 3, expect_warning() invisibly returns the warning
+  # CONDITION object, not the wrapped expression's value (edition 2 returned
+  # the expression's value) -- `result <- expect_warning(apply_adv_cap(...))`
+  # silently captured the condition instead of the function's return list,
+  # making result$capped_w NULL. Found while adding local_edition(3) for the
+  # Tier A snapshot work in this file (#578).
+  expect_warning(
+    result <- apply_adv_cap(w, adv, adv_pct_cap = 0.30),
     regexp = "uninvested cash",
     label = "warns when residual cash exceeds 5%"
   )
@@ -86,8 +94,9 @@ test_that("apply_adv_cap: 4 names × 0.20 cap leaves 20% as uninvested cash (#r2
   w <- c(a = 0.01, b = 0.01, c = 0.01, d = 0.97)
   adv <- c(a = 1, b = 1, c = 1, d = 1)
   # 20% residual cash → warns (20% > 5% threshold)
-  result <- expect_warning(
-    apply_adv_cap(w, adv, adv_pct_cap = 0.20),
+  # See NOTE above: assignment must be inside expect_warning() under edition 3.
+  expect_warning(
+    result <- apply_adv_cap(w, adv, adv_pct_cap = 0.20),
     regexp = "uninvested cash",
     label = "warns when 20% residual cash"
   )
@@ -106,6 +115,19 @@ test_that("apply_adv_cap: empty input returns empty output", {
   result <- apply_adv_cap(numeric(0), numeric(0))
   expect_equal(length(result$capped_w), 0L)
   expect_equal(length(result$hit_cap), 0L)
+})
+
+test_that("apply_adv_cap: function signature is stable (catches API drift)", {
+  expect_snapshot(args(apply_adv_cap))
+})
+
+test_that("apply_adv_cap: uninvested-cash cli_warn wording is stable (#r2122)", {
+  # 3 names, all cap-constrained -> 10% residual cash -> warns. Assigning the
+  # result (rather than letting it auto-print) keeps this Tier A: only the
+  # cli_warn text is captured, not the numeric capped_w/hit_cap payload.
+  w <- c(a = 0.01, b = 0.01, c = 0.98)
+  adv <- c(a = 1, b = 1, c = 1)
+  expect_snapshot(result <- apply_adv_cap(w, adv, adv_pct_cap = 0.30))
 })
 
 test_that("apply_adv_cap: no cap binds when weights are small", {

--- a/tests/testthat/test-utils-metrics.R
+++ b/tests/testthat/test-utils-metrics.R
@@ -90,6 +90,10 @@ test_that("annualise_returns: non-numeric ret aborts with cli_abort", {
     annualise_returns(c("a", "b", "c")),
     class = "rlang_error"
   )
+  expect_snapshot(
+    error = TRUE,
+    annualise_returns(c("a", "b", "c"))
+  )
 })
 
 test_that("annualise_returns: invalid periods_per_year aborts", {
@@ -97,4 +101,12 @@ test_that("annualise_returns: invalid periods_per_year aborts", {
     annualise_returns(c(0.01, 0.02), periods_per_year = -1),
     class = "rlang_error"
   )
+  expect_snapshot(
+    error = TRUE,
+    annualise_returns(c(0.01, 0.02), periods_per_year = -1)
+  )
+})
+
+test_that("annualise_returns: function signature is stable (catches API drift)", {
+  expect_snapshot(args(annualise_returns))
 })

--- a/tests/testthat/test-vignette-utils.R
+++ b/tests/testthat/test-vignette-utils.R
@@ -125,6 +125,10 @@ test_that("safe_tar_read: stops in strict mode when target is absent", {
       safe_tar_read("nonexistent_target_xyz_12345"),
       regexp = "VIGNETTE_STRICT"
     )
+    expect_snapshot(
+      error = TRUE,
+      safe_tar_read("nonexistent_target_xyz_12345")
+    )
   })
 })
 
@@ -135,6 +139,10 @@ test_that("safe_tar_read: VIGNETTE_STRICT=1 triggers strict error (issue #232 + 
     expect_error(
       safe_tar_read("nonexistent_target_xyz_12345"),
       regexp = "VIGNETTE_STRICT"
+    )
+    expect_snapshot(
+      error = TRUE,
+      safe_tar_read("nonexistent_target_xyz_12345")
     )
   })
 })
@@ -183,10 +191,9 @@ test_that(".parse_vignette_strict: VIGNETTE_STRICT=treu returns FALSE AND trigge
     rlang::reset_warning_verbosity("vignette_strict_typo_treu")
     withr::defer(rlang::reset_warning_verbosity("vignette_strict_typo_treu"))
 
-    expect_warning(
-      result <- .parse_vignette_strict(),
-      regexp = "Unrecognised"
-    )
+    # expect_snapshot captures the full cli_warn wording (not just a regexp
+    # match) so any drift in the typo-guard message is visible in review.
+    expect_snapshot(result <- .parse_vignette_strict())
     expect_false(result)
   })
 })
@@ -214,10 +221,12 @@ test_that(".parse_vignette_strict: all #210 required falsy aliases return FALSE"
 test_that(".parse_vignette_strict: 'n' is unrecognised alias — warns and returns FALSE (safe default)", {
   # "n" is not in the canonical falsy list; correct behaviour is warn + default FALSE
   withr::with_envvar(list(VIGNETTE_STRICT = "n"), {
-    expect_warning(
-      result <- .parse_vignette_strict(),
-      regexp = "Unrecognised"
-    )
+    rlang::reset_warning_verbosity("vignette_strict_typo_n")
+    withr::defer(rlang::reset_warning_verbosity("vignette_strict_typo_n"))
+
+    # expect_snapshot pins the exact wording (distinct from the "treu" case
+    # above since {.val {raw}} interpolates the offending value into the text).
+    expect_snapshot(result <- .parse_vignette_strict())
     expect_false(result)
   })
 })
@@ -243,5 +252,18 @@ test_that(".parse_vignette_strict: typo warning fires AT MOST ONCE across N call
     )
     expect_length(warnings_seen, 1L)
     expect_match(warnings_seen[[1]], "Unrecognised")
+    # Pin the exact wording of the single captured warning (Tier A: CLI message).
+    expect_snapshot(cat(warnings_seen[[1]]))
   })
+})
+
+# ---------------------------------------------------------------------------
+# Function signature stability (catches API drift) — Tier A snapshots
+# ---------------------------------------------------------------------------
+
+test_that("function signatures are stable (catches API drift)", {
+  expect_snapshot(args(.parse_vignette_strict))
+  expect_snapshot(args(safe_tar_read))
+  expect_snapshot(args(is_stale_marker))
+  expect_snapshot(args(show_code))
 })


### PR DESCRIPTION
## Summary

Phase 1 Tier A, root suite batch 1 (#578). Brings 6 zero-snapshot files up
to the mandated snapshot ratio, restricted to Tier A categories only.

| File | blocks | before | after | needed |
|---|---|---|---|---|
| test-vignette-utils.R | 27 | 0 | 9 | 9 |
| test-qa-look-ahead-bias.R | 16 | 0 | 5 | 5 |
| test-leaderboard-coverage.R | 10 | 0 | 3 | 3 |
| test-utils-metrics.R | 9 | 0 | 3 | 3 |
| test-stock-backtest.R | 8 | 0 | 2 | 2 |
| test-falsification-peak-value.R | 5 | 0 | 2 | 2 |

All 26 new snapshots are Tier A: error messages (`expect_snapshot(error =
TRUE, ...)`), CLI warnings, or function/schema signatures. No numeric
results or table prints were snapshotted — that is deliberately deferred
to Phase 2.

## Bug found and fixed (in scope)

`test-leaderboard-coverage.R` and `test-stock-backtest.R` needed
`testthat::local_edition(3)` added (matching the convention already used
elsewhere in the suite) since `expect_snapshot()` requires edition 3.

That edition switch surfaced a **pre-existing latent bug** in
`test-stock-backtest.R`: two tests wrote `result <- expect_warning(...)`.
Under testthat edition 3, `expect_warning()` invisibly returns the warning
**condition object**, not the wrapped expression's value (edition 2
returned the expression's value). `result$capped_w` was silently `NULL`,
so `sum(result$capped_w)` and `max(result$capped_w)` were checking `0` and
`-Inf` instead of the real result — the assertions were vacuously
exercising the wrong object. Verified `apply_adv_cap()` itself is correct
via a standalone probe outside testthat. Fixed by moving the assignment
inside the `expect_warning()` expression, matching the pattern already
used correctly elsewhere in the same file (and in my new tests).

## Bug found and NOT fixed (flagged only, out of scope)

`compute_drawdowns_extracted()`'s (and its production original in
`R/plan_falsification.R`'s `compute_drawdowns()`) empty-input early-return
branch uses different field names — `max_dd_duration_days` /
`recovery_days` — than the normal-path return —
`max_dd_duration_obs` / `recovery_obs`. Currently dead code in production
(the sole caller in `plan_falsification.R` guards `length(ret) < 10L`
before ever reaching the empty branch), but a trap for any future direct
caller. Deliberately **not** pinned as a snapshot (would bless the
mismatch as expected) — documented instead as a code comment at
`tests/testthat/test-falsification-peak-value.R` and flagged here for
`#569` follow-up consideration.

## Also noticed, out of scope

Running the full `verify.sh` surfaced two **pre-existing** test files
(`test-liquidity.R`, `test-momentum-decomposition.R`) whose
`expect_snapshot()` calls have no committed `_snaps/` baseline — every run
silently auto-creates a fresh snapshot rather than checking against a
fixed one, so those assertions have effectively never been verifying
anything. Left untouched/untracked (not part of this batch's file list);
worth a follow-up issue.

## Test plan

- [x] `scripts/verify.sh` (full) — root suite 289 tests, 3 failures (exact
      baseline match, 0 skipped); package suite 571 tests, 1 failure
      (exact baseline match, 5 skipped). No regressions.
- [x] All 6 target files individually re-run clean after fixes.
- [x] Each new snapshot manually reviewed for Tier A compliance and
      correctness before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
