### PR TITLE
fix(ci): ignore kaggle.com in lychee — bot-block disguised as 404 (#596)

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -9,3 +9,14 @@
 # Morningstar returns 202 Accepted for bot requests (content-delivery hold).
 # The article is valid and accessible in a browser.
 ^https://www\.morningstar\.com/
+
+# Kaggle bot-blocks with a *404*, not a 403 — link rot and anti-scraping are
+# indistinguishable from the status code alone. Measured 2026-07-31 on
+# /datasets/asadullahcreative/us-stock-market-historical-ohlcv-dataset:
+#   no User-Agent      -> 404
+#   User-Agent: lychee -> 404
+#   browser User-Agent -> 200
+# Since --accept lists 403 but a 404 cannot be accepted globally (it is the
+# one status we actually need to catch), the host has to be ignored instead.
+# Re-verify with a browser UA before assuming any kaggle.com link is dead.
+^https://www\.kaggle\.com/


### PR DESCRIPTION
Closes #596.

The link audit has failed on every push since 2026-07-31 16:50 on exactly one URL:

```
[404] https://www.kaggle.com/datasets/asadullahcreative/us-stock-market-historical-ohlcv-dataset
```

## It is not link rot

Measured today:

| client | status |
|---|---|
| no User-Agent | **404** |
| `User-Agent: lychee/0.15.1` | **404** |
| browser User-Agent | **200** |

Kaggle blocks non-browser clients with a **404 rather than a 403**, so an anti-scraping block is indistinguishable from a dead link by status code alone. The dataset is live and reachable in a browser.

## Why ignore rather than accept

The workflow's `--accept` list already covers `200,206,403,429`. 404 cannot be added there — it is the one status the audit exists to catch. So the host has to be ignored, which is the mechanism `.lycheeignore` already provides for this exact case (DOI publisher walls, Morningstar's 202 content-delivery hold).

The comment records the three measured status codes so nobody has to re-derive them, and instructs re-checking with a browser UA before assuming any `kaggle.com` link is genuinely dead.

## Source of the link

`prompt_database.md:66` — one occurrence, not in a vignette or dashboard.

## Why it surfaced now

The workflow triggers on push to `main` touching `docs/**`; #604 and #606 both did. The 09:19 run the same day passed against the same file, so Kaggle's block is either new today or IP-dependent on the runner.

**The merges triggered the check; they did not break the link.** I initially read the timestamp correlation as evidence I had broken something — worth recording that the correlation was misleading.

## Verification

No R or pipeline code touched — `.lycheeignore` only. The proof is the audit itself: this PR does not touch `docs/**`, so the in-repo check will not fire on it. Confirm on the next push to `main` that touches `docs/`, or via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)