### PR TITLE
fix(qa): seal Validation partition in mf_metrics/ev_metrics OOS windows (#645)

### DIFF
--- a/R/plan_ev_ebit.R
+++ b/R/plan_ev_ebit.R
@@ -96,13 +96,23 @@ plan_ev_ebit <- function() {
 
 
     # ── Metrics: performance table across periods ───────────────────────────────
+    # #645: OOS is bounded at bt_partitions$factor$test_end (R/plan_partitions.R)
+    # so it no longer silently swallows the sealed Validation partition on
+    # every tar_make(). ev_ebit's strategies are FF5 factor (HML/RMW) proxies,
+    # so bt_partitions$factor is the matching partition set. Training keeps
+    # its original pre-2010 definition (narrower than canonical Training, a
+    # comparability wart but not a seal breach -- see #645) and is unaffected
+    # by this bound.
     targets::tar_target(ev_metrics, {
       library(dplyr)
 
-      oos <- ev_params$oos_start
+      oos      <- ev_params$oos_start
+      test_end <- bt_partitions$factor$test_end
 
-      calc_metrics <- function(ret_vec, strategy_name, period_name) {
-        ret_vec <- ret_vec[!is.na(ret_vec)]
+      calc_metrics <- function(ret_vec, date_vec, strategy_name, period_name) {
+        keep     <- !is.na(ret_vec)
+        ret_vec  <- ret_vec[keep]
+        date_vec <- date_vec[keep]
         if (length(ret_vec) < 12L) return(NULL)
         years    <- length(ret_vec) / 12
         cum_ret  <- prod(1 + ret_vec)
@@ -114,14 +124,16 @@ plan_ev_ebit <- function() {
         max_dd   <- min(drawdown) * 100
         calmar   <- ifelse(abs(max_dd) > 0, cagr / abs(max_dd), NA_real_)
         tibble::tibble(
-          strategy = strategy_name,
-          period   = period_name,
-          n_months = length(ret_vec),
-          cagr     = round(cagr, 2),
-          vol      = round(vol, 2),
-          sharpe   = round(sharpe, 3),
-          max_dd   = round(max_dd, 2),
-          calmar   = round(calmar, 3)
+          strategy     = strategy_name,
+          period       = period_name,
+          n_months     = length(ret_vec),
+          cagr         = round(cagr, 2),
+          vol          = round(vol, 2),
+          sharpe       = round(sharpe, 3),
+          max_dd       = round(max_dd, 2),
+          calmar       = round(calmar, 3),
+          window_start = min(date_vec),
+          window_end   = max(date_vec)
         )
       }
 
@@ -135,15 +147,17 @@ plan_ev_ebit <- function() {
         value_qual = "Value+Quality (50% HML + 50% RMW, QVAL proxy)",
         market     = "Benchmark (Cap-Weighted Market)"
       )
-      dates  <- ev_portfolios$date
-      is_oos <- dates >= oos
+      dates <- ev_portfolios$date
+
+      is_pre_oos <- dates < oos
+      is_oos     <- dates >= oos & dates <= test_end
 
       rows <- list()
       for (nm in names(strategies)) {
         rows <- c(rows,
-          list(calc_metrics(strategies[[nm]],          labels[nm], "Full")),
-          list(calc_metrics(strategies[[nm]][!is_oos], labels[nm], "Training")),
-          list(calc_metrics(strategies[[nm]][is_oos],  labels[nm], "OOS"))
+          list(calc_metrics(strategies[[nm]],            dates,             labels[nm], "Full")),
+          list(calc_metrics(strategies[[nm]][is_pre_oos], dates[is_pre_oos], labels[nm], "Training")),
+          list(calc_metrics(strategies[[nm]][is_oos],     dates[is_oos],     labels[nm], "OOS"))
         )
       }
       dplyr::bind_rows(Filter(Negate(is.null), rows))

--- a/R/plan_managed_futures.R
+++ b/R/plan_managed_futures.R
@@ -174,13 +174,23 @@ plan_managed_futures <- function() {
 
 
     # ── Metrics: performance table (Full / Training / OOS) ─────────────────────
+    # #645: OOS is bounded at bt_partitions$macro$test_end (R/plan_partitions.R)
+    # so it no longer silently swallows the sealed Validation partition on
+    # every tar_make(). Managed futures uses SPY+TLT+GLD+DBC -- the macro
+    # asset class -- so bt_partitions$macro is the matching partition set.
+    # Training keeps its original pre-2010 definition (narrower than
+    # canonical Training, a comparability wart but not a seal breach --
+    # see #645) and is unaffected by this bound.
     targets::tar_target(mf_metrics, {
       library(dplyr)
 
-      oos <- mf_params$oos_start
+      oos      <- mf_params$oos_start
+      test_end <- bt_partitions$macro$test_end
 
-      calc_metrics <- function(ret_vec, strategy_name, period_name) {
-        ret_vec <- ret_vec[!is.na(ret_vec)]
+      calc_metrics <- function(ret_vec, date_vec, strategy_name, period_name) {
+        keep     <- !is.na(ret_vec)
+        ret_vec  <- ret_vec[keep]
+        date_vec <- date_vec[keep]
         if (length(ret_vec) < 12L) return(NULL)
         years   <- length(ret_vec) / 12
         cum_ret <- prod(1 + ret_vec)
@@ -192,14 +202,16 @@ plan_managed_futures <- function() {
         max_dd  <- min(dd) * 100
         calmar  <- ifelse(abs(max_dd) > 0, cagr / abs(max_dd), NA_real_)
         tibble::tibble(
-          strategy = strategy_name,
-          period   = period_name,
-          n_months = length(ret_vec),
-          cagr     = round(cagr, 2),
-          vol      = round(vol, 2),
-          sharpe   = round(sharpe, 3),
-          max_dd   = round(max_dd, 2),
-          calmar   = round(calmar, 3)
+          strategy     = strategy_name,
+          period       = period_name,
+          n_months     = length(ret_vec),
+          cagr         = round(cagr, 2),
+          vol          = round(vol, 2),
+          sharpe       = round(sharpe, 3),
+          max_dd       = round(max_dd, 2),
+          calmar       = round(calmar, 3),
+          window_start = min(date_vec),
+          window_end   = max(date_vec)
         )
       }
 
@@ -213,15 +225,17 @@ plan_managed_futures <- function() {
         ls = "Long-Short TS-Mom (MOP 2012, vol-targeted)",
         ew = "Equal-Weight Benchmark (SPY+TLT+GLD+DBC)"
       )
-      dates  <- mf_portfolios$date
-      is_oos <- dates >= oos
+      dates <- mf_portfolios$date
+
+      is_pre_oos <- dates < oos
+      is_oos     <- dates >= oos & dates <= test_end
 
       rows <- list()
       for (nm in names(strategies)) {
         rows <- c(rows,
-          list(calc_metrics(strategies[[nm]],          labels[nm], "Full")),
-          list(calc_metrics(strategies[[nm]][!is_oos], labels[nm], "Training")),
-          list(calc_metrics(strategies[[nm]][is_oos],  labels[nm], "OOS"))
+          list(calc_metrics(strategies[[nm]],            dates,             labels[nm], "Full")),
+          list(calc_metrics(strategies[[nm]][is_pre_oos], dates[is_pre_oos], labels[nm], "Training")),
+          list(calc_metrics(strategies[[nm]][is_oos],     dates[is_oos],     labels[nm], "OOS"))
         )
       }
       dplyr::bind_rows(Filter(Negate(is.null), rows))

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -452,6 +452,98 @@ check_leaderboard_period_vocab <- function(leaderboard) {
 }
 
 
+#' Assert no automatically-computed metric window extends past `test_end`
+#' unless its partition is explicitly "Validation" (S11)
+#'
+#' Guards against the #645 defect class: a strategy's source metrics target
+#' (e.g. `mf_metrics` in R/plan_managed_futures.R, `ev_metrics` in
+#' R/plan_ev_ebit.R) computes a bespoke period window that is unbounded above
+#' and therefore silently includes the sealed Validation partition
+#' (R/plan_partitions.R `bt_partitions`, `backtest-partitions` rule) on every
+#' `tar_make()`.
+#'
+#' Two period labels are exempt from the `test_end` bound, both by design of
+#' `backtest-partitions.md`:
+#'   - `"Validation"` -- the sealed partition itself; its whole purpose is to
+#'     extend past `test_end`.
+#'   - `"Full"` / `"Full Period"` -- the rule's own canonical reference
+#'     implementation lists `calc_metrics(all_data, "Full Period")` alongside
+#'     Training/Testing/Validation as an accepted, full-sample summary that is
+#'     *expected* to span the whole series (including Validation) by
+#'     definition -- it is not a bespoke evaluation/test window like `"OOS"`.
+#'     Every other strategy on the leaderboard already reports a Full Period
+#'     row this way; only a genuinely bespoke window (not itself the sealed
+#'     partition or the full-sample summary) is what #645 is about.
+#'
+#' @param metrics A tibble with at least `strategy`, `period`, `window_end`
+#'   columns (the output of a strategy metrics target, e.g. `mf_metrics` or
+#'   `ev_metrics`).
+#' @param test_end A single Date -- the canonical test-partition upper bound
+#'   for this metrics target's asset class (from `bt_partitions`,
+#'   R/plan_partitions.R).
+#' @param source_label A short string identifying the metrics target being
+#'   checked (used in error messages), e.g. `"mf_metrics"`.
+#' @return `TRUE` invisibly on success.
+#'
+#' @section Scope note (#648):
+#' This function is scoped to window BOUNDS on `mf_metrics`/`ev_metrics`
+#' only. #648 identified a systematic, wider version of the same seal-breach
+#' pattern: `slice_portfolio()` in R/plan_leaderboard.R computes an explicit
+#' `Validation` slice on every `tar_make()` for 7 strategies -- not a bounds
+#' violation (those rows are correctly labelled `"Validation"`), but an
+#' automatic-computation violation (`backtest-partitions.md`: "Validation
+#' metrics are NOT computed automatically by tar_make()"). That is a
+#' different check -- "no row may be automatically labelled Validation at
+#' all" -- and is out of scope here; #648 handles it separately. If it is
+#' later folded into this same S11 gate, `metrics` already carries `period`,
+#' so a `"no period == 'Validation' row present"` assertion could be added
+#' as a second, independent check inside this function (or as a sibling
+#' function called from the same `qa_metric_window_bounds` target) without
+#' needing to change this function's signature.
+#' @noRd
+check_metric_window_bounds <- function(metrics, test_end, source_label) {
+  required_cols <- c("strategy", "period", "window_end")
+  missing_cols <- setdiff(required_cols, names(metrics))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "{source_label} is missing {length(missing_cols)} required column(s): {missing_cols}.",
+      "i" = "check_metric_window_bounds() (S11) requires strategy, period, window_end."
+    ))
+  }
+
+  exempt_periods <- c("Validation", "Full", "Full Period")
+
+  is_offender <- !is.na(metrics$window_end) &
+    !(metrics$period %in% exempt_periods) &
+    metrics$window_end > test_end
+  offenders <- metrics[is_offender, c("strategy", "period", "window_end"), drop = FALSE]
+
+  if (nrow(offenders) > 0L) {
+    msgs <- purrr::pmap_chr(
+      offenders,
+      function(strategy, period, window_end) {
+        sprintf("  %s / %s -- window_end %s exceeds test_end %s",
+                strategy, period, window_end, test_end)
+      }
+    )
+    cli::cli_abort(c(
+      "x" = paste0(
+        source_label, " has ", nrow(offenders),
+        " row(s) whose computed window extends past the sealed Validation ",
+        "partition boundary (test_end = ", test_end, "), #645:"
+      ),
+      setNames(msgs, rep("i", length(msgs))),
+      "i" = paste0(
+        "Bound the window at test_end in the source metrics target, or ",
+        "relabel the period \"Validation\" if the window is intentionally sealed."
+      )
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+
 # ---- QA gate plan ----
 
 plan_qa_gates <- function() {
@@ -627,6 +719,22 @@ plan_qa_gates <- function() {
       command = {
         check_leaderboard_period_vocab(leaderboard)
         cli::cli_inform(c("v" = "qa_leaderboard_period_vocab: S10 passed (canonical period vocabulary, all strategies have a Full Period row)"))
+        TRUE
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: no automatically-computed metric window extends past
+    # `test_end` unless its partition is explicitly "Validation" (S11) --
+    # guards against the #645 defect class where a strategy's bespoke OOS
+    # window (mf_metrics, ev_metrics) is unbounded above and silently
+    # includes the sealed Validation partition on every tar_make().
+    targets::tar_target(
+      qa_metric_window_bounds,
+      command = {
+        check_metric_window_bounds(mf_metrics, bt_partitions$macro$test_end, "mf_metrics")
+        check_metric_window_bounds(ev_metrics, bt_partitions$factor$test_end, "ev_metrics")
+        cli::cli_inform(c("v" = "qa_metric_window_bounds: S11 passed (no non-Validation window extends past test_end)"))
         TRUE
       },
       cue = targets::tar_cue(mode = "always")

--- a/tests/testthat/_snaps/metric-window-bounds.md
+++ b/tests/testthat/_snaps/metric-window-bounds.md
@@ -1,0 +1,19 @@
+# check_metric_window_bounds throws when an OOS window extends past test_end
+
+    Code
+      check_metric_window_bounds(unbounded_oos_metrics, test_end, "mf_metrics")
+    Condition
+      Error in `check_metric_window_bounds()`:
+      x mf_metrics has 1 row(s) whose computed window extends past the sealed Validation partition boundary (test_end = 2022-12-31), #645:
+      i  TS-Mom L/S / OOS -- window_end 2026-01-31 exceeds test_end 2022-12-31
+      i Bound the window at test_end in the source metrics target, or relabel the period "Validation" if the window is intentionally sealed.
+
+# check_metric_window_bounds throws when required columns are missing
+
+    Code
+      check_metric_window_bounds(bad, test_end, "mf_metrics")
+    Condition
+      Error in `check_metric_window_bounds()`:
+      x mf_metrics is missing 1 required column(s): window_end.
+      i check_metric_window_bounds() (S11) requires strategy, period, window_end.
+

--- a/tests/testthat/test-metric-window-bounds.R
+++ b/tests/testthat/test-metric-window-bounds.R
@@ -1,0 +1,108 @@
+testthat::local_edition(3)
+# Tests for check_metric_window_bounds() — QA gate S11 (#645)
+#
+# The function is defined in R/plan_qa_gates.R. Tests exercise the gate
+# directly without running tar_make().
+#
+# Background (#645): R/plan_managed_futures.R (mf_metrics) and
+# R/plan_ev_ebit.R (ev_metrics) computed an "OOS" window bounded only below
+# (dates >= oos_start, no upper bound). Because the canonical Validation
+# partition (R/plan_partitions.R bt_partitions) is sealed at 2023-01-01, that
+# unbounded OOS window silently swallowed the whole Validation partition on
+# every tar_make() -- exactly the seal breach `backtest-partitions.md`
+# prohibits. This gate catches a recurrence of that defect class: any
+# non-Validation, non-Full(-Period) row whose window_end exceeds test_end.
+
+source(here::here("R/plan_qa_gates.R"))
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+test_end <- as.Date("2022-12-31")
+
+# A bounded OOS window -- the #645 fix. window_end sits inside the canonical
+# Testing partition, well before the sealed Validation boundary.
+bounded_metrics <- tibble::tibble(
+  strategy     = c("TS-Mom L/S", "TS-Mom L/S"),
+  period       = c("Training", "OOS"),
+  window_start = as.Date(c("2005-01-01", "2010-01-01")),
+  window_end   = as.Date(c("2009-12-31", "2022-06-30"))
+)
+
+# The #645 regression itself: an "OOS" row whose window_end reaches into the
+# sealed Validation partition (2023+).
+unbounded_oos_metrics <- tibble::tibble(
+  strategy     = c("TS-Mom L/S", "TS-Mom L/S"),
+  period       = c("Training", "OOS"),
+  window_start = as.Date(c("2005-01-01", "2010-01-01")),
+  window_end   = as.Date(c("2009-12-31", "2026-01-31"))
+)
+
+# The same wide window, but explicitly labelled "Validation" -- this is the
+# sealed partition itself and MUST be exempt from the test_end bound.
+validation_metrics <- tibble::tibble(
+  strategy     = c("TS-Mom L/S", "TS-Mom L/S"),
+  period       = c("OOS", "Validation"),
+  window_start = as.Date(c("2010-01-01", "2023-01-01")),
+  window_end   = as.Date(c("2022-06-30", "2026-01-31"))
+)
+
+# The whole-sample "Full Period" row is also expected to extend past
+# test_end by definition (it spans the entire series, including Validation)
+# -- backtest-partitions.md's own reference implementation lists
+# calc_metrics(all_data, "Full Period") alongside Training/Testing/Validation.
+full_period_metrics <- tibble::tibble(
+  strategy     = c("TS-Mom L/S", "TS-Mom L/S"),
+  period       = c("OOS", "Full Period"),
+  window_start = as.Date(c("2010-01-01", "2005-01-01")),
+  window_end   = as.Date(c("2022-06-30", "2026-01-31"))
+)
+
+# ── Tests: bounded window passes ──────────────────────────────────────────────
+
+test_that("check_metric_window_bounds passes when all non-Validation windows are bounded at test_end", {
+  expect_true(check_metric_window_bounds(bounded_metrics, test_end, "mf_metrics"))
+})
+
+# ── Tests: unbounded OOS window aborts (#645 regression) ─────────────────────
+
+test_that("check_metric_window_bounds throws when an OOS window extends past test_end", {
+  expect_error(
+    check_metric_window_bounds(unbounded_oos_metrics, test_end, "mf_metrics"),
+    regexp = "OOS"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_metric_window_bounds(unbounded_oos_metrics, test_end, "mf_metrics")
+  )
+})
+
+test_that("check_metric_window_bounds names the source label and test_end in the error", {
+  expect_error(
+    check_metric_window_bounds(unbounded_oos_metrics, test_end, "mf_metrics"),
+    regexp = "mf_metrics"
+  )
+})
+
+# ── Tests: exempt period labels pass even when window_end > test_end ─────────
+
+test_that("check_metric_window_bounds exempts period == 'Validation'", {
+  expect_true(check_metric_window_bounds(validation_metrics, test_end, "mf_metrics"))
+})
+
+test_that("check_metric_window_bounds exempts period == 'Full Period'", {
+  expect_true(check_metric_window_bounds(full_period_metrics, test_end, "mf_metrics"))
+})
+
+# ── Tests: required columns ───────────────────────────────────────────────────
+
+test_that("check_metric_window_bounds throws when required columns are missing", {
+  bad <- dplyr::select(bounded_metrics, -window_end)
+  expect_error(
+    check_metric_window_bounds(bad, test_end, "mf_metrics"),
+    regexp = "window_end"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_metric_window_bounds(bad, test_end, "mf_metrics")
+  )
+})


### PR DESCRIPTION
## Summary

Fixes #645. `R/plan_managed_futures.R` (`mf_metrics`) and `R/plan_ev_ebit.R` (`ev_metrics`) computed an `OOS` window bounded only below (`dates >= oos_start`, unbounded above) — it silently included the whole sealed Validation partition (2023+, `R/plan_partitions.R` `bt_partitions`) on every `tar_make()`, in violation of `.claude/rules/backtest-partitions.md`.

- Bounded `OOS` at `bt_partitions$<class>$test_end`:
  - **Managed futures** (`R/plan_managed_futures.R`, SPY+TLT+GLD+DBC): `bt_partitions$macro` — matches the asset-class label the issue itself named ("macro defense rotation" universe).
  - **EV/EBIT value sleeve** (`R/plan_ev_ebit.R`, HML/RMW FF5 factors): `bt_partitions$factor`.
  - `Training` keeps its original pre-2010 definition unchanged in both files — it was never part of the seal breach (only the unbounded-above `OOS` window was), and re-bounding it would newly leak Validation dates into `Training` instead. This matches the "narrower than canonical Training, a comparability wart but not a seal breach" framing from the issue.
- `calc_metrics()` in both files now also returns `window_start`/`window_end` (Date columns) computed from the same NA-filtered mask as the return vector actually used, so the window is auditable rather than only inferable from the parameter.
- Added QA gate **S11** (`check_metric_window_bounds()`, `qa_metric_window_bounds` target) in `R/plan_qa_gates.R`, run over both `mf_metrics` and `ev_metrics` on every `tar_make()`. It aborts if any row's `window_end` exceeds `test_end` unless `period` is `"Validation"` **or** `"Full"`/`"Full Period"`.
  - **Design deviation from the issue's literal wording, flagged explicitly:** the issue says "unless its partition is explicitly Validation." Applied literally, that would also fail on every `Full`/`Full Period` row in `mf_metrics`/`ev_metrics`, since a full-sample window necessarily extends past `test_end` by definition — and `backtest-partitions.md`'s own canonical reference implementation lists `calc_metrics(all_data, "Full Period")` alongside Training/Testing/Validation as an accepted category, not a bespoke evaluation window like `OOS`. Exempting `Full`/`Full Period` alongside `Validation` avoids making the gate fail immediately on legitimate, already-accepted leaderboard behavior. Happy to tighten this further if that reading is wrong.
- Added a forward-looking scope-note comment on `check_metric_window_bounds()` (not implemented) for #648, which is a related but distinct systematic seal breach: `slice_portfolio()` in `R/plan_leaderboard.R` computes an explicit `Validation` slice on every `tar_make()` for 7 strategies. That's an automatic-computation violation, not a window-bounds violation, and #648 handles it separately — this PR does not touch `R/plan_leaderboard.R`.

## Test plan

- [x] `parse("_targets.R")` succeeds (`scripts/verify.sh` runs this first)
- [x] `scripts/verify.sh` (full: parse + root suite + package suite) — **PASS**, see verbatim output below
- [x] New tests in `tests/testthat/test-metric-window-bounds.R` (`testthat::local_edition(3)`) covering: bounded window passes; unbounded `OOS` window aborts (the #645 regression shape); `Validation`-labelled window is exempt; `Full Period`-labelled window is exempt; missing required columns aborts. Snapshot tests for both `cli_abort()` messages committed under `tests/testthat/_snaps/metric-window-bounds.md`.
- [ ] **Not verified — could not run `tar_make()`**: this PR was produced in an isolated worktree with scope explicitly forbidding any `tar_make()` run (to avoid corrupting the orchestrator's `_targets` store from a concurrent build in two checkouts). The pipeline wiring (target dependencies via static-code reference to `bt_partitions`, `mf_metrics`, `ev_metrics`) was verified by reading the code and by the fact `parse()` + unit tests pass, but the actual `tar_make()` DAG execution — including whether `qa_metric_window_bounds` runs cleanly against the live `mf_metrics`/`ev_metrics` targets and whether the leaderboard's `.norm_mf`/`.norm_value` helpers tolerate the two new `window_start`/`window_end` columns bubbling into `leaderboard` via `bind_rows` — was not exercised end-to-end.

### `scripts/verify.sh` output (verbatim, final run)

```
PASS: _targets.R parses (verified tree: .../fix/645-oos-window-seal)
PASS: testthat edition 3 active

=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

=== scripts/verify.sh: PASS ===
```

No new failure signatures vs. the documented baseline (`test-crypto-momentum.R:51`, `test-qa-summary-deps.R:196`, `test-stock-backtest.R:161`). Skip count (15 in package suite, 0 in root suite) is unchanged by this PR — all skips are `{alphavantager}` not installed / `HD_TEST_LIVE` opt-in live-endpoint tests, unrelated to these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
