### PR TITLE
knowledge(611): record SPX-VIX lead-lag findings, positive and negative

### DIFF
--- a/explorations/vix_spx_leadlag/results/run_output.txt
+++ b/explorations/vix_spx_leadlag/results/run_output.txt
@@ -81,3 +81,32 @@ VIX RSI(2) <= 20  : n = 2978 (35.7% of days)
 unconditional     : n = 8348
    next-day SPX ret : mean +0.0465%  win rate 54.0%
    next-day VIX chg : mean +0.0010    down-rate 53.0%
+
+=== 6. Marginal contribution: which signal does the work? ===
+            bucket    n pct_days next_spx_pct spx_win next_vix vix_down
+           neither 3200     38.3       0.0077    52.5   0.0509     51.8
+ VIX oversold only 2824     33.8       0.0395    54.4   0.0832     50.5
+ SPX oversold only 2170     26.0       0.1117    55.8  -0.1757     58.1
+     both oversold  154      1.8       0.0648    53.9  -0.0528     50.6
+
+The two conditions are nearly mutually exclusive, not redundant:
+  cor(spx_rsi2, vix_rsi2)          = -0.664
+  P(VIX oversold | SPX oversold)   = 0.066
+  P(SPX oversold | VIX oversold)   = 0.052
+  overlap: 154 of 8348 days (1.8%)
+
+--- largest next-day moves, SPX oversold while VIX calm ---
+       date    px  vix spx_rsi2 vix_rsi2 next_spx_pct next_vix
+ 2008-10-10  64.2 70.0        0      100        14.52   -14.96
+ 2008-10-27  60.9 80.1        0      100        11.69   -13.10
+ 2025-04-08 490.9 52.3        0      100        10.50   -18.71
+ 2020-03-12 226.7 75.5        0      100         8.55   -17.64
+ 2020-03-06 271.8 41.9        0      100        -7.81    12.52
+
+--- largest next-day moves, VIX oversold while SPX not ---
+       date    px  vix spx_rsi2 vix_rsi2 next_spx_pct next_vix
+ 2008-10-14  72.4 55.1     89.5      0.9        -9.84    14.12
+ 2008-11-28  65.4 55.8    100.0     13.3        -8.86    12.67
+ 2020-04-03 228.1 46.8     60.9      0.0         6.72    -1.56
+ 2008-10-21  69.5 53.1     65.5      0.8        -5.45    16.54
+ 1998-10-14  62.3 39.0     73.2     11.2         5.38    -5.62

--- a/explorations/vix_spx_leadlag/run.R
+++ b/explorations/vix_spx_leadlag/run.R
@@ -159,3 +159,60 @@ cat(sprintf("   next-day SPX ret : mean %+.4f%%  win rate %.1f%%\n",
             100 * mean(d3$spx_next), 100 * mean(d3$spx_next > 0)))
 cat(sprintf("   next-day VIX chg : mean %+.4f    down-rate %.1f%%\n",
             mean(d3$vix_next), 100 * mean(d3$vix_next < 0)))
+
+cat("\n=== 6. Marginal contribution: which signal does the work? ===\n")
+# Sections 5's two conditions are not two sensors on one state - they are
+# nearly disjoint. Bucketing shows what each contributes on its own.
+d3 <- d3 |>
+  mutate(bucket = case_when(
+    spx_rsi2 <= 20 & vix_rsi2 <= 20 ~ "both oversold",
+    spx_rsi2 <= 20                  ~ "SPX oversold only",
+    vix_rsi2 <= 20                  ~ "VIX oversold only",
+    TRUE                            ~ "neither"
+  ))
+
+print(as.data.frame(
+  d3 |>
+    dplyr::group_by(bucket) |>
+    dplyr::summarise(
+      n            = dplyr::n(),
+      pct_days     = round(100 * dplyr::n() / nrow(d3), 1),
+      next_spx_pct = round(100 * mean(spx_next), 4),
+      spx_win      = round(100 * mean(spx_next > 0), 1),
+      next_vix     = round(mean(vix_next), 4),
+      vix_down     = round(100 * mean(vix_next < 0), 1),
+      .groups = "drop"
+    ) |>
+    dplyr::arrange(dplyr::desc(n))
+), row.names = FALSE)
+
+cat("\nThe two conditions are nearly mutually exclusive, not redundant:\n")
+cat(sprintf("  cor(spx_rsi2, vix_rsi2)          = %+.3f\n",
+            cor(d3$spx_rsi2, d3$vix_rsi2)))
+cat(sprintf("  P(VIX oversold | SPX oversold)   = %.3f\n",
+            mean(d3$vix_rsi2[d3$spx_rsi2 <= 20] <= 20)))
+cat(sprintf("  P(SPX oversold | VIX oversold)   = %.3f\n",
+            mean(d3$spx_rsi2[d3$vix_rsi2 <= 20] <= 20)))
+cat(sprintf("  overlap: %d of %d days (%.1f%%)\n",
+            sum(d3$spx_rsi2 <= 20 & d3$vix_rsi2 <= 20), nrow(d3),
+            100 * mean(d3$spx_rsi2 <= 20 & d3$vix_rsi2 <= 20)))
+
+cat("\n--- largest next-day moves, SPX oversold while VIX calm ---\n")
+print(as.data.frame(
+  d3 |> dplyr::filter(bucket == "SPX oversold only") |>
+    dplyr::arrange(dplyr::desc(abs(spx_next))) |> head(5) |>
+    dplyr::transmute(date, px = round(px, 1), vix = round(vix, 1),
+                     spx_rsi2 = round(spx_rsi2, 1), vix_rsi2 = round(vix_rsi2, 1),
+                     next_spx_pct = round(100 * spx_next, 2),
+                     next_vix = round(vix_next, 2))
+), row.names = FALSE)
+
+cat("\n--- largest next-day moves, VIX oversold while SPX not ---\n")
+print(as.data.frame(
+  d3 |> dplyr::filter(bucket == "VIX oversold only") |>
+    dplyr::arrange(dplyr::desc(abs(spx_next))) |> head(5) |>
+    dplyr::transmute(date, px = round(px, 1), vix = round(vix, 1),
+                     spx_rsi2 = round(spx_rsi2, 1), vix_rsi2 = round(vix_rsi2, 1),
+                     next_spx_pct = round(100 * spx_next, 2),
+                     next_vix = round(vix_next, 2))
+), row.names = FALSE)

--- a/knowledge/INDEX.md
+++ b/knowledge/INDEX.md
@@ -41,6 +41,7 @@ Cross-cutting patterns live in `~/docs_gh/llm/knowledge/`.
 | Quantocracy May 2026 Roundup | [quantocracy-may-2026.md](wiki/quantocracy-may-2026.md) | Reference |
 | Macrosynergy Macro Data Research | [macrosynergy-research.md](wiki/macrosynergy-research.md) | Draft |
 | Research ROI Framework | [research-roi.md](wiki/research-roi.md) | Draft |
+| SPX ↔ VIX Lead-Lag & RSI(2) Filter Asymmetry | [spx-vix-lead-lag.md](wiki/spx-vix-lead-lag.md) | Active — filter claim confirmed, causal claim contradicted |
 
 ### Workflow & Infrastructure
 

--- a/knowledge/LOG.md
+++ b/knowledge/LOG.md
@@ -166,3 +166,15 @@ Chronological record of findings. Wiki pages synthesise these into structured kn
   2. Risk parity 58-year tail/drawdown audit (Beyond Passive) — empirical context for #114 HRP work
 - **Individual article fetches:** WebFetch permission denied; blurbs sourced from Quantocracy HTML only
 - See [[quantocracy-may-2026]]
+
+## 2026-08-01
+
+### SPX ↔ VIX lead-lag tested, not just reviewed (#611)
+- **Source:** [aligrithm "Chicken and Egg"](https://aligrithm.com/chicken-and-egg-use-the-spx-to-time-the-vix-not-vice-versa/) — not previously reviewed; the site was triaged at pillar level in #592 but this article appears in none of the four existing aligrithm issues
+- **First article we could TEST rather than annotate** — `hd_levy_area()` (#605) landed hours earlier and measures exactly the ordering claimed
+- **Positive result:** the RSI(2) filter claim replicates. SPX RSI(2) ≤ 20 → next-day SPX +0.109% / 55.6% win; VIX RSI(2) ≤ 20 → +0.041% / 54.4%, *below* the unconditional +0.047%
+- **Negative result:** the causal claim does not, and mildly reverses. SPX_t → VIX_{t+1} t = −0.11 (no power); VIX_t → SPX_{t+1} t = +3.15, FPR ≈ 2.7% (modest power)
+- **Reconciling finding:** the two RSI conditions are nearly disjoint (overlap 1.8% of days, `cor = −0.664`). They select opposite market states, not the same state through different sensors — SPX-oversold is a panic bottom, VIX-oversold is post-panic calm
+- **Live consequence:** `plan_avoid_worst.R` triggers on absolute VIX levels — the mechanism under dispute. Not refuted, but tested for the first time (#611 N1)
+- **Rejected:** short-VX strategy — no futures data, source backtest in-sample with self-admitted arbitrary lookback
+- Analysis: `explorations/vix_spx_leadlag/` (reproducible). See [[spx-vix-lead-lag]]

--- a/knowledge/raw/aligrithm-spx-vix-leadlag-2026.md
+++ b/knowledge/raw/aligrithm-spx-vix-leadlag-2026.md
@@ -1,0 +1,61 @@
+# Source record: aligrithm — "Chicken and Egg: Use the SPX to Time the VIX, Not Vice Versa"
+
+- URL: https://aligrithm.com/chicken-and-egg-use-the-spx-to-time-the-vix-not-vice-versa/
+- Author: Ali H. Askar (aligrithm)
+- Retrieved: 2026-07-31
+- Reviewed under: [historical#611](https://github.com/JohnGavin/historical/issues/611)
+
+> External source. Recorded here as a **summary of claims in our own words**, per
+> the zero-trust rule — read for ideas, re-implement in our own style. Short
+> quotes only, for provenance. Nothing here was copied into our codebase.
+
+## Claims as stated by the author
+
+**Central thesis.** Causality runs SPX → VIX, not the reverse. Because VIX is
+computed from SPX option prices, reading VIX to forecast SPX is "reading the
+effect to predict the cause". The author's phrasing: *"The VIX is a reaction to
+SPX price action, and option traders react rather than anticipate."*
+
+**Long-horizon evidence (2007–2023).** SPX trend filters (price above year-ago
+close, above 200-day MA, 50/200 golden cross) reportedly beat buy-and-hold on
+risk-adjusted return. VIX-based filters lagged, at CAR/MDD 0.11–0.13 versus 0.14
+for buy-and-hold. Author's conclusion: *"Long-term VIX levels do not filter the
+SPX."*
+
+**Short-horizon evidence.** SPX RSI(2) ≤ 20 → 57.66% win rate and 1.41 profit
+factor on next-day SPX. VIX RSI(2) ≤ 20 → 55.51% win rate, 1.14 profit factor,
+which the author calls "noise" by comparison.
+
+**VIX futures asymmetry.** VX is claimed to mean-revert faster than SPX
+recovers: after 2008 VX bottomed within ~7 months while SPX took ~5.5 years;
+in 2022 VX made new lows in ~6 months while SPX stayed underwater ~2 years.
+
+**Short-VX filtering (2007–2023), author's table.**
+
+| filter | points captured | max drawdown | win rate | recovery factor |
+|---|---|---|---|---|
+| SPX RSI ≤ 20 | 178.6 | 21.04 | 62.9% | 8.49 |
+| VIX RSI ≤ 20 | 80.23 | — | — | — |
+| naked short VX | 213.52 | 68.86 | — | 3.1 |
+
+SPX-filtered captured 178.6 points while in-market only 34% of the time, profit
+factor 1.47 vs 1.13 unfiltered.
+
+**Methodology notes.** RSI period 2 rather than 14 was chosen deliberately —
+the author argues a 14-period RSI "parks almost everything between 30 and 70",
+while 2 periods makes it "a mean-reversion detector, not a trend gauge". Also
+uses the Rule of 16 (daily vol ≈ VIX ÷ 16, from √252).
+
+## Author's own caveats
+
+- RSI(2) lookback "is a choice rather than a law" — acknowledged overfitting risk.
+- Results are historical backtest 2007–2023; no forward test or walk-forward
+  validation is described.
+- The traded vehicle (VX futures) differs from the index (VIX spot); the piece
+  does not explore the structural difference in depth.
+
+## What we did with it
+
+Tested on our own data (SPY + FRED VIXCLS, 8,351 trading days, 1993-02-01 →
+2026-04-10). Analysis: `explorations/vix_spx_leadlag/`. Findings compiled to
+[`wiki/spx-vix-lead-lag.md`](../wiki/spx-vix-lead-lag.md).

--- a/knowledge/wiki/spx-vix-lead-lag.md
+++ b/knowledge/wiki/spx-vix-lead-lag.md
@@ -1,0 +1,164 @@
+---
+title: SPX ↔ VIX Lead-Lag and RSI(2) Filter Asymmetry
+canonical_question: "Does SPX lead VIX, and is an SPX-based oversold filter better than a VIX-based one — and if so, why?"
+status: active
+fresh_until: 2027-08-01
+consensus_level: split
+sources:
+  - aligrithm-spx-vix-leadlag-2026.md
+compiled_by: orchestrator-tier
+compiled_on: 2026-08-01
+tags: [vix, spx, lead-lag, rsi, mean-reversion, regime, levy-area, volatility-hysteresis, aligrithm, falsification]
+---
+
+# SPX ↔ VIX Lead-Lag and RSI(2) Filter Asymmetry
+
+A source claim ([aligrithm](../raw/aligrithm-spx-vix-leadlag-2026.md)) bundles two
+separate propositions and presents them as one: that SPX *leads* VIX, and that
+therefore an SPX-based oversold filter beats a VIX-based one. Tested against
+8,351 trading days of our own data (SPY + FRED `VIXCLS`, 1993-02-01 → 2026-04-10,
+`explorations/vix_spx_leadlag/`), **the filter claim holds and the causal claim
+does not.** They are true and false for the same underlying reason, which is the
+useful part.
+
+`consensus_level: split` — we confirm one half of the source and contradict the other.
+
+---
+
+## Result 1 — the filter claim replicates (positive)
+
+| condition | share of days | next-day SPX mean | win rate | next-day VIX mean | down-rate |
+|---|---|---|---|---|---|
+| SPX RSI(2) ≤ 20 | 27.8% | **+0.109%** | **55.6%** | **−0.168** | **57.6%** |
+| VIX RSI(2) ≤ 20 | 35.7% | +0.041% | 54.4% | +0.076 | 50.5% |
+| unconditional | — | +0.047% | 54.0% | +0.001 | 53.0% |
+
+VIX-oversold is not merely weaker — its next-day SPX return (+0.041%) sits
+*below* unconditional (+0.047%). Source reported 57.66% vs 55.51%; we get 55.6%
+vs 54.4%. Same ordering, smaller gap, different sample and RSI smoothing.
+
+## Result 2 — the causal claim does not replicate, and mildly reverses (negative)
+
+Cross-correlation is overwhelmingly contemporaneous, and lead-lag is symmetric:
+
+| lag k | `cor(spx_ret[t], vix_chg[t+k])` |
+|---|---|
+| −1 (VIX first) | +0.086 |
+| **0** | **−0.792** |
+| +1 (SPX first) | +0.106 |
+
+Predictive regressions, each controlling for the target's own lag:
+
+| direction | β | t | p | FPR @ equipoise | model R² |
+|---|---|---|---|---|---|
+| SPX_t → VIX_{t+1} | −0.289 | **−0.11** | 0.911 | n/a | 0.0183 |
+| VIX_t → SPX_{t+1} | +0.0004 | **+3.15** | 0.0016 | 0.027 | 0.0079 |
+
+SPX has **no** incremental power over tomorrow's VIX. VIX has modest but real
+power over tomorrow's SPX — the reverse of the stated direction.
+
+## Result 3 — why both hold: the two RSI conditions are nearly disjoint
+
+This is the finding worth carrying forward. The two "filters" are not two sensors
+on one market state; they describe **opposite** states and almost never co-occur.
+
+| bucket | n | % days | next-day SPX | SPX win | next-day VIX | VIX down |
+|---|---|---|---|---|---|---|
+| neither | 3,200 | 38.3% | +0.008% | 52.5% | +0.051 | 51.8% |
+| VIX oversold only | 2,824 | 33.8% | +0.040% | 54.4% | +0.083 | 50.5% |
+| **SPX oversold only** | 2,170 | 26.0% | **+0.112%** | **55.8%** | **−0.176** | **58.1%** |
+| both oversold | 154 | 1.8% | +0.065% | 53.9% | −0.053 | 50.6% |
+
+- `cor(spx_rsi2, vix_rsi2) = −0.664`
+- `P(VIX oversold | SPX oversold) = 0.066`
+- overlap: 154 of 8,348 days (1.8%)
+
+**SPX RSI(2) ≤ 20** means price just fell hard → VIX is *high* → the setup is a
+panic bottom, and both SPX rebound and VIX decay follow.
+**VIX RSI(2) ≤ 20** means VIX just fell hard → the panic already unwound → the
+rebound is behind you.
+
+So "SPX filters better" is not a statement about sensor quality. The two rules
+select different days, and one of those day-sets happens to precede the
+mean-reversion.
+
+## Result 4 — Lévy area shows real ordering that is probably not tradeable
+
+Using `hd_levy_area()` ([#605]; positive = first series leads):
+
+| window | mean | fraction > 0 |
+|---|---|---|
+| 5d | +0.377 | 0.582 |
+| 10d | +1.004 | 0.623 |
+| 21d | +2.555 | 0.671 |
+| 63d | +9.917 | 0.778 |
+
+> ⚠ AI-inferred: the most plausible reading is the **volatility hysteresis loop**
+> — price falls, VIX spikes fast, price recovers, VIX decays slowly. That
+> asymmetric loop encloses signed area regardless of any exploitable lead, which
+> is exactly why it coexists with the Result 2 null. Not independently verified
+> against a hysteresis-specific test.
+
+t-statistics are deliberately omitted: windows overlap n-deep, so effective
+sample size is far below nominal ([#601]).
+
+---
+
+## Lessons learnt
+
+**L1 — A mechanism is not a forecast.** "VIX is computed from SPX options, so
+VIX reacts to SPX" is true by construction and says nothing about predictability.
+A reaction that is instantaneous leaves nothing to forecast. The source treats
+the mechanism as evidence for the forecast; the data separates them cleanly.
+
+**L2 — When two filters are compared, check whether they select the same days.**
+The bucket table (Result 3) took minutes and explained more than the headline
+comparison did. A filter comparison without an overlap statistic is
+under-specified. Generalises to any A-vs-B signal comparison.
+
+**L3 — Contemporaneous dominance can hide the question.** At daily close, VIX is
+computed from SPX options quoted at the same instant, so `cor = −0.79` at lag 0
+is structural. Daily data **cannot** test an intraday causal claim; picking the
+frequency to match the claim is a prerequisite, not a refinement.
+
+**L4 — Path-geometry ordering ≠ predictive lead.** Lévy area found a strong,
+monotone ordering signature in the same data where the regression found nothing.
+Both are correct; they measure different things. Do not read a non-zero Lévy
+area as a tradeable lead.
+
+**L5 — Test what you can, and say what you cannot.** The source's headline is a
+short-**VX-futures** backtest. We hold VIX *spot*. That claim was not tested and
+is not disputed here — it is simply out of reach with our data.
+
+## Live consequence for this project
+
+`R/plan_avoid_worst.R` goes to cash on **absolute VIX level** thresholds
+(`c(25, 30, 35, 40)`) — that is "use VIX to time SPX". Result 2 gives it modest
+support (t = 3.15) rather than refutation, but the effect is small (model
+R² 0.008) and this is the first direct test of the strategy's premise we have
+run. A head-to-head against an SPX-drawdown trigger is tracked in [#611] N1.
+
+## Limitations
+
+- In-sample throughout; no train/test split, no walk-forward.
+- Asymmetry regressors are 79% correlated (VIF ≈ 2.7), inflating SEs ~1.6×. The
+  asymmetry survives; the coefficients are not precisely identified.
+- Single market (US). No cross-geography replication — see
+  `cross-geography-pervasiveness`.
+- The SPX↔VIX relationship is among the most-watched in markets; any surviving
+  edge must clear `priced-in-prohibition`'s incremental-power test, which
+  Result 2 fails.
+
+## Sources
+
+- [aligrithm-spx-vix-leadlag-2026.md](../raw/aligrithm-spx-vix-leadlag-2026.md) — source claims and the author's own caveats
+- `explorations/vix_spx_leadlag/` — `run.R`, `SUMMARY.md`, `results/run_output.txt` (reproducible: `nix develop . --command Rscript explorations/vix_spx_leadlag/run.R`)
+- [historical#611](https://github.com/JohnGavin/historical/issues/611) — review issue and next steps
+- [historical#605](https://github.com/JohnGavin/historical/issues/605) — `hd_levy_area()`, used in Result 4
+- [historical#601](https://github.com/JohnGavin/historical/issues/601) — why Result 4's t-statistics are withheld
+
+## Related
+
+- [[walk-forward-correlation]] — same family of "is this edge real" diagnostics
+- [[anomaly-driven-demand]] — crowding channel; relevant if any VIX-timing rule is widely traded
+- [[regime-trend-following]] — regime classification, the natural consumer of Result 3


### PR DESCRIPTION
Refs #611.

Compiles the #611 review into the knowledge base so future work can reuse it without re-deriving — and adds the analysis that turned out to explain the other two results.

| | |
|---|---|
| new | `knowledge/raw/aligrithm-spx-vix-leadlag-2026.md` — source claims in our own words (zero-trust: summarised, not copied) |
| new | `knowledge/wiki/spx-vix-lead-lag.md` — compiled findings, `consensus_level: split` |
| updated | `knowledge/INDEX.md`, `knowledge/LOG.md` |
| updated | `explorations/vix_spx_leadlag/` — section 6 + regenerated output |

## The new result: the two RSI conditions are nearly disjoint

| bucket | n | % days | next-day SPX | SPX win | next-day VIX | VIX down |
|---|---|---|---|---|---|---|
| neither | 3,200 | 38.3% | +0.008% | 52.5% | +0.051 | 51.8% |
| VIX oversold only | 2,824 | 33.8% | +0.040% | 54.4% | +0.083 | 50.5% |
| **SPX oversold only** | 2,170 | 26.0% | **+0.112%** | **55.8%** | **−0.176** | **58.1%** |
| both oversold | 154 | 1.8% | +0.065% | 53.9% | −0.053 | 50.6% |

`cor(spx_rsi2, vix_rsi2) = −0.664`, `P(VIX oversold | SPX oversold) = 0.066`, overlap 1.8% of days.

They are not two sensors on one state — they select **opposite** states. SPX-oversold means price just fell hard, so VIX is *high*: a panic bottom, with both the SPX rebound and the VIX decay ahead of it. VIX-oversold means the panic already unwound. So "SPX filters better" is not a claim about sensor quality; the two rules pick different days and one of those day-sets precedes the mean reversion.

This reconciles Results 1 and 2 — the filter claim can replicate while the causal claim fails, because they were never the same claim.

## Both directions recorded

Deliberately including the negative. The wiki page carries `consensus_level: split` because we confirm one half of the source and contradict the other, and the LOG entry states the reversal explicitly. A knowledge base that only records confirmations is a citation machine.

## Lessons carried forward (L1–L5 in the wiki)

L1 a mechanism is not a forecast · L2 always report overlap when comparing two filters · L3 contemporaneous dominance can hide the question — match frequency to the claim · L4 path-geometry ordering is not a predictive lead · L5 test what you can, say plainly what you cannot.

## Honesty markers

- The Lévy hysteresis reading is tagged `> ⚠ AI-inferred:` per `confidence-markers` — plausible, not independently verified.
- Lévy t-statistics withheld (overlapping windows, #601).
- Limitations section covers in-sample-only, VIF ≈ 2.7 collinearity, single-market, and the `priced-in-prohibition` test the causal claim fails.

## Verification

`wiki_health_check.sh`: **our page passes.** The 17 reported errors are all pre-existing — 16 of 23 wiki pages predate the frontmatter convention and one uses a retired `consensus_level`. Not fixed here; that is a separate cleanup.

No package or pipeline code touched — `knowledge/` and `explorations/` only, both outside the targets pipeline and both test suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)