### PR TITLE
perf(ci): use RSPM binaries in data poll — install step is ~51 min of source builds

### DIFF
--- a/.github/workflows/data-poll.yml
+++ b/.github/workflows/data-poll.yml
@@ -180,7 +180,20 @@ jobs:
 
           message("Installing ", length(need), " packages: ",
                   paste(sort(need), collapse = ", "))
-          install.packages(need, repos = "https://cloud.r-project.org")
+          # r-lib/actions/setup-r exports RSPM — the Posit Package Manager
+          # binary repo matching this runner's Ubuntu release. Hardcoding
+          # cloud.r-project.org discards it, and cloud serves SOURCE tarballs
+          # only for Linux, so every package (duckdb, arrow, duckplyr, ggplot2)
+          # compiles from scratch. Measured on run 30691340071: the install
+          # step took ~51 minutes. Binaries take ~2.
+          repos <- Sys.getenv("RSPM", unset = "")
+          if (!nzchar(repos)) {
+            repos <- "https://cloud.r-project.org"
+            message("RSPM unset — falling back to CRAN source packages.")
+          }
+          message("Installing from: ", repos)
+
+          install.packages(need, repos = repos)
 
           # Fail loudly here rather than 20 lines later inside load_all().
           missing <- need[!need %in% rownames(installed.packages())]


### PR DESCRIPTION
Found while investigating whether #613 had slowed the poll. **It had not** — the install step has always been this slow.

## Evidence

Run [30691340071](https://github.com/JohnGavin/historical/actions/runs/30691340071) — the failing run #613 fixed, on the **old** code:

| | |
|---|---|
| job started | 2026-08-01T08:13:48Z |
| install step ended | ~2026-08-01T09:04:48Z |
| **duration** | **~51 minutes** |

## Cause

`r-lib/actions/setup-r@v2` exports, for this runner:

```
RSPM: https://packagemanager.posit.co/cran/__linux__/noble/latest
```

Posit Package Manager, serving **prebuilt Linux binaries**. The workflow then hardcoded:

```r
install.packages(need, repos = "https://cloud.r-project.org")
```

and cloud.r-project.org serves **source tarballs only** for Linux. So duckdb, arrow, duckplyr and ggplot2 compiled from scratch on every job, every source, every week.

## Fix

Read `RSPM` when set; fall back to CRAN when not (local runs, non-Linux, or if the action stops exporting it). Fallback verified locally — with `RSPM` unset it prints the fallback message and resolves to cloud.r-project.org.

## Cost of the status quo

~51 min × 5 matrix jobs ≈ **4 hours of runner time per weekly poll**. #618's retry ladder can add up to four more fires, so this was about to multiply.

## Not a #613 regression

Worth stating plainly: I flagged #613 as suspect when the manual run sat at 38 minutes. The comparison above shows the old code took the same ~51 minutes. #613 is exonerated; this is a pre-existing defect it happened to expose.

## Verification limits

YAML parses; the fallback branch is exercised locally. The RSPM path itself is only proven by a real CI run — the next poll, or a `workflow_dispatch`. If the improvement is real the install step should drop from ~51 min to roughly 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)