### PR TITLE
fix(leaderboard): normalise cagr/vol/max_dd to fractions across all strategies (#637)

### DIFF
--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -11,6 +11,27 @@
 #
 # Transposed format: metrics as rows, strategies as columns
 # (fewer strategies than metrics, at least for now)
+#
+# ── Unit convention (#637) ─────────────────────────────────────────────────
+# `cagr`, `vol`, and `max_dd` are stored as DECIMAL FRACTIONS throughout this
+# target (e.g. -0.21 == -21% drawdown), matching the convention documented in
+# R/plan_commodities_mean_reversion.R:210-214 and used natively by
+# R/plan_factormax.R, R/plan_drif.R, R/plan_stock_backtest.R, and
+# R/plan_portfolio_opt.R. Several source metrics targets (ltr_metrics,
+# olmar_metrics, tom_metrics, rsc_metrics, aw_metrics, mom_prepeak_metrics /
+# mom_postpeak_metrics / mom_combined_metrics, mf_metrics, ev_metrics) store
+# these columns as PERCENT (x * 100) natively -- their `.norm_*` helpers below
+# divide by 100 at the point where the source convention is known, so every
+# row entering `all_metrics` is already a fraction. `sharpe` is scale-free and
+# is never converted. Any NEW strategy wired into this target MUST follow the
+# same rule: check the source metrics target's own convention (grep for
+# `* 100` in its calc/metrics function) and convert to fraction in its own
+# `.norm_*` helper -- never infer the unit from the output magnitude
+# (magnitude heuristics misclassify genuine >150% vol or <1% vol strategies).
+# Display-time formatting (x 100, "%") belongs to the consumer
+# (docs/leaderboard.qmd, DT::datatable(), plot labels), not this target.
+# See also: R/plan_qa_gates.R `qa_leaderboard_metric_ranges` -- the range gate
+# that asserts every row here is within a plausible fractional range.
 
 plan_leaderboard <- function() {
   list(
@@ -29,36 +50,54 @@ plan_leaderboard <- function() {
       # Each helper returns a tibble with at minimum: period, months, cagr, vol,
       # sharpe, max_dd. Extra columns are preserved so the final bind_rows()
       # fills NA for columns absent in some strategies.
+      # Canonical unit for cagr/vol/max_dd is FRACTION -- see the module-level
+      # comment above. Each helper below converts from its source's native
+      # unit (fraction or percent) at this boundary.
 
-      # ltr_metrics has hac_sharpe instead of sharpe; no months column
+      # ltr_metrics has hac_sharpe instead of sharpe; no months column.
+      # Source: R/plan_ltr_momentum.R:167-169 (compute_ltr_metrics) stores
+      # cagr/vol/max_dd as PERCENT (round(x * 100, 1)) -- convert to fraction.
       .norm_ltr <- function(m) {
         if (is.null(m) || nrow(m) == 0) return(NULL)
-        m |> rename(sharpe = hac_sharpe)
+        m |>
+          rename(sharpe = hac_sharpe) |>
+          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100)
       }
 
-      # olmar_metrics has `days` instead of `months`; daily ann_factor
+      # olmar_metrics has `days` instead of `months`; daily ann_factor.
+      # Source: R/plan_olmar.R:138-141 (calc) stores cagr/vol/max_dd as
+      # PERCENT (round(x * 100, 2)) -- convert to fraction.
       .norm_olmar <- function(m) {
         if (is.null(m) || nrow(m) == 0) return(NULL)
-        m |> rename(months = days)
+        m |>
+          rename(months = days) |>
+          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100)
       }
 
-      # tom_metrics uses cagr_tom, vol_tom, sharpe_tom, max_dd_tom
-      # Drop benchmark columns; keep TOM strategy row only
+      # tom_metrics uses cagr_tom, vol_tom, sharpe_tom, max_dd_tom.
+      # Drop benchmark columns; keep TOM strategy row only.
+      # Source: R/plan_turn_of_month.R:162-165 stores cagr_tom/vol_tom/max_dd_tom
+      # as PERCENT (round(x * 100, 2); confirmed by the target's own comment at
+      # line 317: "tom_metrics stores cagr/vol/max_dd in percentage units (x 100)")
+      # -- convert to fraction.
       .norm_tom <- function(m) {
         if (is.null(m) || nrow(m) == 0) return(NULL)
         m |> transmute(
           period = period,
           months = n_days,
-          cagr   = cagr_tom,
-          vol    = vol_tom,
+          cagr   = cagr_tom / 100,
+          vol    = vol_tom / 100,
           sharpe = sharpe_tom,
-          max_dd = max_dd_tom
+          max_dd = max_dd_tom / 100
         )
       }
 
       # cmr_summary has lookback (1m/3m/6m) instead of period; no period column.
       # Pick the best-Sharpe lookback for the leaderboard row.
       # We create one synthetic "Full Period" row = the best lookback.
+      # Source: R/plan_commodities_mean_reversion.R:210-221 already stores
+      # cagr/vol/max_dd as FRACTION (documented convention, #336) -- no
+      # conversion needed here.
       .norm_cmr <- function(m) {
         if (is.null(m) || nrow(m) == 0) return(NULL)
         best <- m |> filter(!is.na(sharpe)) |> arrange(desc(sharpe)) |> slice(1)
@@ -77,17 +116,23 @@ plan_leaderboard <- function() {
       # rsc_metrics contains multiple internal strategy variants (SPY_overlay,
       # DRIF_overlay, etc.). Pick only the SPY_overlay rows which represent the
       # strategy's own performance.
+      # Source: R/plan_risk_state.R:270-273 stores cagr/vol/max_dd as PERCENT
+      # (round(x * 100, 2)) -- convert to fraction.
       .norm_rsc <- function(m) {
         if (is.null(m) || nrow(m) == 0) return(NULL)
         m |>
           filter(strategy == "SPY_overlay") |>
           select(-strategy) |>
-          rename(sharpe = hac_sharpe)
+          rename(sharpe = hac_sharpe) |>
+          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100)
       }
 
       # mom_prepeak_metrics / siblings have no period column (one row per
       # strategy); column n_months not months; no period. Synthesise
       # "Full Period" as the single row.
+      # Source: packages/historicaldata/R/utils_mom_prepeak_metrics.R:111-113
+      # (.mom_prepeak_compute_metrics) stores cagr/vol/max_dd as PERCENT
+      # (round(x * 100, 1)) -- convert to fraction.
       .norm_mom_sibling <- function(m) {
         if (is.null(m) || nrow(m) == 0) return(NULL)
         m |>
@@ -95,45 +140,55 @@ plan_leaderboard <- function() {
           transmute(
             period = "Full Period",
             months = n_months,
-            cagr   = cagr,
-            vol    = vol,
+            cagr   = cagr / 100,
+            vol    = vol / 100,
             sharpe = sharpe,
-            max_dd = max_dd
+            max_dd = max_dd / 100
           )
       }
 
       # aw_metrics has scenario × period; keep the "Remove 10 Worst" rows
       # (the protection scenario) and drop the extra scenario column.
+      # Source: R/plan_avoid_worst.R:440-444 (metrics_for) stores
+      # cagr/vol/max_dd as PERCENT (round(x * 100, 1)) -- convert to fraction.
       .norm_aw <- function(m) {
         if (is.null(m) || nrow(m) == 0) return(NULL)
         m |>
           filter(scenario == "Remove 10 Worst") |>
           select(-scenario) |>
-          rename(months = n_days)
+          rename(months = n_days) |>
+          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100)
       }
 
       # mf_metrics has multiple internal strategies (Long-Only, Long-Short, EW benchmark)
       # and columns: strategy, period, n_months, cagr, vol, sharpe, max_dd, calmar.
       # Keep only the canonical MOP 2012 long-short strategy.
       # Period labels ("Full"/"Training"/"OOS") match what other strategies use.
+      # Source: R/plan_managed_futures.R:187-192 (calc_metrics) stores
+      # cagr/vol/max_dd as PERCENT (round(x * 100, 2)) -- convert to fraction.
       .norm_mf <- function(m) {
         if (is.null(m) || nrow(m) == 0) return(NULL)
         m |>
           filter(strategy == "Long-Short TS-Mom (MOP 2012, vol-targeted)") |>
           select(-strategy, -calmar) |>
-          rename(months = n_months)
+          rename(months = n_months) |>
+          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100)
       }
 
       # ev_metrics has multiple internal strategies (Pure Value, Value+Quality, Benchmark)
       # and columns: strategy, period, n_months, cagr, vol, sharpe, max_dd, calmar.
       # Keep only the pure HML strategy that represents "Value (HML)".
       # Period labels ("Full"/"Training"/"OOS") match what other strategies use.
+      # Source: R/plan_ev_ebit.R:109-114 (calc_metrics) stores cagr/vol/max_dd
+      # as PERCENT (x * 100, no explicit round until the tibble build) --
+      # convert to fraction.
       .norm_value <- function(m) {
         if (is.null(m) || nrow(m) == 0) return(NULL)
         m |>
           filter(strategy == "Pure Value (100% HML, EV/EBIT proxy)") |>
           select(-strategy, -calmar) |>
-          rename(months = n_months)
+          rename(months = n_months) |>
+          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100)
       }
 
       all_metrics <- bind_rows(

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -289,6 +289,85 @@ check_vignette_cross_refs <- function(vignettes_dir = here::here("docs")) {
 }
 
 
+#' Assert leaderboard cagr/vol/max_dd are within a plausible FRACTIONAL range (S9)
+#'
+#' Guards against the #637 defect class: a strategy's `.norm_*` helper in
+#' R/plan_leaderboard.R forgetting to convert its source metrics target's
+#' native PERCENT convention (x * 100) to the leaderboard's canonical
+#' FRACTION convention. A strategy stored as percent shows up here as ~100x
+#' its true value (e.g. cagr = 7.70 instead of 0.077), which these bounds
+#' catch even though `sharpe` (scale-free) would look fine either way.
+#'
+#' Bounds are deliberately generous — they are a scale-error gate, not a
+#' performance-plausibility gate:
+#'   - `vol`: [0, 2] (0%-200% annualised volatility)
+#'   - `max_dd`: [-1, 0] (a drawdown cannot exceed -100% of peak equity, and
+#'     drawdown is never positive; mom_prepeak's bankruptcy floor is exactly
+#'     -1.0, see packages/historicaldata/R/utils_mom_prepeak_metrics.R:73)
+#'   - `cagr`: [-1, 3] (-100% to +300% annualised — wide enough for small-n
+#'     sub-period rows and volatile overlay strategies, tight enough to catch
+#'     a stray x100)
+#'
+#' @param leaderboard Tibble with at least `strategy`, `period`, `cagr`,
+#'   `vol`, `max_dd` columns (the output of the `leaderboard` targets
+#'   pipeline target).
+#' @return `TRUE` invisibly on success.
+#' @noRd
+check_leaderboard_metric_ranges <- function(leaderboard) {
+  required_cols <- c("strategy", "period", "cagr", "vol", "max_dd")
+  missing_cols <- setdiff(required_cols, names(leaderboard))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "Leaderboard is missing {length(missing_cols)} required column(s): {missing_cols}.",
+      "i" = "check_leaderboard_metric_ranges() (S9) requires strategy, period, cagr, vol, max_dd."
+    ))
+  }
+
+  bounds <- list(
+    cagr   = c(-1, 3),
+    vol    = c(0, 2),
+    max_dd = c(-1, 0)
+  )
+
+  offenders <- purrr::map_dfr(names(bounds), function(col) {
+    vals <- leaderboard[[col]]
+    lo <- bounds[[col]][1]
+    hi <- bounds[[col]][2]
+    bad <- !is.na(vals) & (vals < lo | vals > hi)
+    if (!any(bad)) return(NULL)
+    tibble::tibble(
+      strategy = leaderboard$strategy[bad],
+      period   = leaderboard$period[bad],
+      metric   = col,
+      value    = vals[bad],
+      lo       = lo,
+      hi       = hi
+    )
+  })
+
+  if (nrow(offenders) > 0L) {
+    msgs <- purrr::pmap_chr(
+      offenders[, c("strategy", "period", "metric", "value", "lo", "hi")],
+      function(strategy, period, metric, value, lo, hi) {
+        sprintf("  %s / %s -- %s = %s (expected [%s, %s])",
+                strategy, period, metric,
+                format(value, digits = 4), lo, hi)
+      }
+    )
+    cli::cli_abort(c(
+      "x" = paste0(
+        "Leaderboard metric(s) out of plausible fractional range in ",
+        "{nrow(offenders)} place(s) (likely a percent-vs-fraction unit bug, #637):"
+      ),
+      setNames(msgs, rep("i", length(msgs))),
+      "i" = "Check the source metrics target's convention and convert in its .norm_* helper in R/plan_leaderboard.R."
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+
 # ---- QA gate plan ----
 
 plan_qa_gates <- function() {
@@ -435,6 +514,21 @@ plan_qa_gates <- function() {
       command = {
         check_vignette_cross_refs(here::here("docs"))
         cli::cli_inform(c("v" = "qa_vignette_cross_refs: S8 passed (all vignettes have Related Vignettes section)"))
+        TRUE
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: leaderboard cagr/vol/max_dd are within a plausible fractional
+    # range (S9) — guards against the #637 percent-vs-fraction unit defect
+    # class where a strategy's source metrics target stores cagr/vol/max_dd
+    # as PERCENT (x * 100) but its .norm_* helper in R/plan_leaderboard.R
+    # forgets to convert to the leaderboard's canonical FRACTION convention.
+    targets::tar_target(
+      qa_leaderboard_metric_ranges,
+      command = {
+        check_leaderboard_metric_ranges(leaderboard)
+        cli::cli_inform(c("v" = "qa_leaderboard_metric_ranges: S9 passed (all cagr/vol/max_dd within fractional range)"))
         TRUE
       },
       cue = targets::tar_cue(mode = "always")

--- a/tests/testthat/_snaps/leaderboard-unit-scale.md
+++ b/tests/testthat/_snaps/leaderboard-unit-scale.md
@@ -1,0 +1,19 @@
+# check_leaderboard_metric_ranges throws when required columns are missing
+
+    Code
+      check_leaderboard_metric_ranges(bad)
+    Condition
+      Error in `check_leaderboard_metric_ranges()`:
+      x Leaderboard is missing 1 required column(s): max_dd.
+      i check_leaderboard_metric_ranges() (S9) requires strategy, period, cagr, vol, max_dd.
+
+# check_leaderboard_metric_ranges catches a percent-scale cagr (#637 regression)
+
+    Code
+      check_leaderboard_metric_ranges(bad)
+    Condition
+      Error in `check_leaderboard_metric_ranges()`:
+      x Leaderboard metric(s) out of plausible fractional range in 1 place(s) (likely a percent-vs-fraction unit bug, #637):
+      i  LTR / Full Period -- cagr = 7.7 (expected [-1, 3])
+      i Check the source metrics target's convention and convert in its .norm_* helper in R/plan_leaderboard.R.
+

--- a/tests/testthat/test-leaderboard-unit-scale.R
+++ b/tests/testthat/test-leaderboard-unit-scale.R
@@ -1,0 +1,226 @@
+testthat::local_edition(3)
+# Tests for the #637 leaderboard unit-scale fix:
+#   1. check_leaderboard_metric_ranges() — QA gate S9 (R/plan_qa_gates.R)
+#   2. The percent-to-fraction conversion applied inside the .norm_* helpers
+#      of R/plan_leaderboard.R (duplicated here as test fixtures, following
+#      the pattern established in test-leaderboard-coverage.R, since the
+#      real helpers are private closures inside the `leaderboard` tar_target
+#      body and cannot be sourced directly without running targets).
+#
+# See R/plan_leaderboard.R:1-27 (module-level "Unit convention (#637)" note)
+# for the canonical-unit contract these tests enforce.
+
+source(here::here("R/plan_qa_gates.R"))
+
+# ── check_leaderboard_metric_ranges() (S9) ────────────────────────────────
+
+good_leaderboard <- tibble::tibble(
+  strategy = c("Factor MAX", "LTR", "PSO Optimal"),
+  period   = "Full Period",
+  cagr     = c(0.0349, 0.0770, 0.0079),
+  vol      = c(0.0892, 0.1720, 0.0682),
+  max_dd   = c(-0.4047, -0.3630, -0.0994)
+)
+
+test_that("check_leaderboard_metric_ranges passes when all metrics are fractional", {
+  expect_true(check_leaderboard_metric_ranges(good_leaderboard))
+})
+
+test_that("check_leaderboard_metric_ranges throws when required columns are missing", {
+  bad <- dplyr::select(good_leaderboard, -max_dd)
+  expect_error(
+    check_leaderboard_metric_ranges(bad),
+    regexp = "max_dd"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_metric_ranges(bad)
+  )
+})
+
+test_that("check_leaderboard_metric_ranges catches a percent-scale cagr (#637 regression)", {
+  # LTR's cagr left un-converted, i.e. 7.70 instead of 0.0770 -- exactly the
+  # #637 defect: a strategy's .norm_* helper forgot to divide by 100.
+  bad <- good_leaderboard
+  bad$cagr[bad$strategy == "LTR"] <- 7.70
+  expect_error(
+    check_leaderboard_metric_ranges(bad),
+    regexp = "LTR"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_metric_ranges(bad)
+  )
+})
+
+test_that("check_leaderboard_metric_ranges catches a percent-scale vol", {
+  bad <- good_leaderboard
+  bad$vol[bad$strategy == "LTR"] <- 17.20
+  expect_error(
+    check_leaderboard_metric_ranges(bad),
+    regexp = "vol"
+  )
+})
+
+test_that("check_leaderboard_metric_ranges catches a percent-scale max_dd", {
+  bad <- good_leaderboard
+  bad$max_dd[bad$strategy == "LTR"] <- -36.30
+  expect_error(
+    check_leaderboard_metric_ranges(bad),
+    regexp = "max_dd"
+  )
+})
+
+test_that("check_leaderboard_metric_ranges ignores NA values", {
+  na_ok <- good_leaderboard
+  na_ok$cagr[1] <- NA_real_
+  expect_true(check_leaderboard_metric_ranges(na_ok))
+})
+
+test_that("check_leaderboard_metric_ranges allows the mom_prepeak bankruptcy floor (max_dd == -1)", {
+  floor_ok <- good_leaderboard
+  floor_ok$max_dd[1] <- -1.0
+  expect_true(check_leaderboard_metric_ranges(floor_ok))
+})
+
+test_that("check_leaderboard_metric_ranges rejects max_dd beyond -100%", {
+  bad <- good_leaderboard
+  bad$max_dd[1] <- -1.5
+  expect_error(
+    check_leaderboard_metric_ranges(bad),
+    regexp = "max_dd"
+  )
+})
+
+# ── Percent-to-fraction conversion in .norm_* helpers ──────────────────────
+# Mirrors the conversion logic added to R/plan_leaderboard.R's .norm_ltr,
+# .norm_olmar, .norm_tom, .norm_rsc, .norm_mom_sibling, .norm_aw, .norm_mf,
+# and .norm_value helpers. Any change to the real conversion factor MUST be
+# reflected here and vice-versa.
+
+.norm_ltr_test <- function(m) {
+  if (is.null(m) || nrow(m) == 0) return(NULL)
+  m |>
+    dplyr::rename(sharpe = hac_sharpe) |>
+    dplyr::mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100)
+}
+
+synthetic_ltr_metrics <- tibble::tibble(
+  period     = "Full Period",
+  months     = 120L,
+  cagr       = 7.70,
+  vol        = 17.20,
+  max_dd     = -36.30,
+  hac_sharpe = 0.45
+)
+
+test_that(".norm_ltr converts percent-native source metrics to fraction", {
+  res <- .norm_ltr_test(synthetic_ltr_metrics)
+  expect_equal(res$cagr, 0.0770, tolerance = 1e-8)
+  expect_equal(res$vol, 0.1720, tolerance = 1e-8)
+  expect_equal(res$max_dd, -0.3630, tolerance = 1e-8)
+  expect_true("sharpe" %in% names(res))
+  expect_false("hac_sharpe" %in% names(res))
+})
+
+.norm_tom_test <- function(m) {
+  if (is.null(m) || nrow(m) == 0) return(NULL)
+  m |> dplyr::transmute(
+    period = period,
+    months = n_days,
+    cagr   = cagr_tom / 100,
+    vol    = vol_tom / 100,
+    sharpe = sharpe_tom,
+    max_dd = max_dd_tom / 100
+  )
+}
+
+synthetic_tom_metrics <- tibble::tibble(
+  period     = "Full Period",
+  n_days     = 250L,
+  cagr_tom   = 2.24,
+  vol_tom    = 8.01,
+  sharpe_tom = 0.28,
+  max_dd_tom = -19.27
+)
+
+test_that(".norm_tom converts percent-native source metrics to fraction", {
+  res <- .norm_tom_test(synthetic_tom_metrics)
+  expect_equal(res$cagr, 0.0224, tolerance = 1e-8)
+  expect_equal(res$vol, 0.0801, tolerance = 1e-8)
+  expect_equal(res$max_dd, -0.1927, tolerance = 1e-8)
+  expect_equal(res$sharpe, 0.28)  # sharpe is scale-free, never converted
+})
+
+.norm_mom_sibling_test <- function(m) {
+  if (is.null(m) || nrow(m) == 0) return(NULL)
+  m |>
+    dplyr::select(-dplyr::any_of("strategy")) |>
+    dplyr::transmute(
+      period = "Full Period",
+      months = n_months,
+      cagr   = cagr / 100,
+      vol    = vol / 100,
+      sharpe = sharpe,
+      max_dd = max_dd / 100
+    )
+}
+
+synthetic_mom_metrics <- tibble::tibble(
+  strategy = "mom_prepeak",
+  n_months = 200L,
+  sharpe   = 0.55,
+  cagr     = 9.50,
+  vol      = 19.80,
+  max_dd   = -68.20
+)
+
+test_that(".norm_mom_sibling converts percent-native source metrics to fraction", {
+  res <- .norm_mom_sibling_test(synthetic_mom_metrics)
+  expect_equal(res$cagr, 0.0950, tolerance = 1e-8)
+  expect_equal(res$vol, 0.1980, tolerance = 1e-8)
+  expect_equal(res$max_dd, -0.6820, tolerance = 1e-8)
+})
+
+test_that(".norm_mom_sibling preserves NA cagr on bankruptcy (max_dd floor -100%)", {
+  bankrupt <- synthetic_mom_metrics
+  bankrupt$cagr <- NA_real_
+  bankrupt$max_dd <- -100.0  # bankruptcy floor stored as percent (-100)
+  res <- .norm_mom_sibling_test(bankrupt)
+  expect_true(is.na(res$cagr))
+  expect_equal(res$max_dd, -1.0, tolerance = 1e-8)
+})
+
+# ── cmr_summary is already fractional -- confirm no double-conversion ─────
+
+.norm_cmr_test <- function(m) {
+  if (is.null(m) || nrow(m) == 0) return(NULL)
+  best <- m |> dplyr::filter(!is.na(sharpe)) |> dplyr::arrange(dplyr::desc(sharpe)) |> dplyr::slice(1)
+  if (nrow(best) == 0L) return(NULL)
+  best |> dplyr::transmute(
+    period = "Full Period",
+    months = n_months,
+    cagr   = cagr,
+    vol    = vol,
+    sharpe = sharpe,
+    max_dd = max_dd,
+    cmr_lookback = lookback
+  )
+}
+
+synthetic_cmr_summary <- tibble::tibble(
+  lookback = c("1m", "3m", "6m"),
+  n_months = c(240L, 240L, 240L),
+  sharpe   = c(0.20, 0.55, 0.10),
+  cagr     = c(-0.02, -0.0079, 0.01),
+  vol      = c(0.05, 0.0504, 0.06),
+  max_dd   = c(-0.90, -0.9956, -0.80)
+)
+
+test_that(".norm_cmr does not rescale already-fractional source metrics", {
+  res <- .norm_cmr_test(synthetic_cmr_summary)
+  # Best sharpe row is lookback = "3m"
+  expect_equal(res$cagr, -0.0079, tolerance = 1e-8)
+  expect_equal(res$vol, 0.0504, tolerance = 1e-8)
+  expect_equal(res$max_dd, -0.9956, tolerance = 1e-8)
+})


### PR DESCRIPTION
## Summary

Fixes #637. The `leaderboard` target's `cagr`, `vol`, and `max_dd` columns mixed decimal-fraction and percent units across strategies, so any consumer that assumed a single convention was wrong by 100x for half the rows. Canonicalised on **fraction** (the majority convention, and the one `docs/leaderboard.qmd` already assumes when it multiplies by 100 for display) and added a QA range gate so this class of defect fails `tar_make()` loudly instead of silently corrupting the dashboard.

## Root cause

`R/plan_leaderboard.R`'s `.norm_*` schema-normalisation helpers (lines 33-192) only renamed/reshaped columns from each strategy's source metrics target — none checked or converted the source's native unit convention. Ten strategies' source targets store `cagr`/`vol`/`max_dd` as **percent** (`x * 100`); the other seven already store **fraction**.

## Provenance table (per-strategy unit audit — this is the evidence the fix is correct)

| Strategy | Source target | file:line | Native unit | Converted? |
|---|---|---|---|---|
| Factor MAX | `fm_metrics` | [R/plan_factormax.R:173-178](https://github.com/JohnGavin/historical/blob/8ebdc1dc27076251a7c69a4e2ff96df38f89dfbb/R/plan_factormax.R#L173-L178) | fraction | no (already correct) |
| Factor DRIF | `drif_metrics` | [R/plan_drif.R:289-293](https://github.com/JohnGavin/historical/blob/8ebdc1dc27076251a7c69a4e2ff96df38f89dfbb/R/plan_drif.R#L289-L293) | fraction | no (already correct) |
| Stock MAX | `stk_max_metrics` via `calc_backtest_metrics()` | [R/plan_stock_backtest.R:357-372](https://github.com/JohnGavin/historical/blob/8ebdc1dc27076251a7c69a4e2ff96df38f89dfbb/R/plan_stock_backtest.R#L357-L372) | fraction | no (already correct) |
| Stock DRIF | `stk_drif_metrics` via `calc_backtest_metrics()` | same as above | fraction | no (already correct) |
| XGB DRIF | `xgb_drif_metrics` via `calc_backtest_metrics()` | [R/plan_xgb_signal.R:143-150](https://github.com/JohnGavin/historical/blob/8ebdc1dc27076251a7c69a4e2ff96df38f89dfbb/R/plan_xgb_signal.R#L143-L150) | fraction | no (already correct) |
| PSO Optimal | `port_metrics` | [R/plan_portfolio_opt.R:191-194](https://github.com/JohnGavin/historical/blob/8ebdc1dc27076251a7c69a4e2ff96df38f89dfbb/R/plan_portfolio_opt.R#L191-L194) (explicit comment at line 249) | fraction | no (already correct) |
| CMR | `cmr_summary` | [R/plan_commodities_mean_reversion.R:210-221](https://github.com/JohnGavin/historical/blob/8ebdc1dc27076251a7c69a4e2ff96df38f89dfbb/R/plan_commodities_mean_reversion.R#L210-L221) (explicit "Unit convention (#336)" comment) | fraction | no (already correct) |
| LTR | `ltr_metrics` | [R/plan_ltr_momentum.R:167-169](https://github.com/JohnGavin/historical/blob/8ebdc1dc27076251a7c69a4e2ff96df38f89dfbb/R/plan_ltr_momentum.R#L167-L169) | **percent** (`round(x*100,1)`) | **yes** — `.norm_ltr` now divides by 100 |
| OLMAR-1 | `olmar_metrics` | [R/plan_olmar.R:138-141](https://github.com/JohnGavin/historical/blob/8ebdc1dc27076251a7c69a4e2ff96df38f89dfbb/R/plan_olmar.R#L138-L141) | **percent** (`round(x*100,2)`) | **yes** — `.norm_olmar` now divides by 100 |
| TOM | `tom_metrics` | [R/plan_turn_of_month.R:162-165](https://github.com/JohnGavin/historical/blob/8ebdc1dc27076251a7c69a4e2ff96df38f89dfbb/R/plan_turn_of_month.R#L162-L165) (explicit comment at line 317: "tom_metrics stores cagr/vol/max_dd in percentage units (x 100)") | **percent** | **yes** — `.norm_tom` now divides by 100 |
| Risk State | `rsc_metrics` | [R/plan_risk_state.R:270-273](https://github.com/JohnGavin/historical/blob/8ebdc1dc27076251a7c69a4e2ff96df38f89dfbb/R/plan_risk_state.R#L270-L273) | **percent** (`round(x*100,2)`) | **yes** — `.norm_rsc` now divides by 100 |
| Avoid Worst | `aw_metrics` | [R/plan_avoid_worst.R:440-444](https://github.com/JohnGavin/historical/blob/8ebdc1dc27076251a7c69a4e2ff96df38f89dfbb/R/plan_avoid_worst.R#L440-L444) | **percent** (`round(x*100,1)`) | **yes** — `.norm_aw` now divides by 100 |
| Mom Pre-Peak | `mom_prepeak_metrics` via `.mom_prepeak_compute_metrics()` | [packages/historicaldata/R/utils_mom_prepeak_metrics.R:111-113](https://github.com/JohnGavin/historical/blob/8ebdc1dc27076251a7c69a4e2ff96df38f89dfbb/packages/historicaldata/R/utils_mom_prepeak_metrics.R#L111-L113) | **percent** (`round(x*100,1)`) | **yes** — `.norm_mom_sibling` now divides by 100 |
| Mom Post-Peak | `mom_postpeak_metrics` via same helper | same as above | **percent** | **yes** — same `.norm_mom_sibling` |
| Mom 12-2 | `mom_combined_metrics` via same helper | same as above | **percent** | **yes** — same `.norm_mom_sibling` |
| Value (HML) | `ev_metrics` | [R/plan_ev_ebit.R:109-114](https://github.com/JohnGavin/historical/blob/8ebdc1dc27076251a7c69a4e2ff96df38f89dfbb/R/plan_ev_ebit.R#L109-L114) | **percent** (`x*100`) | **yes** — `.norm_value` now divides by 100 |
| Managed Futures | `mf_metrics` | [R/plan_managed_futures.R:187-192](https://github.com/JohnGavin/historical/blob/8ebdc1dc27076251a7c69a4e2ff96df38f89dfbb/R/plan_managed_futures.R#L187-L192) | **percent** (`x*100`) | **yes** — `.norm_mf` now divides by 100 |

`sharpe` is scale-free and was never touched in any helper.

## The fix

- Divide `cagr`/`vol`/`max_dd` by 100 inside each affected `.norm_*` helper in [`R/plan_leaderboard.R`](https://github.com/JohnGavin/historical/blob/8ebdc1dc27076251a7c69a4e2ff96df38f89dfbb/R/plan_leaderboard.R), at the point where the source convention is known from the source code — **not** inferred from output magnitude (a magnitude heuristic would misclassify a genuine >150% vol strategy or a <1% vol one; this is exactly the anti-pattern the task explicitly forbade).
- Added a module-level "Unit convention (#637)" comment documenting the canonical-fraction contract and the source→conversion mapping, so the next strategy wired in follows the same rule.
- `.norm_cmr` is unchanged (already fraction, confirmed by its own "Unit convention (#336)" comment).

## New QA gate (S9)

`check_leaderboard_metric_ranges()` / target `qa_leaderboard_metric_ranges` in `R/plan_qa_gates.R` asserts every leaderboard row has `cagr ∈ [-1, 3]`, `vol ∈ [0, 2]`, `max_dd ∈ [-1, 0]`. Bounds are a scale-error gate, not a plausibility gate — wide enough for volatile sub-period rows, tight enough to catch a stray `x100`. Runs on every `tar_make()` via `cue = "always"`, same pattern as S1-S8. This is the gate whose absence let the original defect ship silently — it matters as much as the unit fix itself.

## Consumers checked

- **`docs/leaderboard.qmd`** — already multiplies `cagr`/`vol`/`max_dd`/`net_cagr`/`cvar_95` by 100 for display in both the "Full Period" and "By Partition" tabs (`round(cagr * 100, 1)` etc.) — i.e. it already assumed the canonical fraction convention this PR now delivers consistently. **No changes needed**; this also means the *visible* dashboard bug (LTR showing "770%" CAGR instead of "7.7%") is fixed by this PR with zero qmd changes. Checked every tab: Full Period table, By Partition table, Assumptions tab (static content, doesn't read `leaderboard`), and the Alpha Decay / Regime tabs (read `decay_half_life` / `regime_metrics` — separate targets, out of scope).
- **Strategy digest (`R/plan_strategy_digest.R` → `historicaldata::hd_digest_delta()`)** — reads `leaderboard$max_dd`/`cagr`/`sharpe` directly and diffs against a persisted snapshot. **No code change needed** (it's unit-agnostic, just diffs whatever's in the column), but flagging an operational consequence: I inspected the tracked snapshot `packages/historicaldata/inst/extdata/digest/leaderboard_snapshot.parquet` and confirmed it holds the **pre-fix, percent-scale** values for LTR/OLMAR-1/TOM (e.g. LTR `max_dd = -36.30`). The next `tar_make()` run after this merges will compute `d_max_dd` etc. against that stale baseline, producing a spurious ~100x-looking "improvement" delta for the 10 previously-percent-native strategies. This is a one-time transitional artifact of the fix, not a new bug — noting it here so it isn't mistaken for a real regression when the digest next runs. Did not touch the snapshot file myself (binary data change requiring explicit confirmation per this repo's deletion/data-touching conventions); recommend the maintainer regenerate or reset the baseline after the next full pipeline run.
- **`strat_deflated_sharpe`** — checked: this target is a *producer* joined **into** `leaderboard` (computed from `port_returns` raw return series), not a consumer of it. Not affected.
- **Registry writers** (`.ltr_register_runs`, `.olmar_register_runs`, `.rsc_register_runs`, `.tom_register_runs`, `.avoid_worst_register_runs`, etc.) — these are **not** consumers of the `leaderboard` target; they read the same raw (percent-native) source metrics targets directly and write to the `bt.metric` registry DB, independent of `plan_leaderboard.R`'s `.norm_*` conversions. This means `historicaldata::hd_leaderboard_from_registry()` (the stated eventual replacement for this target, per the file's own deprecation header) likely has the **same percent-vs-fraction inconsistency**, unaffected by this PR. **Out of scope** for #637 — flagging as a separate, related follow-up worth its own issue.
- **`R/plan_te_ir.R`** (`leaderboard_with_te_ir` / `add_te_ir_to_leaderboard()`) — confirmed `plan_te_ir()` is **not called** in either `_targets.R` or `docs/_targets.R` (dead/unwired code, matches its own "Placeholder" comment). Not a real consumer; no action needed.
- Other files matching `leaderboard` (`docs/index.qmd`, `docs/evidence.qmd`, `docs/DASHBOARDS.md`, etc.) are prose links to `leaderboard.html`, not data consumers.

## Tests

Added `tests/testthat/test-leaderboard-unit-scale.R` (13 `test_that` blocks, `local_edition(3)`):
- `check_leaderboard_metric_ranges()`: passes on good fixtures; throws on missing columns; catches a percent-scale `cagr`/`vol`/`max_dd` individually (regression guard reproducing the exact #637 LTR values); ignores `NA`; allows the mom_prepeak bankruptcy floor (`max_dd == -1`); rejects `max_dd` beyond -100%.
- Conversion logic for `.norm_ltr`, `.norm_tom`, `.norm_mom_sibling` (incl. bankruptcy-NA handling), and `.norm_cmr` (confirms no double-conversion of already-fractional CMR data) — duplicated as test fixtures per the existing `.norm_mf_test`/`.norm_value_test` pattern in `test-leaderboard-coverage.R`, since the real helpers are private closures inside the `leaderboard` tar_target body and can't be sourced directly without running targets.
- New snapshots committed: `tests/testthat/_snaps/leaderboard-unit-scale.md`.

**I could not run `tar_make()`** (main checkout has a live `_targets/` store; concurrent runs conflict per this repo's convention), so I could not observe the corrected `leaderboard` target's actual output. The fix is verified by **code-tracing the provenance table above and by the unit tests**, not by an end-to-end pipeline run.

## Verify

```
parse("_targets.R")      → OK
parse("docs/_targets.R") → OK
parse("R/plan_leaderboard.R") → OK
parse("R/plan_qa_gates.R")    → OK
```

`scripts/verify.sh` (full run, after adding the new test file):

```
PASS: _targets.R parses (verified tree: .../agent-a078566b4d4dc6fc9)
PASS: testthat edition 3 active

=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

=== scripts/verify.sh: PASS ===
```

Raw counts: root `total=302 failed=3 skipped=0` (was `total=289` before the 13 new tests; baseline failures unchanged); package `total=678 failed=1 skipped=15` (unchanged).

**CI does not cover this change** — `r-tests`/`pkgctx` CI is path-filtered to `packages/historicaldata/**`, and this PR only touches root `R/` and `tests/testthat/`. `scripts/verify.sh` (above) is the only gate.

## Test plan

- [x] `parse("_targets.R")` and `parse("docs/_targets.R")` succeed
- [x] `scripts/verify.sh` full run passes, baselines unchanged (root 3 failures/0 skips, package 1 failure/15 skips)
- [x] New unit tests for the conversion logic and the new QA gate pass in isolation
- [ ] **Not done — requires a full pipeline rebuild, out of scope for this PR**: run `tar_make()` and visually confirm `docs/leaderboard.qmd`'s Full Period table now shows plausible percentages (e.g. LTR CAGR ≈ 7.7%, not 770%) for all 10 previously-percent-native strategies
- [ ] After the next full rebuild, sanity-check the strategy digest email/report for the one-time spurious delta noted above and reset the snapshot baseline if needed
