### PR TITLE
research(explorations): test aligrithm SPX-times-VIX claim on our data (#611)

### DIFF
--- a/explorations/vix_spx_leadlag/SUMMARY.md
+++ b/explorations/vix_spx_leadlag/SUMMARY.md
@@ -1,0 +1,95 @@
+# SPX ↔ VIX lead-lag: testing "use the SPX to time the VIX, not vice versa"
+
+Source: [aligrithm — Chicken and Egg](https://aligrithm.com/chicken-and-egg-use-the-spx-to-time-the-vix-not-vice-versa/).
+Issue: [historical#611](https://github.com/JohnGavin/historical/issues/611).
+
+Reproduce: `nix develop . --command Rscript explorations/vix_spx_leadlag/run.R`
+Output: [`results/run_output.txt`](results/run_output.txt)
+
+Data: SPY `adjusted_close` + FRED `VIXCLS`, 8,351 complete trading days,
+1993-02-01 → 2026-04-10. Contemporaneous `cor(spx_ret, vix_chg) = -0.79`.
+
+## Verdict: the practical claim replicates, the causal claim does not
+
+The article makes two claims and treats them as one. They separate cleanly under test.
+
+### Claim A — "SPX RSI(2) is a better filter than VIX RSI(2)" → **replicates**
+
+| condition | share of days | next-day SPX mean | win rate | next-day VIX mean | down-rate |
+|---|---|---|---|---|---|
+| SPX RSI(2) ≤ 20 | 27.8% | **+0.109%** | **55.6%** | **−0.168** | **57.6%** |
+| VIX RSI(2) ≤ 20 | 35.7% | +0.041% | 54.4% | +0.076 | 50.5% |
+| unconditional | 100% | +0.047% | 54.0% | +0.001 | 53.0% |
+
+SPX oversold more than doubles the next-day SPX drift versus unconditional, and
+flips the next-day VIX change from flat to clearly negative. VIX oversold does
+neither — its next-day SPX return (+0.041%) is *below* unconditional (+0.047%).
+
+The article reported 57.66% vs 55.51% win rates; we get 55.6% vs 54.4%. Lower in
+level, same in ordering, smaller in gap (1.2pp vs 2.15pp). Different sample
+(1993–2026 vs 2007–2023) and a simple-MA rather than Wilder RSI smoothing.
+
+### Claim B — "SPX leads VIX, so don't use VIX to time SPX" → **not supported; mildly reversed**
+
+Cross-correlation is overwhelmingly contemporaneous, and what little lead-lag
+exists is symmetric:
+
+| lag k | `cor(spx_ret[t], vix_chg[t+k])` |
+|---|---|
+| −1 (VIX first) | +0.086 |
+| **0** | **−0.792** |
+| +1 (SPX first) | +0.106 |
+
+Predictive regressions, each controlling for the target's own lag:
+
+| direction | β | t | p | FPR @ equipoise | model R² |
+|---|---|---|---|---|---|
+| SPX_t → VIX_{t+1} | −0.289 | **−0.11** | 0.911 | n/a | 0.0183 |
+| VIX_t → SPX_{t+1} | +0.0004 | **+3.15** | 0.0016 | 0.027 | 0.0079 |
+
+SPX has **no** incremental power over tomorrow's VIX change. VIX change has
+modest but real incremental power over tomorrow's SPX return. That is the
+opposite of the stated direction.
+
+### Why both can be true
+
+They are different claims. Claim A is about **signal quality** — SPX price is a
+cleaner series than VIX, which is itself a nonlinear transform of option prices
+and noisier as a mean-reversion trigger. Claim B is about **causal timing**. The
+article's mechanism ("the VIX is a reaction to SPX price action") is true by
+construction, but it does not imply SPX *predicts* VIX at daily horizon — a
+reaction that is instantaneous leaves nothing to forecast.
+
+## Lévy area: a real ordering signature that is probably not tradeable
+
+Using `hd_levy_area()` ([#605](https://github.com/JohnGavin/historical/issues/605), merged today; positive = first series leads):
+
+| window | mean | fraction > 0 | n |
+|---|---|---|---|
+| 5d | +0.377 | 0.582 | 8,347 |
+| 10d | +1.004 | 0.623 | 8,342 |
+| 21d | +2.555 | 0.671 | 8,331 |
+| 63d | +9.917 | 0.778 | 8,289 |
+
+Systematically positive, and strengthening with window length — SPX does lead
+VIX in the path-geometry sense. But this is most plausibly the **volatility
+hysteresis loop**: price falls → VIX spikes fast → price recovers → VIX decays
+slowly. That asymmetric loop encloses signed area regardless of any exploitable
+lead, which is exactly why it coexists with the null result in Claim B.
+
+**The t-statistics are omitted deliberately.** Windows overlap n-deep, so
+effective sample size is far below 8,289 and any t-statistic computed on the
+nominal count is meaningless — see [#601](https://github.com/JohnGavin/historical/issues/601).
+
+## What this cannot test
+
+- **The headline backtest.** The article's result is a short-**VX-futures**
+  strategy. We hold VIX *spot*. Not replicable without futures data.
+- **Intraday causality.** At daily close, VIX is computed from SPX options
+  quoted at the same instant. Contemporaneity is structural, not a finding.
+- **Collinearity.** The two regressors in the asymmetry test are 79% correlated
+  (VIF ≈ 2.7), inflating standard errors ~1.6×. The asymmetry survives; the
+  coefficients are not precisely identified.
+
+Everything here is in-sample, with no train/test split — the same defect the
+article carries.

--- a/explorations/vix_spx_leadlag/results/run_output.txt
+++ b/explorations/vix_spx_leadlag/results/run_output.txt
@@ -1,0 +1,83 @@
+Using saved setting for 'extra-substituters = https://rstats-on-nix.cachix.org' from ~/.local/share/nix/trusted-settings.json.
+Using saved setting for 'extra-trusted-public-keys = rstats-on-nix.cachix.org-1:vdiiVgocg6WeJrODIqdprZRUrhi1JzhBnXv7aWI6+F0=' from ~/.local/share/nix/trusted-settings.json.
+==================================================
+T Project: historical_data
+==================================================
+
+Available commands:
+  t repl              - Start T REPL
+  t run <file>        - Run a T file
+  t test              - Run tests
+
+To add dependencies:
+  * Add them to tproject.toml
+  * Run 't update' to sync flake.nix
+
+Quarto is enabled via [additional-tools]. Render {t} chunks with filters: [tlang].
+
+=== 1. Load and align ===
+Warning message:
+"equity_daily" is survivorship-biased: 0 delisting events recorded across full
+history.
+ℹ Universe contains only currently-listed tickers.
+ℹ Known failed firms (Enron, Lehman, Bear Stearns, WorldCom, WaMu) are absent.
+✖ Per-stock Sharpe / CAGR / drawdown metrics OVER-ESTIMATE achievable
+  performance.
+→ True fix requires a point-in-time universe with delisting records
+  (CRSP/WRDS/Sharadar). See GitHub issue #150. 
+SPY date class: POSIXct/POSIXt 
+VIX date class: Date 
+Warning message:
+There was 1 warning in `mutate()`.
+ℹ In argument: `date = as.Date(date)`.
+Caused by warning in `as.Date.POSIXct()`:
+! Coercing nanoseconds to a lower resolution may result in a loss of data. 
+SPY rows: 8356  range: 1993-01-29 - 2026-04-10 
+VIX rows: 9470  NA values: 302 
+SPY price column used: adjusted_close 
+joined rows: 8356 
+complete rows after NA filter: 8351  range: 1993-02-01 - 2026-04-10 
+contemporaneous cor(spx_ret, vix_chg): -0.7916 
+
+=== 2. Cross-correlation lead-lag ===
+cor( spx_ret[t] , vix_chg[t+k] ). k>0 means SPX moves FIRST.
+  k = -5 : +0.0116
+  k = -4 : +0.0221
+  k = -3 : -0.0050
+  k = -2 : -0.0023
+  k = -1 : +0.0861
+  k = +0 : -0.7916   <- contemporaneous
+  k = +1 : +0.1063
+  k = +2 : +0.0409
+  k = +3 : +0.0210
+  k = +4 : +0.0449
+  k = +5 : +0.0095
+
+=== 3. Predictive asymmetry (the actual thesis) ===
+Does SPX predict tomorrow's VIX more than VIX predicts tomorrow's SPX?
+Each direction controls for the target's own lag.
+
+SPX_t -> VIX_{t+1}  (controlling VIX_t)
+  beta = -0.2890  t = -0.11  p = 0.911  FPR@equipoise = n/a (p >= 1/e)  model R2 = 0.01830
+VIX_t -> SPX_{t+1}  (controlling SPX_t)
+  beta = +0.0004  t = +3.15  p = 0.00162  FPR@equipoise = 0.027  model R2 = 0.00794
+
+=== 4. Levy area: does SPX lead VIX within the window? ===
+hd_levy_area sign convention: positive = FIRST series leads.
+  window  5: mean = +0.3767  frac>0 = 0.582  t = +16.64  n = 8347
+  window 10: mean = +1.0035  frac>0 = 0.623  t = +28.67  n = 8342
+  window 21: mean = +2.5551  frac>0 = 0.671  t = +39.07  n = 8331
+  window 63: mean = +9.9172  frac>0 = 0.778  t = +59.39  n = 8289
+
+=== 5. RSI(2) conditional asymmetry (the article's own signal) ===
+SPX RSI(2) <= 20  : n = 2324 (27.8% of days)
+   next-day SPX ret : mean +0.1086%  win rate 55.6%
+   next-day VIX chg : mean -0.1675    down-rate 57.6%
+
+VIX RSI(2) <= 20  : n = 2978 (35.7% of days)
+   next-day SPX ret : mean +0.0408%  win rate 54.4%
+   next-day VIX chg : mean +0.0761    down-rate 50.5%
+
+unconditional     : n = 8348
+   next-day SPX ret : mean +0.0465%  win rate 54.0%
+   next-day VIX chg : mean +0.0010    down-rate 53.0%

--- a/explorations/vix_spx_leadlag/run.R
+++ b/explorations/vix_spx_leadlag/run.R
@@ -1,0 +1,161 @@
+# Test the aligrithm "use SPX to time VIX, not vice versa" claim on our data.
+#
+# Source article:
+#   https://aligrithm.com/chicken-and-egg-use-the-spx-to-time-the-vix-not-vice-versa/
+# Issue: historical#611
+#
+# Exploration of data already in the canonical store (allowed under the
+# reproducible-ingestion rule). No new source is being ingested here.
+#
+# Run:  nix develop . --command Rscript explorations/vix_spx_leadlag/run.R
+# Last output committed at results/run_output.txt (8351 rows, 1993-02 to 2026-04).
+#
+# READ THE CAVEATS BEFORE QUOTING ANY NUMBER FROM THIS:
+#
+#  1. Daily closes cannot resolve intraday causality. VIX is computed from SPX
+#     options quoted at the same instant, so at daily frequency the two are
+#     contemporaneous by construction (measured cor = -0.79). The article's
+#     mechanical claim ("VIX is a reaction to SPX") is true by definition and
+#     is NOT testable at this frequency.
+#  2. Section 3's two regressors are 79% correlated (VIF ~2.7), so standard
+#     errors are inflated roughly 1.6x. The asymmetry reported is large enough
+#     to survive that, but the coefficients are not precisely identified.
+#  3. Section 4's t-statistics are NOT valid inference. The rolling windows
+#     overlap n-deep, so effective sample size is far below the reported n.
+#     See historical#601 (K_eff_xs). They are printed as a magnitude cue only.
+#  4. We hold VIX SPOT, not VX FUTURES. The article's headline backtest is a
+#     short-VX strategy and CANNOT be replicated here. Sections 2-5 test the
+#     lead-lag and filter-quality claims, not the tradeable one.
+#  5. In-sample throughout. No train/test split, no walk-forward.
+
+suppressMessages(pkgload::load_all("packages/historicaldata", quiet = TRUE))
+suppressMessages(library(dplyr))
+
+cat("=== 1. Load and align ===\n")
+spy <- hd_ohlcv("SPY")
+vix <- hd_macro("VIXCLS")
+
+# Memory: Date vs POSIXct silently joins to 0 rows. Coerce defensively.
+cat("SPY date class:", paste(class(spy$date), collapse = "/"), "\n")
+cat("VIX date class:", paste(class(vix$date), collapse = "/"), "\n")
+
+spy <- spy |> mutate(date = as.Date(date)) |> arrange(date)
+vix <- vix |> mutate(date = as.Date(date)) |> arrange(date)
+
+cat("SPY rows:", nrow(spy), " range:", format(min(spy$date)), "-", format(max(spy$date)), "\n")
+cat("VIX rows:", nrow(vix), " NA values:", sum(is.na(vix$value)), "\n")
+
+px_col <- if ("adjusted_close" %in% names(spy)) "adjusted_close" else "close"
+cat("SPY price column used:", px_col, "\n")
+
+d <- spy |>
+  select(date, px = all_of(px_col)) |>
+  inner_join(vix |> select(date, vix = value), by = "date") |>
+  arrange(date) |>
+  mutate(
+    spx_ret = (px - lag(px)) / lag(px),
+    vix_chg = vix - lag(vix)
+  )
+
+cat("joined rows:", nrow(d), "\n")
+d <- d |> filter(!is.na(spx_ret), !is.na(vix_chg), !is.na(vix))
+cat("complete rows after NA filter:", nrow(d),
+    " range:", format(min(d$date)), "-", format(max(d$date)), "\n")
+cat("contemporaneous cor(spx_ret, vix_chg):",
+    round(cor(d$spx_ret, d$vix_chg), 4), "\n\n")
+
+cat("=== 2. Cross-correlation lead-lag ===\n")
+cat("cor( spx_ret[t] , vix_chg[t+k] ). k>0 means SPX moves FIRST.\n")
+for (k in -5:5) {
+  if (k >= 0) {
+    x <- d$spx_ret[seq_len(nrow(d) - k)]
+    y <- d$vix_chg[(1 + k):nrow(d)]
+  } else {
+    x <- d$spx_ret[(1 - k):nrow(d)]
+    y <- d$vix_chg[seq_len(nrow(d) + k)]
+  }
+  cat(sprintf("  k = %+d : %+.4f%s\n", k, cor(x, y),
+              if (k == 0) "   <- contemporaneous" else ""))
+}
+
+cat("\n=== 3. Predictive asymmetry (the actual thesis) ===\n")
+cat("Does SPX predict tomorrow's VIX more than VIX predicts tomorrow's SPX?\n")
+cat("Each direction controls for the target's own lag.\n\n")
+
+d2 <- d |>
+  mutate(
+    spx_next = lead(spx_ret),
+    vix_next = lead(vix_chg)
+  ) |>
+  filter(!is.na(spx_next), !is.na(vix_next))
+
+m_spx_to_vix <- lm(vix_next ~ spx_ret + vix_chg, data = d2)
+m_vix_to_spx <- lm(spx_next ~ vix_chg + spx_ret, data = d2)
+
+s1 <- summary(m_spx_to_vix); s2 <- summary(m_vix_to_spx)
+c1 <- coef(s1)["spx_ret", ]; c2 <- coef(s2)["vix_chg", ]
+
+report <- function(label, cf, sm) {
+  p <- cf["Pr(>|t|)"]
+  # NB: sm$r.squared is the FULL-MODEL R2 (both regressors), not the partial
+  # R2 of the named coefficient. Labelled accordingly.
+  cat(sprintf("%s\n  beta = %+.4f  t = %+.2f  p = %.3g  FPR@equipoise = %s  model R2 = %.5f\n",
+              label, cf["Estimate"], cf["t value"], p,
+              ifelse(is.na(hd_fpr_equipoise(p)), "n/a (p >= 1/e)",
+                     sprintf("%.3f", hd_fpr_equipoise(p))),
+              sm$r.squared))
+}
+report("SPX_t -> VIX_{t+1}  (controlling VIX_t)", c1, s1)
+report("VIX_t -> SPX_{t+1}  (controlling SPX_t)", c2, s2)
+
+cat("\n=== 4. Levy area: does SPX lead VIX within the window? ===\n")
+cat("hd_levy_area sign convention: positive = FIRST series leads.\n")
+for (n in c(5L, 10L, 21L, 63L)) {
+  la <- hd_roll_levy_area(d$spx_ret, d$vix_chg, n = n, scale = TRUE)
+  ok <- !is.na(la)
+  frac_pos <- mean(la[ok] > 0)
+  tt <- t.test(la[ok])
+  cat(sprintf("  window %2d: mean = %+.4f  frac>0 = %.3f  t = %+.2f  n = %d\n",
+              n, mean(la[ok]), frac_pos, tt$statistic, sum(ok)))
+}
+
+cat("\n=== 5. RSI(2) conditional asymmetry (the article's own signal) ===\n")
+rsi2 <- function(x, n = 2L) {
+  ch <- c(NA, diff(x))
+  g <- pmax(ch, 0); l <- pmax(-ch, 0)
+  ag <- slider::slide_dbl(g, mean, .before = n - 1L, .complete = TRUE)
+  al <- slider::slide_dbl(l, mean, .before = n - 1L, .complete = TRUE)
+  ifelse(al == 0, 100, 100 - 100 / (1 + ag / al))
+}
+
+d3 <- d |>
+  mutate(
+    spx_rsi2 = rsi2(px),
+    vix_rsi2 = rsi2(vix),
+    spx_next = lead(spx_ret),
+    vix_next = lead(vix_chg)
+  ) |>
+  filter(!is.na(spx_rsi2), !is.na(vix_rsi2), !is.na(spx_next), !is.na(vix_next))
+
+sig_spx <- d3 |> filter(spx_rsi2 <= 20)
+sig_vix <- d3 |> filter(vix_rsi2 <= 20)
+
+cat(sprintf("SPX RSI(2) <= 20  : n = %4d (%.1f%% of days)\n",
+            nrow(sig_spx), 100 * nrow(sig_spx) / nrow(d3)))
+cat(sprintf("   next-day SPX ret : mean %+.4f%%  win rate %.1f%%\n",
+            100 * mean(sig_spx$spx_next), 100 * mean(sig_spx$spx_next > 0)))
+cat(sprintf("   next-day VIX chg : mean %+.4f    down-rate %.1f%%\n",
+            mean(sig_spx$vix_next), 100 * mean(sig_spx$vix_next < 0)))
+
+cat(sprintf("\nVIX RSI(2) <= 20  : n = %4d (%.1f%% of days)\n",
+            nrow(sig_vix), 100 * nrow(sig_vix) / nrow(d3)))
+cat(sprintf("   next-day SPX ret : mean %+.4f%%  win rate %.1f%%\n",
+            100 * mean(sig_vix$spx_next), 100 * mean(sig_vix$spx_next > 0)))
+cat(sprintf("   next-day VIX chg : mean %+.4f    down-rate %.1f%%\n",
+            mean(sig_vix$vix_next), 100 * mean(sig_vix$vix_next < 0)))
+
+cat(sprintf("\nunconditional     : n = %4d\n", nrow(d3)))
+cat(sprintf("   next-day SPX ret : mean %+.4f%%  win rate %.1f%%\n",
+            100 * mean(d3$spx_next), 100 * mean(d3$spx_next > 0)))
+cat(sprintf("   next-day VIX chg : mean %+.4f    down-rate %.1f%%\n",
+            mean(d3$vix_next), 100 * mean(d3$vix_next < 0)))


### PR DESCRIPTION
Refs #611.

Adds `explorations/vix_spx_leadlag/` — a reproducible test of [aligrithm's SPX↔VIX lead-lag claim](https://aligrithm.com/chicken-and-egg-use-the-spx-to-time-the-vix-not-vice-versa/) against 8,351 trading days of our own SPY + VIXCLS (1993-02 → 2026-04).

Full conclusions and next steps are in #611 and `SUMMARY.md`. Headline: the article's **practical** claim (SPX RSI(2) is a better filter than VIX RSI(2)) replicates; its **causal** claim (SPX leads VIX) does not, and is mildly reversed — SPX has no incremental power over tomorrow's VIX (t = −0.11), while VIX has modest power over tomorrow's SPX (t = +3.15, FPR ≈ 2.7%).

## Why this is committed rather than left in /tmp

The numbers are quoted in an issue that will be read months from now. A scratch script makes them model-eyeballed and unreproducible — the exact failure the reproducible-ingestion rule exists to prevent. `run.R` regenerates every figure with one command.

This is exploration of data **already in the canonical store** (`hd_ohlcv`, `hd_macro`), not ingestion of a new source.

## Caveats live in the code, not just the issue

`run.R`'s header carries the five limitations that must travel with any quoted number — daily closes cannot resolve intraday causality, the asymmetry test's regressors are 79% correlated, the Lévy t-statistics are invalid under overlapping windows (#601), we hold VIX spot not VX futures so the headline backtest is not replicable, and everything is in-sample.

## Two defensive details worth noting

- SPY dates arrive as `POSIXct`, VIXCLS as `Date`. Joining without coercion silently yields zero matches — the script coerces both and prints the classes.
- VIXCLS carries 302 scattered NAs. `hd_roll_levy_area()` returns `NA` for any window containing one rather than splicing across the gap, which is why the Lévy `n` values fall slightly below the row count.

## Verification

No package or pipeline code touched — a new `explorations/` directory only, which is outside the targets pipeline and both test suites. Per `explorations/CONVENTIONS.md` this is scratch-tier work (minimum score 60), not production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)