### PR TITLE
test(historicaldata): Tier A snapshots for 5 zero-snapshot files (#578 Phase 1)

### DIFF
--- a/packages/historicaldata/tests/testthat/_snaps/add-signal.md
+++ b/packages/historicaldata/tests/testthat/_snaps/add-signal.md
@@ -1,0 +1,71 @@
+# hd_compute_add: errors on non-data-frame input
+
+    Code
+      hd_compute_add("not a tibble")
+    Condition
+      Error in `hd_compute_add()`:
+      x `quintile_assignments` must be a data frame or tibble.
+      i Got <character>.
+
+# hd_compute_add: errors on missing required columns
+
+    Code
+      hd_compute_add(bad)
+    Condition
+      Error in `hd_compute_add()`:
+      x `quintile_assignments` is missing required columns: anomaly_id and quintile.
+      i Found columns: stock and date.
+
+# hd_compute_add: errors on empty input
+
+    Code
+      hd_compute_add(empty)
+    Condition
+      Error in `hd_compute_add()`:
+      x `quintile_assignments` must not be empty.
+      i Pass a tibble with at least one row.
+
+# hd_compute_add: errors on non-Date date column
+
+    Code
+      hd_compute_add(bad)
+    Condition
+      Error in `hd_compute_add()`:
+      x Column date must be a <Date> or <POSIXct>.
+      i Got <character>.
+
+# hd_compute_add: errors on out-of-range quintile values
+
+    Code
+      hd_compute_add(bad)
+    Condition
+      Error in `hd_compute_add()`:
+      x Column quintile must contain integers in 1-5 or NA.
+      i Got values outside [1, 5].
+
+# hd_aggregate_add: errors on missing columns
+
+    Code
+      hd_aggregate_add(bad)
+    Condition
+      Error in `hd_aggregate_add()`:
+      x `add_tbl` is missing required columns: anomaly_id and add.
+      i These are produced by `hd_compute_add()`.
+
+# hd_aggregate_add: errors on unsupported 'by' argument
+
+    Code
+      hd_aggregate_add(add_tbl, by = "anomaly_date")
+    Condition
+      Error in `hd_aggregate_add()`:
+      x Only "stock_date" is supported for `by`.
+      i Got "anomaly_date".
+
+# hd_aggregate_add: errors on empty input
+
+    Code
+      hd_aggregate_add(empty)
+    Condition
+      Error in `hd_aggregate_add()`:
+      x `add_tbl` must not be empty.
+

--- a/packages/historicaldata/tests/testthat/_snaps/cpcv.md
+++ b/packages/historicaldata/tests/testthat/_snaps/cpcv.md
@@ -1,0 +1,88 @@
+# hd_cpcv_purge removes contaminated training observations
+
+    Code
+      args(hd_cpcv_purge)
+    Output
+      function (train_idx, test_idx, label_horizon = 1L) 
+      NULL
+
+# hd_cpcv_purge rejects negative label_horizon
+
+    Code
+      hd_cpcv_purge(1L:15L, 16L:20L, label_horizon = -1L)
+    Condition
+      Error in `hd_cpcv_purge()`:
+      x `label_horizon` must be >= 0.
+      i Got -1.
+
+# hd_cpcv_embargo rejects negative embargo_n
+
+    Code
+      hd_cpcv_embargo(1L:15L, 16L:20L, embargo_n = -1L)
+    Condition
+      Error in `hd_cpcv_embargo()`:
+      x `embargo_n` must be >= 0.
+      i Got -1.
+
+# hd_cpcv_paths rejects invalid inputs
+
+    Code
+      hd_cpcv_paths(1L, 1L)
+    Condition
+      Error in `hd_cpcv_paths()`:
+      x `n_groups` must be an integer >= 2.
+      i Got 1.
+
+---
+
+    Code
+      hd_cpcv_paths(6L, 0L)
+    Condition
+      Error in `hd_cpcv_paths()`:
+      x `n_test_groups` must be between 1 and 5.
+      i Got 0 with `n_groups` = 6.
+
+---
+
+    Code
+      hd_cpcv_paths(6L, 6L)
+    Condition
+      Error in `hd_cpcv_paths()`:
+      x `n_test_groups` must be between 1 and 5.
+      i Got 6 with `n_groups` = 6.
+
+# hd_pbo returns near 1 when IS/OOS are perfectly anti-correlated
+
+    Code
+      args(hd_pbo)
+    Output
+      function (is_scores, oos_scores) 
+      NULL
+
+# hd_pbo rejects dimension mismatch
+
+    Code
+      hd_pbo(is_scores, oos_scores)
+    Condition
+      Error in `hd_pbo()`:
+      x `is_scores` and `oos_scores` must have the same dimensions.
+      i is_scores: 5 and 2, oos_scores: 5 and 3.
+
+# hd_pbo rejects fewer than 2 paths
+
+    Code
+      hd_pbo(matrix(rnorm(4L), 1L, 4L), matrix(rnorm(4L), 1L, 4L))
+    Condition
+      Error in `hd_pbo()`:
+      x At least 2 paths are required to compute PBO.
+      i Got 1 path(s).
+
+# hd_pbo rejects fewer than 2 strategies
+
+    Code
+      hd_pbo(matrix(rnorm(5L), 5L, 1L), matrix(rnorm(5L), 5L, 1L))
+    Condition
+      Error in `hd_pbo()`:
+      x At least 2 strategies are required to compute PBO.
+      i Got 1 strategy/strategies.
+

--- a/packages/historicaldata/tests/testthat/_snaps/olmar.md
+++ b/packages/historicaldata/tests/testthat/_snaps/olmar.md
@@ -1,0 +1,67 @@
+# simplex_project: output sums to 1
+
+    Code
+      args(olmar_simplex_project)
+    Output
+      function (v) 
+      NULL
+
+# simplex_project: errors on non-numeric input
+
+    Code
+      olmar_simplex_project("a")
+    Condition
+      Error in `olmar_simplex_project()`:
+      x `v` must be a non-empty numeric vector.
+      i Got class <character> of length 1.
+
+# simplex_project: errors on empty vector
+
+    Code
+      olmar_simplex_project(numeric(0L))
+    Condition
+      Error in `olmar_simplex_project()`:
+      x `v` must be a non-empty numeric vector.
+      i Got class <numeric> of length 0.
+
+# olmar_update: errors on length mismatch
+
+    Code
+      olmar_update(b, x)
+    Condition
+      Error in `olmar_update()`:
+      x Length mismatch: `b_prev` has 2, `x_pred` has 3.
+
+# olmar_update: errors on non-positive epsilon
+
+    Code
+      olmar_update(b, x, epsilon = 0)
+    Condition
+      Error in `olmar_update()`:
+      x `epsilon` must be a positive scalar.
+      i Got 0.
+
+---
+
+    Code
+      olmar_update(b, x, epsilon = -1)
+    Condition
+      Error in `olmar_update()`:
+      x `epsilon` must be a positive scalar.
+      i Got -1.
+
+# olmar_backtest: returns expected columns
+
+    Code
+      names(result)
+    Output
+      [1] "date"      "gross_ret" "net_ret"   "turnover" 
+
+# olmar_backtest: errors on insufficient rows
+
+    Code
+      olmar_backtest(prices, window = 25L)
+    Condition
+      Error in `olmar_backtest()`:
+      x `prices` has 4 rows but `window` = 25 requires at least 26.
+

--- a/packages/historicaldata/tests/testthat/_snaps/sharpe-stability-ratio.md
+++ b/packages/historicaldata/tests/testthat/_snaps/sharpe-stability-ratio.md
@@ -1,0 +1,72 @@
+# hd_sharpe_stability_ratio: return is named list with correct field types
+
+    Code
+      args(hd_sharpe_stability_ratio)
+    Output
+      function (r, w, ann_factor = 252, lag_nw = NULL) 
+      NULL
+
+# hd_rolling_sharpe: rejects non-numeric r
+
+    Code
+      hd_rolling_sharpe("not numeric", w = 10L)
+    Condition
+      Error in `hd_rolling_sharpe()`:
+      x `r` must be a numeric vector.
+
+# hd_rolling_sharpe: rejects non-integer w
+
+    Code
+      hd_rolling_sharpe(rnorm(100), w = -1L)
+    Condition
+      Error in `hd_rolling_sharpe()`:
+      x `w` must be a positive integer scalar.
+
+# hd_sharpe_stability_ratio: rejects negative ann_factor
+
+    Code
+      hd_sharpe_stability_ratio(rnorm(100), w = 20L, ann_factor = -1)
+    Condition
+      Error in `hd_sharpe_stability_ratio()`:
+      x `ann_factor` must be a positive numeric scalar.
+
+# hd_sharpe_stability_ratio: rejects non-integer lag_nw
+
+    Code
+      hd_sharpe_stability_ratio(rnorm(100), w = 20L, lag_nw = 1.5)
+    Condition
+      Error in `hd_sharpe_stability_ratio()`:
+      x `lag_nw` must be NULL or a non-negative integer scalar.
+
+# hd_top5pct_share: pct=0 triggers error
+
+    Code
+      hd_top5pct_share(rep(0.01, 10L), pct = 0)
+    Condition
+      Error in `hd_top5pct_share()`:
+      ! `pct` must be in (0, 1); got 0.
+
+# hd_top5pct_share: pct=1 triggers error
+
+    Code
+      hd_top5pct_share(rep(0.01, 10L), pct = 1)
+    Condition
+      Error in `hd_top5pct_share()`:
+      ! `pct` must be in (0, 1); got 1.
+
+# hd_top5pct_share: pct=1.5 triggers error
+
+    Code
+      hd_top5pct_share(rep(0.01, 10L), pct = 1.5)
+    Condition
+      Error in `hd_top5pct_share()`:
+      ! `pct` must be in (0, 1); got 1.5.
+
+# hd_top5pct_share: pct=-0.1 triggers error
+
+    Code
+      hd_top5pct_share(rep(0.01, 10L), pct = -0.1)
+    Condition
+      Error in `hd_top5pct_share()`:
+      ! `pct` must be in (0, 1); got -0.1.
+

--- a/packages/historicaldata/tests/testthat/_snaps/topological-risk-parity.md
+++ b/packages/historicaldata/tests/testthat/_snaps/topological-risk-parity.md
@@ -1,0 +1,62 @@
+# hrp_weights: weights sum to 1 (5-asset)
+
+    Code
+      args(hrp_weights)
+    Output
+      function (cov_mat, method = "complete") 
+      NULL
+
+# hrp_weights: error on non-matrix input
+
+    Code
+      hrp_weights(list(a = 1))
+    Condition
+      Error in `.validate_cov_input()`:
+      x `cov_mat` must be a matrix.
+      i Got <list>.
+
+# hrp_weights: error on non-square matrix
+
+    Code
+      hrp_weights(m)
+    Condition
+      Error in `.validate_cov_input()`:
+      x `cov_mat` must be square.
+      i Got 2 x 3.
+
+# hrp_weights: error on unnamed matrix
+
+    Code
+      hrp_weights(m)
+    Condition
+      Error in `.validate_cov_input()`:
+      x `cov_mat` must have named rows and columns.
+      i Set `rownames(cov_mat)` and `colnames(cov_mat)`.
+
+# hrp_weights: error on mismatched row/col names
+
+    Code
+      hrp_weights(m)
+    Condition
+      Error in `.validate_cov_input()`:
+      x Row names and column names of `cov_mat` must be identical.
+      i Found mismatched row/column names.
+
+# hrp_weights: error on single-asset matrix
+
+    Code
+      hrp_weights(m)
+    Condition
+      Error in `.validate_cov_input()`:
+      x `cov_mat` must have at least 2 assets.
+      i Got 1 asset(s).
+
+# trp_weights: error on non-matrix input
+
+    Code
+      trp_weights(data.frame(a = 1))
+    Condition
+      Error in `.validate_cov_input()`:
+      x `cov_mat` must be a matrix.
+      i Got <data.frame>.
+

--- a/packages/historicaldata/tests/testthat/test-add-signal.R
+++ b/packages/historicaldata/tests/testthat/test-add-signal.R
@@ -169,12 +169,12 @@ test_that("hd_compute_add: LOOK-AHEAD GUARD — perturbing only future quintiles
 # ── hd_compute_add: error handling ───────────────────────────────────────────
 
 test_that("hd_compute_add: errors on non-data-frame input", {
-  expect_error(hd_compute_add("not a tibble"), "data frame or tibble")
+  expect_snapshot(error = TRUE, hd_compute_add("not a tibble"))
 })
 
 test_that("hd_compute_add: errors on missing required columns", {
   bad <- tibble::tibble(stock = "A", date = Sys.Date())
-  expect_error(hd_compute_add(bad), "missing required columns")
+  expect_snapshot(error = TRUE, hd_compute_add(bad))
 })
 
 test_that("hd_compute_add: errors on empty input", {
@@ -182,7 +182,7 @@ test_that("hd_compute_add: errors on empty input", {
     stock = character(), date = as.Date(character()),
     anomaly_id = character(), quintile = integer()
   )
-  expect_error(hd_compute_add(empty), "must not be empty")
+  expect_snapshot(error = TRUE, hd_compute_add(empty))
 })
 
 test_that("hd_compute_add: errors on non-Date date column", {
@@ -190,7 +190,7 @@ test_that("hd_compute_add: errors on non-Date date column", {
     stock = "A", date = "2023-01-01",
     anomaly_id = "val", quintile = 3L
   )
-  expect_error(hd_compute_add(bad), "Date")
+  expect_snapshot(error = TRUE, hd_compute_add(bad))
 })
 
 test_that("hd_compute_add: errors on out-of-range quintile values", {
@@ -198,7 +198,7 @@ test_that("hd_compute_add: errors on out-of-range quintile values", {
     stock = "A", date = as.Date("2023-01-01"),
     anomaly_id = "val", quintile = 6L
   )
-  expect_error(hd_compute_add(bad), "1-5")
+  expect_snapshot(error = TRUE, hd_compute_add(bad))
 })
 
 test_that("hd_compute_add: allows NA quintile (stock not ranked)", {
@@ -261,12 +261,12 @@ test_that("hd_aggregate_add: errors on non-data-frame input", {
 
 test_that("hd_aggregate_add: errors on missing columns", {
   bad <- tibble::tibble(stock = "A", date = Sys.Date())
-  expect_error(hd_aggregate_add(bad), "missing required columns")
+  expect_snapshot(error = TRUE, hd_aggregate_add(bad))
 })
 
 test_that("hd_aggregate_add: errors on unsupported 'by' argument", {
   add_tbl <- hd_compute_add(make_quintile_tbl())
-  expect_error(hd_aggregate_add(add_tbl, by = "anomaly_date"), "stock_date")
+  expect_snapshot(error = TRUE, hd_aggregate_add(add_tbl, by = "anomaly_date"))
 })
 
 test_that("hd_aggregate_add: errors on empty input", {
@@ -274,7 +274,7 @@ test_that("hd_aggregate_add: errors on empty input", {
     stock = character(), date = as.Date(character()),
     anomaly_id = character(), quintile = integer(), add = integer()
   )
-  expect_error(hd_aggregate_add(empty), "must not be empty")
+  expect_snapshot(error = TRUE, hd_aggregate_add(empty))
 })
 
 # ── hd_register_add_dataset ───────────────────────────────────────────────────

--- a/packages/historicaldata/tests/testthat/test-cpcv.R
+++ b/packages/historicaldata/tests/testthat/test-cpcv.R
@@ -8,6 +8,9 @@ test_that("hd_cpcv_purge removes contaminated training observations", {
     label_horizon = 1L
   )
   expect_equal(result, 1L:14L)
+
+  # Tier A: function signature snapshot (catches param renames/additions).
+  expect_snapshot(args(hd_cpcv_purge))
 })
 
 test_that("hd_cpcv_purge with label_horizon = 0 removes nothing", {
@@ -41,10 +44,7 @@ test_that("hd_cpcv_purge returns empty if all training obs contaminated", {
 })
 
 test_that("hd_cpcv_purge rejects negative label_horizon", {
-  expect_error(
-    hd_cpcv_purge(1L:15L, 16L:20L, label_horizon = -1L),
-    "label_horizon"
-  )
+  expect_snapshot(error = TRUE, hd_cpcv_purge(1L:15L, 16L:20L, label_horizon = -1L))
 })
 
 test_that("hd_cpcv_purge handles empty inputs gracefully", {
@@ -85,10 +85,7 @@ test_that("hd_cpcv_embargo with embargo_n = 1 removes one observation", {
 })
 
 test_that("hd_cpcv_embargo rejects negative embargo_n", {
-  expect_error(
-    hd_cpcv_embargo(1L:15L, 16L:20L, embargo_n = -1L),
-    "embargo_n"
-  )
+  expect_snapshot(error = TRUE, hd_cpcv_embargo(1L:15L, 16L:20L, embargo_n = -1L))
 })
 
 test_that("hd_cpcv_embargo handles empty inputs gracefully", {
@@ -132,9 +129,9 @@ test_that("hd_cpcv_paths returns C(5,3) = 10 for n=5, k=3", {
 })
 
 test_that("hd_cpcv_paths rejects invalid inputs", {
-  expect_error(hd_cpcv_paths(1L, 1L), "n_groups")  # n_groups < 2
-  expect_error(hd_cpcv_paths(6L, 0L), "n_test_groups")  # n_test_groups < 1
-  expect_error(hd_cpcv_paths(6L, 6L), "n_test_groups")  # n_test_groups >= n_groups
+  expect_snapshot(error = TRUE, hd_cpcv_paths(1L, 1L))  # n_groups < 2
+  expect_snapshot(error = TRUE, hd_cpcv_paths(6L, 0L))  # n_test_groups < 1
+  expect_snapshot(error = TRUE, hd_cpcv_paths(6L, 6L))  # n_test_groups >= n_groups
 })
 
 # ── PBO ────────────────────────────────────────────────────────────────────────
@@ -150,6 +147,9 @@ test_that("hd_pbo returns near 1 when IS/OOS are perfectly anti-correlated", {
   expect_equal(res$pbo, 1.0)
   expect_equal(res$n_paths, n_paths)
   expect_equal(res$n_strategies, n_strat)
+
+  # Tier A: function signature snapshot (catches param renames/additions).
+  expect_snapshot(args(hd_pbo))
 })
 
 test_that("hd_pbo returns near 0 when IS/OOS are perfectly correlated", {
@@ -177,20 +177,20 @@ test_that("hd_pbo result is between 0 and 1 for random scores", {
 test_that("hd_pbo rejects dimension mismatch", {
   is_scores  <- matrix(rnorm(10L), 5L, 2L)
   oos_scores <- matrix(rnorm(15L), 5L, 3L)
-  expect_error(hd_pbo(is_scores, oos_scores), "same dimensions")
+  expect_snapshot(error = TRUE, hd_pbo(is_scores, oos_scores))
 })
 
 test_that("hd_pbo rejects fewer than 2 paths", {
-  expect_error(
-    hd_pbo(matrix(rnorm(4L), 1L, 4L), matrix(rnorm(4L), 1L, 4L)),
-    "2 paths"
+  expect_snapshot(
+    error = TRUE,
+    hd_pbo(matrix(rnorm(4L), 1L, 4L), matrix(rnorm(4L), 1L, 4L))
   )
 })
 
 test_that("hd_pbo rejects fewer than 2 strategies", {
-  expect_error(
-    hd_pbo(matrix(rnorm(5L), 5L, 1L), matrix(rnorm(5L), 5L, 1L)),
-    "2 strategies"
+  expect_snapshot(
+    error = TRUE,
+    hd_pbo(matrix(rnorm(5L), 5L, 1L), matrix(rnorm(5L), 5L, 1L))
   )
 })
 

--- a/packages/historicaldata/tests/testthat/test-olmar.R
+++ b/packages/historicaldata/tests/testthat/test-olmar.R
@@ -8,6 +8,9 @@ test_that("simplex_project: output sums to 1", {
   v <- c(3, 1, -1, 2)
   w <- olmar_simplex_project(v)
   expect_equal(sum(w), 1, tolerance = 1e-8)
+
+  # Tier A: function signature snapshot (catches param renames/additions).
+  expect_snapshot(args(olmar_simplex_project))
 })
 
 test_that("simplex_project: all elements >= 0", {
@@ -36,11 +39,11 @@ test_that("simplex_project: handles single-element vector", {
 })
 
 test_that("simplex_project: errors on non-numeric input", {
-  expect_error(olmar_simplex_project("a"), "non-empty numeric")
+  expect_snapshot(error = TRUE, olmar_simplex_project("a"))
 })
 
 test_that("simplex_project: errors on empty vector", {
-  expect_error(olmar_simplex_project(numeric(0L)), "non-empty numeric")
+  expect_snapshot(error = TRUE, olmar_simplex_project(numeric(0L)))
 })
 
 # ── olmar_update ─────────────────────────────────────────────────────────
@@ -76,14 +79,14 @@ test_that("olmar_update: equal x_pred leaves weights unchanged", {
 test_that("olmar_update: errors on length mismatch", {
   b <- c(0.5, 0.5)
   x <- c(1.0, 1.0, 1.0)
-  expect_error(olmar_update(b, x), "Length mismatch")
+  expect_snapshot(error = TRUE, olmar_update(b, x))
 })
 
 test_that("olmar_update: errors on non-positive epsilon", {
   b <- c(0.5, 0.5)
   x <- c(1.1, 0.9)
-  expect_error(olmar_update(b, x, epsilon = 0), "positive scalar")
-  expect_error(olmar_update(b, x, epsilon = -1), "positive scalar")
+  expect_snapshot(error = TRUE, olmar_update(b, x, epsilon = 0))
+  expect_snapshot(error = TRUE, olmar_update(b, x, epsilon = -1))
 })
 
 # ── olmar_backtest ────────────────────────────────────────────────────────
@@ -111,6 +114,9 @@ test_that("olmar_backtest: returns expected columns", {
   expect_s3_class(result, "tbl_df")
   expect_named(result, c("date", "gross_ret", "net_ret", "turnover"))
   expect_equal(nrow(result), nrow(prices))
+
+  # Tier A: schema snapshot (catches column renames/additions/removals).
+  expect_snapshot(names(result))
 })
 
 test_that("olmar_backtest: net_ret <= gross_ret where turnover > 0", {
@@ -168,10 +174,7 @@ test_that("olmar_backtest: small numeric sanity check (2 assets, 5 days)", {
 
 test_that("olmar_backtest: errors on insufficient rows", {
   prices <- matrix(rnorm(20), nrow = 4L, ncol = 5L)
-  expect_error(
-    olmar_backtest(prices, window = 25L),
-    "requires at least"
-  )
+  expect_snapshot(error = TRUE, olmar_backtest(prices, window = 25L))
 })
 
 test_that("olmar_backtest: handles data.frame with date column", {

--- a/packages/historicaldata/tests/testthat/test-sharpe-stability-ratio.R
+++ b/packages/historicaldata/tests/testthat/test-sharpe-stability-ratio.R
@@ -200,6 +200,9 @@ test_that("hd_sharpe_stability_ratio: return is named list with correct field ty
   expect_type(res$w,           "integer")
   expect_type(res$lag_nw,      "integer")
   expect_type(res$ann_factor,  "double")
+
+  # Tier A: function signature snapshot (catches param renames/additions).
+  expect_snapshot(args(hd_sharpe_stability_ratio))
 })
 
 
@@ -208,23 +211,19 @@ test_that("hd_sharpe_stability_ratio: return is named list with correct field ty
 # ─────────────────────────────────────────────────────────────────────────────
 
 test_that("hd_rolling_sharpe: rejects non-numeric r", {
-  expect_error(hd_rolling_sharpe("not numeric", w = 10L),
-               class = "rlang_error")
+  expect_snapshot(error = TRUE, hd_rolling_sharpe("not numeric", w = 10L))
 })
 
 test_that("hd_rolling_sharpe: rejects non-integer w", {
-  expect_error(hd_rolling_sharpe(rnorm(100), w = -1L),
-               class = "rlang_error")
+  expect_snapshot(error = TRUE, hd_rolling_sharpe(rnorm(100), w = -1L))
 })
 
 test_that("hd_sharpe_stability_ratio: rejects negative ann_factor", {
-  expect_error(hd_sharpe_stability_ratio(rnorm(100), w = 20L, ann_factor = -1),
-               class = "rlang_error")
+  expect_snapshot(error = TRUE, hd_sharpe_stability_ratio(rnorm(100), w = 20L, ann_factor = -1))
 })
 
 test_that("hd_sharpe_stability_ratio: rejects non-integer lag_nw", {
-  expect_error(hd_sharpe_stability_ratio(rnorm(100), w = 20L, lag_nw = 1.5),
-               class = "rlang_error")
+  expect_snapshot(error = TRUE, hd_sharpe_stability_ratio(rnorm(100), w = 20L, lag_nw = 1.5))
 })
 
 test_that("hd_rolling_sharpe: returns empty vector when T < w", {
@@ -332,23 +331,19 @@ test_that("hd_top5pct_share: pct=0.10 override yields share=0.10 for uniform ser
 
 # Test 7: pct validation -- out-of-range values trigger cli_abort
 test_that("hd_top5pct_share: pct=0 triggers error", {
-  expect_error(hd_top5pct_share(rep(0.01, 10L), pct = 0),
-               class = "rlang_error")
+  expect_snapshot(error = TRUE, hd_top5pct_share(rep(0.01, 10L), pct = 0))
 })
 
 test_that("hd_top5pct_share: pct=1 triggers error", {
-  expect_error(hd_top5pct_share(rep(0.01, 10L), pct = 1),
-               class = "rlang_error")
+  expect_snapshot(error = TRUE, hd_top5pct_share(rep(0.01, 10L), pct = 1))
 })
 
 test_that("hd_top5pct_share: pct=1.5 triggers error", {
-  expect_error(hd_top5pct_share(rep(0.01, 10L), pct = 1.5),
-               class = "rlang_error")
+  expect_snapshot(error = TRUE, hd_top5pct_share(rep(0.01, 10L), pct = 1.5))
 })
 
 test_that("hd_top5pct_share: pct=-0.1 triggers error", {
-  expect_error(hd_top5pct_share(rep(0.01, 10L), pct = -0.1),
-               class = "rlang_error")
+  expect_snapshot(error = TRUE, hd_top5pct_share(rep(0.01, 10L), pct = -0.1))
 })
 
 

--- a/packages/historicaldata/tests/testthat/test-topological-risk-parity.R
+++ b/packages/historicaldata/tests/testthat/test-topological-risk-parity.R
@@ -40,6 +40,9 @@ make_2asset_cov <- function() {
 test_that("hrp_weights: weights sum to 1 (5-asset)", {
   w <- hrp_weights(make_5asset_cov())
   expect_equal(sum(w), 1, tolerance = 1e-10)
+
+  # Tier A: function signature snapshot (catches param renames/additions).
+  expect_snapshot(args(hrp_weights))
 })
 
 test_that("hrp_weights: all weights strictly positive (5-asset)", {
@@ -133,35 +136,35 @@ test_that("trp_weights: works with 2 assets", {
 # ── Input validation ──────────────────────────────────────────────────────────
 
 test_that("hrp_weights: error on non-matrix input", {
-  expect_error(hrp_weights(list(a = 1)), class = "rlang_error")
+  expect_snapshot(error = TRUE, hrp_weights(list(a = 1)))
 })
 
 test_that("hrp_weights: error on non-square matrix", {
   m <- matrix(1:6, nrow = 2)
   rownames(m) <- c("A", "B")
-  expect_error(hrp_weights(m), class = "rlang_error")
+  expect_snapshot(error = TRUE, hrp_weights(m))
 })
 
 test_that("hrp_weights: error on unnamed matrix", {
   m <- matrix(c(1, 0.5, 0.5, 1), nrow = 2)
-  expect_error(hrp_weights(m), class = "rlang_error")
+  expect_snapshot(error = TRUE, hrp_weights(m))
 })
 
 test_that("hrp_weights: error on mismatched row/col names", {
   m <- matrix(c(1, 0.5, 0.5, 1), nrow = 2)
   rownames(m) <- c("A", "B")
   colnames(m) <- c("C", "D")
-  expect_error(hrp_weights(m), class = "rlang_error")
+  expect_snapshot(error = TRUE, hrp_weights(m))
 })
 
 test_that("hrp_weights: error on single-asset matrix", {
   m <- matrix(0.04, nrow = 1, ncol = 1)
   rownames(m) <- colnames(m) <- "A"
-  expect_error(hrp_weights(m), class = "rlang_error")
+  expect_snapshot(error = TRUE, hrp_weights(m))
 })
 
 test_that("trp_weights: error on non-matrix input", {
-  expect_error(trp_weights(data.frame(a = 1)), class = "rlang_error")
+  expect_snapshot(error = TRUE, trp_weights(data.frame(a = 1)))
 })
 
 # ── Consistency: TRP vs HRP ───────────────────────────────────────────────────


### PR DESCRIPTION
Phase 1 Tier A of [#578](https://github.com/JohnGavin/historical/issues/578). Five package-suite files that had **zero** snapshots despite the mandated ratio.

| File | blocks | snapshots (was 0) | required |
|---|---|---|---|
| `test-sharpe-stability-ratio.R` | 28 | 9 | 9 |
| `test-add-signal.R` | 26 | 8 | 8 |
| `test-cpcv.R` | 24 | 10 | 8 |
| `test-topological-risk-parity.R` | 23 | 7 | 7 |
| `test-olmar.R` | 21 | 8 | 7 |

## Tier A only — the constraint is the point

Composition across all five files:

| Snapshot type | Count |
|---|---|
| `expect_snapshot(error = TRUE, …)` | 36 |
| `args()` | 5 |
| `names()` | 1 |
| `str()` / `print()` / `cat()` | **0** |

Every snapshot captures something a reviewer can judge by **reading it** — an error message, a signature, a schema. There are no numeric results, no `str()` of numeric output, no multi-row tibble prints.

That exclusion is deliberate. Bulk-generating numeric snapshots would record whatever the code currently computes as the expected value, converting "untested" into "looks tested" while permanently blessing unreviewed behaviour — the exact failure #578 exists to prevent, and the same shape as [#574](https://github.com/JohnGavin/historical/issues/574) (a control that exists but does not fire). Those belong in Phase 2, one at a time, each actually checked. **Nothing here was padded to reach a ratio.**

Sample of what landed:

```
# hd_cpcv_purge rejects negative label_horizon
    Code
      hd_cpcv_purge(1L:15L, 16L:20L, label_horizon = -1L)
    Condition
      Error in `hd_cpcv_purge()`:
      x `label_horizon` must be >= 0.
      i Got -1.
```

## Verification

`scripts/verify.sh`, run **serially**:

```
PASS: _targets.R parses (verified tree: …/agent-abd93df307851c7b5)
root suite     total=282 failed=3 skipped=0   -> baseline exactly
package suite  total=571 failed=1 skipped=5   -> baseline exactly
=== scripts/verify.sh: PASS ===   (exit 0)
```

### A caveat reviewers should know

A run of **this same tree** minutes earlier reported `package failed=8`. Clean `origin/main` reported the identical 8 at that moment. Those 7 extra failures are remote `hf://` parquet reads dying with `TProtocolException: Invalid data` — unrelated to this diff, which touches only test files. The run above is clean because the remote recovered in between.

That transience is itself the finding, raised as [#580](https://github.com/JohnGavin/historical/issues/580): the package suite is non-hermetic, so its baseline of 1 is not stable, and a green run cannot currently be distinguished from a lucky one. Until #580 is resolved, package-suite verification should be read against a *contemporaneous* clean-`main` run rather than the hardcoded baseline.

## Related

[#578](https://github.com/JohnGavin/historical/issues/578) · [#579](https://github.com/JohnGavin/historical/pull/579) (Phase 0) · [#580](https://github.com/JohnGavin/historical/issues/580) · [#574](https://github.com/JohnGavin/historical/issues/574)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
