### PR TITLE
fix(ci): derive data-poll deps from DESCRIPTION — unbreaks commodities poll

### DIFF
--- a/.github/workflows/data-poll.yml
+++ b/.github/workflows/data-poll.yml
@@ -41,13 +41,50 @@ jobs:
       - name: Install R dependencies
         shell: Rscript {0}
         run: |
-          install.packages(
-            c("jsonlite", "arrow", "dplyr", "cli", "here",
-              "httr2", "tibble", "tidyr", "purrr", "quantmod", "pkgload",
-              "DBI", "duckdb", "duckplyr", "ggplot2",
-              "lubridate", "slider", "rlang"),
-            repos = "https://cloud.r-project.org"
+          # The fetch scripts call pkgload::load_all() on packages/historicaldata,
+          # which hard-fails if any DESCRIPTION Import is absent. Keeping a
+          # hand-written list in sync with DESCRIPTION does not work: adding
+          # `digest` there (historical#598) broke this job on the next scheduled
+          # run, because only one of the two lists was updated.
+          #
+          # So derive the package's Imports from DESCRIPTION and union them with
+          # the extras that only the fetch scripts need. The literal list is
+          # retained as a floor, so a DESCRIPTION parse failure degrades to the
+          # previous behaviour rather than installing nothing.
+          script_deps <- c(
+            "jsonlite", "arrow", "dplyr", "cli", "here",
+            "httr2", "tibble", "tidyr", "purrr", "quantmod", "pkgload",
+            "DBI", "duckdb", "duckplyr", "ggplot2",
+            "lubridate", "slider", "rlang", "digest"
           )
+
+          pkg_imports <- tryCatch({
+            dcf <- read.dcf("packages/historicaldata/DESCRIPTION", fields = "Imports")
+            raw <- dcf[1L, 1L]
+            if (is.na(raw)) character(0) else {
+              x <- strsplit(raw, ",")[[1]]
+              trimws(sub("\\(.*\\)", "", x))
+            }
+          }, error = function(e) {
+            message("DESCRIPTION parse failed, falling back to literal list: ",
+                    conditionMessage(e))
+            character(0)
+          })
+
+          # base/recommended packages ship with R; installing them is wasteful
+          # and `base`/`stats` are not on CRAN at all.
+          base_pkgs <- rownames(installed.packages(priority = "base"))
+          need <- setdiff(unique(c(script_deps, pkg_imports)), c(base_pkgs, ""))
+
+          message("Installing ", length(need), " packages: ",
+                  paste(sort(need), collapse = ", "))
+          install.packages(need, repos = "https://cloud.r-project.org")
+
+          # Fail loudly here rather than 20 lines later inside load_all().
+          missing <- need[!need %in% rownames(installed.packages())]
+          if (length(missing) > 0L) {
+            stop("Failed to install: ", paste(missing, collapse = ", "))
+          }
 
       - name: Run fetch script
         env:


### PR DESCRIPTION
Fixes the failing [Weekly Data Poll run](https://github.com/JohnGavin/historical/actions/runs/30691340071).

## My regression

PR #604 added `digest` to `packages/historicaldata/DESCRIPTION` Imports for SHA-256 hypothesis sealing (#598). `data-poll.yml` keeps a **second, hand-written package list**, and I updated only the first. The next scheduled run failed:

```
Error in load_imports(path) : The package "digest" is required.
Calls: <Anonymous> ... load_imports -> deps_check_installed -> check_installed
```

The fetch scripts call `pkgload::load_all()`, which hard-fails on any missing Import — so drift between the two lists is guaranteed to break the poll rather than degrade gracefully.

## Why not just add `digest` to the list

That fixes today and reintroduces the identical failure the next time anyone adds an Import. The job now parses `DESCRIPTION` Imports and unions them with the extras only the fetch scripts need (`jsonlite`, `arrow`, `here`, `httr2`, `tidyr`, `quantmod`, `pkgload`).

The literal list is **retained as a floor**: if `read.dcf()` fails, the job degrades to exactly the previous behaviour rather than installing nothing.

## Verified locally

```
parsed Imports -> cli DBI digest dplyr duckdb duckplyr ggplot2 lubridate
                  MASS purrr rlang slider stats tibble
install set (20) -> correctly drops 'stats' as base, includes 'digest'
```

That check also surfaced that **`MASS` was missing from the old list too** — it only worked because MASS ships with R as a recommended package. Two silent gaps, not one, which is the argument for deriving rather than maintaining.

Also adds a post-install assertion so a failed install stops with the package name rather than 20 lines later inside `load_all()`.

## Pattern

Third hand-maintained list found stale in two days — #607 covers the `verify.sh` skip baseline and the CI-coverage claim in `.claude/CLAUDE.md`. Same root cause: a fact about the build duplicated by hand instead of derived.

## Verification limits

I cannot execute the workflow locally. What I verified is the R logic in isolation (output above) against the real `DESCRIPTION`. The workflow itself is proven only by the next scheduled run or a `workflow_dispatch`. The four sibling matrix jobs (guardian/kalshi/cboe_vol/ecb) passed on the failing run, so the change is exercised by all five on the next fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)