### PR TITLE
feat(leaderboard): column order, partition sort, and NA-free warnings (#637 follow-up)

### DIFF
--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -83,9 +83,20 @@ if (!is.null(lb)) {
       # the two previously fed literal NA strategy names into the WARNING
       # note below (#637 follow-up).
       Credible   = dplyr::case_when(
-        is.na(credible) ~ "—",
+        is.na(credible) ~ "not computed",
         !credible        ~ "NO",
         TRUE              ~ "yes"
+      ),
+      # Explicit sort rank for Credible: the display string ("NO" / "not
+      # computed" / "yes") sorts alphabetically wrong under DT's default
+      # string comparator (ascending gives NO, not computed, yes -- neither
+      # ascending nor descending puts assessed-and-passed first, then
+      # assessed-and-failed, then never-assessed). This hidden column
+      # supplies the intended rank instead (#637 follow-up).
+      .credible_rank = dplyr::case_when(
+        is.na(credible) ~ 3L,
+        !credible        ~ 2L,
+        TRUE              ~ 1L
       ),
       Redundant  = if ("redundant" %in% names(full)) {
         ifelse(is.na(redundant), "—", ifelse(redundant, "YES", "no"))
@@ -94,7 +105,7 @@ if (!is.null(lb)) {
         ifelse(is.na(incremental_sharpe), "—", as.character(round(incremental_sharpe, 3)))
       } else "—"
     ) |>
-    select(Strategy = strategy, Credible, Sharpe, `Net CAGR`, `Max DD`, `CVaR 95%`, Vol, Gross,
+    select(Strategy = strategy, Credible, .credible_rank, Sharpe, `Net CAGR`, `Max DD`, `CVaR 95%`, Vol, Gross,
            `Cost (bps)`, SSR, `Top5% Share`, Redundant, `Incremental Sharpe`)
 
   # NA credible (not is.na(credible) | !credible) is deliberate here: `!NA`
@@ -208,14 +219,62 @@ if (!is.null(lb)) {
     "the portfolio is better off without it. Both feed the new-strategy value gate (#496)."
   )
 
-  hd_dt(metrics_table, paste0(
+  full_caption <- paste0(
     "Strategies ranked by Sharpe (highest first). ",
     "Net CAGR after 0.20% round-trip/month cost where available. ",
     "SSR = Sharpe Stability Ratio (HAC t-stat of rolling 36-month Sharpes; ≥2 = consistent). ",
     "Top5% Share = fraction of total return from best 5% of months. ",
-    "Credible = plausible CAGR (<20%) and cum P&L (<50x); — where cost-adjusted metrics are not computed for this strategy.",
+    "Credible = plausible CAGR (<20%) and cum P&L (<50x): \"NO\" marks a strategy that was ",
+    "assessed and failed that check, \"not computed\" marks a strategy for which cost-adjusted ",
+    "metrics were never assessed at all (not the same as failing the check).",
     flag_note, bias_note, gross_note, cost_note, diversification_note
-  ))
+  )
+
+  # Bespoke DT call (not hd_dt()): the Credible column needs an explicit sort
+  # rank (.credible_rank, added above) instead of DT's default alphabetical
+  # string comparator -- ascending on the display string gives NO / not
+  # computed / yes, which puts assessed-and-failed before never-assessed
+  # before assessed-and-passed, not the intended priority order. orderData
+  # points the Credible column's sort at the hidden rank column instead
+  # (#637 follow-up).
+  credible_col <- which(names(metrics_table) == "Credible") - 1L
+  rank_col     <- which(names(metrics_table) == ".credible_rank") - 1L
+  numeric_cols <- which(sapply(metrics_table, function(x) is.numeric(x) ||
+                                  grepl("^[0-9.%$,-]+$", as.character(x[1]))))
+
+  DT::datatable(
+    metrics_table,
+    caption = htmltools::tags$caption(
+      style = "caption-side: top; text-align: left; font-weight: bold;",
+      class = "dt-caption",
+      full_caption
+    ),
+    rownames = FALSE,
+    filter = "top",
+    options = list(
+      pageLength = 15,
+      scrollX = TRUE,
+      autoWidth = FALSE,
+      dom = "frtip",
+      search = list(regex = TRUE, caseInsensitive = TRUE),
+      columnDefs = list(
+        list(className = 'dt-right', targets = numeric_cols - 1),
+        list(visible = FALSE, targets = rank_col),
+        list(orderData = rank_col, targets = credible_col)
+      ),
+      initComplete = DT::JS(
+        "function(settings, json) {",
+        "  var isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark'",
+        "    || document.body.classList.contains('dark-mode');",
+        "  if (isDark) {",
+        "    $(this.api().table().container()).css({'color': '#ddd', 'background-color': '#1a1a1a'});",
+        "    $(this.api().table().header()).css({'color': '#ddd', 'background-color': '#222'});",
+        "    $('input', this.api().table().container()).css({'color': '#ddd', 'background-color': '#333', 'border-color': '#555'});",
+        "  }",
+        "}"
+      )
+    )
+  )
 }
 ```
 

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -39,67 +39,6 @@ disc_path <- if (file.exists("../R/disclosures.R")) "../R/disclosures.R" else
 source(disc_path)
 ```
 
-# Falsification
-
-## Row
-
-### {.tabset}
-
-#### Scorecard
-
-The falsification framework tests 5 strategies against multiple statistical hurdles: <abbr title="Newey-West heteroskedasticity-autocorrelation consistent estimator">HAC</abbr>-corrected t-statistics, 6 null environment rejection rates, and <abbr title="Fama-French 5-Factor model (MktRF, SMB, HML, RMW, CMA)">FF5</abbr> + Momentum alpha regression. Strategies that pass all tests show genuine alpha; those that fail are explained by known factor exposure (beta). Note: this covers 5 strategies from the falsification pipeline — partially overlapping with the leaderboard strategies above.
-
-```{r}
-#| label: fals-scorecard
-fals_sc <- safe_tar_read("fals_vig_scorecard")
-fals_sc_cap <- safe_tar_read("fals_vig_scorecard_caption")
-if (!is.null(fals_sc)) {
-  cap_text <- if (!is.null(fals_sc_cap)) fals_sc_cap else "Strategy falsification scorecard"
-  hd_dt(fals_sc, cap_text)
-}
-```
-
-#### Null Rejection
-
-Rejection rates across 6 null environments (M = 100 simulations each). A low rate means the strategy's performance is easily replicated under the null — no genuine signal. A high rate means the null cannot explain the observed returns.
-
-```{r}
-#| label: fals-heatmap
-#| fig-height: 5
-#| fig-width: 10
-safe_tar_read("fals_vig_null_heatmap")
-```
-
-```{r}
-#| label: fals-heatmap-caption
-#| results: asis
-cap <- safe_tar_read("fals_vig_null_heatmap_caption")
-if (!is.null(cap)) cat(paste0("\n*", cap, "*\n"))
-```
-
-#### Alpha vs Factor Exposure
-
-Scatter plot of annualised alpha (%) against R² (%) from the Fama-French 5-Factor + Momentum regression. Genuine alpha strategies cluster in the top-left (low factor exposure, positive alpha). Beta strategies cluster on the right (high R²).
-
-```{r}
-#| label: fals-alpha-plot
-#| fig-height: 5
-#| fig-width: 10
-safe_tar_read("fals_vig_ff_alpha_plot")
-```
-
-```{r}
-#| label: fals-alpha-caption
-#| results: asis
-cap <- safe_tar_read("fals_vig_ff_caption")
-if (!is.null(cap)) cat(paste0("\n*", cap, "*\n"))
-```
-
-#### See Also
-
-For detailed methodology, HAC analysis, factor regression betas, multiplicity correction (<abbr title="Effective number of independent strategies (spectral participation ratio)">K_eff</abbr>, delta-Z), and the full null environment heatmap, see the [Strategy Falsification dashboard](falsification.html).
-
-
 # Rankings
 
 ::: {.callout-warning collapse="false" title="Survivorship bias"}
@@ -138,7 +77,16 @@ if (!is.null(lb)) {
       ),
       SSR        = ifelse(is.na(ssr),           "—", as.character(round(ssr, 2))),
       `Top5% Share` = ifelse(is.na(top5pct_share), "—", paste0(round(top5pct_share * 100, 1), "%")),
-      Credible   = ifelse(is.na(credible) | !credible, "NO", "yes"),
+      # NA credible means cost metrics were never computed for this strategy
+      # (cost_rows in R/plan_leaderboard.R only covers 5 core strategies +
+      # PSO Optimal) -- that is "unknown", not "explicitly failed". Conflating
+      # the two previously fed literal NA strategy names into the WARNING
+      # note below (#637 follow-up).
+      Credible   = dplyr::case_when(
+        is.na(credible) ~ "—",
+        !credible        ~ "NO",
+        TRUE              ~ "yes"
+      ),
       Redundant  = if ("redundant" %in% names(full)) {
         ifelse(is.na(redundant), "—", ifelse(redundant, "YES", "no"))
       } else "—",
@@ -146,13 +94,18 @@ if (!is.null(lb)) {
         ifelse(is.na(incremental_sharpe), "—", as.character(round(incremental_sharpe, 3)))
       } else "—"
     ) |>
-    select(Strategy = strategy, Sharpe, `Net CAGR`, `Max DD`, `CVaR 95%`, Vol, Gross,
-           `Cost (bps)`, SSR, `Top5% Share`, Credible, Redundant, `Incremental Sharpe`)
+    select(Strategy = strategy, Credible, Sharpe, `Net CAGR`, `Max DD`, `CVaR 95%`, Vol, Gross,
+           `Cost (bps)`, SSR, `Top5% Share`, Redundant, `Incremental Sharpe`)
 
-  n_flagged <- sum(!full$credible, na.rm = TRUE)
+  # NA credible (not is.na(credible) | !credible) is deliberate here: `!NA`
+  # is NA, and indexing a character vector with a logical vector containing
+  # NA inserts a literal NA element into the result -- that is the root
+  # cause of the "WARNING: NA, NA, NA, ..." defect (#637 follow-up). Only
+  # strategies with an explicit, computed FALSE are flagged.
+  n_flagged <- sum(!is.na(full$credible) & !full$credible)
   flag_note <- if (n_flagged > 0) {
-    flagged <- full$strategy[!full$credible]
-    paste0(" WARNING: ", paste(flagged, collapse=", "),
+    flagged <- full$strategy[!is.na(full$credible) & !full$credible]
+    paste0(" WARNING: ", paste(flagged, collapse = ", "),
            " flagged as non-credible (>20% CAGR or >50x cum P&L — likely unrealistic).")
   } else ""
 
@@ -260,7 +213,7 @@ if (!is.null(lb)) {
     "Net CAGR after 0.20% round-trip/month cost where available. ",
     "SSR = Sharpe Stability Ratio (HAC t-stat of rolling 36-month Sharpes; ≥2 = consistent). ",
     "Top5% Share = fraction of total return from best 5% of months. ",
-    "Credible = plausible CAGR (<20%) and cum P&L (<50x).",
+    "Credible = plausible CAGR (<20%) and cum P&L (<50x); — where cost-adjusted metrics are not computed for this strategy.",
     flag_note, bias_note, gross_note, cost_note, diversification_note
   ))
 }
@@ -287,19 +240,71 @@ if (!is.null(lb)) {
     }
   )
 
+  # Explicit period display order (NOT alphabetical, per rule): Testing,
+  # Full Period, Training. Implemented via factor levels so dplyr::arrange()
+  # sorts by this order rather than alphabetically ("Full Period" < "Testing"
+  # < "Training").
+  period_order <- c("Testing", "Full Period", "Training")
+
   by_part <- lb |>
     filter(period != "Validation") |>
     left_join(years_map, by = "period") |>
+    mutate(period = factor(period, levels = period_order)) |>
+    # Sort on the NUMERIC sharpe column before it is formatted to character
+    # below -- sorting the formatted string ("9.5" vs "10.2") would sort
+    # lexicographically and put "9.5" above "10.2".
+    arrange(period, desc(sharpe)) |>
     mutate(
       CAGR = paste0(round(cagr * 100, 1), "%"),
       Vol = paste0(round(vol * 100, 1), "%"),
       Sharpe = ifelse(is.na(sharpe), "—", as.character(round(sharpe, 2))),
       `Max DD` = paste0(round(max_dd * 100, 1), "%"),
-      `CVaR 95%` = ifelse(is.na(cvar_95), "—", paste0(round(cvar_95 * 100, 1), "%"))
+      `CVaR 95%` = ifelse(is.na(cvar_95), "—", paste0(round(cvar_95 * 100, 1), "%")),
+      Period = as.character(period)
     ) |>
-    select(Strategy = strategy, Period = period, Years, CAGR, Vol, Sharpe, `Max DD`, `CVaR 95%`)
+    select(Strategy = strategy, Period, Sharpe, Years, CAGR, Vol, `Max DD`, `CVaR 95%`)
 
-  hd_dt(by_part, "All strategies × Training and Testing partitions. Years column shows date ranges. Validation partition is sealed — not shown until production deployment.")
+  # Bespoke DT call (not hd_dt()): rows above are already sorted by Period
+  # (Testing / Full Period / Training) then Sharpe descending. hd_dt()'s
+  # fixed options list has no `order` entry, so DT would apply its default
+  # initial sort (column 0 ascending = Strategy) and silently undo the sort
+  # above -- `order = list()` (empty array) disables DT's initial sort and
+  # preserves the incoming row order.
+  numeric_cols <- which(sapply(by_part, function(x) is.numeric(x) ||
+                                  grepl("^[0-9.%$,-]+$", as.character(x[1]))))
+
+  DT::datatable(
+    by_part,
+    caption = htmltools::tags$caption(
+      style = "caption-side: top; text-align: left; font-weight: bold;",
+      class = "dt-caption",
+      "All strategies × Training and Testing partitions, ordered Testing / Full Period / Training then by Sharpe (descending). Years column shows date ranges. Validation partition is sealed — not shown until production deployment."
+    ),
+    rownames = FALSE,
+    filter = "top",
+    options = list(
+      pageLength = 15,
+      scrollX = TRUE,
+      autoWidth = FALSE,
+      dom = "frtip",
+      order = list(),
+      search = list(regex = TRUE, caseInsensitive = TRUE),
+      columnDefs = list(
+        list(className = 'dt-right', targets = numeric_cols - 1)
+      ),
+      initComplete = DT::JS(
+        "function(settings, json) {",
+        "  var isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark'",
+        "    || document.body.classList.contains('dark-mode');",
+        "  if (isDark) {",
+        "    $(this.api().table().container()).css({'color': '#ddd', 'background-color': '#1a1a1a'});",
+        "    $(this.api().table().header()).css({'color': '#ddd', 'background-color': '#222'});",
+        "    $('input', this.api().table().container()).css({'color': '#ddd', 'background-color': '#333', 'border-color': '#555'});",
+        "  }",
+        "}"
+      )
+    )
+  )
 }
 ```
 
@@ -329,6 +334,66 @@ if (!is.null(w)) {
   hd_dt(w_df, "PSO optimal weights (trained on Training partition Sharpe). Strategies with 0% weight omitted.")
 }
 ```
+
+# Falsification
+
+## Row
+
+### {.tabset}
+
+#### Scorecard
+
+The falsification framework tests 5 strategies against multiple statistical hurdles: <abbr title="Newey-West heteroskedasticity-autocorrelation consistent estimator">HAC</abbr>-corrected t-statistics, 6 null environment rejection rates, and <abbr title="Fama-French 5-Factor model (MktRF, SMB, HML, RMW, CMA)">FF5</abbr> + Momentum alpha regression. Strategies that pass all tests show genuine alpha; those that fail are explained by known factor exposure (beta). Note: this covers 5 strategies from the falsification pipeline — partially overlapping with the leaderboard strategies above.
+
+```{r}
+#| label: fals-scorecard
+fals_sc <- safe_tar_read("fals_vig_scorecard")
+fals_sc_cap <- safe_tar_read("fals_vig_scorecard_caption")
+if (!is.null(fals_sc)) {
+  cap_text <- if (!is.null(fals_sc_cap)) fals_sc_cap else "Strategy falsification scorecard"
+  hd_dt(fals_sc, cap_text)
+}
+```
+
+#### Null Rejection
+
+Rejection rates across 6 null environments (M = 100 simulations each). A low rate means the strategy's performance is easily replicated under the null — no genuine signal. A high rate means the null cannot explain the observed returns.
+
+```{r}
+#| label: fals-heatmap
+#| fig-height: 5
+#| fig-width: 10
+safe_tar_read("fals_vig_null_heatmap")
+```
+
+```{r}
+#| label: fals-heatmap-caption
+#| results: asis
+cap <- safe_tar_read("fals_vig_null_heatmap_caption")
+if (!is.null(cap)) cat(paste0("\n*", cap, "*\n"))
+```
+
+#### Alpha vs Factor Exposure
+
+Scatter plot of annualised alpha (%) against R² (%) from the Fama-French 5-Factor + Momentum regression. Genuine alpha strategies cluster in the top-left (low factor exposure, positive alpha). Beta strategies cluster on the right (high R²).
+
+```{r}
+#| label: fals-alpha-plot
+#| fig-height: 5
+#| fig-width: 10
+safe_tar_read("fals_vig_ff_alpha_plot")
+```
+
+```{r}
+#| label: fals-alpha-caption
+#| results: asis
+cap <- safe_tar_read("fals_vig_ff_caption")
+if (!is.null(cap)) cat(paste0("\n*", cap, "*\n"))
+```
+
+#### See Also
+
+For detailed methodology, HAC analysis, factor regression betas, multiplicity correction (<abbr title="Effective number of independent strategies (spectral participation ratio)">K_eff</abbr>, delta-Z), and the full null environment heatmap, see the [Strategy Falsification dashboard](falsification.html).
 
 # Performance
 


### PR DESCRIPTION
## Summary

Five presentation-layer fixes to `docs/leaderboard.qmd`, all on top of the unit-scale fix from #637. No re-fix of scaling; no `tar_make()`; no render was run in this worktree (see Verification below).

### Task 1 — Move `Credible` column
`Credible` now sits immediately after `Strategy` and before `Sharpe` in the main ranking table's `select()`. The table's default sort is by `Credible` then `Sharpe`, so the sort-driving column is now visible without scrolling. `hd_dt()`'s `columnDefs`/`targets` (right-alignment) are computed dynamically from the actual `df` passed in (`numeric_cols <- which(sapply(df, ...))`), so no manual index update was needed there.

### Task 2 — Partition table: column order and sort
- `Sharpe` moved to sit immediately after `Period`.
- `Period` now sorts in the explicit order **Testing, Full Period, Training** (not alphabetical) via `factor(period, levels = c("Testing", "Full Period", "Training"))` + `arrange()`.
- Within each period, sorted by **numeric** `sharpe` descending, *before* it is formatted to the display string (avoids "9.5" sorting above "10.2").
- Switched this table from `hd_dt()` to a bespoke `DT::datatable()` call with `order = list()` (empty array) so DT's default initial sort (column 0 ascending) doesn't undo the pre-sorted row order. Kept the same look/feel (caption style, `filter = "top"`, dark-mode `initComplete` JS, numeric right-alignment via the same dynamic-detection logic `hd_dt()` uses).

### Task 3 — NA waffle in the credibility warning

**Root cause:** `credible` is only computed for the 5 core strategies (Factor MAX, Factor DRIF, Stock MAX, Stock DRIF, XGB DRIF) plus PSO Optimal — see `cost_rows` in `R/plan_leaderboard.R` (~line 290). The other strategies (LTR, OLMAR-1, TOM, CMR, Risk State, Avoid Worst, the 3 Mom Pre/Post-Peak variants, Value (HML), Managed Futures) get `credible = NA` via `left_join`. In `docs/leaderboard.qmd`, `full$strategy[!full$credible]` used `!NA` (which is `NA`, not `FALSE`) as an index — and indexing a character vector with a logical vector containing `NA` inserts a literal `NA` *element* into the result, not the corresponding strategy name. That produced the "WARNING: NA, NA, NA, ..." string; "XGB DRIF" (one of the 5 covered strategies) was the one genuine flag.

**Fix:** `n_flagged` and `flagged` now use `!is.na(full$credible) & !full$credible` (matching the pattern already used correctly for `bias_note` and `zero_cost_strategies` two blocks below). Also changed the `Credible` table-column mutate from `ifelse(is.na(credible) | !credible, "NO", "yes")` to a `case_when()` that shows `"—"` for NA (unknown/not computed) instead of lumping it in with `"NO"` (explicitly failed) — consistent with how every other optional column in this table (SSR, Top5% Share, Gross, Cost (bps), Redundant, Incremental Sharpe) already displays `"—"`. Caption text updated to explain the `—` state. The message already degraded properly when nothing is flagged (`flag_note <- if (n_flagged > 0) {...} else ""`) — no separate fix needed there.

**Repo-wide sweep** (grep `docs/*.qmd` and `R/*.R` for `paste`/`paste0`/`sprintf`/`glue` from a vector that could contain NA, plus a targeted grep for the riskier base-R `vec[logical-with-NA]` indexing pattern):

Fixed (this PR):
- `docs/leaderboard.qmd` — the bug above.

One other candidate found, **left for follow-up** (falsification page, not leaderboard page, per task scope):
- `R/plan_falsification_vignette.R:59-63` — `alpha_mask <- summary$ff_alpha_tstat > 2.0 & summary$ff_r_squared < 0.15` and `border_mask` are raw comparisons that can be `NA` if either column is `NA` for a row; `nms$long_name[alpha_mask]` / `[border_mask]` / `[!alpha_mask & !border_mask]` then index without an `is.na()` guard — same defect class. Feeds `fals_vig_scorecard_caption`, used both on `docs/falsification.qmd` and the embedded Scorecard tab of the "# Falsification" section in `docs/leaderboard.qmd`.

Checked and confirmed **not** defects (NA-safe already):
- Everything using `dplyr::filter()` upstream of the `paste(..., collapse=)` (filter drops NA-condition rows by design): `R/plan_european_overlay.R:374,382`, `R/plan_vix_macro_overlay.R:130,133`, `R/plan_interval_coverage.R:206,243,246`, `R/plan_causal_graph.R:524`, `docs/falsification.qmd:1063`.
- Explicit `!is.na(x) & ...` guards already in place: `R/utils_validation.R` (multiple), `R/plan_wf_correlation.R`, `R/plan_turn_of_month.R`, `R/plan_jst_trend.R`, `R/plan_mom_prepeak_gauntlet.R`, `packages/historicaldata/R/bdbb.R`, and the two other blocks already correct in `docs/leaderboard.qmd` (`bias_note`, `zero_cost_strategies`).
- `sort()` (default `na.last = NA`, drops NAs): `docs/evidence.qmd:436`.
- Fixed config vectors with no NA risk: `docs/stock-backtest.qmd:511,579` (`params$factors`), `docs/index.qmd:383,394` (nix flake JSON metadata).
- `match()` against a superset filtered from the same source vector, guaranteeing a hit: `R/plan_strategy_decay.R:182,186`.

### Task 4 — Navigation order
No project-wide navbar exists (`docs/_quarto.yml` has no `navbar:` key; `project: type: default`). The only concrete "site navigation" this instruction can refer to is `docs/leaderboard.qmd`'s own Quarto **dashboard** nav — `format: dashboard` treats every level-1 (`# `) heading as a separate page/tab in that document's own top nav bar. Moved `# Rankings` to precede `# Falsification` (previously the reverse), so the page titled "Strategy Leaderboard" lands on Rankings by default. No file renamed, no URL changed — this is a heading reorder within the single `leaderboard.qmd` file. Confirmed no other page hardcodes an assumption about which section is first: grepped every `leaderboard.html` reference repo-wide (14 files) — all link bare to `leaderboard.html` with no `#falsification`/`#rankings` anchor, so none depend on section order. (Separately, `docs/index.qmd`'s own hand-written card grid and nav list already list "Strategy Leaderboard" before "Falsification Tests" — no change needed there.)

## Verification

- `parse("_targets.R")` — OK
- `parse("docs/_targets.R")` — OK
- `knitr::purl("docs/leaderboard.qmd")` + `parse()` on the result — OK (all R chunks syntactically valid)
- **`tar_make()` and render were NOT run** — no targets store in this worktree; the orchestrator will re-render and commit the HTML.
- `scripts/verify.sh` (full run), verbatim tail:

```
=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

=== scripts/verify.sh: PASS ===
```

Root suite: `total=302 failed=3 skipped=0` (baseline unchanged). Package suite: `total=678 failed=1 skipped=15` (baseline unchanged).

## Test plan

- [ ] Orchestrator runs `tar_make()` + renders `docs/leaderboard.qmd`, confirms Credible column position and no NA in the warning caption
- [ ] Visually confirm partition table sorts Testing -> Full Period -> Training, Sharpe descending within each
- [ ] Visually confirm the Rankings tab is the default/first tab on the rendered leaderboard.html dashboard
- [ ] Follow-up issue filed for `R/plan_falsification_vignette.R:59-63`

Generated with Claude Code (https://claude.com/claude-code)
