### PR TITLE
test(metadata): confirm #576's missing_pct fix already shipped in #569/#570

### DIFF
--- a/tests/test_fetch_metadata.py
+++ b/tests/test_fetch_metadata.py
@@ -11,7 +11,7 @@ trading days; the fix derives the expected calendar from the dataset itself.
 """
 
 import sys
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 
 # Allow running from repo root or from tests/
@@ -160,6 +160,57 @@ class TestExpectedTradingDays:
             "crypto_daily", [], date(2024, 1, 2), date(2024, 1, 2), days_span=0
         )
         assert result == 0
+
+    def test_holiday_containing_period_below_naive_252_365_estimate(self):
+        """A real span crossing known market holidays yields a calendar-derived
+        expected count strictly below the naive ``days_span * 252 / 365``
+        ratio that ``scripts/fetch_metadata.py`` used before this fix
+        (historical#569/#570; re-confirmed for historical#576, which filed
+        the same defect separately and was already resolved by #569/#570 by
+        the time it was opened).
+
+        Window: 2024-11-15 to 2025-01-15 (62 calendar days), crossing three
+        NYSE holidays — Thanksgiving (2024-11-28), Christmas (2024-12-25),
+        and New Year's Day (2025-01-01). See
+        https://www.nyse.com/markets/hours-calendars.
+
+        A short, holiday-dense window is used deliberately: over a *full*
+        calendar year the 252/365 ratio is calibrated to roughly match the
+        real NYSE holiday count (empirically verified: 2024 in full gives
+        expected == naive == 252, no divergence). Only a holiday-clustered
+        sub-period exposes the naive ratio's local error — this is exactly
+        the failure mode #569/#570/#576 describe: a fixed yearly-average
+        ratio misprices any window that isn't itself a full year.
+        """
+        holidays = {
+            date(2024, 11, 28),  # Thanksgiving
+            date(2024, 12, 25),  # Christmas
+            date(2025, 1, 1),  # New Year's Day
+        }
+        start = date(2024, 11, 15)
+        end = date(2025, 1, 15)
+        days_span = (end - start).days
+
+        all_dates = []
+        d = start
+        while d <= end:
+            if d.weekday() < 5 and d not in holidays:
+                all_dates.append(d)
+            d += timedelta(days=1)
+
+        expected = _expected_trading_days("equity_daily", all_dates, start, end, days_span)
+        naive_252_365 = int(days_span * 252 / 365)
+
+        # Sanity-pin the fixture's own arithmetic so a future edit to the
+        # holiday list or window can't silently change what's being compared.
+        assert expected == 41
+        assert naive_252_365 == 42
+
+        assert expected < naive_252_365, (
+            "calendar-derived expected days must fall below the old naive "
+            "252/365 estimate for a holiday-containing period that is not "
+            "itself a full year"
+        )
 
 
 class TestMissingPct:


### PR DESCRIPTION
## Summary

Investigated #576 (`missing_pct` uses a hardcoded 252/365 estimate) before writing any fix. **The described defect no longer exists on `main`.** It was already replaced by a data-derived calendar in #569/#570 (commit `21e3bea`, merged 2026-07-20T08:40 UTC) — roughly 45 minutes after #576 was filed against the same finding from #567's provisional-constants audit sweep. #576 is a duplicate of an already-shipped fix, not an open defect.

`scripts/fetch_metadata.py:175` today reads:

```python
expected = _expected_trading_days(dataset, df["date"], start, end, days_span)
```

not the `int(days_span * 252 / 365)` cited in #576. `_expected_trading_days()` (in `scripts/metadata_helpers.py`) counts distinct observed dates across the whole dataset's dataframe within the ticker's own `[start, end]` window — exactly the "in-frame exchange calendar" fix #576 asks for.

This PR does **not** re-implement that fix (it already exists and 19 pre-existing tests already cover it). It adds the specific regression test the task brief asked for and documents the duplicate finding for triage.

## Assumption on per-ticker vs per-exchange calendar (already made by #569/#570, restated here)

- **Per-ticker is wrong** and was explicitly rejected: using only the ticker's own observed dates as its own "expected calendar" makes `missing_pct == 0` by construction for every ticker — the bug is invisible by definition. Documented in `_expected_trading_days()`'s docstring.
- **The implemented choice is per-dataset**, not per-exchange: `equity_daily` pools US equities + LSE ETFs + 2 European equities into one union calendar, and `crypto_daily` is its own bucket (calendar-day, not calendar-derived, since crypto trades every day).
- **True per-exchange grouping is not implemented and would need a larger change.** `compute_data_stats()` reads only `columns=["date", "ticker", "volume"]` from the OHLCV parquet — no `exchange` column is present at that point (exchange comes from a separate yfinance `.info` API call in `fetch_yahoo_info()`, joined into the output row only, never back into the calendar computation). Building a true per-exchange calendar would require joining ticker→exchange into the OHLCV read before deriving `all_dates`, which is a materially bigger change than #576's literal text asks for ("the observed exchange calendar sits in the **same dataframe**" — the OHLCV dataframe genuinely has no exchange column). Flagging this as a real limitation, not silently deciding it away: pooling US + LSE + European calendars into one union will inflate the "expected" count for any single-exchange ticker relative to that ticker's own exchange's true holiday calendar (different exchanges close on different days, so the union is closer to "all exchanges open" than any one exchange's true calendar). Given `EUROPEAN_EQUITIES` is only 2 tickers and LSE ETFs are a minority of `equity_daily`, the US-heavy pool dominates and the practical distortion is likely small — but it is a real, uncited approximation worth a follow-up issue if anyone starts trusting `missing_pct` at high precision for the non-US names specifically. Not filing that issue myself per this task's scope.

## Before/after `missing_pct` numbers (real computation, not hand-derived)

No `data/raw/yfinance_equity.parquet` or `crypto_all.parquet` exists in this worktree (large data files aren't checked in), so I could not run `compute_data_stats()` against live production data. Instead I computed both the pre-#569 naive formula and the current calendar-derived formula against a real calendar window with known NYSE holidays, using the actual `_expected_trading_days()` function (not a re-derivation):

Window: 2024-11-15 to 2025-01-15 (62 calendar days, `days_span=61`), crossing Thanksgiving (2024-11-28), Christmas (2024-12-25), New Year's Day (2025-01-01):

| | old naive `int(days_span * 252/365)` | current `_expected_trading_days()` |
|---|---|---|
| expected trading days | 42 | 41 |

For `total=41` real observations in that window, that's the difference between `missing_pct = round(100*(1-41/42),1) = 2.4%` (naive) vs `missing_pct = round(100*(1-41/41),1) = 0.0%` (calendar-derived, correct) — the naive formula would have falsely reported ~2.4% missing data for a ticker with a perfectly complete holiday-adjusted record.

I also checked a **full calendar year** (2024, `days_span=365`): both formulas give exactly 252 — no divergence. This is expected: 252/365 is itself calibrated to the average annual NYSE trading-day count, so only a holiday-*clustered sub-period* (not a full year) exposes the old formula's error. This is why the new regression test uses a ~2-month window, not a full year.

## Test infrastructure found

- `tests/test_fetch_metadata.py` — existing pytest suite (pure-stdlib, imports only from `scripts/metadata_helpers.py`, no pandas/pyarrow/yfinance needed to run it), 19 tests before this PR, already covering `_expected_trading_days()` / `_missing_pct()` / `_yield_fields()` including multi-ticker union calendar, single-ticker limitation, empty calendar, zero-span, and crypto branch cases.
- `.github/workflows/pytest.yml` — CI **does** run `pytest tests/test_fetch_metadata.py -v` on every push/PR touching `scripts/**.py` or `tests/test_**.py`. (Note: this contradicts this repo's `.claude/CLAUDE.md`, which currently says Python changes get no CI at all — that doc is stale for this specific path; not fixing that here, out of scope.)
- `nix develop` provides `pytest` via `py-env` in `flake.nix`.

This PR adds one new test: `test_holiday_containing_period_below_naive_252_365_estimate`, demonstrating the exact before/after divergence above using the real `_expected_trading_days()` function.

## Test results

```
tests/test_fetch_metadata.py — 20 passed in 0.02s (19 pre-existing + 1 new)
```

## `scripts/verify.sh` summary (full mode)

```
PASS: _targets.R parses
PASS: testthat edition 3 active

=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

=== scripts/verify.sh: PASS ===
```

## Recommendation

#576 is a duplicate of the fix already shipped in #569/#570. The `Closes #576` keyword below will auto-close it if/when this PR is merged — merging is a maintainer/orchestrator action, not something this dispatch performs. If a maintainer prefers to close #576 directly as "duplicate of #570" without merging this PR at all, that is equally correct; either path resolves it. This PR's own contribution is the added regression test above, which is useful regardless of how #576 gets closed.

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)
