### PR TITLE
fix(leaderboard): canonical period vocabulary + tri-state column labelling (#643)

### DIFF
--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -32,6 +32,17 @@
 # (docs/leaderboard.qmd, DT::datatable(), plot labels), not this target.
 # See also: R/plan_qa_gates.R `qa_leaderboard_metric_ranges` -- the range gate
 # that asserts every row here is within a plausible fractional range.
+#
+# ── Period vocabulary (#643) ────────────────────────────────────────────────
+# The `period` column MUST only contain values from `PERIOD_LABELS_ALLOWED`
+# (R/plan_partitions.R). Two source targets (mf_metrics, ev_metrics) used
+# "Full" for the full-sample row where every other strategy uses "Full
+# Period" -- their `.norm_mf()` / `.norm_value()` helpers below rename it at
+# this boundary, same pattern as the unit conversion above. Their "OOS" label
+# is intentionally NOT renamed to "Testing" -- see the `.norm_mf()` comment
+# and R/plan_partitions.R for why the two windows differ. See also:
+# R/plan_qa_gates.R `qa_leaderboard_period_vocab` -- the vocabulary gate that
+# asserts every row here uses an allowed label.
 
 plan_leaderboard <- function() {
   list(
@@ -163,32 +174,51 @@ plan_leaderboard <- function() {
       # mf_metrics has multiple internal strategies (Long-Only, Long-Short, EW benchmark)
       # and columns: strategy, period, n_months, cagr, vol, sharpe, max_dd, calmar.
       # Keep only the canonical MOP 2012 long-short strategy.
-      # Period labels ("Full"/"Training"/"OOS") match what other strategies use.
       # Source: R/plan_managed_futures.R:187-192 (calc_metrics) stores
       # cagr/vol/max_dd as PERCENT (round(x * 100, 2)) -- convert to fraction.
+      # Period-label normalisation (#643): mf_metrics' own vocabulary is
+      # "Full"/"Training"/"OOS" -- everywhere else in the leaderboard uses
+      # "Full Period" for the same full-sample concept, so "Full" is renamed
+      # here at the boundary (same rule as the unit conversion above -- fix
+      # at the point where the source convention is known). "OOS" is NOT
+      # renamed to "Testing": mf_metrics' OOS window is `dates >= oos_start`
+      # (2010-01-01, unbounded), a different span from the canonical Testing
+      # partition (2020-01-01..2022-12-31, R/plan_partitions.R) -- see the
+      # PERIOD_LABELS_ALLOWED comment in R/plan_partitions.R for the full
+      # rationale. Renaming it would misrepresent the wider sample as the
+      # shared cross-strategy test partition.
       .norm_mf <- function(m) {
         if (is.null(m) || nrow(m) == 0) return(NULL)
         m |>
           filter(strategy == "Long-Short TS-Mom (MOP 2012, vol-targeted)") |>
           select(-strategy, -calmar) |>
           rename(months = n_months) |>
-          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100)
+          mutate(
+            period = ifelse(period == "Full", "Full Period", period),
+            cagr   = cagr / 100, vol = vol / 100, max_dd = max_dd / 100
+          )
       }
 
       # ev_metrics has multiple internal strategies (Pure Value, Value+Quality, Benchmark)
       # and columns: strategy, period, n_months, cagr, vol, sharpe, max_dd, calmar.
       # Keep only the pure HML strategy that represents "Value (HML)".
-      # Period labels ("Full"/"Training"/"OOS") match what other strategies use.
       # Source: R/plan_ev_ebit.R:109-114 (calc_metrics) stores cagr/vol/max_dd
       # as PERCENT (x * 100, no explicit round until the tibble build) --
       # convert to fraction.
+      # Period-label normalisation (#643): see the matching comment in
+      # .norm_mf() above -- "Full" -> "Full Period" is a safe rename, "OOS"
+      # is intentionally left as-is (ev_metrics' OOS window is `dates >=
+      # 2010-01-01`, unbounded, not the canonical bounded Testing partition).
       .norm_value <- function(m) {
         if (is.null(m) || nrow(m) == 0) return(NULL)
         m |>
           filter(strategy == "Pure Value (100% HML, EV/EBIT proxy)") |>
           select(-strategy, -calmar) |>
           rename(months = n_months) |>
-          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100)
+          mutate(
+            period = ifelse(period == "Full", "Full Period", period),
+            cagr   = cagr / 100, vol = vol / 100, max_dd = max_dd / 100
+          )
       }
 
       all_metrics <- bind_rows(

--- a/R/plan_partitions.R
+++ b/R/plan_partitions.R
@@ -7,6 +7,30 @@
 # Testing:    calibration, hyperparameter tuning, strategy comparison
 # Validation: final one-shot evaluation (sealed envelope)
 
+# ── Canonical period vocabulary (#643) ──────────────────────────────────────
+# Single source of truth for every value the `period` column is allowed to
+# hold, across every strategy metrics target AND the `leaderboard` target
+# that aggregates them. Sourced before plan_leaderboard.R / plan_qa_gates.R /
+# plan_ev_ebit.R / plan_managed_futures.R in docs/_targets.R, so this object
+# is available wherever those files reference it.
+#
+# "OOS" is INTENTIONALLY separate from "Testing" — they are not synonyms:
+#   - "Testing" is the canonical, bounded window in `bt_partitions` above
+#     (currently 2020-01-01..2022-12-31 for every asset class).
+#   - "OOS" labels a strategy-local out-of-sample split defined by its own
+#     `oos_start` parameter with NO end bound (e.g. R/plan_ev_ebit.R and
+#     R/plan_managed_futures.R both use `dates >= 2010-01-01`, which spans
+#     the canonical Training tail (2010-2019), all of Testing (2020-2022),
+#     and all of Validation (2023+) in one undifferentiated block).
+# Renaming "OOS" to "Testing" would misrepresent that wider, strategy-defined
+# sample as the shared cross-strategy test partition — so both labels stay
+# in the allowed set, and no `.norm_*` helper in R/plan_leaderboard.R may
+# rename OOS to Testing. Only "Full" -> "Full Period" is a safe rename
+# (pure spelling difference for the same concept — see #643).
+PERIOD_LABELS_ALLOWED <- c(
+  "Training", "Testing", "Validation", "Full Period", "OOS"
+)
+
 plan_partitions <- function() {
   list(
     targets::tar_target(bt_partitions, {

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -368,6 +368,90 @@ check_leaderboard_metric_ranges <- function(leaderboard) {
 }
 
 
+#' Assert leaderboard period labels are canonical (S10)
+#'
+#' Guards against the #643 defect class: a strategy's source metrics target
+#' uses a non-canonical `period` label (e.g. "Full" instead of "Full Period")
+#' that silently drops the strategy from every `filter(period == "Full
+#' Period")` consumer -- the docs/leaderboard.qmd headline ranking table
+#' (filters on "Full Period" at two places) and the correlation/redundancy
+#' join in R/plan_leaderboard.R (`ifelse(period == "Full Period", ...)`).
+#'
+#' Two assertions:
+#'   1. Every distinct `strategy` has at least one row with
+#'      `period == "Full Period"` -- the canonical full-sample label every
+#'      leaderboard consumer filters on.
+#'   2. Every value in `period` is a member of `PERIOD_LABELS_ALLOWED`
+#'      (R/plan_partitions.R) -- the single source of truth for the allowed
+#'      vocabulary. "OOS" is deliberately its own label, distinct from
+#'      "Testing" -- see the `PERIOD_LABELS_ALLOWED` comment in
+#'      R/plan_partitions.R for why the two windows are not interchangeable.
+#'
+#' @param leaderboard Tibble with at least `strategy` and `period` columns
+#'   (the output of the `leaderboard` targets pipeline target).
+#' @return `TRUE` invisibly on success.
+#' @noRd
+check_leaderboard_period_vocab <- function(leaderboard) {
+  required_cols <- c("strategy", "period")
+  missing_cols <- setdiff(required_cols, names(leaderboard))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "Leaderboard is missing {length(missing_cols)} required column(s): {missing_cols}.",
+      "i" = "check_leaderboard_period_vocab() (S10) requires strategy, period."
+    ))
+  }
+
+  # ── Assertion 1: every strategy has a canonical "Full Period" row ────────
+  full_period_strategies <- unique(
+    leaderboard$strategy[leaderboard$period == "Full Period"]
+  )
+  all_strategies <- unique(leaderboard$strategy)
+  missing_full <- setdiff(all_strategies, full_period_strategies)
+
+  if (length(missing_full) > 0L) {
+    cli::cli_abort(c(
+      "x" = paste0(
+        "Leaderboard has ", length(missing_full),
+        " strategy/strategies missing a canonical {.val Full Period} row:"
+      ),
+      setNames(sprintf("  %s", missing_full), rep("i", length(missing_full))),
+      "i" = paste0(
+        "Every consumer of the leaderboard (docs/leaderboard.qmd headline ",
+        "table, correlation/redundancy join in R/plan_leaderboard.R) filters ",
+        "on period == \"Full Period\" -- a strategy using a different label ",
+        "(e.g. \"Full\") for its full-sample row is silently dropped (#643)."
+      ),
+      "i" = "Normalise the label in the strategy's .norm_* helper in R/plan_leaderboard.R."
+    ))
+  }
+
+  # ── Assertion 2: no period value outside the canonical vocabulary ────────
+  observed_periods <- unique(leaderboard$period)
+  bad_periods <- setdiff(observed_periods, PERIOD_LABELS_ALLOWED)
+
+  if (length(bad_periods) > 0L) {
+    offender_msgs <- vapply(bad_periods, function(p) {
+      strats <- unique(leaderboard$strategy[leaderboard$period == p])
+      sprintf("  %s -- used by: %s", p, paste(strats, collapse = ", "))
+    }, character(1L))
+    cli::cli_abort(c(
+      "x" = paste0(
+        "Leaderboard {.field period} column has ", length(bad_periods),
+        " value(s) outside the canonical vocabulary:"
+      ),
+      setNames(offender_msgs, rep("i", length(offender_msgs))),
+      "i" = paste0(
+        "Allowed values (R/plan_partitions.R PERIOD_LABELS_ALLOWED): ",
+        paste(PERIOD_LABELS_ALLOWED, collapse = ", "), "."
+      ),
+      "i" = "Normalise the label in the strategy's .norm_* helper in R/plan_leaderboard.R (#643)."
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+
 # ---- QA gate plan ----
 
 plan_qa_gates <- function() {
@@ -529,6 +613,20 @@ plan_qa_gates <- function() {
       command = {
         check_leaderboard_metric_ranges(leaderboard)
         cli::cli_inform(c("v" = "qa_leaderboard_metric_ranges: S9 passed (all cagr/vol/max_dd within fractional range)"))
+        TRUE
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: leaderboard period labels are canonical (S10) — guards against
+    # the #643 defect class where a strategy's source metrics target uses a
+    # non-canonical period label (e.g. "Full" instead of "Full Period") that
+    # silently drops the strategy from every period == "Full Period" filter.
+    targets::tar_target(
+      qa_leaderboard_period_vocab,
+      command = {
+        check_leaderboard_period_vocab(leaderboard)
+        cli::cli_inform(c("v" = "qa_leaderboard_period_vocab: S10 passed (canonical period vocabulary, all strategies have a Full Period row)"))
         TRUE
       },
       cue = targets::tar_cue(mode = "always")

--- a/R/plan_structural_breaks.R
+++ b/R/plan_structural_breaks.R
@@ -330,7 +330,8 @@ plan_structural_breaks <- function() {
       structural_breaks_caption,
       {
         df <- structural_breaks_summary
-        n_strats   <- nrow(df)
+        n_strats      <- nrow(df)
+        n_not_computed <- sum(is.na(df$n_breaks))
         n_with_breaks <- sum(df$n_breaks > 0L, na.rm = TRUE)
         n_material    <- sum(df$material_divergence, na.rm = TRUE)
         alpha_pct  <- sb_params$alpha * 100
@@ -344,6 +345,12 @@ plan_structural_breaks <- function() {
           "Breaks are detected using an iterative forward-split t-test on ",
           "vol-normalised returns with a minimum segment of ",
           sb_params$min_years, " years. ",
+          "Material column: \"YES\" is a break with post-break Sharpe diverging ",
+          "beyond the threshold above; \"no\" is a strategy that WAS tested and ",
+          "either showed no break or a break too small to call material; ",
+          "\"not computed\" (", n_not_computed, " of ", n_strats,
+          " strategies) marks a strategy the break test could not run for at ",
+          "all (see its Note column) — that is unassessed, not a passed check. ",
           "Per the resulting-prohibition rule, a detected break is evidence ",
           "requiring investigation — not a signal to revise strategy allocation. ",
           "Per Carver's own finding, 'no break' often wins OOS: ",

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -98,15 +98,36 @@ if (!is.null(lb)) {
         !credible        ~ 2L,
         TRUE              ~ 1L
       ),
+      # NA redundant means this strategy is outside the 5-strategy correlation
+      # universe computed by R/plan_strategy_correlation.R (Stock MAX, Stock
+      # DRIF, Factor MAX, Factor DRIF, LTR only) -- that is "unassessed", not
+      # "assessed and found not redundant". Previously both NA and a computed
+      # FALSE fell through to the same ambiguous "—" (#643, same conflation
+      # class as Credible, #637 follow-up).
       Redundant  = if ("redundant" %in% names(full)) {
-        ifelse(is.na(redundant), "—", ifelse(redundant, "YES", "no"))
-      } else "—",
+        dplyr::case_when(
+          is.na(redundant) ~ "not computed",
+          redundant         ~ "YES",
+          TRUE              ~ "no"
+        )
+      } else "not computed",
+      # Explicit sort rank for Redundant: same rationale as .credible_rank —
+      # DT's default string comparator sorts "YES" / "no" / "not computed"
+      # alphabetically, which does not put assessed-good first, then
+      # assessed-bad, then never-assessed (#643).
+      .redundant_rank = if ("redundant" %in% names(full)) {
+        dplyr::case_when(
+          is.na(redundant) ~ 3L,
+          redundant         ~ 2L,
+          TRUE              ~ 1L
+        )
+      } else 3L,
       `Incremental Sharpe` = if ("incremental_sharpe" %in% names(full)) {
         ifelse(is.na(incremental_sharpe), "—", as.character(round(incremental_sharpe, 3)))
       } else "—"
     ) |>
     select(Strategy = strategy, Credible, .credible_rank, Sharpe, `Net CAGR`, `Max DD`, `CVaR 95%`, Vol, Gross,
-           `Cost (bps)`, SSR, `Top5% Share`, Redundant, `Incremental Sharpe`)
+           `Cost (bps)`, SSR, `Top5% Share`, Redundant, .redundant_rank, `Incremental Sharpe`)
 
   # NA credible (not is.na(credible) | !credible) is deliberate here: `!NA`
   # is NA, and indexing a character vector with a logical vector containing
@@ -210,13 +231,18 @@ if (!is.null(lb)) {
     gh_base, git_sha
   )
   n_redundant <- if ("redundant" %in% names(full)) sum(full$redundant, na.rm = TRUE) else 0L
+  n_redundant_na <- if ("redundant" %in% names(full)) sum(is.na(full$redundant)) else nrow(full)
   diversification_note <- paste0(
-    " Redundant = TRUE when a strategy's Full-Period monthly-return correlation with another, ",
+    " Redundant = \"YES\" when a strategy's Full-Period monthly-return correlation with another, ",
     "higher-Sharpe strategy exceeds the threshold fixed in ", corr_registry_link,
     " (", n_redundant, " of ", nrow(full),
-    " strategies currently flagged); Incremental Sharpe = the change in equal-weight-portfolio Sharpe from ",
-    "including this strategy vs excluding it — positive means it adds diversification value, negative means ",
-    "the portfolio is better off without it. Both feed the new-strategy value gate (#496)."
+    " strategies currently flagged); \"not computed\" (", n_redundant_na,
+    " strategies) marks a strategy outside the 5-strategy correlation universe ",
+    "(Stock MAX, Stock DRIF, Factor MAX, Factor DRIF, LTR) that R/plan_strategy_correlation.R ",
+    "currently covers — that is unassessed, not assessed-and-passed. Incremental Sharpe = the ",
+    "change in equal-weight-portfolio Sharpe from including this strategy vs excluding it — ",
+    "positive means it adds diversification value, negative means the portfolio is better off ",
+    "without it. Both feed the new-strategy value gate (#496)."
   )
 
   full_caption <- paste0(
@@ -230,15 +256,18 @@ if (!is.null(lb)) {
     flag_note, bias_note, gross_note, cost_note, diversification_note
   )
 
-  # Bespoke DT call (not hd_dt()): the Credible column needs an explicit sort
-  # rank (.credible_rank, added above) instead of DT's default alphabetical
-  # string comparator -- ascending on the display string gives NO / not
-  # computed / yes, which puts assessed-and-failed before never-assessed
-  # before assessed-and-passed, not the intended priority order. orderData
-  # points the Credible column's sort at the hidden rank column instead
-  # (#637 follow-up).
-  credible_col <- which(names(metrics_table) == "Credible") - 1L
-  rank_col     <- which(names(metrics_table) == ".credible_rank") - 1L
+  # Bespoke DT call (not hd_dt()): the Credible and Redundant columns each
+  # need an explicit sort rank (.credible_rank / .redundant_rank, added
+  # above) instead of DT's default alphabetical string comparator --
+  # ascending on the display string gives NO / not computed / yes (Credible)
+  # or YES / no / not computed (Redundant), neither of which puts
+  # assessed-good first, then assessed-bad, then never-assessed. orderData
+  # points each column's sort at its hidden rank column instead (#637
+  # follow-up; Redundant added #643).
+  credible_col  <- which(names(metrics_table) == "Credible") - 1L
+  cred_rank_col <- which(names(metrics_table) == ".credible_rank") - 1L
+  redundant_col <- which(names(metrics_table) == "Redundant") - 1L
+  red_rank_col  <- which(names(metrics_table) == ".redundant_rank") - 1L
   numeric_cols <- which(sapply(metrics_table, function(x) is.numeric(x) ||
                                   grepl("^[0-9.%$,-]+$", as.character(x[1]))))
 
@@ -259,8 +288,9 @@ if (!is.null(lb)) {
       search = list(regex = TRUE, caseInsensitive = TRUE),
       columnDefs = list(
         list(className = 'dt-right', targets = numeric_cols - 1),
-        list(visible = FALSE, targets = rank_col),
-        list(orderData = rank_col, targets = credible_col)
+        list(visible = FALSE, targets = c(cred_rank_col, red_rank_col)),
+        list(orderData = cred_rank_col, targets = credible_col),
+        list(orderData = red_rank_col, targets = redundant_col)
       ),
       initComplete = DT::JS(
         "function(settings, json) {",
@@ -730,15 +760,49 @@ if (!is.null(sb_sum) && !is.null(snames)) {
         is.na(sharpe_divergence_pct), "—",
         paste0(sharpe_divergence_pct, "%")
       ),
-      Material            = ifelse(
-        is.na(material_divergence), "—",
-        ifelse(material_divergence, "YES", "no")
+      # `material_divergence` is NA for two structurally different reasons
+      # that were previously conflated into the same "—" (#643, same
+      # conflation class as Credible, #637 follow-up):
+      #   1. The break test itself errored or was skipped for this strategy
+      #      (n_breaks is NA_integer_, see the `entry$error` branch in
+      #      R/plan_structural_breaks.R) -- genuinely "not computed".
+      #   2. The break test ran and found NO break at all (n_breaks == 0) --
+      #      there is nothing to diverge from, so "no material divergence"
+      #      is a real, assessed answer, not an unknown one. A break WAS
+      #      found (n_breaks > 0) but the divergence percentage could not be
+      #      reliably computed (near-zero whole_sharpe denominator or too
+      #      few post-break observations) is its own indeterminate case and
+      #      stays "not computed" -- a break with an unmeasurable divergence
+      #      is not the same as "no material divergence".
+      Material            = dplyr::case_when(
+        is.na(n_breaks)                            ~ "not computed",
+        n_breaks == 0L                             ~ "no",
+        n_breaks > 0L & is.na(material_divergence) ~ "not computed",
+        material_divergence                        ~ "YES",
+        TRUE                                       ~ "no"
+      ),
+      # Explicit sort rank for Material -- same rationale as .credible_rank /
+      # .redundant_rank: DT's default string comparator sorts "YES" / "no" /
+      # "not computed" alphabetically, not assessed-good, assessed-bad,
+      # never-assessed (#643).
+      .material_rank      = dplyr::case_when(
+        is.na(n_breaks)                            ~ 3L,
+        n_breaks == 0L                             ~ 1L,
+        n_breaks > 0L & is.na(material_divergence) ~ 3L,
+        material_divergence                        ~ 2L,
+        TRUE                                       ~ 1L
       ),
       Note                = ifelse(is.na(note), "", note)
     )
 
   cap_text <- if (!is.null(sb_cap)) sb_cap else
     "Structural break analysis — run tar_make() to populate."
+
+  # Explicit sort rank for Material -- same rationale as .credible_rank /
+  # .redundant_rank above: DT's default string comparator sorts the display
+  # string alphabetically, not assessed-good, assessed-bad, never-assessed.
+  material_col      <- which(names(sb_disp) == "Material") - 1L
+  material_rank_col <- which(names(sb_disp) == ".material_rank") - 1L
 
   DT::datatable(
     sb_disp,
@@ -753,6 +817,10 @@ if (!is.null(sb_sum) && !is.null(snames)) {
       pageLength   = 20L,
       scrollX      = TRUE,
       dom          = "frtip",
+      columnDefs   = list(
+        list(visible = FALSE, targets = material_rank_col),
+        list(orderData = material_rank_col, targets = material_col)
+      ),
       initComplete = DT::JS(
         "function(settings, json) {",
         "  var isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark'",

--- a/tests/testthat/_snaps/leaderboard-period-vocab.md
+++ b/tests/testthat/_snaps/leaderboard-period-vocab.md
@@ -1,0 +1,31 @@
+# check_leaderboard_period_vocab throws when a strategy is missing its Full Period row
+
+    Code
+      check_leaderboard_period_vocab(missing_full_period_leaderboard)
+    Condition
+      Error in `check_leaderboard_period_vocab()`:
+      x Leaderboard has 1 strategy/strategies missing a canonical "Full Period" row:
+      i  Value (HML)
+      i Every consumer of the leaderboard (docs/leaderboard.qmd headline table, correlation/redundancy join in R/plan_leaderboard.R) filters on period == "Full Period" -- a strategy using a different label (e.g. "Full") for its full-sample row is silently dropped (#643).
+      i Normalise the label in the strategy's .norm_* helper in R/plan_leaderboard.R.
+
+# check_leaderboard_period_vocab throws when a period value is outside the canonical vocabulary
+
+    Code
+      check_leaderboard_period_vocab(bad_vocab_leaderboard)
+    Condition
+      Error in `check_leaderboard_period_vocab()`:
+      x Leaderboard period column has 1 value(s) outside the canonical vocabulary:
+      i  Full-Sample -- used by: Managed Futures
+      i Allowed values (R/plan_partitions.R PERIOD_LABELS_ALLOWED): Training, Testing, Validation, Full Period, OOS.
+      i Normalise the label in the strategy's .norm_* helper in R/plan_leaderboard.R (#643).
+
+# check_leaderboard_period_vocab throws when required columns are missing
+
+    Code
+      check_leaderboard_period_vocab(bad)
+    Condition
+      Error in `check_leaderboard_period_vocab()`:
+      x Leaderboard is missing 1 required column(s): period.
+      i check_leaderboard_period_vocab() (S10) requires strategy, period.
+

--- a/tests/testthat/test-leaderboard-coverage.R
+++ b/tests/testthat/test-leaderboard-coverage.R
@@ -18,7 +18,8 @@ source(here::here("R/plan_qa_gates.R"))
   m |>
     dplyr::filter(strategy == "Long-Short TS-Mom (MOP 2012, vol-targeted)") |>
     dplyr::select(-strategy, -calmar) |>
-    dplyr::rename(months = n_months)
+    dplyr::rename(months = n_months) |>
+    dplyr::mutate(period = ifelse(period == "Full", "Full Period", period))
 }
 
 .norm_value_test <- function(m) {
@@ -26,7 +27,8 @@ source(here::here("R/plan_qa_gates.R"))
   m |>
     dplyr::filter(strategy == "Pure Value (100% HML, EV/EBIT proxy)") |>
     dplyr::select(-strategy, -calmar) |>
-    dplyr::rename(months = n_months)
+    dplyr::rename(months = n_months) |>
+    dplyr::mutate(period = ifelse(period == "Full", "Full Period", period))
 }
 
 # ── Synthetic metrics fixtures (same schema as mf_metrics / ev_metrics) ──────
@@ -66,7 +68,7 @@ synthetic_ev_metrics <- tibble::tibble(
 test_that(".norm_mf returns only canonical TS-Mom rows with base leaderboard columns", {
   res <- .norm_mf_test(synthetic_mf_metrics)
   expect_false(is.null(res))
-  expect_true(nrow(res) == 3L)  # Full / Training / OOS
+  expect_true(nrow(res) == 3L)  # Full Period / Training / OOS
   expect_true(all(c("period", "months", "cagr", "vol", "sharpe", "max_dd") %in% names(res)))
   expect_false("strategy" %in% names(res))
   expect_false("calmar"   %in% names(res))
@@ -78,12 +80,27 @@ test_that(".norm_mf returns NULL on empty input", {
   expect_null(.norm_mf_test(NULL))
 })
 
+test_that(".norm_mf renames 'Full' to the canonical 'Full Period' label (#643)", {
+  res <- .norm_mf_test(synthetic_mf_metrics)
+  expect_true("Full Period" %in% res$period)
+  expect_false("Full" %in% res$period)
+})
+
+test_that(".norm_mf does NOT rename 'OOS' to 'Testing' (#643 -- different window)", {
+  # mf_metrics' OOS window (dates >= oos_start, unbounded) is not the same
+  # span as the canonical Testing partition (bounded, R/plan_partitions.R)
+  # -- see the .norm_mf() comment in R/plan_leaderboard.R for the evidence.
+  res <- .norm_mf_test(synthetic_mf_metrics)
+  expect_true("OOS" %in% res$period)
+  expect_false("Testing" %in% res$period)
+})
+
 # ── Tests: .norm_value ────────────────────────────────────────────────────────
 
 test_that(".norm_value returns only Pure Value rows with base leaderboard columns", {
   res <- .norm_value_test(synthetic_ev_metrics)
   expect_false(is.null(res))
-  expect_true(nrow(res) == 3L)  # Full / Training / OOS
+  expect_true(nrow(res) == 3L)  # Full Period / Training / OOS
   expect_true(all(c("period", "months", "cagr", "vol", "sharpe", "max_dd") %in% names(res)))
   expect_false("strategy" %in% names(res))
   expect_false("calmar"   %in% names(res))
@@ -93,6 +110,21 @@ test_that(".norm_value returns only Pure Value rows with base leaderboard column
 test_that(".norm_value returns NULL on empty input", {
   expect_null(.norm_value_test(tibble::tibble()))
   expect_null(.norm_value_test(NULL))
+})
+
+test_that(".norm_value renames 'Full' to the canonical 'Full Period' label (#643)", {
+  res <- .norm_value_test(synthetic_ev_metrics)
+  expect_true("Full Period" %in% res$period)
+  expect_false("Full" %in% res$period)
+})
+
+test_that(".norm_value does NOT rename 'OOS' to 'Testing' (#643 -- different window)", {
+  # ev_metrics' OOS window (dates >= oos_start, unbounded) is not the same
+  # span as the canonical Testing partition (bounded, R/plan_partitions.R)
+  # -- see the .norm_value() comment in R/plan_leaderboard.R for the evidence.
+  res <- .norm_value_test(synthetic_ev_metrics)
+  expect_true("OOS" %in% res$period)
+  expect_false("Testing" %in% res$period)
 })
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────

--- a/tests/testthat/test-leaderboard-period-vocab.R
+++ b/tests/testthat/test-leaderboard-period-vocab.R
@@ -1,0 +1,119 @@
+testthat::local_edition(3)
+# Tests for check_leaderboard_period_vocab() — QA gate S10 (#643)
+#
+# The function is defined in R/plan_qa_gates.R and depends on
+# PERIOD_LABELS_ALLOWED, defined in R/plan_partitions.R (single source of
+# truth for the canonical `period` vocabulary). Tests exercise the gate
+# directly without running tar_make().
+#
+# Background (#643): mf_metrics and ev_metrics used "Full" for their
+# full-sample row where every other strategy in the leaderboard uses
+# "Full Period" -- the headline ranking table filters on period ==
+# "Full Period", so "Value (HML)" and "Managed Futures" were silently
+# dropped. This gate catches a recurrence of that defect class.
+
+source(here::here("R/plan_partitions.R"))
+source(here::here("R/plan_qa_gates.R"))
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+good_leaderboard <- tibble::tibble(
+  strategy = c(
+    "Factor MAX", "Factor MAX", "Factor MAX",
+    "Value (HML)", "Value (HML)", "Value (HML)"
+  ),
+  period = c(
+    "Training", "Testing", "Full Period",
+    "Training", "OOS",     "Full Period"
+  )
+)
+
+# Value (HML) never got a "Full Period" row -- the #643 regression itself
+# (its .norm_value() helper forgot to rename "Full" -> "Full Period").
+missing_full_period_leaderboard <- tibble::tibble(
+  strategy = c(
+    "Factor MAX", "Factor MAX", "Factor MAX",
+    "Value (HML)", "Value (HML)", "Value (HML)"
+  ),
+  period = c(
+    "Training", "Testing", "Full Period",
+    "Training", "OOS",     "Full"          # should be "Full Period"
+  )
+)
+
+# A period value entirely outside the canonical vocabulary (typo / new
+# strategy wired in without checking the allowed set). Every strategy still
+# has a valid "Full Period" row so this fixture isolates assertion 2 (bad
+# vocabulary) from assertion 1 (missing Full Period row).
+bad_vocab_leaderboard <- tibble::tibble(
+  strategy = c("Factor MAX", "Factor MAX", "Managed Futures", "Managed Futures"),
+  period   = c("Training", "Full Period", "Full Period", "Full-Sample")  # typo
+)
+
+# ── Tests: assertion 1 (every strategy has a Full Period row) ────────────────
+
+test_that("check_leaderboard_period_vocab passes when every strategy has a Full Period row", {
+  expect_true(check_leaderboard_period_vocab(good_leaderboard))
+})
+
+test_that("check_leaderboard_period_vocab throws when a strategy is missing its Full Period row", {
+  expect_error(
+    check_leaderboard_period_vocab(missing_full_period_leaderboard),
+    regexp = "Value \\(HML\\)"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_period_vocab(missing_full_period_leaderboard)
+  )
+})
+
+# ── Tests: assertion 2 (no period value outside PERIOD_LABELS_ALLOWED) ───────
+
+test_that("check_leaderboard_period_vocab passes with 'OOS' as a distinct, allowed label", {
+  # OOS is deliberately its own label, not a synonym for Testing (#643) --
+  # see R/plan_partitions.R PERIOD_LABELS_ALLOWED.
+  expect_true("OOS" %in% PERIOD_LABELS_ALLOWED)
+  expect_false("Testing" == "OOS")
+  expect_true(check_leaderboard_period_vocab(good_leaderboard))
+})
+
+test_that("check_leaderboard_period_vocab throws when a period value is outside the canonical vocabulary", {
+  expect_error(
+    check_leaderboard_period_vocab(bad_vocab_leaderboard),
+    regexp = "Full-Sample"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_period_vocab(bad_vocab_leaderboard)
+  )
+})
+
+test_that("check_leaderboard_period_vocab names the offending strategy for a bad vocabulary value", {
+  expect_error(
+    check_leaderboard_period_vocab(bad_vocab_leaderboard),
+    regexp = "Managed Futures"
+  )
+})
+
+# ── Tests: required columns ───────────────────────────────────────────────────
+
+test_that("check_leaderboard_period_vocab throws when required columns are missing", {
+  bad <- dplyr::select(good_leaderboard, -period)
+  expect_error(
+    check_leaderboard_period_vocab(bad),
+    regexp = "period"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_period_vocab(bad)
+  )
+})
+
+# ── PERIOD_LABELS_ALLOWED itself ─────────────────────────────────────────────
+
+test_that("PERIOD_LABELS_ALLOWED contains the 5 expected canonical labels", {
+  expect_setequal(
+    PERIOD_LABELS_ALLOWED,
+    c("Training", "Testing", "Validation", "Full Period", "OOS")
+  )
+})


### PR DESCRIPTION
## Summary

### Task 1 — period vocabulary (#643 root cause)

`mf_metrics`/`ev_metrics` used `"Full"` for the full-sample row where every
other strategy in the leaderboard uses `"Full Period"`. The headline ranking
table (`docs/leaderboard.qmd:58` and `:651`) and the correlation/redundancy
join in `R/plan_leaderboard.R` both filter on `period == "Full Period"`, so
**Value (HML)** and **Managed Futures** were silently dropped from the
headline table and never got a `redundant`/`incremental_sharpe` value.

**`.norm_mf()` / `.norm_value()` in `R/plan_leaderboard.R`** now rename
`"Full"` → `"Full Period"` at the source boundary, mirroring the pattern
#637 used for unit conversion (fix where the source convention is known,
never at the consumer).

**`OOS` semantics — investigated, NOT renamed to `Testing`.** `mf_metrics`
(`R/plan_managed_futures.R:180`) and `ev_metrics` (`R/plan_ev_ebit.R:102`)
each define their own OOS split as `dates >= oos_start` (`2010-01-01`,
**unbounded** end). The canonical `Testing` partition in `bt_partitions`
(`R/plan_partitions.R`) is `2020-01-01..2022-12-31` — **bounded**, and a
completely different span: the strategies' own "OOS" window spans the tail
of canonical Training (2010-2019), all of canonical Testing (2020-2022),
*and* all of canonical Validation (2023+) as one undifferentiated block.
Renaming `OOS` → `Testing` would misrepresent that wider, strategy-defined
sample as the shared cross-strategy test partition, so both labels stay
distinct in the allowed vocabulary. Documented at length in
`R/plan_partitions.R` and in the `.norm_mf()`/`.norm_value()` comments.

**Single source of truth**: `PERIOD_LABELS_ALLOWED` in `R/plan_partitions.R`
— `c("Training", "Testing", "Validation", "Full Period", "OOS")`.

**New QA gate (S10)**: `check_leaderboard_period_vocab()` /
`qa_leaderboard_period_vocab` in `R/plan_qa_gates.R` asserts (1) every
distinct strategy has at least one `"Full Period"` row, and (2) no `period`
value falls outside `PERIOD_LABELS_ALLOWED` — `cli_abort`s naming the
offending strategy/value in both cases.

### Task 2 — tri-state columns (same conflation class as `Credible`, #642)

- **`Redundant`** (`docs/leaderboard.qmd`, headline table): had the exact
  same defect `Credible` had before #642 — `NA` (never assessed, because
  the strategy sits outside the 5-strategy correlation universe computed by
  `R/plan_strategy_correlation.R`: Stock MAX, Stock DRIF, Factor MAX,
  Factor DRIF, LTR) rendered as the same ambiguous `"—"` as a genuinely
  computed `FALSE`. Fixed the same way as `Credible`: `"not computed"` /
  `"no"` / `"YES"`, a hidden `.redundant_rank` sort column, and the caption
  now names the correlation universe and explains the third state.

- **`Material`** (Structural Breaks summary table): had the same
  conflation, but with an extra wrinkle. `material_divergence` is `NA` for
  **two different reasons**: (a) the break test errored/was skipped for
  that strategy (`n_breaks` is `NA_integer_`) — genuinely "not computed",
  and (b) the test ran cleanly but found **no break at all**
  (`n_breaks == 0`) — a real, assessed "no material divergence" answer, not
  an unknown one. A third case — a break WAS found (`n_breaks > 0`) but the
  divergence percentage couldn't be reliably computed (near-zero
  denominator or too few post-break observations) — is genuinely
  indeterminate and stays `"not computed"` rather than defaulting to `"no"`.
  Fixed with a `case_when` discriminating on `n_breaks`/`material_divergence`
  together, a hidden `.material_rank` sort column, and the
  `structural_breaks_caption` target (`R/plan_structural_breaks.R`) now
  explains all three states with a dynamic `not computed` count.

### Task 3 — captions

Both captions (`diversification_note` in `docs/leaderboard.qmd`, and the
`structural_breaks_caption` target) now spell out what each of the three
states means and explicitly avoid implying a strategy failed a check it was
never subjected to. All figures are computed dynamically from the data
(`n_redundant`, `n_redundant_na`, `n_not_computed`, etc.) — no hardcoded
counts.

## Verification

Neither `tar_make()` nor a render was run (no targets store in this
worktree, per project convention) — verified by `parse()` +
`knitr::purl()` + `parse()` on the qmd, then a full `scripts/verify.sh` run:

```
::VERIFY:EDITION:: 3
::VERIFY:PARSE_OK::
::VERIFY:ROOT_SUMMARY:: total=313 failed=3 skipped=0
::VERIFY:PKG_SUMMARY:: total=678 failed=1 skipped=15
```

Both match the documented baselines exactly (root: 3 known pre-existing
failures, 0 skips; package: 1 known pre-existing failure, 15 skips) — no
regressions. `test-crypto-momentum.R`, `test-qa-summary-deps.R`,
`test-stock-backtest.R` (root) and
`test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short
returns at +100%` (package) are the pre-existing failures; unrelated to
this change.

New/extended tests:

- `tests/testthat/test-leaderboard-period-vocab.R` (new) — `S10` gate:
  passes with canonical labels, throws naming the missing strategy /
  offending value, snapshot tests for all three abort paths, confirms `OOS`
  stays distinct from `Testing`.
- `tests/testthat/test-leaderboard-coverage.R` (extended) — `.norm_mf`/
  `.norm_value` mirror helpers updated to include the `"Full"` →
  `"Full Period"` rename, with new tests confirming the rename happens and
  that `OOS` is left alone.

## Test plan

- [x] `parse("_targets.R")` and `parse("docs/_targets.R")` succeed
- [x] `knitr::purl("docs/leaderboard.qmd")` + `parse()` succeeds
- [x] `scripts/verify.sh` full run — root and package suites match baseline
      exactly (no new failures, no new skips)
- [x] New QA gate has both passing and failing (snapshot-tested) test cases
- [x] `.norm_mf`/`.norm_value` test mirrors updated to match the real
      helpers' new period-rename behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)