### PR TITLE
feat(falsification): surface crisis-vs-calm tail independence + fix doc drift (#624)

### DIFF
--- a/R/plan_falsification_vignette.R
+++ b/R/plan_falsification_vignette.R
@@ -377,6 +377,91 @@ plan_falsification_vignette <- function() {
     }),
 
 
+    # ── Crisis-vs-calm tail independence (#624) ──────────────────────────
+    # fals_tail_independence is computed on every pipeline run but was never
+    # surfaced. Formats it as a Metric/Value table for the existing
+    # "Multiplicity Correction" tabset, following the fals_vig_multiplicity
+    # pattern above.
+    targets::tar_target(fals_vig_tail_table, {
+      tk <- fals_tail_independence$tail_keff
+      ratio <- if (!is.na(tk$K_eff_frob_calm) && tk$K_eff_frob_calm != 0) {
+        tk$K_eff_frob_crisis / tk$K_eff_frob_calm
+      } else {
+        NA_real_
+      }
+
+      td <- fals_tail_independence$tail_dependence
+      mean_lambda_l <- mean(td$lambda_L, na.rm = TRUE)
+
+      dd <- fals_tail_independence$drawdown_overlap
+      mean_dd_overlap <- mean(dd[upper.tri(dd)], na.rm = TRUE)
+
+      tibble::tibble(
+        Metric = c(
+          "K_eff_frob (calm regime)",
+          "K_eff_frob (crisis regime)",
+          "Collapse ratio (crisis / calm)",
+          "N calm-regime months",
+          "N crisis-regime months",
+          "Mean lower tail dependence (lambda_L)",
+          "Mean pairwise drawdown overlap"
+        ),
+        Value = as.character(c(
+          round(tk$K_eff_frob_calm, 2),
+          round(tk$K_eff_frob_crisis, 2),
+          round(ratio, 2),
+          tk$n_calm_days,
+          tk$n_crisis_days,
+          round(mean_lambda_l, 3),
+          round(mean_dd_overlap, 3)
+        ))
+      )
+    }),
+
+    targets::tar_target(fals_vig_tail_caption, {
+      tk <- fals_tail_independence$tail_keff
+      ratio <- if (!is.na(tk$K_eff_frob_calm) && tk$K_eff_frob_calm != 0) {
+        tk$K_eff_frob_crisis / tk$K_eff_frob_calm
+      } else {
+        NA_real_
+      }
+      collapse_pct <- round((1 - ratio) * 100, 0)
+
+      verdict <- if (is.na(ratio)) {
+        paste0(
+          "too few crisis-regime months (", tk$n_crisis_days,
+          ") to draw a conclusion"
+        )
+      } else if (ratio < 0.85) {
+        paste0(
+          "diversification is failing exactly when it matters most: K_eff_frob falls by ",
+          collapse_pct, "% from the calm to the crisis regime"
+        )
+      } else {
+        "diversification holds up in the crisis regime -- no material collapse detected"
+      }
+
+      gh <- "https://github.com/JohnGavin/historical/blob/main"
+      a_ <- function(text, url) paste0('<a href="', url, '" target="_blank" rel="noopener noreferrer">', text, '</a>')
+
+      paste0(
+        "Regime-conditional independence test. ",
+        "The 6-strategy return matrix is split into a crisis regime (any strategy below its own 5% monthly-return quantile) ",
+        "and the complementary calm regime, and K_eff_frob is recomputed within each. ",
+        "K_eff_frob (calm) = ", round(tk$K_eff_frob_calm, 2),
+        " vs K_eff_frob (crisis) = ", round(tk$K_eff_frob_crisis, 2),
+        " across ", tk$n_calm_days, " calm and ", tk$n_crisis_days, " crisis months: ",
+        verdict, ". ",
+        "Mean lower tail dependence (lambda_L) across the 15 strategy pairs is ",
+        round(mean(fals_tail_independence$tail_dependence$lambda_L, na.rm = TRUE), 3),
+        " -- under independence this converges to the 0.05 quantile used to define the tail. ",
+        "Source: ", a_("hd_tail_keff_frob()", paste0(gh, "/packages/historicaldata/R/falsification.R#L558")), ", ",
+        a_("hd_tail_dependence()", paste0(gh, "/packages/historicaldata/R/falsification.R#L638")), ", ",
+        a_("hd_drawdown_overlap()", paste0(gh, "/packages/historicaldata/R/falsification.R#L687")), "."
+      )
+    }),
+
+
     # ── HAC dot chart (Cleveland style) ─────────────────────────────
     targets::tar_target(fals_vig_hac_plot, {
       library(ggplot2)

--- a/docs/falsification.qmd
+++ b/docs/falsification.qmd
@@ -368,7 +368,7 @@ Where:
 - Alpha t < 2.0, R² (%) > 20: **Disguised beta** — just buy the factors directly
 - Alpha t < 2.0, R² (%) < 10: Strategy is noise
 
-**Data source:** [Kenneth French Data Library](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html){target="_blank" rel="noopener noreferrer"}, daily frequency. Implemented in [`hd_factor_null_test()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/falsification.R){target="_blank" rel="noopener noreferrer"}.
+**Data source:** [Kenneth French Data Library](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html){target="_blank" rel="noopener noreferrer"}, daily frequency. Implemented in [`hd_factor_null_test()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/falsification.R#L738){target="_blank" rel="noopener noreferrer"}.
 
 
 # Multiplicity Correction {#multiplicity}
@@ -384,6 +384,15 @@ Where:
 mult_tbl <- safe_tar_read("fals_vig_multiplicity")
 cap <- safe_tar_read("fals_vig_multiplicity_caption")
 if (!is.null(mult_tbl)) fals_dt(mult_tbl, cap)
+```
+
+#### Crisis vs Calm
+
+```{r}
+#| label: tail-independence-table
+tail_tbl <- safe_tar_read("fals_vig_tail_table")
+cap <- safe_tar_read("fals_vig_tail_caption")
+if (!is.null(tail_tbl)) fals_dt(tail_tbl, cap)
 ```
 
 #### Methodology
@@ -411,6 +420,15 @@ Delta-Z = max(t_IS) - max(t_OOS) — the gap between the best in-sample and best
 - Delta-Z > 2: Severe overfitting, in-sample performance is misleading
 
 In this framework, "in-sample" = HAC t-stat (strategy returns), "out-of-sample" = FF alpha t-stat (after removing known factor exposure). The OOS test is not a temporal holdout but a *structural* holdout — does the signal survive factor decomposition?
+
+**Crisis vs Calm (tail-weighted regime-conditional independence):**
+
+K_eff measures diversification on the *full* sample, averaged across calm and turbulent periods alike. A portfolio can look diversified on average while its strategies quietly converge to the same bet exactly when a crash hits — the moment diversification is actually needed. [`hd_tail_keff_frob()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/falsification.R#L558){target="_blank" rel="noopener noreferrer"} tests for this directly: it splits the 6-strategy monthly return matrix into a **crisis regime** (any month where at least one strategy falls below its own 5% lower-tail quantile) and the complementary **calm regime**, then recomputes K_eff_frob separately within each.
+
+- **K_eff_frob (crisis) ≈ K_eff_frob (calm)**: diversification is regime-stable — the independence you see in normal markets is still there when it matters.
+- **K_eff_frob (crisis) < K_eff_frob (calm)**: diversification is collapsing precisely during drawdowns — strategies that look independent on average are converging to a single correlated bet in a crisis.
+
+The tab also reports the mean lower tail dependence coefficient (lambda_L) across all 15 strategy pairs, via [`hd_tail_dependence()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/falsification.R#L638){target="_blank" rel="noopener noreferrer"} — the conditional probability that one strategy is in its own worst 5% of months given that another strategy is in its worst 5% — and the mean pairwise drawdown overlap fraction via [`hd_drawdown_overlap()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/falsification.R#L687){target="_blank" rel="noopener noreferrer"}, the fraction of days two strategies are simultaneously underwater. Both are complementary evidence for the same question: do the 6 strategies actually lose money together?
 
 
 # Covariance Regularisation {#covreg}
@@ -523,18 +541,17 @@ A 60-month rolling walk-forward backtest estimates portfolio weights using each 
 
 - **Raw MVO** — Plug-in tangency portfolio w ∝ Σ⁻¹μ from the *sample* covariance and *sample* mean, with no regularisation. Small errors in the estimated returns swing the weights hard, so it trades heavily and piles into a few assets. It also breaks down (singular sample Σ) once the number of assets approaches the training-window length.
 - **GMV (Global Min-Var)** — `w ∝ Σ⁻¹1` via a regularised (Ledoit-Wolf) covariance. No expected-return input. Implemented in [`hd_min_var_weights()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/min_var_weights.R#L65){target="_blank" rel="noopener noreferrer"}.
-- **Shrunk-μ (James-Stein)** — Tangency portfolio using Bayes-Stein (Jorion 1986) shrinkage on μ toward the grand mean, with a regularised Σ. Implemented in [`hd_returns_shrink(method = "james_stein")`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/returns_shrink.R){target="_blank" rel="noopener noreferrer"}.
-- **Black-Litterman (no views)** — Tangency portfolio from the BL (1992) posterior μ̂ and Σ_BL using [`hd_black_litterman()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/black_litterman.R){target="_blank" rel="noopener noreferrer"}. Shown here with no investor views (w_mkt = 1/p, risk_aversion = 2.5). **With no views, Black-Litterman just returns the equal-weight starting point**, so its row matches Equal-Weight below. That is expected behaviour, not a bug — there are no views to tilt away from.
+- **Shrunk-μ (James-Stein)** — Tangency portfolio using Bayes-Stein (Jorion 1986) shrinkage on μ toward the grand mean, with a regularised Σ. Implemented in [`hd_returns_shrink(method = "james_stein")`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/returns_shrink.R#L112){target="_blank" rel="noopener noreferrer"}.
+- **Black-Litterman (no views)** — Tangency portfolio from the BL (1992) posterior μ̂ and Σ_BL using [`hd_black_litterman()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/black_litterman.R#L142){target="_blank" rel="noopener noreferrer"}. Shown here with no investor views (w_mkt = 1/p, risk_aversion = 2.5). **With no views, Black-Litterman just returns the equal-weight starting point**, so its row matches Equal-Weight below. That is expected behaviour, not a bug — there are no views to tilt away from.
 - **Equal-Weight (1/N)** — The robust benchmark. Zero turnover by construction.
-- **HRP (Hierarchical Risk Parity)** — Lopez de Prado (2016) hierarchical diversification using a regularised Σ. Implemented in [`hrp_weights()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/topological_risk_parity.R){target="_blank" rel="noopener noreferrer"}.
+- **HRP (Hierarchical Risk Parity)** — Lopez de Prado (2016) hierarchical diversification using a regularised Σ. Implemented in [`hrp_weights()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/topological_risk_parity.R#L210){target="_blank" rel="noopener noreferrer"}.
 
 **Metrics explained:**
 
-- **Avg Turnover** — Mean L₁ weight change between consecutive OOS windows: mean(‖w_t − w_{t−1}‖₁). Higher = more rebalancing cost. Equal-Weight = 0 by construction.
-- **Max |w|** — Mean across windows of the largest absolute weight. Equal-Weight → 1/p = 0.25 for 4 assets. Raw MVO → values often exceed 1: a leveraged bet (more than 100% in one asset, funded by short/negative positions in the others), which the unconstrained optimiser permits and the regularised methods do not.
-- **OOS Sharpe** — Annualised Sharpe ratio of OOS portfolio returns (mean/sd × √12) over non-failed windows. On this 4-asset universe 0 of 182 windows failed for every method (the covariance is never singular with 4 well-behaved assets); failures only occur in wide universes where the asset count approaches the training-window length.
-- **Eff N** — Mean effective number of holdings (1/Σw_j²; Herfindahl measure). Equal-Weight → p = 4; concentrated raw MVO → near 1.
-- **Failed** — Windows where weight construction failed (e.g. singular sample Σ for raw MVO). Counted but excluded from all performance metrics.
+- **Avg turnover** — Mean L₁ weight change between consecutive OOS windows: mean(‖w_t − w_{t−1}‖₁). Higher = more rebalancing cost. Equal-Weight = 0 by construction.
+- **Max weight** — Mean across windows of the largest absolute weight. Equal-Weight → 1/p = 0.25 for 4 assets. Raw MVO → values often exceed 1: a leveraged bet (more than 100% in one asset, funded by short/negative positions in the others), which the unconstrained optimiser permits and the regularised methods do not.
+- **OOS Sharpe** — Annualised Sharpe ratio of OOS portfolio returns (mean/sd × √12) over non-failed windows. On this 4-asset universe 0 of 182 windows failed for every method (the covariance is never singular with 4 well-behaved assets); failures only occur in wide universes where the asset count approaches the training-window length. Windows where weight construction fails (e.g. singular sample Σ for raw MVO) are counted but excluded from all performance metrics and from this table.
+- **Effective holdings** — Mean effective number of holdings (1/Σw_j²; Herfindahl measure). Equal-Weight → p = 4; concentrated raw MVO → near 1.
 
 **Honest interpretation:**
 
@@ -607,7 +624,7 @@ if (!is.null(wfc_tbl) && nrow(wfc_tbl) > 0) {
 
 **Strategies not included:** OLMAR, TOM, and other non-parametric strategies have no tunable grid. XGB DRIF operates at the stock level (not a factor-rotation grid); factor-level XGB is tracked as a follow-up to [#318](https://github.com/JohnGavin/historical/issues/318){target="_blank" rel="noopener noreferrer"}.
 
-**Reference:** Tinsley, M. (2026). "Walk Forward Correlation." Trade Like A Machine Ltd. [SSRN 6324079](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6324079){target="_blank" rel="noopener noreferrer"}. Implemented in [`hd_wf_correlation()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/wf_correlation.R){target="_blank" rel="noopener noreferrer"}.
+**Reference:** Tinsley, M. (2026). "Walk Forward Correlation." Trade Like A Machine Ltd. [SSRN 6324079](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6324079){target="_blank" rel="noopener noreferrer"}. Implemented in [`hd_wf_correlation()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/wf_correlation.R#L84){target="_blank" rel="noopener noreferrer"}.
 
 
 # Assumptions {#assumptions}
@@ -810,7 +827,7 @@ The value factor (HML) and volatility index (VIX) are NOT independent. This mean
 |-------------|---------------|--------|
 | **[DRIF strategy](https://github.com/JohnGavin/historical/blob/main/R/plan_drif.R)** | DRIF loads on HML. During VIX spikes, DRIF underperforms MORE than the Vol_regime node alone predicts. | Consider reducing DRIF weight in crisis regimes |
 | **[Multi-strategy portfolio](https://github.com/JohnGavin/historical/blob/main/R/plan_multi_strategy.R) ([#52](https://github.com/JohnGavin/historical/issues/52))** | Diversification between VIX overlay and value-heavy strategies is LESS than K_eff suggests — they correlate in crises, exactly when diversification matters most | Recompute weights with crisis-conditional correlations |
-| **[Tail independence](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/falsification.R) ([#55](https://github.com/JohnGavin/historical/issues/55))** | K_eff_crisis < K_eff_calm is expected — this finding explains why | Run [`hd_tail_keff()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/falsification.R) to quantify |
+| **[Tail independence](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/falsification.R#L558) ([#55](https://github.com/JohnGavin/historical/issues/55))** | K_eff_crisis < K_eff_calm is expected — this finding explains why | See the [Crisis vs Calm tab](#multiplicity), computed via [`hd_tail_keff_frob()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/falsification.R#L558) |
 | **[DAG revision](https://github.com/JohnGavin/historical/blob/main/R/plan_causal_graph.R)** | Need either: VIX → HML edge (direct), or latent "Crisis_mode" → {VIX, HML} | Added VIX → HML edge (dashed yellow in diagram) |
 
 **Economic explanation:** In crises, investors sell risky assets indiscriminately. Value stocks (high book-to-market) are often distressed firms — they get sold first. Simultaneously, VIX spikes as options demand surges. The correlation is not VIX *causing* value to fall, but both responding to the same flight-to-safety mechanism.
@@ -994,9 +1011,9 @@ positives. The runs test has power against any non-random pattern; ACF
 specifically targets persistence.
 
 **Source code:**
-[`hd_dd_duration()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/risk_metrics.R)
+[`hd_dd_duration()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/risk_metrics.R#L38)
 and
-[`hd_loss_clustering()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/risk_metrics.R)
+[`hd_loss_clustering()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/risk_metrics.R#L140)
 in `packages/historicaldata/R/risk_metrics.R`. Tests in
 [`test-risk-metrics.R`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/tests/testthat/test-risk-metrics.R).
 Issue [#269](https://github.com/JohnGavin/historical/issues/269).

--- a/packages/historicaldata/_pkgdown.yml
+++ b/packages/historicaldata/_pkgdown.yml
@@ -113,9 +113,10 @@ reference:
       - hd_kelly_bayesian
       - hd_kelly_bounded
       - hd_kelly_rolling
-      - hd_keff
-      - hd_tail_keff
+      - hd_keff_frob
+      - hd_tail_keff_frob
       - hd_tail_dependence
+      - hd_strat_keff_vertox
 
   - title: Trade Analysis
     desc: Trade-level metrics and event analysis
@@ -144,6 +145,13 @@ reference:
       - hd_results_append
       - hd_results_query
       - hd_results_schema
+
+  - title: Portfolio Construction
+    desc: Risk-parity weight construction and OOS weight-stability diagnostics
+    contents:
+      - hrp_weights
+      - trp_weights
+      - hd_weight_stability_diagnostic
 
   - title: Infrastructure
     desc: DuckDB connections, caching, and downloads


### PR DESCRIPTION
## Summary

- **Task 1 — surface `fals_tail_independence`**: this target (`R/plan_falsification.R:934-978`) computes, on every pipeline run, `hd_tail_keff_frob()` (crisis vs calm regime `K_eff_frob`), `hd_tail_dependence()` (pairwise lower tail dependence), and `hd_drawdown_overlap()` — but the output was displayed nowhere. Adds `fals_vig_tail_table` / `fals_vig_tail_caption` (`R/plan_falsification_vignette.R:385-462`) and a new **"Crisis vs Calm"** tab inside the *existing* `# Multiplicity Correction {#multiplicity}` tabset in `docs/falsification.qmd` (between the "K_eff and Delta-Z" and "Methodology" tabs), plus a matching prose block in the Methodology tab explaining what a collapse means. No new dashboard was created, per the `dashboard-output-first` rule (#514).
- **Task 2 — fix documentation drift** found while wiring the new tab.
- **Task 3 — fix stale `_pkgdown.yml` export names** and add missing entries to the reference index.

## `fals_tail_independence` structure (as found)

```r
list(
  tail_keff = list(          # from hd_tail_keff_frob(mat, q = 0.05)
    K_eff_frob_crisis, K_eff_frob_calm,
    n_crisis_days, n_calm_days,
    correlation_crisis, correlation_calm
  ),
  tail_dependence = tibble(  # one row per strategy pair (15 rows for 6 strategies)
    strategy_1, strategy_2, lambda_L, n_pairs
  ),
  drawdown_overlap = matrix  # K x K, from hd_drawdown_overlap()
)
```

## What the new "Crisis vs Calm" tab shows

A Metric/Value table: `K_eff_frob (calm)`, `K_eff_frob (crisis)`, the collapse ratio (crisis/calm), N calm/crisis months, mean lower tail dependence (lambda_L) across the 15 strategy pairs, and mean pairwise drawdown overlap. The dynamically-computed caption (`fals_vig_tail_caption`) states both values, the ratio, and — depending on whether the ratio is below 0.85 — an explicit verdict sentence on whether diversification is collapsing in the crisis regime. The Methodology tab gets a matching static-prose paragraph explaining the crisis/calm split and how to read a K_eff_frob(crisis) < K_eff_frob(calm) result.

## Doc-drift fixes (Task 2), by file:line

| File:Line | Defect | Fix |
|---|---|---|
| `docs/falsification.qmd:813` (pre-edit) | Told readers to "Run `hd_tail_keff()`" — function does not exist; real export is `hd_tail_keff_frob()`; link had no `#L` anchor | Corrected name, anchored to `falsification.R#L558`, reworded to point at the new Crisis vs Calm tab instead of "run this by hand" |
| `docs/falsification.qmd:529` | `hrp_weights()` link had no `#L` anchor | Anchored to `topological_risk_parity.R#L210` |
| `docs/falsification.qmd:534` | Prose documented column **"Max \|w\|"** — rendered table (`R/plan_weight_stability_vignette.R:65-74`) actually emits **"Max weight"** | Prose corrected to "Max weight" |
| `docs/falsification.qmd:537` | Prose documented column **"Failed"** — table deliberately drops `n_failed` (per the plan file's own comment) | Bullet removed; existing "0 of 182 windows failed" sentence (OOS Sharpe bullet) already covers this without implying a table column |
| `docs/falsification.qmd:536` (bonus, same class of drift) | Prose said **"Eff N"**, table column is **"Effective holdings"** | Corrected to match |
| `docs/falsification.qmd` various | 6 single-function source links missing `#L` anchors: `hd_factor_null_test`, `hd_returns_shrink`, `hd_black_litterman`, `hd_wf_correlation`, `hd_dd_duration`, `hd_loss_clustering` | Anchored each to its `function <- function(...)` definition line |

**Scoping note:** grepped the whole file for `github.com/JohnGavin/historical/blob` — ~18 remaining hits are whole-file "Source:" references (to `plan_*.R` pipeline files, `.claude/rules/*.md`, wiki digest `.md`, and test files) that don't name a single function. These match an established file-level citation pattern used dozens of times throughout the document (e.g. lines 271, 651-654, 694, 707, 718, 811, 812, 814) and pre-date this PR. Left as-is; anchoring a whole-file citation to one line would misrepresent it as function-specific.

## `_pkgdown.yml` fixes (Task 3)

- `hd_keff` → `hd_keff_frob`, `hd_tail_keff` → `hd_tail_keff_frob` (neither old name is in `NAMESPACE`; correct names are exported there)
- Added `hd_strat_keff_vertox` to the same "Kelly & Position Sizing" section (exported, documented, was missing from the index)
- Added new **"Portfolio Construction"** section for `hrp_weights`, `trp_weights`, `hd_weight_stability_diagnostic` — all three are exported and have `man/*.Rd` files but were absent from the reference index entirely
- Verified all 6 touched/added names have a corresponding `man/*.Rd` file

## Verification

`nix develop <repo-root> --command Rscript -e 'parse("_targets.R")'` and `parse("docs/_targets.R")` both succeed. Also sourced `R/plan_falsification_vignette.R` standalone and confirmed the plan function evaluates to 20 targets including the 2 new ones (`fals_vig_tail_table`, `fals_vig_tail_caption`) with no syntax errors.

`scripts/verify.sh` (full run) — **PASS**, verbatim summary:

```
PASS: _targets.R parses (verified tree: .../agent-a87787be3a81f0db1)
PASS: testthat edition 3 active

=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

=== scripts/verify.sh: PASS ===
```

Baseline failure counts and skip counts are unchanged (root: 3 failed / 0 skipped; package: 1 failed / 15 skipped) — no regressions.

**The qmd was NOT rendered.** Per the task instructions, `tar_make()` was not run because the main repo has a live `_targets/` store and a concurrent run would conflict with it. Verification here is limited to `parse()` on both `_targets.R` files, standalone-sourcing the modified plan file, and manual code inspection of the new targets' output structure against the upstream functions' documented return values. The new "Crisis vs Calm" tab and its table/caption have not been visually confirmed in a rendered HTML page.

## Test plan

- [x] `parse("_targets.R")` succeeds (root)
- [x] `parse("docs/_targets.R")` succeeds (real pipeline)
- [x] `R/plan_falsification_vignette.R` sources standalone with no errors, produces 20 targets
- [x] `scripts/verify.sh` full run passes, baselines unchanged
- [ ] Render `docs/falsification.qmd` and visually confirm the new tab (not done — see note above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
