### PR TITLE
fix(portfolio): full/left-join port_returns instead of inner_join chain (#641)

### DIFF
--- a/R/plan_portfolio_opt.R
+++ b/R/plan_portfolio_opt.R
@@ -23,6 +23,51 @@ plan_portfolio_opt <- function() {
     }),
 
     # ── Combine all strategy returns into one matrix ──────────────
+    #
+    # #641: this used to be a 4-way inner_join chain, so any `ym` missing
+    # from ANY ONE of the four constituents silently deleted that month for
+    # ALL FOUR -- 128 of an expected ~190+ rows, including every March
+    # (`stk_drif_portfolio` had no March rows at all; the upstream root
+    # cause is tracked and fixed separately in R/plan_stock_backtest.R,
+    # not here).
+    #
+    # The spine is now an explicit CALENDAR-COMPLETE monthly sequence
+    # bounded by the OVERLAP of the two stock-level series' own date ranges
+    # (`max(min(s1$ym), min(s2$ym))` .. `min(max(s1$ym), max(s2$ym))`), not
+    # a plain union of whatever rows happen to exist. This matters because:
+    #   - Using `seq()` to build the spine (rather than the literal ym
+    #     values present in s1/s2) is what actually fixes #641 -- a month
+    #     entirely absent from a constituent (e.g. every March in
+    #     stk_drif_portfolio) still gets a spine row, with that constituent
+    #     left NA rather than the row never existing.
+    #   - Bounding to the stock-level OVERLAP (not the union) keeps the
+    #     span close to the historical inner_join's implicit intersection.
+    #     fac_max / fac_drif (data from 1964-/1968- onward) run six decades
+    #     longer than stk_max / stk_drif (2005-/2010- onward); a plain
+    #     `full_join` across all four would silently expand `port_returns`,
+    #     and every "Full Period" metric/plot downstream, to include
+    #     decades where no stock-level strategy exists -- a different,
+    #     much bigger analysis than the 4-strategy stock+factor combination
+    #     this target is for. It would also introduce a large block of NA
+    #     into `stk_drif` (or `stk_max`, whichever starts later) for every
+    #     pre-overlap month, which downstream consumers that read
+    #     `port_returns` directly and do a *plain* `ret_matrix %*% w` (not
+    #     the NA-aware `.port_weighted_return()` below) -- e.g.
+    #     R/plan_regime.R's `regime_vol`/`regime_portfolio` -- are not
+    #     written to expect.
+    # Factor-level series are LEFT-joined onto that stock-bounded spine:
+    # they cover the whole overlap window so this introduces no new NAs in
+    # practice, but a genuine internal gap in either of them, or the normal
+    # live-edge lag between stock-level and factor-level data feeds (the
+    # most recent 1-2 months at the time of writing), now surfaces as an
+    # honest NA in that column instead of silently deleting the row.
+    #
+    # A missing constituent is therefore an explicit NA in its own column,
+    # never a deleted row. See `.port_weighted_return()` below for how
+    # `port_combined` turns a row with one or more NA constituents into a
+    # single portfolio return, and `check_portfolio_join_coverage()`
+    # (R/plan_qa_gates.R) for the pipeline assertion guarding against a
+    # calendar-month gap reappearing.
     targets::tar_target(port_returns, {
       library(dplyr)
 
@@ -32,10 +77,26 @@ plan_portfolio_opt <- function() {
       s3 <- fm_portfolio |> select(ym, fac_max = portfolio_ret)
       s4 <- drif_portfolio |> select(ym, fac_drif = portfolio_ret)
 
-      combined <- s1 |>
-        inner_join(s2, by = "ym") |>
-        inner_join(s3, by = "ym") |>
-        inner_join(s4, by = "ym")
+      # Calendar-complete monthly spine bounded to the stock-level overlap
+      # window (see comment above) -- NOT the literal set of ym values
+      # present in s1/s2, which is exactly what would silently re-drop a
+      # month like March if stk_drif_portfolio ever loses it again.
+      spine_start <- max(min(s1$ym), min(s2$ym))
+      spine_end   <- min(max(s1$ym), max(s2$ym))
+      spine <- tibble::tibble(
+        ym = format(
+          seq(as.Date(paste0(spine_start, "-01")),
+              as.Date(paste0(spine_end, "-01")),
+              by = "month"),
+          "%Y-%m"
+        )
+      )
+
+      combined <- spine |>
+        left_join(s1, by = "ym") |>
+        left_join(s2, by = "ym") |>
+        left_join(s3, by = "ym") |>
+        left_join(s4, by = "ym")
 
       # Add risk-free
       combined |>
@@ -146,17 +207,34 @@ plan_portfolio_opt <- function() {
     }),
 
     # ── Portfolio returns with optimal weights ────────────────────
+    #
+    # #641: port_returns can now carry an explicit NA for a constituent
+    # that is missing that month (see the port_returns target above). A
+    # plain `ret_matrix %*% w` would turn any such NA into an NA for the
+    # WHOLE portfolio return that month -- and because cumprod() propagates
+    # NA forward to every subsequent element, one missing constituent would
+    # silently NA out the rest of optimal_cum/hrp_cum/equalwt_cum too.
+    # `.port_weighted_return()` instead renormalises the target weight
+    # vector over the strategies actually present that month (a missing
+    # strategy contributes zero and present strategies are rescaled to sum
+    # to 1) with a floor of 2 strategies required -- see its roxygen doc
+    # below for the full rationale and the guard against a 1-strategy month
+    # masquerading as a diversified portfolio. `port_metrics`'s
+    # `calc_port_metrics()` below drops any remaining NA before computing
+    # cagr/vol/sharpe/max_dd so a handful of live-edge NA months cannot
+    # poison the whole-sample metrics.
     targets::tar_target(port_combined, {
       library(dplyr)
 
       strat_cols <- c("stk_max", "stk_drif", "fac_max", "fac_drif")
       w_pso <- port_optimal_weights
       w_hrp <- port_hrp_weights
+      w_eq  <- stats::setNames(rep(1 / length(strat_cols), length(strat_cols)), strat_cols)
 
       ret_matrix <- as.matrix(port_returns[, strat_cols])
-      pso_ret <- as.numeric(ret_matrix %*% w_pso)
-      hrp_ret <- as.numeric(ret_matrix %*% w_hrp)
-      eq_ret  <- rowMeans(ret_matrix)
+      pso_ret <- .port_weighted_return(ret_matrix, w_pso)
+      hrp_ret <- .port_weighted_return(ret_matrix, w_hrp)
+      eq_ret  <- .port_weighted_return(ret_matrix, w_eq)
 
       port_returns |>
         mutate(
@@ -173,31 +251,55 @@ plan_portfolio_opt <- function() {
     targets::tar_target(port_metrics, {
       library(dplyr)
 
+      # #641: optimal_ret/hrp_ret/equalwt_ret can now contain NA for months
+      # where fewer than 2 of the 4 constituent strategies reported a value
+      # (see .port_weighted_return() used by the port_combined target
+      # above). cumprod() propagates NA forward to every SUBSEQUENT
+      # element, so computing cagr/vol/sharpe/max_dd on the raw column
+      # would silently NA-poison the whole metric from the first gap
+      # onward. Each helper below drops NA returns for its own column
+      # before computing, and annualises using that column's own non-NA
+      # month count (not the shared `n`) -- `months` stays nrow(df), the
+      # calendar span of the period, for readability.
+      cagr_of <- function(r) {
+        r <- r[!is.na(r)]
+        if (length(r) < 1) return(NA_real_)
+        prod(1 + r)^(12 / length(r)) - 1
+      }
+      vol_of <- function(r) {
+        r <- r[!is.na(r)]
+        if (length(r) < 2) return(NA_real_)
+        sd(r) * sqrt(12)
+      }
+      sharpe_of <- function(r, rf_ann) {
+        r <- r[!is.na(r)]
+        if (length(r) < 2) return(NA_real_)
+        ann <- prod(1 + r)^(12 / length(r)) - 1
+        v <- sd(r) * sqrt(12)
+        if (v < 1e-8) NA_real_ else (ann - rf_ann) / v
+      }
+      maxdd_of <- function(r) {
+        r <- r[!is.na(r)]
+        if (length(r) < 1) return(NA_real_)
+        cum <- cumprod(1 + r)
+        min(cum / cummax(cum) - 1)
+      }
       calc_port_metrics <- function(df, label) {
         n <- nrow(df)
         if (n < 12) return(NULL)
         rf_ann <- mean(df$rf_ret, na.rm = TRUE) * 12
-        sharpe <- function(r) {
-          ann <- prod(1 + r)^(12/n) - 1
-          vol <- sd(r) * sqrt(12)
-          if (vol < 1e-8) NA_real_ else (ann - rf_ann) / vol
-        }
-        maxdd <- function(r) {
-          cum <- cumprod(1 + r)
-          min(cum / cummax(cum) - 1)
-        }
         tibble(
           period = label, months = n,
-          opt_cagr   = prod(1 + df$optimal_ret)^(12/n) - 1,
-          opt_vol    = sd(df$optimal_ret) * sqrt(12),
-          opt_sharpe = sharpe(df$optimal_ret),
-          opt_maxdd  = maxdd(df$optimal_ret),
-          hrp_cagr   = prod(1 + df$hrp_ret)^(12/n) - 1,
-          hrp_sharpe = sharpe(df$hrp_ret),
-          hrp_maxdd  = maxdd(df$hrp_ret),
-          eq_cagr    = prod(1 + df$equalwt_ret)^(12/n) - 1,
-          eq_sharpe  = sharpe(df$equalwt_ret),
-          eq_maxdd   = maxdd(df$equalwt_ret)
+          opt_cagr   = cagr_of(df$optimal_ret),
+          opt_vol    = vol_of(df$optimal_ret),
+          opt_sharpe = sharpe_of(df$optimal_ret, rf_ann),
+          opt_maxdd  = maxdd_of(df$optimal_ret),
+          hrp_cagr   = cagr_of(df$hrp_ret),
+          hrp_sharpe = sharpe_of(df$hrp_ret, rf_ann),
+          hrp_maxdd  = maxdd_of(df$hrp_ret),
+          eq_cagr    = cagr_of(df$equalwt_ret),
+          eq_sharpe  = sharpe_of(df$equalwt_ret, rf_ann),
+          eq_maxdd   = maxdd_of(df$equalwt_ret)
         )
       }
 
@@ -295,6 +397,65 @@ plan_portfolio_opt <- function() {
         as_tibble()
     })
   )
+}
+
+
+# ── Internal helper: NA-aware weighted portfolio return (#641) ────────────────
+
+#' Combine strategy returns into a single weighted portfolio return, one row
+#' at a time, treating any NA constituent as absent rather than propagating
+#' the NA to the whole row
+#'
+#' `port_returns` (#641) left-joins its four constituent strategies onto a
+#' calendar-complete month spine bounded to the stock-level overlap window,
+#' so a constituent missing that month is an explicit `NA` in its own
+#' column rather than a deleted row. Plain matrix
+#' multiplication (`ret_matrix %*% w`) would turn any such `NA` into `NA` for
+#' the whole row regardless of that constituent's weight, and because
+#' `cumprod()` propagates `NA` forward to every subsequent element, a single
+#' missing constituent early in the series would silently `NA` out the rest
+#' of the cumulative growth series too.
+#'
+#' Instead, for each row, the target weight vector `w` is renormalised over
+#' the strategies actually present that month: a missing strategy
+#' contributes zero and the present strategies' weights are rescaled to sum
+#' to 1 (i.e. their *relative* weights are preserved, just no longer diluted
+#' by a strategy that reported nothing). This is a deliberate modelling
+#' choice, not an artefact of the join -- treating a missing value as a zero
+#' return instead would understate the drawdown/CAGR contribution the
+#' missing strategy is actually making that month (unknown, not zero).
+#'
+#' Guard: a month where FEWER THAN 2 of the (currently 4) strategies report
+#' a value is NOT renormalised into a portfolio observation -- that would
+#' silently turn into a 100%-single-strategy bet dressed up as "PSO
+#' Optimal"/"HRP"/"Equal Weight". Such rows return `NA`. In the data as of
+#' #641 this affects only the most recent 1-2 months, where the
+#' factor-level return series (`fac_max`/`fac_drif`) lag the stock-level
+#' series (`stk_max`/`stk_drif`) at the live edge -- an expected, benign
+#' data-feed lag, not a defect. `calc_port_metrics()` (used by the
+#' `port_metrics` target) drops any remaining NA per-column before computing
+#' cagr/vol/sharpe/max_dd, so this cannot poison whole-sample metrics; the
+#' `port_comparison_plot` growth chart will show a break at that row, which
+#' honestly reflects "we don't know this month's return" rather than
+#' inventing one.
+#'
+#' @param ret_matrix Numeric matrix, one column per strategy (colnames
+#'   matching the names of `w`), one row per period. May contain `NA`.
+#' @param w Named numeric weight vector, same names/order as
+#'   `colnames(ret_matrix)`, non-negative, summing to 1 over the full set.
+#' @return Numeric vector, one weighted return per row of `ret_matrix`
+#'   (`NA` where fewer than 2 columns are non-NA that row, or where the
+#'   available strategies' weights sum to (numerically) zero).
+#' @noRd
+.port_weighted_return <- function(ret_matrix, w) {
+  apply(ret_matrix, 1L, function(row) {
+    avail <- !is.na(row)
+    if (sum(avail) < 2L) return(NA_real_)
+    w_avail <- w[avail]
+    w_sum <- sum(w_avail)
+    if (w_sum < 1e-8) return(NA_real_)
+    sum(row[avail] * w_avail) / w_sum
+  })
 }
 
 

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -453,7 +453,7 @@ check_leaderboard_period_vocab <- function(leaderboard) {
 
 
 #' Assert port_returns has no calendar-month gaps and flag thin-coverage
-#' months
+#' months (S13)
 #'
 #' Guards against the #641 defect class: `port_returns` used to chain four
 #' `inner_join()`s across its constituent strategies (`stk_max`, `stk_drif`,
@@ -497,7 +497,7 @@ check_portfolio_join_coverage <- function(port_returns) {
   if (length(missing_cols) > 0L) {
     cli::cli_abort(c(
       "x" = "port_returns is missing {length(missing_cols)} required column(s): {missing_cols}.",
-      "i" = "check_portfolio_join_coverage() requires date, stk_max, stk_drif, fac_max, fac_drif."
+      "i" = "check_portfolio_join_coverage() (S13) requires date, stk_max, stk_drif, fac_max, fac_drif."
     ))
   }
 
@@ -737,7 +737,7 @@ plan_qa_gates <- function() {
     ),
 
     # QA gate: port_returns has no calendar-month gaps, thin-coverage months
-    # are flagged (#641) — guards against the #641 defect class where a
+    # are flagged (S13) — guards against the #641 defect class where a
     # 4-way inner_join chain in R/plan_portfolio_opt.R silently deleted any
     # month missing from ONE constituent strategy for ALL FOUR (128 of an
     # expected ~190+ rows, including every March). port_returns is now built
@@ -748,7 +748,7 @@ plan_qa_gates <- function() {
       qa_portfolio_join_coverage,
       command = {
         check_portfolio_join_coverage(port_returns)
-        cli::cli_inform(c("v" = "qa_portfolio_join_coverage: passed (no calendar-month gaps in port_returns)"))
+        cli::cli_inform(c("v" = "qa_portfolio_join_coverage: S13 passed (no calendar-month gaps in port_returns)"))
         TRUE
       },
       cue = targets::tar_cue(mode = "always")

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -452,6 +452,110 @@ check_leaderboard_period_vocab <- function(leaderboard) {
 }
 
 
+#' Assert port_returns has no calendar-month gaps and flag thin-coverage
+#' months
+#'
+#' Guards against the #641 defect class: `port_returns` used to chain four
+#' `inner_join()`s across its constituent strategies (`stk_max`, `stk_drif`,
+#' `fac_max`, `fac_drif`), so any month missing from ONE constituent
+#' silently deleted that month for ALL FOUR -- 128 of an expected ~190+
+#' rows, including every March (`stk_drif_portfolio` had no March rows at
+#' all). R/plan_portfolio_opt.R now builds `port_returns` from an explicit
+#' calendar-complete monthly spine (bounded to the overlap of the two
+#' stock-level series' own date ranges) and LEFT-joins all four
+#' constituents onto it -- a missing constituent surfaces as an explicit NA
+#' in that column, not a deleted row.
+#'
+#' Two assertions:
+#'   1. `cli_abort()` if the `date` column has ANY calendar-month gap
+#'      between its min and max -- structurally this should be impossible
+#'      given the spine-based join described above (see the comment on the
+#'      `port_returns` target), so a gap here means either the spine
+#'      construction was changed back to using literal ym values, or
+#'      `stk_max_portfolio`/`stk_drif_portfolio` (R/plan_stock_backtest.R)
+#'      no longer overlap at all. Names every missing month.
+#'   2. `cli_warn()` (deliberately NOT abort) for any row where fewer than 2
+#'      of the 4 constituents report a value -- `port_combined`'s
+#'      `.port_weighted_return()` renormalisation guard (R/plan_portfolio_opt.R)
+#'      turns such rows into NA rather than a single-strategy bet dressed up
+#'      as a diversified portfolio. In the data as of #641 this is the
+#'      expected, benign live-edge lag between stock-level and factor-level
+#'      data feeds (currently the most recent 1-2 months) -- NOT a defect --
+#'      so it warns rather than aborting, and names the affected month(s)
+#'      plus which constituent(s) are missing so a genuine regression is
+#'      still visible.
+#'
+#' @param port_returns Tibble from the `port_returns` target; must have
+#'   `date` and the four strategy columns `stk_max`, `stk_drif`, `fac_max`,
+#'   `fac_drif`.
+#' @return `TRUE` invisibly (assertion 1 always holds on return; assertion 2
+#'   may have warned).
+#' @noRd
+check_portfolio_join_coverage <- function(port_returns) {
+  required_cols <- c("date", "stk_max", "stk_drif", "fac_max", "fac_drif")
+  missing_cols <- setdiff(required_cols, names(port_returns))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "port_returns is missing {length(missing_cols)} required column(s): {missing_cols}.",
+      "i" = "check_portfolio_join_coverage() requires date, stk_max, stk_drif, fac_max, fac_drif."
+    ))
+  }
+
+  # ── Assertion 1: no calendar-month gap in the date sequence ─────────────
+  d <- sort(unique(port_returns$date))
+  expected_ym <- format(seq(min(d), max(d), by = "month"), "%Y-%m")
+  # port_returns dates are anchored to the 15th (paste0(ym, "-15")); compare
+  # on year-month, not exact Date, so day-of-month never produces a false gap.
+  observed_ym <- format(d, "%Y-%m")
+  missing_months <- setdiff(expected_ym, observed_ym)
+
+  if (length(missing_months) > 0L) {
+    cli::cli_abort(c(
+      "x" = paste0(
+        "port_returns has ", length(missing_months),
+        " calendar-month gap(s) in its date sequence:"
+      ),
+      setNames(sprintf("  %s", missing_months), rep("i", length(missing_months))),
+      "i" = paste0(
+        "port_returns builds a calendar-complete spine specifically so ",
+        "this cannot happen (#641) -- check for a changed spine/join in ",
+        "R/plan_portfolio_opt.R or a new gap in stk_max_portfolio / ",
+        "stk_drif_portfolio (R/plan_stock_backtest.R)."
+      )
+    ))
+  }
+
+  # ── Assertion 2: flag (warn, don't abort) thin-coverage months ──────────
+  strat_cols <- c("stk_max", "stk_drif", "fac_max", "fac_drif")
+  avail <- rowSums(!is.na(as.matrix(port_returns[, strat_cols])))
+  thin <- port_returns[avail < 2L, , drop = FALSE]
+
+  if (nrow(thin) > 0L) {
+    thin_msgs <- vapply(seq_len(nrow(thin)), function(i) {
+      row <- thin[i, ]
+      missing_strats <- strat_cols[is.na(row[strat_cols])]
+      sprintf("  %s -- missing: %s", format(row$date, "%Y-%m"),
+              paste(missing_strats, collapse = ", "))
+    }, character(1L))
+    cli::cli_warn(c(
+      "!" = paste0(
+        length(thin_msgs), " month(s) have fewer than 2 of 4 constituent ",
+        "strategies reporting a value (renormalised to NA in port_combined ",
+        "rather than a single-strategy bet, #641):"
+      ),
+      setNames(thin_msgs, rep("i", length(thin_msgs))),
+      "i" = paste0(
+        "Usually the benign live-edge lag between stock-level and ",
+        "factor-level data feeds -- verify if this list grows or covers ",
+        "a month that isn't at the trailing edge."
+      )
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+
 # ---- QA gate plan ----
 
 plan_qa_gates <- function() {
@@ -627,6 +731,24 @@ plan_qa_gates <- function() {
       command = {
         check_leaderboard_period_vocab(leaderboard)
         cli::cli_inform(c("v" = "qa_leaderboard_period_vocab: S10 passed (canonical period vocabulary, all strategies have a Full Period row)"))
+        TRUE
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: port_returns has no calendar-month gaps, thin-coverage months
+    # are flagged (#641) — guards against the #641 defect class where a
+    # 4-way inner_join chain in R/plan_portfolio_opt.R silently deleted any
+    # month missing from ONE constituent strategy for ALL FOUR (128 of an
+    # expected ~190+ rows, including every March). port_returns is now built
+    # from a calendar-complete spine with everything left-joined onto it, so
+    # a missing constituent surfaces as an explicit NA rather than a deleted
+    # row; this gate asserts that guarantee holds.
+    targets::tar_target(
+      qa_portfolio_join_coverage,
+      command = {
+        check_portfolio_join_coverage(port_returns)
+        cli::cli_inform(c("v" = "qa_portfolio_join_coverage: passed (no calendar-month gaps in port_returns)"))
         TRUE
       },
       cue = targets::tar_cue(mode = "always")

--- a/tests/testthat/_snaps/portfolio-join-coverage.md
+++ b/tests/testthat/_snaps/portfolio-join-coverage.md
@@ -1,0 +1,29 @@
+# check_portfolio_join_coverage aborts when a calendar month is missing entirely (#641)
+
+    Code
+      check_portfolio_join_coverage(gapped_port_returns)
+    Condition
+      Error in `check_portfolio_join_coverage()`:
+      x port_returns has 1 calendar-month gap(s) in its date sequence:
+      i  2021-03
+      i port_returns builds a calendar-complete spine specifically so this cannot happen (#641) -- check for a changed spine/join in R/plan_portfolio_opt.R or a new gap in stk_max_portfolio / stk_drif_portfolio (R/plan_stock_backtest.R).
+
+# check_portfolio_join_coverage names the missing constituents for a thin-coverage month
+
+    Code
+      check_portfolio_join_coverage(thin_march)
+    Condition
+      Warning:
+      ! 1 month(s) have fewer than 2 of 4 constituent strategies reporting a value (renormalised to NA in port_combined rather than a single-strategy bet, #641):
+      i  2021-03 -- missing: stk_drif, fac_max, fac_drif
+      i Usually the benign live-edge lag between stock-level and factor-level data feeds -- verify if this list grows or covers a month that isn't at the trailing edge.
+
+# check_portfolio_join_coverage throws when required columns are missing
+
+    Code
+      check_portfolio_join_coverage(bad)
+    Condition
+      Error in `check_portfolio_join_coverage()`:
+      x port_returns is missing 1 required column(s): stk_drif.
+      i check_portfolio_join_coverage() requires date, stk_max, stk_drif, fac_max, fac_drif.
+

--- a/tests/testthat/_snaps/portfolio-join-coverage.md
+++ b/tests/testthat/_snaps/portfolio-join-coverage.md
@@ -25,5 +25,5 @@
     Condition
       Error in `check_portfolio_join_coverage()`:
       x port_returns is missing 1 required column(s): stk_drif.
-      i check_portfolio_join_coverage() requires date, stk_max, stk_drif, fac_max, fac_drif.
+      i check_portfolio_join_coverage() (S13) requires date, stk_max, stk_drif, fac_max, fac_drif.
 

--- a/tests/testthat/test-plan-portfolio-opt.R
+++ b/tests/testthat/test-plan-portfolio-opt.R
@@ -1,5 +1,11 @@
 testthat::local_edition(3)
 
+# .port_weighted_return() is a genuine top-level (non-tar_target) function in
+# R/plan_portfolio_opt.R (#641) -- source the real file rather than
+# reproducing it, unlike calc_port_metrics() below which is still locked
+# inside the port_metrics tar_target() body.
+source(here::here("R/plan_portfolio_opt.R"))
+
 # ── Fix 4 (#489 Cluster D): complete month grid before pivot_wider ────────────
 # When port_combined is missing a calendar month (e.g. month 3 = March) the
 # hardcoded rename(Mar = `3`, ...) used to fail with
@@ -64,30 +70,48 @@ test_that("port_monthly_returns: missing month still yields all 12 renamed colum
 # We reproduce the exact definition to regression-test the column set.
 
 make_calc_port_metrics <- function(rf_ann = 0) {
+  # #641: optimal_ret/hrp_ret/equalwt_ret can now contain NA (fewer than 2
+  # of the 4 constituents reported that month -- see .port_weighted_return()
+  # in R/plan_portfolio_opt.R). Reproduces the NA-dropping helpers added to
+  # calc_port_metrics() alongside the original opt_vol fix (#2748).
+  cagr_of <- function(r) {
+    r <- r[!is.na(r)]
+    if (length(r) < 1) return(NA_real_)
+    prod(1 + r)^(12 / length(r)) - 1
+  }
+  vol_of <- function(r) {
+    r <- r[!is.na(r)]
+    if (length(r) < 2) return(NA_real_)
+    sd(r) * sqrt(12)
+  }
+  sharpe_of <- function(r, rf_ann) {
+    r <- r[!is.na(r)]
+    if (length(r) < 2) return(NA_real_)
+    ann <- prod(1 + r)^(12 / length(r)) - 1
+    v <- sd(r) * sqrt(12)
+    if (v < 1e-8) NA_real_ else (ann - rf_ann) / v
+  }
+  maxdd_of <- function(r) {
+    r <- r[!is.na(r)]
+    if (length(r) < 1) return(NA_real_)
+    cum <- cumprod(1 + r)
+    min(cum / cummax(cum) - 1)
+  }
   function(df, label) {
     n <- nrow(df)
     if (n < 12L) return(NULL)
-    sharpe <- function(r) {
-      ann <- prod(1 + r)^(12 / n) - 1
-      vol <- sd(r) * sqrt(12)
-      if (vol < 1e-8) NA_real_ else (ann - rf_ann) / vol
-    }
-    maxdd <- function(r) {
-      cum <- cumprod(1 + r)
-      min(cum / cummax(cum) - 1)
-    }
     tibble::tibble(
       period    = label, months = n,
-      opt_cagr   = prod(1 + df$optimal_ret)^(12 / n) - 1,
-      opt_vol    = sd(df$optimal_ret) * sqrt(12),          # fix: was absent
-      opt_sharpe = sharpe(df$optimal_ret),
-      opt_maxdd  = maxdd(df$optimal_ret),
-      hrp_cagr   = prod(1 + df$hrp_ret)^(12 / n) - 1,
-      hrp_sharpe = sharpe(df$hrp_ret),
-      hrp_maxdd  = maxdd(df$hrp_ret),
-      eq_cagr    = prod(1 + df$equalwt_ret)^(12 / n) - 1,
-      eq_sharpe  = sharpe(df$equalwt_ret),
-      eq_maxdd   = maxdd(df$equalwt_ret)
+      opt_cagr   = cagr_of(df$optimal_ret),
+      opt_vol    = vol_of(df$optimal_ret),          # fix: was absent (#2748)
+      opt_sharpe = sharpe_of(df$optimal_ret, rf_ann),
+      opt_maxdd  = maxdd_of(df$optimal_ret),
+      hrp_cagr   = cagr_of(df$hrp_ret),
+      hrp_sharpe = sharpe_of(df$hrp_ret, rf_ann),
+      hrp_maxdd  = maxdd_of(df$hrp_ret),
+      eq_cagr    = cagr_of(df$equalwt_ret),
+      eq_sharpe  = sharpe_of(df$equalwt_ret, rf_ann),
+      eq_maxdd   = maxdd_of(df$equalwt_ret)
     )
   }
 }
@@ -157,4 +181,220 @@ test_that("calc_port_metrics: returns NULL when n < 12", {
   )
   calc_port_metrics <- make_calc_port_metrics()
   expect_null(calc_port_metrics(df_short, "Short"))
+})
+
+# ── F4: calc_port_metrics is NA-aware (#641) ───────────────────────────────
+# A month with fewer than 2 constituents can now surface as NA in
+# optimal_ret/hrp_ret/equalwt_ret instead of the row being deleted. Without
+# NA-dropping, cumprod() would propagate that NA to every subsequent element
+# and cagr_of()/vol_of()/sharpe_of()/maxdd_of() would silently return NA for
+# the whole period from the first gap onward.
+
+test_that("calc_port_metrics: a single NA return does not poison the whole-period metrics (#641)", {
+  set.seed(11L)
+  n <- 24L
+  full_ret <- rnorm(n, mean = 0.008, sd = 0.03)
+  gapped_ret <- full_ret
+  gapped_ret[12] <- NA_real_  # mid-series gap, mirrors a thin-coverage month
+
+  df_full <- data.frame(
+    date        = seq.Date(as.Date("2020-01-31"), by = "month", length.out = n),
+    optimal_ret = full_ret, hrp_ret = full_ret, equalwt_ret = full_ret,
+    rf_ret      = rep(0.001, n)
+  )
+  df_gapped <- df_full
+  df_gapped$optimal_ret <- gapped_ret
+  df_gapped$hrp_ret     <- gapped_ret
+  df_gapped$equalwt_ret <- gapped_ret
+
+  calc_port_metrics <- make_calc_port_metrics(rf_ann = 0.012)
+  result_full   <- calc_port_metrics(df_full,   "Full Period")
+  result_gapped <- calc_port_metrics(df_gapped, "Full Period")
+
+  # The pre-#641 (naive) implementation would make every one of these NA.
+  expect_false(is.na(result_gapped$opt_cagr))
+  expect_false(is.na(result_gapped$opt_vol))
+  expect_false(is.na(result_gapped$opt_sharpe))
+  expect_false(is.na(result_gapped$opt_maxdd))
+
+  # `months` (calendar span) is unchanged; the metrics quietly used one
+  # fewer observation.
+  expect_equal(result_gapped$months, n)
+
+  # Excluding one near-zero-magnitude-neutral draw should not move the
+  # CAGR/vol dramatically -- both should stay in the same ballpark.
+  expect_equal(result_gapped$opt_cagr, result_full$opt_cagr, tolerance = 0.05)
+})
+
+test_that("calc_port_metrics: opt_vol/opt_sharpe are NA (not NaN) when fewer than 2 non-NA months", {
+  df <- data.frame(
+    date        = seq.Date(as.Date("2020-01-31"), by = "month", length.out = 13L),
+    optimal_ret = c(rep(NA_real_, 12L), 0.01),
+    hrp_ret     = c(rep(NA_real_, 12L), 0.01),
+    equalwt_ret = c(rep(NA_real_, 12L), 0.01),
+    rf_ret      = rep(0.001, 13L)
+  )
+  calc_port_metrics <- make_calc_port_metrics(rf_ann = 0.012)
+  result <- calc_port_metrics(df, "Thin")
+
+  expect_true(is.na(result$opt_vol))
+  expect_true(is.na(result$opt_sharpe))
+  expect_false(is.nan(result$opt_vol))
+  expect_false(is.nan(result$opt_sharpe))
+  # A single non-NA return still yields a (degenerate) cagr/maxdd, not NA.
+  expect_false(is.na(result$opt_cagr))
+})
+
+# ── Join fix: calendar-complete spine preserves a month missing one
+# constituent (#641) ────────────────────────────────────────────────────
+# Reproduces the port_returns spine-building logic (still inside a
+# tar_target() body, so not directly sourceable) with synthetic
+# constituents. Two things are asserted: (1) a missing-constituent month
+# survives as an explicit NA row instead of being deleted by the old 4-way
+# inner_join chain, and (2) the spine is bounded to the OVERLAP of the two
+# stock-level series' own ranges, not a plain union -- a month outside that
+# overlap (where only a factor-level series has data) must NOT appear.
+
+.build_test_spine <- function(s1, s2, s3, s4) {
+  spine_start <- max(min(s1$ym), min(s2$ym))
+  spine_end   <- min(max(s1$ym), max(s2$ym))
+  spine <- tibble::tibble(
+    ym = format(
+      seq(as.Date(paste0(spine_start, "-01")),
+          as.Date(paste0(spine_end, "-01")),
+          by = "month"),
+      "%Y-%m"
+    )
+  )
+  spine |>
+    dplyr::left_join(s1, by = "ym") |>
+    dplyr::left_join(s2, by = "ym") |>
+    dplyr::left_join(s3, by = "ym") |>
+    dplyr::left_join(s4, by = "ym")
+}
+
+test_that("port_returns spine: a month missing from stk_drif is kept with stk_drif = NA, not deleted (#641)", {
+  s1 <- tibble::tibble(ym = sprintf("2021-%02d", 1:12), stk_max = seq(0.01, 0.12, length.out = 12))
+  # stk_drif has no March row at all -- mirrors the #641 symptom
+  s2 <- tibble::tibble(ym = setdiff(sprintf("2021-%02d", 1:12), "2021-03"),
+                        stk_drif = seq(0.02, 0.12, length.out = 11))
+  s3 <- tibble::tibble(ym = sprintf("2021-%02d", 1:12), fac_max = seq(0.005, 0.06, length.out = 12))
+  s4 <- tibble::tibble(ym = sprintf("2021-%02d", 1:12), fac_drif = seq(0.003, 0.05, length.out = 12))
+
+  combined <- .build_test_spine(s1, s2, s3, s4)
+
+  # All 12 months survive -- the old inner_join chain would have dropped March.
+  expect_equal(nrow(combined), 12L)
+  expect_true("2021-03" %in% combined$ym)
+
+  march_row <- combined[combined$ym == "2021-03", ]
+  expect_true(is.na(march_row$stk_drif))
+  expect_false(is.na(march_row$stk_max))
+  expect_false(is.na(march_row$fac_max))
+  expect_false(is.na(march_row$fac_drif))
+})
+
+test_that("port_returns spine: bounded to the stock-level overlap, not the factor-level union (#641)", {
+  # fac_max/fac_drif have a much longer history (mirrors fm_portfolio /
+  # drif_portfolio going back to the 1960s) than the stock-level series.
+  # The spine must NOT extend back to cover it.
+  s1 <- tibble::tibble(ym = sprintf("2020-%02d", 6:12), stk_max = seq(0.01, 0.07, length.out = 7))
+  s2 <- tibble::tibble(ym = sprintf("2020-%02d", 6:12), stk_drif = seq(0.02, 0.08, length.out = 7))
+  s3 <- tibble::tibble(ym = c(sprintf("2015-%02d", 1:12), sprintf("2020-%02d", 6:12)),
+                        fac_max = seq(0.001, 0.02, length.out = 19))
+  s4 <- tibble::tibble(ym = c(sprintf("2015-%02d", 1:12), sprintf("2020-%02d", 6:12)),
+                        fac_drif = seq(0.001, 0.02, length.out = 19))
+
+  combined <- .build_test_spine(s1, s2, s3, s4)
+
+  # Bounded to the stk_max/stk_drif overlap: 2020-06 .. 2020-12 (7 months),
+  # NOT expanded back to 2015 where only fac_max/fac_drif have data.
+  expect_equal(nrow(combined), 7L)
+  expect_false(any(grepl("^2015", combined$ym)))
+  expect_setequal(combined$ym, sprintf("2020-%02d", 6:12))
+})
+
+# ── .port_weighted_return() (#641) ──────────────────────────────────────────
+# Sourced from the real R/plan_portfolio_opt.R (top of this file) -- not
+# reproduced, since it is a genuine top-level function.
+
+test_that(".port_weighted_return: matches plain matrix multiplication when no NA is present", {
+  ret_matrix <- matrix(
+    c(0.01, 0.02, 0.03, 0.04, 0.02, 0.01, -0.01, 0.00),
+    nrow = 4L, ncol = 2L,
+    dimnames = list(NULL, c("a", "b"))
+  )
+  w <- c(a = 0.6, b = 0.4)
+
+  got <- .port_weighted_return(ret_matrix, w)
+  want <- as.numeric(ret_matrix %*% w)
+
+  expect_equal(got, want, tolerance = 1e-12)
+})
+
+test_that(".port_weighted_return: renormalises weights over available strategies (#641)", {
+  # 3 strategies (a, b, c) so a 2-of-3 renormalisation can be shown without
+  # tripping the <2-available floor (covered by a dedicated test below).
+  # Row 1: all three present. Row 2: b is missing -> a and c's weights
+  # (0.5, 0.2) are rescaled to sum to 1, preserving their *relative* split.
+  # Row 3: only a present -> below the floor -> NA.
+  ret_matrix <- matrix(
+    c(0.05, 0.10, 0.20,          # a
+      0.02, NA_real_, NA_real_,  # b
+      0.01, 0.03, NA_real_),     # c
+    nrow = 3L, ncol = 3L,
+    dimnames = list(NULL, c("a", "b", "c"))
+  )
+  w <- c(a = 0.5, b = 0.3, c = 0.2)
+
+  got <- .port_weighted_return(ret_matrix, w)
+
+  expect_equal(got[1], 0.05 * 0.5 + 0.02 * 0.3 + 0.01 * 0.2, tolerance = 1e-12)
+  expect_equal(got[2], (0.10 * 0.5 + 0.03 * 0.2) / 0.7, tolerance = 1e-12)
+  expect_true(is.na(got[3]))  # only a present -> below the 2-strategy floor
+})
+
+test_that(".port_weighted_return: a single available strategy returns NA (guard against a 1-strategy bet, #641)", {
+  # 4-strategy case mirroring port_combined: only stk_max reports.
+  ret_matrix <- matrix(
+    c(0.03, NA_real_, NA_real_, NA_real_),
+    nrow = 1L, ncol = 4L,
+    dimnames = list(NULL, c("stk_max", "stk_drif", "fac_max", "fac_drif"))
+  )
+  w <- c(stk_max = 0.25, stk_drif = 0.25, fac_max = 0.25, fac_drif = 0.25)
+
+  got <- .port_weighted_return(ret_matrix, w)
+
+  expect_true(is.na(got))
+  expect_false(identical(got, 0.03))  # must not silently become a 100% stk_max bet
+})
+
+test_that(".port_weighted_return: two available strategies is the minimum renormalised case (#641)", {
+  ret_matrix <- matrix(
+    c(0.03, 0.05, NA_real_, NA_real_),
+    nrow = 1L, ncol = 4L,
+    dimnames = list(NULL, c("stk_max", "stk_drif", "fac_max", "fac_drif"))
+  )
+  w <- c(stk_max = 0.25, stk_drif = 0.25, fac_max = 0.25, fac_drif = 0.25)
+
+  got <- .port_weighted_return(ret_matrix, w)
+
+  # Equal weights among the two available strategies (0.25/0.25 renormalised to 0.5/0.5)
+  expect_equal(got, mean(c(0.03, 0.05)), tolerance = 1e-12)
+})
+
+test_that(".port_weighted_return: zero available weight mass returns NA, not NaN (#641)", {
+  ret_matrix <- matrix(
+    c(0.03, 0.05, NA_real_, NA_real_),
+    nrow = 1L, ncol = 4L,
+    dimnames = list(NULL, c("stk_max", "stk_drif", "fac_max", "fac_drif"))
+  )
+  # Only the two MISSING strategies carry any weight -- the two available
+  # ones are weighted zero, so renormalising would divide by zero.
+  w <- c(stk_max = 0, stk_drif = 0, fac_max = 0.5, fac_drif = 0.5)
+
+  got <- .port_weighted_return(ret_matrix, w)
+
+  expect_true(is.na(got))
+  expect_false(is.nan(got))
 })

--- a/tests/testthat/test-portfolio-join-coverage.R
+++ b/tests/testthat/test-portfolio-join-coverage.R
@@ -1,5 +1,5 @@
 testthat::local_edition(3)
-# Tests for check_portfolio_join_coverage() — QA gate (#641)
+# Tests for check_portfolio_join_coverage() — QA gate S13 (#641)
 #
 # The function is defined in R/plan_qa_gates.R and depends on nothing else
 # in this repo, so it is exercised directly without running tar_make().

--- a/tests/testthat/test-portfolio-join-coverage.R
+++ b/tests/testthat/test-portfolio-join-coverage.R
@@ -1,0 +1,96 @@
+testthat::local_edition(3)
+# Tests for check_portfolio_join_coverage() — QA gate (#641)
+#
+# The function is defined in R/plan_qa_gates.R and depends on nothing else
+# in this repo, so it is exercised directly without running tar_make().
+#
+# Background (#641): port_returns used to chain four inner_join()s across
+# its constituent strategies (stk_max, stk_drif, fac_max, fac_drif), so any
+# month missing from ONE constituent silently deleted that month for ALL
+# FOUR — 128 of an expected ~190+ rows, including every March
+# (stk_drif_portfolio had no March rows at all). The join in
+# R/plan_portfolio_opt.R is now full_join(s1, s2) |> left_join(s3) |>
+# left_join(s4) — a missing constituent surfaces as an explicit NA in that
+# column, not a deleted row. This gate catches a recurrence of the deleted-
+# row defect and flags (without aborting) genuinely thin-coverage months.
+
+source(here::here("R/plan_qa_gates.R"))
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+# 12 calendar-complete months, all four constituents present every month.
+good_port_returns <- tibble::tibble(
+  date     = seq.Date(as.Date("2021-01-15"), as.Date("2021-12-15"), by = "month"),
+  stk_max  = seq(0.01, 0.12, length.out = 12L),
+  stk_drif = seq(0.02, 0.13, length.out = 12L),
+  fac_max  = seq(0.005, 0.06, length.out = 12L),
+  fac_drif = seq(0.003, 0.05, length.out = 12L)
+)
+
+# March is entirely absent from the date column -- the pre-#641 symptom
+# (a row deleted outright), which should be structurally impossible after
+# the full/left join fix and MUST abort if it recurs.
+gapped_port_returns <- good_port_returns[format(good_port_returns$date, "%m") != "03", ]
+
+# All 12 months present, but March has only 1 of 4 constituents (stk_max) --
+# the expected, benign live-edge-lag shape after the #641 fix. Must warn,
+# not abort.
+thin_march <- good_port_returns
+thin_march$stk_drif[thin_march$date == as.Date("2021-03-15")] <- NA_real_
+thin_march$fac_max[thin_march$date == as.Date("2021-03-15")]  <- NA_real_
+thin_march$fac_drif[thin_march$date == as.Date("2021-03-15")] <- NA_real_
+
+# ── Tests: assertion 1 (no calendar-month gap) ─────────────────────────────
+
+test_that("check_portfolio_join_coverage passes on a calendar-complete date sequence", {
+  expect_true(check_portfolio_join_coverage(good_port_returns))
+})
+
+test_that("check_portfolio_join_coverage aborts when a calendar month is missing entirely (#641)", {
+  expect_error(
+    check_portfolio_join_coverage(gapped_port_returns),
+    regexp = "2021-03"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_portfolio_join_coverage(gapped_port_returns)
+  )
+})
+
+# ── Tests: assertion 2 (thin-coverage warning, not abort) ──────────────────
+
+test_that("check_portfolio_join_coverage warns (does not abort) on a thin-coverage month", {
+  expect_warning(
+    result <- check_portfolio_join_coverage(thin_march),
+    regexp = "2021-03"
+  )
+  expect_true(result)  # still returns TRUE -- a warning is not a failure
+})
+
+test_that("check_portfolio_join_coverage names the missing constituents for a thin-coverage month", {
+  expect_warning(
+    check_portfolio_join_coverage(thin_march),
+    regexp = "stk_drif, fac_max, fac_drif"
+  )
+  expect_snapshot(
+    check_portfolio_join_coverage(thin_march)
+  )
+})
+
+test_that("check_portfolio_join_coverage does not warn when every month has >= 2 constituents", {
+  expect_no_warning(check_portfolio_join_coverage(good_port_returns))
+})
+
+# ── Tests: required columns ───────────────────────────────────────────────────
+
+test_that("check_portfolio_join_coverage throws when required columns are missing", {
+  bad <- dplyr::select(good_port_returns, -stk_drif)
+  expect_error(
+    check_portfolio_join_coverage(bad),
+    regexp = "stk_drif"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_portfolio_join_coverage(bad)
+  )
+})


### PR DESCRIPTION
## Summary

Fixes the join-layer half of #641: `R/plan_portfolio_opt.R`'s `port_returns`
target chained four `inner_join()`s across `stk_max`/`stk_drif`/`fac_max`/
`fac_drif`, so any month missing from ONE constituent silently deleted that
month for ALL FOUR — 128 of an expected ~190+ rows, including every March.
PSO Optimal's published CAGR/vol/Sharpe were computed on that non-randomly
truncated series.

This PR does **not** touch `R/plan_stock_backtest.R` (the upstream
`stk_drif_portfolio` March-gap root cause is a separate, concurrently-fixed
defect per the issue) and does not claim the S11 metric-window-bounds gate
(also concurrent, different agent).

## What changed

- **Join → calendar-complete spine.** `port_returns` now builds an explicit
  monthly spine (`seq()`-generated, not the literal `ym` values present in
  the source series) bounded to the **overlap** of `stk_max_portfolio` and
  `stk_drif_portfolio`'s own date ranges, then left-joins all four
  constituents onto it. A missing constituent is an explicit `NA` in its
  own column, never a deleted row.
  - Bounded to the *stock-level overlap*, not a plain union of all four:
    `fac_max`/`fac_drif` run six decades longer than the stock-level
    series, so a naive `full_join` across all four would silently expand
    "Full Period" back into 1960s factor-only history and introduce a large
    block of `NA` that `R/plan_regime.R`'s plain `ret_matrix %*% w` is not
    written to expect. Verified empirically against the real built store
    (read-only `tar_read`) before choosing this design — see PR discussion.
- **Weighting decision, made explicit.** `port_combined` now combines
  constituents via a new `.port_weighted_return()` helper: renormalises the
  target weight vector over the strategies actually present that month
  (missing strategy → zero weight, present strategies rescaled to sum to
  1), with a **floor of 2 strategies required** — a month with only 1
  reporting strategy returns `NA` rather than being silently dressed up as
  a diversified-portfolio observation.
- **NA-safe metrics.** `port_metrics`'s `calc_port_metrics()` drops `NA`
  per-column before computing `cagr`/`vol`/`sharpe`/`max_dd`, since
  `cumprod()` propagates `NA` forward to every subsequent element — without
  this, a single gap would silently `NA`-poison the whole-sample metric.
- **New QA gate** (`R/plan_qa_gates.R`, matching the existing S9/S10
  style): `check_portfolio_join_coverage()` / `qa_portfolio_join_coverage`
  target. `cli_abort()`s on any calendar-month gap (should be structurally
  impossible after this fix); `cli_warn()`s (not abort) on a genuinely
  thin-coverage month, naming the affected month and which constituent(s)
  are missing.
- **Tests.** Extended `tests/testthat/test-plan-portfolio-opt.R` (spine
  construction, `.port_weighted_return()` renormalisation/guards, NA-aware
  `calc_port_metrics()`) and added
  `tests/testthat/test-portfolio-join-coverage.R` with committed
  `_snaps/portfolio-join-coverage.md` snapshots per the project's
  snapshot-test policy.

## Downstream consumers checked (read-only, via `tar_read` against the real
built store — no `tar_make()` run)

| Consumer | Status |
|---|---|
| `R/plan_leaderboard.R` (`opt_returns_df`, `strategy_correlation`, `strat_deflated_sharpe`) | Already `filter(if_all(..., !is.na))` / `r[!is.na(r)]` before use — compatible, unmodified |
| `R/plan_strategy_correlation.R` (`strat_returns_aligned`) | Already `filter(!is.na(...))` on all four columns before use — compatible, unmodified |
| `R/plan_structural_breaks.R` | Already `port_returns[!is.na(port_returns[[col]]), ]` — compatible, unmodified |
| `R/plan_regime.R` (`regime_vol`, `regime_portfolio`) | Plain `ret_matrix %*% w`, not NA-aware — but with the *bounded* spine design, `NA` is now confined to the trailing 1-2 live-edge-lag months (not a multi-year block), and `regime_classification`/`regime_metrics` already `is.na()`-guard downstream. Left unmodified; flagged as a finding below since it doesn't use the same renormalisation discipline as `port_combined`. |

## Findings: same `inner_join` month-loss hazard, unfixed (per #641 request to sweep)

Reported per the issue's ask to check whether this is systemic. **Not
fixed here** — listed for separate issues:

- `R/plan_stock_backtest.R:1014-1033` (`stk_all_comparison`) — identical
  4-way `inner_join` chain over the same four constituents. Off-limits for
  this PR (owned by the concurrent #641 upstream-fix agent).
- `R/plan_bootstrap_ci.R:22-35` (`boot_monthly_returns`) — identical 4-way
  `inner_join` chain; this is the pre-existing #603 defect the issue
  references. Already has a *reporting* target (`ic_contiguity` in
  `R/plan_interval_coverage.R`) but the join itself is unfixed.
- `R/plan_multi_strategy.R:36-38` (`ms_portfolio`) — 3-way `inner_join`
  feeding a **weighted portfolio return**, same defect class as
  `port_returns`/`port_combined` (arguably highest priority of this list).
- `R/plan_marginal_contribution.R:22-24` (`mc_analysis`, `all3`) — 3-way
  `inner_join` combining strategies into portfolio stats.
- `R/plan_causal_graph.R:228-232` — 4-way `inner_join` chain aligning
  regime/factor series by `date` for causal-DAG estimation.
- `R/plan_xgb_signal.R:167` (`xgb_vs_enet`) — 2-way `inner_join` feeding a
  comparison plot; lower blast radius (2 series, not 4).
- `R/plan_add_crowding.R:154` — per-strategy 2-way join to an SPY
  benchmark; **lower risk** — already self-reports `n_months_matched` as an
  explicit diagnostic column, so silent loss is at least visible.
- `R/plan_strategy_decay.R:93` — joins ONE strategy to a regime
  classification (not a multi-strategy combination); different, lower-risk
  pattern.

## Verification

`scripts/verify.sh` (full: parse + root suite + package suite), run in the
nix devshell per project convention — **PASS**:

```
PASS: _targets.R parses
PASS: testthat edition 3 active
=== root suite ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)
=== package suite ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%
=== scripts/verify.sh: PASS ===
```

New tests (`test-portfolio-join-coverage.R`: 10/10 pass;
`test-plan-portfolio-opt.R`: 44/44 pass) are included in that root-suite
total with no new failure signatures.

**What remains unverified:** I cannot run `tar_make()` (per dispatch scope
— a concurrent build in another checkout could corrupt the shared
`docs/_targets` store), so I cannot show the real, pipeline-produced
`port_returns` row count after this fix merges alongside the concurrent
upstream `stk_drif_portfolio` fix. The row counts and NA patterns quoted in
this PR description come from a **read-only** `tar_read()` simulation
against the current built store (before the upstream fix lands) — actual
post-merge numbers will differ once `stk_drif_portfolio` itself gains its
missing March rows.

## Test plan

- [x] `scripts/verify.sh` passes (root + package suites, baseline failures
      match exactly, no new failures)
- [x] `parse("_targets.R")` succeeds
- [x] New unit tests for the spine construction, `.port_weighted_return()`,
      and `calc_port_metrics()` NA-handling
- [x] New QA-gate tests + committed snapshots
- [ ] `tar_make()` full pipeline run — out of scope for this dispatch (read-only store access only)

Closes the join-layer half of #641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
