### PR TITLE
feat(liquidity): re-express plan_liquidity against equity_daily (#625)

### DIFF
--- a/R/plan_liquidity.R
+++ b/R/plan_liquidity.R
@@ -77,3 +77,102 @@ plan_liquidity <- function() {
     )
   )
 }
+
+# ── equity_daily-sourced variant (#625 Option A, decided 2026-08-04) ───────
+#
+# plan_liquidity() above cannot run inside docs/_targets.R: consolidated_equity
+# only exists in the ROOT ingestion pipeline (_targets.R:58). This second plan
+# function re-expresses the same three-step liquidity computation
+# (calculate_adv -> filter_liquidity -> liquidity_summary) against
+# `stk_universe` (R/plan_stock_backtest.R:421) instead — the equity source the
+# dashboard's own backtests actually trade — so it can be wired into
+# docs/_targets.R. It is a SEPARATE function, not an extension of
+# plan_liquidity(), because plan_liquidity()'s targets are combined into the
+# root pipeline (_targets.R:61) where `stk_universe` does not exist; keeping
+# them apart lets both sets of targets build in their respective pipelines
+# without either referencing an undefined symbol.
+#
+# Column-shape note: stk_universe already carries date, ticker, close, volume
+# (plus adjusted) -- exactly the schema calculate_adv() expects. No adaptation
+# of calculate_adv()/filter_liquidity()/liquidity_summary() themselves was
+# needed or made.
+#
+# Volume-corruption guard note: stk_universe's own comment says its universe
+# is "S&P 500 + STOXX 600 majors, excluding LSE ETFs" (R/plan_stock_backtest.R:4)
+# -- i.e. it DOES contain non-US (European) tickers. stk_universe excludes
+# `.L` (LSE) tickers via a hardcoded regex (R/plan_stock_backtest.R:432), but
+# that is a narrower, DIFFERENT filter than the yfinance non-US
+# volume-corruption guard (hd_unreliable_volume_ticker(), packages/
+# historicaldata/R/volume_reliability.R) -- .DE/.PA/.AS/.SW/.MC/.MI/.ST/.CO
+# tickers pass through stk_universe with their raw (unreliable) volume
+# intact. hd_ohlcv_single() (packages/historicaldata/R/query.R:227-237)
+# applies hd_unreliable_volume_ticker() automatically when data is fetched
+# through hd_ohlcv()/hd_lazy(), but stk_universe bypasses those wrappers --
+# it queries hd_datasets()[["equity_daily"]]$url directly via
+# duckplyr::read_parquet_duckdb(). The guard is therefore applied explicitly
+# below, before calculate_adv() ever sees the volume column.
+#
+# ── Provenance divergence risk (flagged here per #625; not resolved here) ──
+# The ingestion-side liquidity_summary_tbl/volume_stats above are computed
+# from consolidated_equity (ALL ingested equity tickers). The dashboard-side
+# equity_daily_liquidity_summary_tbl/equity_daily_volume_stats below are
+# computed from stk_universe, which is restricted to the top
+# stk_params$top_n_market_cap (100) tickers by current market cap
+# (R/plan_stock_backtest.R:405-418) with >= stk_params$min_history_days of
+# history. Nothing asserts these two equity sources agree, and now that the
+# dashboard computes liquidity from a DIFFERENT (narrower, cap-weighted)
+# ticker set than ingestion's full universe, the two liquidity views can
+# diverge silently -- e.g. the dashboard's median ADV will structurally run
+# higher because it excludes the long tail of small/illiquid names ingestion
+# still reports on. This is flagged as a follow-up, not built here: no
+# reconciliation check is added by this change.
+plan_liquidity_dashboard <- function() {
+  list(
+    targets::tar_target(
+      equity_daily_with_adv,
+      {
+        stk_universe |>
+          dplyr::mutate(
+            volume = dplyr::if_else(
+              hd_unreliable_volume_ticker(ticker),
+              NA_real_,
+              as.numeric(volume)
+            )
+          ) |>
+          calculate_adv(window_days = 20)
+      }
+    ),
+
+    targets::tar_target(
+      equity_daily_liquidity_filtered,
+      {
+        equity_daily_with_adv |>
+          filter_liquidity(min_adv_usd = 1e6, filter_mode = "warn")
+      }
+    ),
+
+    targets::tar_target(
+      equity_daily_liquidity_summary_tbl,
+      {
+        equity_daily_liquidity_filtered |>
+          liquidity_summary()
+      }
+    ),
+
+    # === Volume statistics for the dashboard ===
+    targets::tar_target(
+      equity_daily_volume_stats,
+      {
+        equity_daily_liquidity_filtered |>
+          dplyr::summarise(
+            total_tickers = dplyr::n_distinct(ticker),
+            total_observations = dplyr::n(),
+            median_adv_all = median(adv_usd, na.rm = TRUE),
+            pct_liquid = 100 * mean(liquidity_flag == "liquid", na.rm = TRUE),
+            pct_illiquid = 100 * mean(liquidity_flag == "illiquid", na.rm = TRUE),
+            min_adv_threshold = 1e6
+          )
+      }
+    )
+  )
+}

--- a/docs/DASHBOARDS.md
+++ b/docs/DASHBOARDS.md
@@ -16,7 +16,7 @@
 |---|---|---|---|
 | `index.qmd` | Portal + dataset catalogue | Headline stat block (tickers/rows/datasets/years/functions); 4 dataset cards; card grid → downstream dashboards | `hd_datasets()`, `hd_tickers()`, `hd_factors()` |
 | `leaderboard.qmd` | Rank all strategies by risk-adjusted return; central output | Ranking table (Sharpe/CAGR/MaxDD/CVaR95/Vol/SSR/Top5%/Credible); partition table; equity-curve plotly (range slider); monthly-returns heatmap; bootstrap-CI table; deflated-Sharpe table; alpha-decay; regime-adjusted Sharpe; Kelly table; structural-breaks dot plot; correlation matrix | `tar_read(leaderboard)`, `boot_ci_summary`, `structural_breaks_summary`, `strategy_correlation` |
-| `falsification.qmd` | Test causal integrity / robustness gauntlet + **Failed Strategies section (#514 merge 3/3)** | Scorecard (Verdict/HAC t/Sharpe/Alpha/R²); null-rejection heatmap (6 envs × strats); FF5+Mom alpha scatter; HAC t comparison; multiplicity K_eff table; WFC 2×2; **covariance regularisation table + conditioning/OOS dot plots (#498)**; causal DAG (Mermaid/D3, tabbed); implication tests; risk-architecture table; **failed-strategy filtered scorecard + pattern table + portfolio implications**; **Liquidity tab: ADV-cap on/off impact table (#625, discharges the standing `backtest-robustness.md` reporting requirement); universe liquidity summary + volume stats (pending #625 pipeline wiring)** | `fals_vig_*`, `wfc_all_summary`, `cov_diag_vig_table`, `cg_dag`, `cg_test_implications`, `fals_summary`, `fals_vig_names`, `stk_max_adv_cap_impact`, `liquidity_summary_tbl` (not yet wired), `volume_stats` (not yet wired) |
+| `falsification.qmd` | Test causal integrity / robustness gauntlet + **Failed Strategies section (#514 merge 3/3)** | Scorecard (Verdict/HAC t/Sharpe/Alpha/R²); null-rejection heatmap (6 envs × strats); FF5+Mom alpha scatter; HAC t comparison; multiplicity K_eff table; WFC 2×2; **covariance regularisation table + conditioning/OOS dot plots (#498)**; causal DAG (Mermaid/D3, tabbed); implication tests; risk-architecture table; **failed-strategy filtered scorecard + pattern table + portfolio implications**; **Liquidity tab: ADV-cap on/off impact table (#625, discharges the standing `backtest-robustness.md` reporting requirement); dashboard-universe liquidity summary + volume stats, computed against `stk_universe` rather than the ingestion-side `consolidated_equity` (#625 Option A, wired but not yet `tar_make()`-verified)** | `fals_vig_*`, `wfc_all_summary`, `cov_diag_vig_table`, `cg_dag`, `cg_test_implications`, `fals_summary`, `fals_vig_names`, `stk_max_adv_cap_impact`, `equity_daily_liquidity_summary_tbl`, `equity_daily_volume_stats` |
 | `evidence.qmd` | Negative results + 155-yr pervasiveness | Failed-strategies scorecard; pattern-analysis table; negative-result cards; JST pervasiveness table (18 countries); equity-premium heatmap; crisis timeline; crisis-frequency table | `fals_summary`, `jst_equity_premium`, `jst_pervasiveness`, `jst_crises` |
 | ~~`factor-max.qmd`~~ | ~~MAX signal at factor level~~ | ~~Cumulative-return plotly (log); metrics table (IS/OOS/Full); factor-selection bar chart; MAX-signal heatmap; ETF comparison~~ | ~~`fm_cumret_plot`, `fm_metrics`, `fm_selection_freq`, `fm_heatmap`~~ **→ merged into `stock-backtest.qmd#factor-level-deep-dive` (#514 merge 2/3)** |
 | ~~`drif.qmd`~~ | ~~DRIF elastic-net signal at factor level~~ | ~~Cumulative-return plotly; metrics table (seal warning on Validation); selection-frequency table; DRIF-vs-MAX comparison; parameters table~~ | ~~`drif_cumret_plot`, `drif_metrics`, `drif_params`, `drif_selection_freq`, `drif_vs_max_plot`~~ **→ merged into `stock-backtest.qmd#factor-level-deep-dive` (#514 merge 2/3)** |
@@ -73,7 +73,11 @@ data with a stub, render, attach for approval.
   count.
 
 **Consolidation decision, #625 (liquidity module):** no change to dashboard
-count. `stk_max_adv_cap_impact` and (pending #625 pipeline-wiring) the
-liquidity module's outputs are added as a tab inside the existing
-`falsification.qmd`, not a new standalone dashboard — this is the intended
-default per the `dashboard-output-first` rule (extend, don't spin up).
+count. `stk_max_adv_cap_impact` and, since the #625 Option A pipeline-wiring
+PR, the dashboard-side liquidity module outputs (`equity_daily_liquidity_summary_tbl`,
+`equity_daily_volume_stats`, both computed against `stk_universe`) are added
+as a tab inside the existing `falsification.qmd`, not a new standalone
+dashboard — this is the intended default per the `dashboard-output-first`
+rule (extend, don't spin up). The original ingestion-side targets
+(`liquidity_summary_tbl`, `volume_stats`, computed against `consolidated_equity`)
+remain root-pipeline-only and are not displayed on any dashboard.

--- a/docs/_targets.R
+++ b/docs/_targets.R
@@ -27,17 +27,16 @@ pkgload::load_all(here::here("packages/historicaldata"), quiet = TRUE)
 # Source Tier 1 & 2 gap functions
 # TODO: create tracking_error.R (tail_keff.R tracked under #624)
 #
-# liquidity.R already exists (R/liquidity.R, #105/#569) but is NOT wired into
-# THIS pipeline (#625 investigated this). plan_liquidity()'s targets read a
-# `consolidated_equity` symbol that only exists in the ROOT ingestion
-# pipeline's _targets.R — this dashboard pipeline has no target of that name
-# and instead loads equity prices directly from
-# hd_datasets()[["equity_daily"]] (see stk_universe, R/plan_stock_backtest.R:421).
-# Registering plan_liquidity() here as-is would create a target that fails at
-# build time; re-pointing it at the hd_datasets() pattern is a data-source
-# decision (which columns/filters/universe) left for a follow-up, not made
-# unilaterally here. See PR discharging #625 for the investigation.
-# source(here::here("R/liquidity.R"))
+# liquidity.R (R/liquidity.R, #105/#569) provides calculate_adv() /
+# filter_liquidity() / liquidity_summary(). plan_liquidity() (the
+# consolidated_equity-based targets) still cannot run here — consolidated_equity
+# only exists in the ROOT ingestion pipeline's _targets.R. Resolved by #625
+# (decided 2026-08-04): plan_liquidity_dashboard() (also in R/plan_liquidity.R)
+# re-expresses the same three-step computation against stk_universe
+# (R/plan_stock_backtest.R:421), which IS available in this pipeline. See
+# R/plan_liquidity.R for the full rationale and the flagged provenance-
+# divergence risk between the two equity sources.
+source(here::here("R/liquidity.R"))
 # source(here::here("R/tracking_error.R"))
 # source(here::here("R/tail_keff.R"))
 # Phase B of #389: regime_correlations.R functions used by plan_cross_asset_corr.R
@@ -97,6 +96,12 @@ source(here::here("R/plan_factormax.R"))
 source(here::here("R/plan_drif.R"))
 source(here::here("R/plan_drif_v2.R"))
 source(here::here("R/plan_stock_backtest.R"))
+# #625: dashboard-side liquidity targets (plan_liquidity_dashboard()), sourced
+# after plan_stock_backtest.R because its targets reference stk_universe.
+# Source-file order does not affect DAG resolution (targets are matched by
+# name at build time, not by source() order) but is kept adjacent for
+# readability.
+source(here::here("R/plan_liquidity.R"))
 source(here::here("R/plan_xgb_signal.R"))
 source(here::here("R/plan_portfolio_opt.R"))
 source(here::here("R/plan_etf_replication.R"))
@@ -175,7 +180,7 @@ source(here::here("R/plan_strategy_digest.R"))
 # Combine: strategy_names FIRST, then partitions, strategies, portfolio, ETF replication, leaderboard, QA
 c(plan_strategy_names(),
   plan_partitions(), plan_vignette(), plan_backtest(), plan_factormax(), plan_drif(), plan_drif_v2(),
-  plan_stock_backtest(), plan_xgb_signal(), plan_portfolio_opt(),
+  plan_stock_backtest(), plan_liquidity_dashboard(), plan_xgb_signal(), plan_portfolio_opt(),
   plan_etf_replication(), plan_kelly(), plan_bootstrap_ci(),
   plan_interval_coverage(),
   plan_regime(), plan_alpha_decay(),

--- a/docs/falsification.qmd
+++ b/docs/falsification.qmd
@@ -640,19 +640,27 @@ Two liquidity mechanisms exist in this codebase and neither one currently remove
 ```{r}
 #| label: liquidity-summary-table
 #| results: asis
-liq_tbl <- safe_tar_read("liquidity_summary_tbl")
+liq_tbl <- safe_tar_read("equity_daily_liquidity_summary_tbl")
 if (!is.null(liq_tbl)) {
   cap <- paste0(
-    "**Per-ticker average daily volume (ADV) summary, universe-wide.** ",
-    "One row per ticker: observation count, median daily share volume, median close, ",
-    "median 20-day dollar ADV, and the percent of that ticker's history flagged illiquid. ",
-    "Sourced from [`liquidity_summary()`](https://github.com/JohnGavin/historical/blob/main/R/liquidity.R#L74){target=\"_blank\" rel=\"noopener noreferrer\"}."
+    "**Per-ticker average daily volume (ADV) summary, dashboard universe.** ",
+    "One row per ticker in the top ",
+    "[`stk_params$top_n_market_cap`](https://github.com/JohnGavin/historical/blob/main/R/plan_stock_backtest.R#L400){target=\"_blank\" rel=\"noopener noreferrer\"} ",
+    "by market cap ([`stk_universe`](https://github.com/JohnGavin/historical/blob/main/R/plan_stock_backtest.R#L421){target=\"_blank\" rel=\"noopener noreferrer\"} — ",
+    "the same equity source the stock backtests on this dashboard trade): observation count, ",
+    "median daily share volume, median close, median 20-day dollar ADV, and the percent of ",
+    "that ticker's history flagged illiquid. Non-US tickers with known-unreliable yfinance volume ",
+    "([`hd_unreliable_volume_ticker()`](https://github.com/JohnGavin/historical/blob/main/packages/historicaldata/R/volume_reliability.R#L35){target=\"_blank\" rel=\"noopener noreferrer\"}) ",
+    "have their volume nulled before this summary is computed. ",
+    "Sourced from [`liquidity_summary()`](https://github.com/JohnGavin/historical/blob/main/R/liquidity.R#L74){target=\"_blank\" rel=\"noopener noreferrer\"} ",
+    "via [`plan_liquidity_dashboard()`](https://github.com/JohnGavin/historical/blob/main/R/plan_liquidity.R){target=\"_blank\" rel=\"noopener noreferrer\"} ",
+    "([#625](https://github.com/JohnGavin/historical/issues/625){target=\"_blank\" rel=\"noopener noreferrer\"})."
   )
   fals_dt(liq_tbl, cap)
 } else {
   cat(paste0(
-    "*Not available: `plan_liquidity()` is not wired into this dashboard pipeline ",
-    "yet — see the “How to Read This” tab and ",
+    "*Not available: `equity_daily_liquidity_summary_tbl` has not been built by this run of ",
+    "`tar_make()` yet — see the “How to Read This” tab and ",
     "[#625](https://github.com/JohnGavin/historical/issues/625){target=\"_blank\" rel=\"noopener noreferrer\"}.*"
   ))
 }
@@ -663,19 +671,22 @@ if (!is.null(liq_tbl)) {
 ```{r}
 #| label: liquidity-volume-stats
 #| results: asis
-vol_stats <- safe_tar_read("volume_stats")
+vol_stats <- safe_tar_read("equity_daily_volume_stats")
 if (!is.null(vol_stats)) {
   cap <- paste0(
-    "**Universe-level liquid/illiquid split.** One row: total tickers, total observations, ",
-    "the universe median 20-day dollar ADV, and the percent of observations flagged ",
+    "**Dashboard-universe liquid/illiquid split.** One row: total tickers, total observations, ",
+    "the dashboard-universe median 20-day dollar ADV, and the percent of observations flagged ",
     "liquid vs. illiquid against the $", scales::comma(vol_stats$min_adv_threshold), " threshold. ",
-    "Sourced from `volume_stats` (R/plan_liquidity.R)."
+    "Computed over the same top-market-cap equity universe ",
+    "([`stk_universe`](https://github.com/JohnGavin/historical/blob/main/R/plan_stock_backtest.R#L421){target=\"_blank\" rel=\"noopener noreferrer\"}) ",
+    "the stock backtests on this dashboard trade. Sourced from `equity_daily_volume_stats` ",
+    "([`R/plan_liquidity.R`](https://github.com/JohnGavin/historical/blob/main/R/plan_liquidity.R){target=\"_blank\" rel=\"noopener noreferrer\"})."
   )
   fals_dt(vol_stats, cap)
 } else {
   cat(paste0(
-    "*Not available: `plan_liquidity()` is not wired into this dashboard pipeline ",
-    "yet — see the “How to Read This” tab and ",
+    "*Not available: `equity_daily_volume_stats` has not been built by this run of ",
+    "`tar_make()` yet — see the “How to Read This” tab and ",
     "[#625](https://github.com/JohnGavin/historical/issues/625){target=\"_blank\" rel=\"noopener noreferrer\"}.*"
   ))
 }
@@ -735,9 +746,9 @@ if (!is.null(adv_impact) && !is.null(sp)) {
 - `min_adv_threshold` = $1M (`R/plan_liquidity.R`, and the default in [`filter_liquidity()`](https://github.com/JohnGavin/historical/blob/main/R/liquidity.R#L35){target="_blank" rel="noopener noreferrer"}) — a **universe-wide liquidity flag**. It answers "is this name tradeable at all" and governs the Universe Summary / Volume Stats tabs above.
 - `stk_params$adv_threshold` = $5M ([`R/plan_stock_backtest.R:399`](https://github.com/JohnGavin/historical/blob/main/R/plan_stock_backtest.R#L399){target="_blank" rel="noopener noreferrer"}) — a stricter **investability gate** used only inside decile construction for the Factor MAX / DRIF stock backtests ([#312](https://github.com/JohnGavin/historical/issues/312){target="_blank" rel="noopener noreferrer"}). It is higher because a long-short decile book concentrates capital in far fewer names than the full universe.
 
-Neither value governs the other, and **`filter_liquidity()` runs in `filter_mode = "warn"`** — it flags illiquid rows but removes nothing. `stk_universe` ([`R/plan_stock_backtest.R:421`](https://github.com/JohnGavin/historical/blob/main/R/plan_stock_backtest.R#L421){target="_blank" rel="noopener noreferrer"}) does not depend on `equity_liquidity_filtered` at all. **Illiquid stocks are not excluded from any backtest portfolio shown on this dashboard today.** Do not read the Universe Summary / Volume Stats tabs as implying otherwise; they are a diagnostic, not a filter.
+Neither value governs the other, and **`filter_liquidity()` runs in `filter_mode = "warn"`** — it flags illiquid rows but removes nothing, for both the ingestion-side (`equity_liquidity_filtered`) and dashboard-side (`equity_daily_liquidity_filtered`) targets. `stk_universe` ([`R/plan_stock_backtest.R:421`](https://github.com/JohnGavin/historical/blob/main/R/plan_stock_backtest.R#L421){target="_blank" rel="noopener noreferrer"}) does not depend on either filtered target — the dependency runs the other way (`equity_daily_liquidity_filtered` is derived *from* `stk_universe`, not vice versa). **Illiquid stocks are not excluded from any backtest portfolio shown on this dashboard today.** Do not read the Universe Summary / Volume Stats tabs as implying otherwise; they are a diagnostic, not a filter.
 
-**Universe Summary / Volume Stats availability:** `plan_liquidity()` ([`R/plan_liquidity.R`](https://github.com/JohnGavin/historical/blob/main/R/plan_liquidity.R){target="_blank" rel="noopener noreferrer"}) is wired into the *ingestion* pipeline (root `_targets.R`) but not into *this* dashboard pipeline (`docs/_targets.R`) — that pipeline has no `consolidated_equity` target to build on. If those two tabs above show "Not available," this is why; see [#625](https://github.com/JohnGavin/historical/issues/625){target="_blank" rel="noopener noreferrer"} for the investigation and the follow-up needed to wire them in.
+**Universe Summary / Volume Stats now wired in (#625, resolved 2026-08-04):** the two tabs above are computed by [`plan_liquidity_dashboard()`](https://github.com/JohnGavin/historical/blob/main/R/plan_liquidity.R){target="_blank" rel="noopener noreferrer"} in `R/plan_liquidity.R`, which re-expresses the same `calculate_adv()` → `filter_liquidity()` → `liquidity_summary()` pipeline against `stk_universe` instead of `consolidated_equity` (which only exists in the root ingestion pipeline). This means the two tabs describe the **top-market-cap dashboard universe**, not the full ingested equity universe — see the per-table captions above for the exact scope. The original `plan_liquidity()` targets (`liquidity_summary_tbl`, `volume_stats`) are unchanged and still run only in the ingestion pipeline (root `_targets.R`); this dashboard has never depended on them. **Provenance risk:** nothing asserts the two equity sources (`consolidated_equity` vs. `stk_universe`) agree, so the ingestion-side and dashboard-side liquidity summaries can diverge — this is flagged as a follow-up in [#625](https://github.com/JohnGavin/historical/issues/625){target="_blank" rel="noopener noreferrer"}, not resolved here. **Also unverified:** this PR could not run `tar_make()` (concurrent-store conflict with other work on this repo), so neither of these two tabs has been confirmed to actually render — the "Not available" fallback text above will show if the target has not yet been built by a subsequent pipeline run.
 
 **ADV-Cap Impact (MAX HRP) is a live target** ([`stk_max_adv_cap_impact`](https://github.com/JohnGavin/historical/blob/main/R/plan_stock_backtest.R#L656){target="_blank" rel="noopener noreferrer"}) already built by the deployed pipeline — it compares the [HRP-weighted](https://github.com/JohnGavin/historical/blob/main/R/plan_stock_backtest.R#L609){target="_blank" rel="noopener noreferrer"} Stock MAX portfolio with and without the 10% ADV participation cap, and this tab is the first place it is displayed.
 


### PR DESCRIPTION
## Summary

`plan_liquidity()`'s targets depend on `consolidated_equity`, which only
exists in the root ingestion pipeline (`_targets.R:58`). `docs/_targets.R`
has zero occurrences of it, so the Liquidity tab's Universe Summary / Volume
Stats sub-tabs (added by #634) rendered "not available".

**Decision (user, 2026-08-04):** re-express `plan_liquidity()` against
`equity_daily`/`stk_universe` — Option A on #625. Rationale: the liquidity
view must describe the *same* data the backtests actually trade, not a
different equity source.

## Task 0 — gating check (done first, before any implementation)

The decision was conditional on `equity_daily` carrying usable volume data:

1. **Volume column exists.** `equity_daily`'s registry schema
   (`packages/historicaldata/R/registry.R:33-34`) includes `volume`.
   `stk_universe` (`R/plan_stock_backtest.R:421-449`) already selects it
   directly from `hd_datasets()[["equity_daily"]]`, and `stk_monthly_adv`
   (`R/plan_stock_backtest.R:494-507`) already derives `adv_dollars` from it
   — proving the capability exists and demonstrating the access pattern
   reused here.
2. **Coverage.** `stk_universe`'s own header comment describes its universe
   as "S&P 500 + STOXX 600 majors, excluding LSE ETFs"
   (`R/plan_stock_backtest.R:4`), restricted further to the top
   `stk_params$top_n_market_cap` (100) tickers by current market cap with
   `>= stk_params$min_history_days` (252) days of history
   (`R/plan_stock_backtest.R:405-449`). I could not run `tar_make()` (see
   below) so I could not empirically confirm row counts / date range /
   non-NA fraction — this is a real gap in verification, noted explicitly.
3. **Non-US volume-corruption guard — found a real gap.**
   `hd_unreliable_volume_ticker()`
   (`packages/historicaldata/R/volume_reliability.R:35`) nulls volume for 9
   non-US exchange suffixes (`.L .DE .PA .AS .SW .MC .MI .ST .CO`).
   `hd_ohlcv_single()` (`packages/historicaldata/R/query.R:227-237`) applies
   this guard automatically — but `stk_universe` bypasses that wrapper
   entirely (it queries `hd_datasets()[["equity_daily"]]$url` directly via
   `duckplyr::read_parquet_duckdb()`), and only excludes `.L$` tickers via a
   separate, narrower, hardcoded regex
   (`R/plan_stock_backtest.R:432`). `.DE/.PA/.AS/.SW/.MC/.MI/.ST/.CO` tickers
   pass through `stk_universe` with their raw (unreliable) volume intact.
   Since `stk_universe`'s universe explicitly includes STOXX 600 majors,
   this is not a theoretical concern. **Fixed:** the guard is now applied
   explicitly in the new `equity_daily_with_adv` target before
   `calculate_adv()` ever sees the volume column.

Given (1) and (3) resolved satisfactorily (volume exists; the corruption
gap is now closed explicitly), I proceeded to Task 1/2/3.

## What changed

- **`R/plan_liquidity.R`** — added `plan_liquidity_dashboard()`, a *separate*
  function from `plan_liquidity()`. It re-expresses the same
  `calculate_adv()` → `filter_liquidity()` → `liquidity_summary()` pipeline
  against `stk_universe` instead of `consolidated_equity`, producing
  `equity_daily_with_adv`, `equity_daily_liquidity_filtered`,
  `equity_daily_liquidity_summary_tbl`, `equity_daily_volume_stats`.
  `calculate_adv()`/`filter_liquidity()`/`liquidity_summary()` themselves
  are unchanged — only the target-level input was adapted (`stk_universe`
  already carries the exact `date, ticker, close, volume` schema these
  functions expect, so no column-shape adaptation was needed).
  **The ingestion-side `plan_liquidity()` targets are untouched** and
  continue to run unmodified in the root pipeline.
- **`docs/_targets.R`** — sources `R/liquidity.R` and `R/plan_liquidity.R`,
  registers `plan_liquidity_dashboard()` in the combined plan list (after
  `plan_stock_backtest()`, since its targets reference `stk_universe`).
  Updated the stale comment block that previously explained why
  `plan_liquidity()` couldn't be wired in.
- **`docs/falsification.qmd`** — the Universe Summary and Volume Stats
  sub-tabs of the Liquidity section now read
  `equity_daily_liquidity_summary_tbl` / `equity_daily_volume_stats`
  instead of the old (never-available-here) `liquidity_summary_tbl` /
  `volume_stats`. Captions updated to state the dashboard-universe scope
  and link to the corruption-guard handling. Kept, as instructed: the
  prose that `filter_liquidity()` runs in `filter_mode = "warn"` and that
  `stk_universe` does not depend on either filtered target, so **illiquid
  stocks are not excluded from any backtest portfolio shown on this
  dashboard today** — a populated tab must not be read as implying
  otherwise. The `ADV-Cap Impact (MAX HRP)` sub-tab (`stk_max_adv_cap_impact`)
  is untouched — it already worked.
- **`docs/DASHBOARDS.md`** — updated the `falsification.qmd` inventory row
  and the #625 consolidation-decision note to reflect the new target names
  and wiring status (was "pending #625 pipeline wiring").

## Provenance divergence risk (flagged, not resolved)

The ingestion-side `liquidity_summary_tbl`/`volume_stats` are computed from
`consolidated_equity` (the full ingested equity universe). The new
dashboard-side `equity_daily_liquidity_summary_tbl`/`equity_daily_volume_stats`
are computed from `stk_universe` (top-100-by-market-cap only). Nothing
asserts these two equity sources agree, and the dashboard's median ADV will
structurally run higher because it excludes the long tail of small/illiquid
names the ingestion side still reports on. This divergence is documented in
`R/plan_liquidity.R` and in the dashboard's "How to Read This" tab. **No
reconciliation check was built** — that's out of scope per the dispatch
instructions and is a follow-up for a future #625-adjacent issue.

## What was NOT run

- **`tar_make()` was not run** — concurrent-store conflict with other work
  on this repo. The new targets (`equity_daily_with_adv`,
  `equity_daily_liquidity_filtered`, `equity_daily_liquidity_summary_tbl`,
  `equity_daily_volume_stats`) are therefore **unproven to actually build**,
  and the two dashboard sub-tabs are **unproven to actually render** with
  real content rather than falling through to the "Not available" branch.
  This is the real limitation of this PR: the whole point of the change is
  that the targets resolve, and that remains unverified until someone runs
  the pipeline.
- No Quarto render was performed for the same reason.

## Explicitly out of scope (per dispatch instructions)

- Did not flip `filter_mode` to `"remove"` or wire `equity_liquidity_filtered`
  / `equity_daily_liquidity_filtered` into `stk_universe`.
- Did not change `adv_threshold` (5e6) or `min_adv_usd` (1e6).
- Did not modify `calculate_adv()` / `filter_liquidity()` / `liquidity_summary()`
  internals.
- Did not delete `R/plan_integration.R`.
- No reconciliation check between the two equity sources.

## CI coverage note

`packages/historicaldata/R/` was not touched (no `regen_api_context.sh`
needed). Changes are to root `R/`, `docs/_targets.R`, and `docs/*.qmd` —
per project convention, CI does not cover these paths (path-filtered to
`packages/historicaldata/**`); local `scripts/verify.sh` is the only gate
for this PR.

## Test plan

- [x] `parse("_targets.R")` and `parse("docs/_targets.R")` succeed
- [x] `bash ~/.claude/scripts/check_qmd_fence_parity.sh docs/falsification.qmd` — OK, 0 violations
- [x] `scripts/verify.sh` full run — PASS, both baselines unchanged (root: 3 known failures / 0 skips; package: 1 known failure / 15 skips)
- [ ] `tar_make()` — **not run** (concurrent-store conflict); targets unproven to build
- [ ] Quarto render / visual confirmation of the two sub-tabs — **not run**, follow-up needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
