### PR TITLE
fix(docs): add Related vignettes sections to the four redirect stubs (#514)

### DIFF
--- a/docs/drif.qmd
+++ b/docs/drif.qmd
@@ -21,3 +21,9 @@ Redirecting automatically…
 
 <meta http-equiv="refresh" content="0; url=stock-backtest.html#factor-level-deep-dive">
 <script>window.location.href = "stock-backtest.html#factor-level-deep-dive";</script>
+
+## Related vignettes
+
+- **[Stock-Level Backtests (Factor-Level Deep Dive)](stock-backtest.html#factor-level-deep-dive)** — the DRIF elastic-net factor-rotation signal now lives here, alongside Factor MAX, in the Factor-Level Deep Dive tab
+- **[Strategy Leaderboard](leaderboard.html)** — overall strategy rankings, including this factor rotation approach
+- **[Strategy Falsification](falsification.html)** — hypothesis-testing framework applied to DRIF and every other systematic strategy

--- a/docs/factor-max.qmd
+++ b/docs/factor-max.qmd
@@ -21,3 +21,9 @@ Redirecting automatically…
 
 <meta http-equiv="refresh" content="0; url=stock-backtest.html#factor-level-deep-dive">
 <script>window.location.href = "stock-backtest.html#factor-level-deep-dive";</script>
+
+## Related vignettes
+
+- **[Stock-Level Backtests (Factor-Level Deep Dive)](stock-backtest.html#factor-level-deep-dive)** — the Factor MAX signal now lives here, alongside DRIF, in the Factor-Level Deep Dive tab
+- **[Strategy Leaderboard](leaderboard.html)** — overall strategy rankings, including this factor rotation approach
+- **[Strategy Falsification](falsification.html)** — hypothesis-testing framework applied to Factor MAX and every other systematic strategy

--- a/docs/jst-dashboard.qmd
+++ b/docs/jst-dashboard.qmd
@@ -21,3 +21,9 @@ Redirecting automatically…
 
 <meta http-equiv="refresh" content="0; url=evidence.html#historical-evidence">
 <script>window.location.href = "evidence.html#historical-evidence";</script>
+
+## Related vignettes
+
+- **[Evidence & Context (Historical Evidence)](evidence.html#historical-evidence)** — the JST Macrohistory long-run equity premium analysis (155 years, 18 countries) now lives here
+- **[Strategy Falsification](falsification.html)** — applies formal hypothesis testing to each strategy's claims, using this long-run evidence as a prior
+- **[Strategy Leaderboard](leaderboard.html)** — ranks all strategies on risk-adjusted return; contextualise against 155 years of equity premium

--- a/docs/negative-results.qmd
+++ b/docs/negative-results.qmd
@@ -24,3 +24,9 @@ Redirecting automatically…
 
 <meta http-equiv="refresh" content="0; url=falsification.html#failed-strategies">
 <script>window.location.href = "falsification.html#failed-strategies";</script>
+
+## Related vignettes
+
+- **[Strategy Falsification (Failed Strategies)](falsification.html#failed-strategies)** — the failed-strategies scorecard now lives here
+- **[Evidence & Context (Negative Results)](evidence.html#negative-results)** — per-strategy failure cards and lessons learned
+- **[Strategy Leaderboard](leaderboard.html)** — performance rankings across all strategies, for contrast against what failed


### PR DESCRIPTION
## Summary

`tar_make()` on `main` currently errors and halts the pipeline at the `qa_vignette_cross_refs` gate (S8):

```
✖ qa_vignette_cross_refs errored
Error: ✖ Vignettes missing 'Related Vignettes' section (4 files):
ℹ  drif.qmd
ℹ  factor-max.qmd
ℹ  jst-dashboard.qmd
ℹ  negative-results.qmd
```

These four files are the redirect stubs created by the #514 dashboard consolidation. This PR adds a `## Related vignettes` section to each, satisfying the gate and — more importantly — giving a reader who lands on a stub a one-click path to the content that absorbed it, instead of relying solely on the meta-refresh/JS redirect.

## The gate's matching logic

`check_vignette_cross_refs()` in `R/plan_qa_gates.R` (lines 268-289):

```r
has_section <- grepl("## Related [Vv]ignettes", txt) ||
               grepl("#### Related [Vv]ignettes", txt)
```

Accepts either `## Related Vignettes`/`## Related vignettes` (H2) or `#### Related Vignettes`/`#### Related vignettes` (H4) — the only case flexibility is the first letter of "vignettes"; "Related" must be capitalized exactly as shown. All four stubs use `## Related vignettes`, matching the H2 form already used by other standalone (non-tabbed) pages such as `bdbb-sol.qmd` and `evidence.qmd`.

## Files changed and destinations linked

Mappings confirmed against `docs/DASHBOARDS.md` before use (all four rows there explicitly note "merged into ... (#514 merge n/3)"):

| Stub | Primary link (destination) | Secondary links |
|---|---|---|
| `docs/drif.qmd` | [`stock-backtest.qmd#factor-level-deep-dive`](https://github.com/JohnGavin/historical/blob/main/docs/stock-backtest.qmd#L431) | `leaderboard.qmd`, `falsification.qmd` |
| `docs/factor-max.qmd` | [`stock-backtest.qmd#factor-level-deep-dive`](https://github.com/JohnGavin/historical/blob/main/docs/stock-backtest.qmd#L431) | `leaderboard.qmd`, `falsification.qmd` |
| `docs/jst-dashboard.qmd` | [`evidence.qmd#historical-evidence`](https://github.com/JohnGavin/historical/blob/main/docs/evidence.qmd#L252) | `falsification.qmd`, `leaderboard.qmd` |
| `docs/negative-results.qmd` | [`falsification.qmd#failed-strategies`](https://github.com/JohnGavin/historical/blob/main/docs/falsification.qmd#L1143) | `evidence.qmd#negative-results`, `leaderboard.qmd` |

All anchors were verified to exist in the target `.qmd` files before linking (`grep -n "{#factor-level-deep-dive}\|{#historical-evidence}\|{#failed-strategies}"`), and links follow the same relative `.html`/`#anchor` convention used by sibling dashboards (e.g. `evidence.qmd`'s existing "Related vignettes" section links `stock-backtest.html#factor-level-deep-dive`).

## Verification

**`tar_make()` was NOT executed** — the main checkout has a live `_targets/` store and concurrent runs conflict with parallel agents working on this repo. The gate was verified by code inspection instead:

1. Read `check_vignette_cross_refs()` (`R/plan_qa_gates.R:268-289`) and confirmed the exact regex it uses (quoted above).
2. Re-grepped all four edited files for `## Related [Vv]ignettes` — each matches:
   ```
   docs/drif.qmd:25:## Related vignettes
   docs/factor-max.qmd:25:## Related vignettes
   docs/jst-dashboard.qmd:25:## Related vignettes
   docs/negative-results.qmd:28:## Related vignettes
   ```
3. `nix develop <repo-root> --command Rscript -e 'parse("_targets.R")'` — parses cleanly.
4. `scripts/verify.sh --quick` — PASS (parse-only, appropriate for a documentation-only change).

## Scope

Touched only the four files named in the task: `docs/drif.qmd`, `docs/factor-max.qmd`, `docs/jst-dashboard.qmd`, `docs/negative-results.qmd`. No other files (leaderboard.qmd, falsification.qmd, R/plan_leaderboard.R, R/plan_qa_gates.R, R/plan_liquidity.R, docs/DASHBOARDS.md) were touched — those are being edited by parallel agents.

## Test plan

- [ ] CI / roborev review
- [ ] Confirm `tar_make()` on `main` (after merge, run in isolation) no longer halts at `qa_vignette_cross_refs`
- [ ] Spot-check rendered stub pages show the new section above/alongside the redirect notice
