### PR TITLE
fix(stock-drif): trailing lookback window instead of calendar-month confinement (#641)

### DIFF
--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -452,6 +452,77 @@ check_leaderboard_period_vocab <- function(leaderboard) {
 }
 
 
+#' Assert a monthly portfolio target has complete calendar-month coverage (S11)
+#'
+#' Guards against the #641 defect class: a systematic construction bug (a
+#' lookback/rebalance window confined to a single calendar month) can
+#' silently drop an entire calendar month -- month 3/March in the #641
+#' case -- from EVERY year of a monthly strategy target, with no error and
+#' no warning anywhere else in the pipeline. `stk_max_portfolio` (255 rows,
+#' all 12 months) was the healthy sibling that exposed `stk_drif_portfolio`
+#' (129 rows, month 3 entirely absent) as broken.
+#'
+#' Two assertions:
+#'   1. Every calendar month 1-12 is represented by at least one row.
+#'   2. The number of distinct `ym` values covers a minimum fraction of the
+#'      target's own [min(ym), max(ym)] calendar-month span (default 60%) --
+#'      catches broader coverage collapse even when no single calendar
+#'      month is entirely absent.
+#'
+#' @param portfolio Tibble with a `ym` column ("YYYY-MM").
+#' @param target_name Character scalar, the target's name, used in messages.
+#' @param min_span_coverage Numeric in (0, 1]. Minimum fraction of the
+#'   target's own calendar-month span that must be present.
+#' @return `TRUE` invisibly on success.
+#' @noRd
+check_month_coverage <- function(portfolio, target_name, min_span_coverage = 0.6) {
+  if (!"ym" %in% names(portfolio)) {
+    cli::cli_abort(c(
+      "x" = "{target_name} is missing the required {.field ym} column.",
+      "i" = "check_month_coverage() (S11) requires a ym (\"YYYY-MM\") column."
+    ))
+  }
+
+  yms <- sort(unique(portfolio$ym))
+  if (length(yms) == 0L) {
+    cli::cli_abort(c("x" = "{target_name} has zero rows -- cannot assess month coverage."))
+  }
+
+  observed_month_nums <- sort(unique(as.integer(substr(yms, 6, 7))))
+  missing_month_nums <- setdiff(1:12, observed_month_nums)
+
+  if (length(missing_month_nums) > 0L) {
+    cli::cli_abort(c(
+      "x" = paste0(
+        target_name, ": calendar month(s) ", paste(missing_month_nums, collapse = ", "),
+        " {.strong entirely absent} across the whole sample (", length(yms),
+        " month(s), ", min(yms), " to ", max(yms), ")."
+      ),
+      "i" = "A whole calendar month missing every year is a systematic construction bug, not sampling noise (#641).",
+      "i" = "Check for a lookback/rebalance window confined to a single calendar month, or a silent NA/join drop upstream."
+    ))
+  }
+
+  full_span <- seq.Date(as.Date(paste0(min(yms), "-01")), as.Date(paste0(max(yms), "-01")), by = "month")
+  full_span_ym <- format(full_span, "%Y-%m")
+  span_coverage <- length(yms) / length(full_span_ym)
+
+  if (span_coverage < min_span_coverage) {
+    cli::cli_abort(c(
+      "x" = paste0(
+        target_name, ": only ", length(yms), "/", length(full_span_ym), " (",
+        sprintf("%.0f%%", span_coverage * 100), ") of its own [", min(yms), ", ",
+        max(yms), "] calendar-month span is present -- below the ",
+        sprintf("%.0f%%", min_span_coverage * 100), " minimum."
+      ),
+      "i" = "This may indicate systematic month loss upstream (#641) even though no single calendar month is entirely absent."
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+
 # ---- QA gate plan ----
 
 plan_qa_gates <- function() {
@@ -627,6 +698,20 @@ plan_qa_gates <- function() {
       command = {
         check_leaderboard_period_vocab(leaderboard)
         cli::cli_inform(c("v" = "qa_leaderboard_period_vocab: S10 passed (canonical period vocabulary, all strategies have a Full Period row)"))
+        TRUE
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: stk_drif_portfolio has complete calendar-month coverage (S11) —
+    # guards against the #641 defect class where a lookback/rebalance window
+    # confined to a single calendar month silently drops an entire month
+    # (March, fed by a structurally-short February) from every year.
+    targets::tar_target(
+      qa_stk_drif_month_coverage,
+      command = {
+        check_month_coverage(stk_drif_portfolio, "stk_drif_portfolio")
+        cli::cli_inform(c("v" = "qa_stk_drif_month_coverage: S11 passed (all 12 calendar months present in stk_drif_portfolio)"))
         TRUE
       },
       cue = targets::tar_cue(mode = "always")

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -452,7 +452,7 @@ check_leaderboard_period_vocab <- function(leaderboard) {
 }
 
 
-#' Assert a monthly portfolio target has complete calendar-month coverage (S11)
+#' Assert a monthly portfolio target has complete calendar-month coverage (S12)
 #'
 #' Guards against the #641 defect class: a systematic construction bug (a
 #' lookback/rebalance window confined to a single calendar month) can
@@ -479,7 +479,7 @@ check_month_coverage <- function(portfolio, target_name, min_span_coverage = 0.6
   if (!"ym" %in% names(portfolio)) {
     cli::cli_abort(c(
       "x" = "{target_name} is missing the required {.field ym} column.",
-      "i" = "check_month_coverage() (S11) requires a ym (\"YYYY-MM\") column."
+      "i" = "check_month_coverage() (S12) requires a ym (\"YYYY-MM\") column."
     ))
   }
 
@@ -703,7 +703,7 @@ plan_qa_gates <- function() {
       cue = targets::tar_cue(mode = "always")
     ),
 
-    # QA gate: stk_drif_portfolio has complete calendar-month coverage (S11) —
+    # QA gate: stk_drif_portfolio has complete calendar-month coverage (S12) —
     # guards against the #641 defect class where a lookback/rebalance window
     # confined to a single calendar month silently drops an entire month
     # (March, fed by a structurally-short February) from every year.
@@ -711,7 +711,7 @@ plan_qa_gates <- function() {
       qa_stk_drif_month_coverage,
       command = {
         check_month_coverage(stk_drif_portfolio, "stk_drif_portfolio")
-        cli::cli_inform(c("v" = "qa_stk_drif_month_coverage: S11 passed (all 12 calendar months present in stk_drif_portfolio)"))
+        cli::cli_inform(c("v" = "qa_stk_drif_month_coverage: S12 passed (all 12 calendar months present in stk_drif_portfolio)"))
         TRUE
       },
       cue = targets::tar_cue(mode = "always")

--- a/R/plan_stock_backtest.R
+++ b/R/plan_stock_backtest.R
@@ -45,6 +45,80 @@ assign_decile <- function(df, signal_col, n_groups = 10L) {
     dplyr::ungroup()
 }
 
+#' Build DRIF lookback features for a single target month (#641)
+#'
+#' Constructs the chronological ("c1".."c{lb}") and rank-sorted ("r1".."r{lb}")
+#' daily-return feature columns for every ticker with sufficient trailing
+#' history, joined to next-month realised return as target_ret.
+#'
+#' CRITICAL (#641): the lookback window is the trailing `lb` TRADING DAYS per
+#' ticker strictly before the first trading date of `target_ym` -- it deliberately
+#' SPANS calendar-month boundaries. The prior implementation confined the
+#' window to the single PRECEDING calendar month (`daily |> filter(ym ==
+#' prev_m)`). Because February supplies only 19-21 trading days a year
+#' (median 19-20, max 20-21 -- see #641 diagnosis), that confinement left the
+#' `c{lb}`/`r{lb}` columns NA for nearly every ticker whenever `target_ym` was
+#' March, and `predict.glmnet()` propagates any NA feature to an NA
+#' prediction for the whole row downstream in stk_drif_signal -- wiping out
+#' 14 of 17 March months entirely (and, by the identical mechanism, 23
+#' further single-year months fed by an unusually short predecessor month).
+#'
+#' @param daily Tibble with `ticker`, `date`, `daily_ret`, `ym` (== stk_daily_ret
+#'   with a `ym = format(date, "%Y-%m")` column added), sorted by ticker then
+#'   date ascending.
+#' @param target_ym Character scalar, "YYYY-MM" -- the month being predicted.
+#' @param monthly Tibble with `ticker`, `ym`, `monthly_ret` (== stk_monthly),
+#'   used to attach `target_ret` for `target_ym`.
+#' @param lb Integer trailing-window length in trading days.
+#' @param min_days Integer minimum trailing trading days required per ticker
+#'   (else that ticker is dropped for this month; was previously a per-month
+#'   10-day minimum -- see #43).
+#' @return Tibble with `ticker`, chrono cols `c1..c{lb}`, rank cols
+#'   `r1..r{lb}`, `target_ret`, `ym`. Zero rows (never NULL) when no ticker
+#'   has `min_days` trailing trading days before `target_ym`.
+#' @noRd
+stk_drif_month_features <- function(daily, target_ym, monthly, lb = 21L, min_days = 10L) {
+  cutoff_dates <- daily$date[daily$ym == target_ym]
+  if (length(cutoff_dates) == 0L) return(tibble::tibble())
+  cutoff_date <- min(cutoff_dates)
+
+  prior <- daily |>
+    dplyr::filter(date < cutoff_date) |>
+    dplyr::group_by(ticker) |>
+    dplyr::slice_max(order_by = date, n = lb, with_ties = FALSE) |>
+    dplyr::filter(dplyr::n() >= min_days) |>
+    dplyr::arrange(date, .by_group = TRUE) |>
+    dplyr::mutate(day_rank = dplyr::row_number()) |>
+    dplyr::ungroup()
+
+  if (nrow(prior) == 0L) return(tibble::tibble())
+
+  chrono <- prior |>
+    tidyr::pivot_wider(
+      id_cols = ticker, names_from = day_rank,
+      names_prefix = "c", values_from = daily_ret
+    )
+
+  ranked <- prior |>
+    dplyr::group_by(ticker) |>
+    dplyr::arrange(daily_ret, .by_group = TRUE) |>
+    dplyr::mutate(rank_idx = dplyr::row_number()) |>
+    dplyr::ungroup() |>
+    tidyr::pivot_wider(
+      id_cols = ticker, names_from = rank_idx,
+      names_prefix = "r", values_from = daily_ret
+    )
+
+  target <- monthly |>
+    dplyr::filter(ym == target_ym) |>
+    dplyr::select(ticker, target_ret = monthly_ret)
+
+  chrono |>
+    dplyr::inner_join(ranked, by = "ticker") |>
+    dplyr::inner_join(target, by = "ticker") |>
+    dplyr::mutate(ym = target_ym)
+}
+
 #' Compute long-short portfolio returns with realistic costs
 #' @param df Data frame with ym, ticker, decile, and monthly_ret columns
 #' @param long_decile Which decile to go long (default 1 = top)
@@ -812,65 +886,42 @@ plan_stock_backtest <- function() {
       library(dplyr)
 
       lb <- stk_params$lookback_days
-      daily <- stk_daily_ret |> mutate(ym = format(date, "%Y-%m"))
+      daily <- stk_daily_ret |>
+        mutate(ym = format(date, "%Y-%m")) |>
+        arrange(ticker, date)
 
-      # For each stock-month, get the prior month's daily returns
-      # Strategy: pivot wide by day-of-month rank, then compute features
       all_months <- sort(unique(daily$ym))
 
-      # Pre-compute: for each stock, the last `lb` trading days before each month
-      # Using a rolling join approach for efficiency
-      features_list <- lapply(seq_along(all_months)[-1], function(i) {
-        m <- all_months[i]
-        prev_m <- all_months[i - 1]
-
-        # Get prior month's trading days for all stocks
-        prior <- daily |>
-          filter(ym == prev_m) |>
-          group_by(ticker) |>
-          filter(n() >= 10) |>  # 10 days minimum (was 15 — see #43)
-          mutate(day_rank = row_number()) |>
-          ungroup()
-
-        if (nrow(prior) == 0) return(NULL)
-
-        # Chronological features: pad/trim to exactly lb days
-        chrono <- prior |>
-          filter(day_rank <= lb) |>
-          tidyr::pivot_wider(
-            id_cols = ticker,
-            names_from = day_rank,
-            names_prefix = "c",
-            values_from = daily_ret
-          )
-
-        # Rank features: sort within each stock, then pivot
-        ranked <- prior |>
-          group_by(ticker) |>
-          arrange(daily_ret) |>
-          mutate(rank_idx = row_number()) |>
-          ungroup() |>
-          filter(rank_idx <= lb) |>
-          tidyr::pivot_wider(
-            id_cols = ticker,
-            names_from = rank_idx,
-            names_prefix = "r",
-            values_from = daily_ret
-          )
-
-        # Get next month's return as target
-        target <- stk_monthly |> filter(ym == m) |> select(ticker, target_ret = monthly_ret)
-
-        # Combine
-        result <- chrono |>
-          inner_join(ranked, by = "ticker") |>
-          inner_join(target, by = "ticker") |>
-          mutate(ym = m)
-
-        result
+      # Trailing `lb`-trading-day lookback per ticker, spanning calendar-month
+      # boundaries where needed (#641 -- see stk_drif_month_features() roxygen
+      # for why the window must NOT be confined to a single calendar month).
+      features_list <- lapply(all_months[-1], function(m) {
+        stk_drif_month_features(daily, m, stk_monthly, lb = lb, min_days = 10L)
       })
+      names(features_list) <- all_months[-1]
 
-      bind_rows(Filter(Negate(is.null), features_list))
+      result <- bind_rows(features_list)
+
+      # Fail loudly (#641): a target month with zero feature rows silently
+      # vanishes from every downstream target with no signal anywhere. This
+      # should now only happen very early in the sample, before any ticker
+      # has accumulated `lb` trailing trading days.
+      produced_months <- sort(unique(result$ym))
+      zero_row_months <- setdiff(all_months[-1], produced_months)
+      if (length(zero_row_months) > 0L) {
+        cli::cli_warn(c(
+          "!" = paste0(
+            "stk_drif_features: ", length(zero_row_months),
+            " target month(s) produced ZERO feature rows (no ticker had ",
+            "the minimum trailing trading-day history) and will be entirely ",
+            "absent from every downstream DRIF target:"
+          ),
+          setNames(sprintf("  %s", zero_row_months), rep("i", length(zero_row_months))),
+          "i" = "See #641 -- expected only for the earliest month(s) of the sample."
+        ))
+      }
+
+      result
     }),
 
     # ── DRIF signal: pooled elastic net, expanding window ─────────
@@ -890,6 +941,8 @@ plan_stock_backtest <- function() {
       trade_months <- months[(min_train + 1):length(months)]
       cli::cli_inform(c("i" = "DRIF stock-level: {length(trade_months)} months to process"))
 
+      skip_reasons <- character(0)
+
       predictions <- lapply(seq_along(trade_months), function(j) {
         m <- trade_months[j]
         if (j %% 24 == 0) cli::cli_inform(c("i" = "  Month {j}/{length(trade_months)}: {m}"))
@@ -899,7 +952,10 @@ plan_stock_backtest <- function() {
         train <- features |> filter(ym %in% train_months)
         test <- features |> filter(ym == m)
 
-        if (nrow(test) == 0) return(NULL)
+        if (nrow(test) == 0) {
+          skip_reasons[[m]] <<- "no feature rows for this month (see stk_drif_features warnings)"
+          return(NULL)
+        }
 
         X_train <- as.matrix(train[, feat_cols])
         y_train <- train$target_ret
@@ -910,7 +966,12 @@ plan_stock_backtest <- function() {
         X_train <- X_train[complete, , drop = FALSE]
         y_train <- y_train[complete]
 
-        if (length(y_train) < 200) return(NULL)  # need decent sample
+        if (length(y_train) < 200) {
+          skip_reasons[[m]] <<- paste0(
+            "only ", length(y_train), " complete training rows (< 200 minimum)"
+          )
+          return(NULL)
+        }
 
         fit <- tryCatch({
           glmnet::cv.glmnet(X_train, y_train, alpha = 0.5,
@@ -920,7 +981,10 @@ plan_stock_backtest <- function() {
           NULL
         })
 
-        if (is.null(fit)) return(NULL)
+        if (is.null(fit)) {
+          skip_reasons[[m]] <<- "cv.glmnet failed (see warning above)"
+          return(NULL)
+        }
         pred <- as.numeric(predict(fit, X_test, s = "lambda.min"))
 
         tibble(
@@ -929,6 +993,20 @@ plan_stock_backtest <- function() {
         )
       })
 
+      # Fail loudly (#641): every trade month that produced NO predictions at
+      # all -- for whatever reason -- used to vanish from stk_drif_signal
+      # with zero signal anywhere in the pipeline.
+      if (length(skip_reasons) > 0L) {
+        msgs <- sprintf("  %s -- %s", names(skip_reasons), skip_reasons)
+        cli::cli_warn(c(
+          "!" = paste0(
+            "DRIF stock-level: ", length(skip_reasons),
+            " of ", length(trade_months), " trade month(s) produced NO predictions:"
+          ),
+          setNames(msgs, rep("i", length(msgs)))
+        ))
+      }
+
       bind_rows(Filter(Negate(is.null), predictions))
     }),
 
@@ -936,9 +1014,28 @@ plan_stock_backtest <- function() {
     targets::tar_target(stk_drif_portfolio, {
       library(dplyr)
 
-      signal <- stk_drif_signal |>
-        filter(!is.na(predicted_ret)) |>
+      signal_joined <- stk_drif_signal |>
         inner_join(stk_monthly |> select(ticker, ym, monthly_ret), by = c("ticker", "ym"))
+
+      months_before_na_filter <- sort(unique(signal_joined$ym))
+      signal <- signal_joined |> filter(!is.na(predicted_ret))
+      months_after_na_filter <- sort(unique(signal$ym))
+
+      # Fail loudly (#641): a month whose predicted_ret is NA for EVERY
+      # ticker used to disappear here with no signal anywhere -- this is
+      # exactly how March vanished from stk_drif_portfolio in every year.
+      dropped_na_months <- setdiff(months_before_na_filter, months_after_na_filter)
+      if (length(dropped_na_months) > 0L) {
+        cli::cli_warn(c(
+          "!" = paste0(
+            "stk_drif_portfolio: ", length(dropped_na_months),
+            " month(s) had predicted_ret == NA for every ticker and were ",
+            "dropped entirely:"
+          ),
+          setNames(sprintf("  %s", dropped_na_months), rep("i", length(dropped_na_months))),
+          "i" = "See #641 -- check stk_drif_signal warnings for cv.glmnet failures or insufficient training rows for these months."
+        ))
+      }
 
       # Variant A (filter-then-rank, Cakici 2023 / #312):
       # Drop sub-ADV names BEFORE cutting deciles — illiquid micro-caps with extreme
@@ -954,8 +1051,27 @@ plan_stock_backtest <- function() {
 
       # Re-apply minimum-stocks guard AFTER the ADV filter (#312):
       # the gate can drop names and push some months below the decile threshold.
+      min_stocks <- stk_params$n_deciles * 5
       stocks_per_month <- signal |> count(ym, name = "n_stocks")
-      valid_months <- stocks_per_month |> filter(n_stocks >= stk_params$n_deciles * 5) |> pull(ym)
+      valid_months <- stocks_per_month |> filter(n_stocks >= min_stocks) |> pull(ym)
+
+      # Fail loudly (#641): months dropped by the min-stocks guard used to
+      # vanish silently too -- report which months and how many stocks short.
+      dropped_liquidity <- stocks_per_month |> filter(n_stocks < min_stocks)
+      if (nrow(dropped_liquidity) > 0L) {
+        msgs <- sprintf(
+          "  %s -- %d stock(s) after ADV gate (need >= %d)",
+          dropped_liquidity$ym, dropped_liquidity$n_stocks, min_stocks
+        )
+        cli::cli_warn(c(
+          "!" = paste0(
+            "stk_drif_portfolio: ", nrow(dropped_liquidity),
+            " month(s) dropped by the min-stocks guard after the ADV filter:"
+          ),
+          setNames(msgs, rep("i", length(msgs)))
+        ))
+      }
+
       signal <- signal |> filter(ym %in% valid_months)
 
       deciled <- assign_decile(signal, predicted_ret, stk_params$n_deciles)

--- a/tests/testthat/_snaps/stk-drif-month-coverage.md
+++ b/tests/testthat/_snaps/stk-drif-month-coverage.md
@@ -1,0 +1,27 @@
+# check_month_coverage throws when a calendar month is entirely absent (#641)
+
+    Code
+      check_month_coverage(make_march_missing(), "stk_drif_portfolio")
+    Condition
+      Error in `check_month_coverage()`:
+      x stk_drif_portfolio: calendar month(s) 3 entirely absent across the whole sample (66 month(s), 2010-01 to 2015-12).
+      i A whole calendar month missing every year is a systematic construction bug, not sampling noise (#641).
+      i Check for a lookback/rebalance window confined to a single calendar month, or a silent NA/join drop upstream.
+
+# check_month_coverage throws when the ym column is missing
+
+    Code
+      check_month_coverage(bad, "test_portfolio")
+    Condition
+      Error in `check_month_coverage()`:
+      x test_portfolio is missing the required ym column.
+      i check_month_coverage() (S11) requires a ym ("YYYY-MM") column.
+
+# check_month_coverage signature is stable (catches API drift)
+
+    Code
+      args(check_month_coverage)
+    Output
+      function (portfolio, target_name, min_span_coverage = 0.6) 
+      NULL
+

--- a/tests/testthat/_snaps/stk-drif-month-coverage.md
+++ b/tests/testthat/_snaps/stk-drif-month-coverage.md
@@ -15,7 +15,7 @@
     Condition
       Error in `check_month_coverage()`:
       x test_portfolio is missing the required ym column.
-      i check_month_coverage() (S11) requires a ym ("YYYY-MM") column.
+      i check_month_coverage() (S12) requires a ym ("YYYY-MM") column.
 
 # check_month_coverage signature is stable (catches API drift)
 

--- a/tests/testthat/_snaps/stk-drif-month-features.md
+++ b/tests/testthat/_snaps/stk-drif-month-features.md
@@ -1,0 +1,8 @@
+# stk_drif_month_features signature is stable (catches API drift)
+
+    Code
+      args(stk_drif_month_features)
+    Output
+      function (daily, target_ym, monthly, lb = 21L, min_days = 10L) 
+      NULL
+

--- a/tests/testthat/test-stk-drif-month-coverage.R
+++ b/tests/testthat/test-stk-drif-month-coverage.R
@@ -1,0 +1,105 @@
+testthat::local_edition(3)
+# Tests for check_month_coverage() — QA gate S11 (#641)
+#
+# The function is defined in R/plan_qa_gates.R. Guards against the #641
+# defect class: a lookback/rebalance window confined to a single calendar
+# month can silently drop an entire calendar month (March, fed by a
+# structurally-short February -- see stk_drif_month_features() in
+# R/plan_stock_backtest.R) from EVERY year of a monthly strategy target,
+# with no error and no warning anywhere else in the pipeline.
+
+source(here::here("R/plan_qa_gates.R"))
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+make_full_coverage <- function() {
+  yms <- format(seq.Date(as.Date("2010-01-01"), as.Date("2015-12-01"), by = "month"), "%Y-%m")
+  tibble::tibble(ym = yms)
+}
+
+make_march_missing <- function() {
+  full <- make_full_coverage()
+  dplyr::filter(full, substr(ym, 6, 7) != "03")
+}
+
+make_sparse_but_all_months <- function() {
+  # Every calendar month 1-12 appears at least once (one row per calendar
+  # month, taken from 2010 only), but the [min, max] span implied by that
+  # single year is 12 months while only 12 rows exist -- deliberately pair
+  # this fixture with a year-spanning `full` set below so span coverage
+  # comes out well under 100%.
+  one_of_each_month <- make_full_coverage() |>
+    dplyr::filter(substr(ym, 1, 4) == "2010")
+  # Add a single row 4 years later so the [min, max] span is 5 years
+  # (60 months) while only 12 rows are present: coverage = 12/60 = 20%.
+  dplyr::bind_rows(one_of_each_month, tibble::tibble(ym = "2014-01"))
+}
+
+# ── Test: full coverage passes ───────────────────────────────────────────────
+
+test_that("check_month_coverage passes when all 12 calendar months are present", {
+  expect_true(check_month_coverage(make_full_coverage(), "test_portfolio"))
+})
+
+# ── Test: a wholly-missing calendar month aborts (the #641 regression) ──────
+
+test_that("check_month_coverage throws when a calendar month is entirely absent (#641)", {
+  expect_error(
+    check_month_coverage(make_march_missing(), "stk_drif_portfolio"),
+    regexp = "stk_drif_portfolio"
+  )
+  expect_error(
+    check_month_coverage(make_march_missing(), "stk_drif_portfolio"),
+    regexp = "3"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_month_coverage(make_march_missing(), "stk_drif_portfolio")
+  )
+})
+
+# ── Test: broad span-coverage collapse aborts even with all 12 months present ──
+
+test_that("check_month_coverage throws when span coverage is below the minimum", {
+  sparse <- make_sparse_but_all_months()
+  expect_setequal(sort(unique(as.integer(substr(sparse$ym, 6, 7)))), 1:12)
+  expect_error(
+    check_month_coverage(sparse, "test_portfolio", min_span_coverage = 0.9),
+    regexp = "span"
+  )
+})
+
+test_that("check_month_coverage passes the same sparse fixture at a lower min_span_coverage", {
+  sparse <- make_sparse_but_all_months()
+  expect_true(check_month_coverage(sparse, "test_portfolio", min_span_coverage = 0.2))
+})
+
+# ── Test: required column ────────────────────────────────────────────────────
+
+test_that("check_month_coverage throws when the ym column is missing", {
+  bad <- dplyr::select(make_full_coverage(), -ym)
+  expect_error(
+    check_month_coverage(bad, "test_portfolio"),
+    regexp = "ym"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_month_coverage(bad, "test_portfolio")
+  )
+})
+
+# ── Test: zero-row input ─────────────────────────────────────────────────────
+
+test_that("check_month_coverage throws on zero-row input", {
+  empty <- make_full_coverage()[0, , drop = FALSE]
+  expect_error(
+    check_month_coverage(empty, "test_portfolio"),
+    regexp = "zero rows"
+  )
+})
+
+# ── Test: function signature is stable (catches API drift) ──────────────────
+
+test_that("check_month_coverage signature is stable (catches API drift)", {
+  expect_snapshot(args(check_month_coverage))
+})

--- a/tests/testthat/test-stk-drif-month-coverage.R
+++ b/tests/testthat/test-stk-drif-month-coverage.R
@@ -1,5 +1,5 @@
 testthat::local_edition(3)
-# Tests for check_month_coverage() — QA gate S11 (#641)
+# Tests for check_month_coverage() — QA gate S12 (#641)
 #
 # The function is defined in R/plan_qa_gates.R. Guards against the #641
 # defect class: a lookback/rebalance window confined to a single calendar

--- a/tests/testthat/test-stk-drif-month-features.R
+++ b/tests/testthat/test-stk-drif-month-features.R
@@ -1,0 +1,134 @@
+testthat::local_edition(3)
+# Tests for stk_drif_month_features() -- #641 fix.
+#
+# Root cause of #641: the pre-fix implementation confined the DRIF lookback
+# window to the single PRECEDING calendar month (`daily |> filter(ym ==
+# prev_m)`). February supplies only 19-21 trading days a year (never
+# reliably `lookback_days` = 21), so the `c20`/`c21` (and `r20`/`r21`)
+# feature columns came out NA for nearly every ticker whenever the target
+# month was March -- and `predict.glmnet()` propagates any NA feature to an
+# NA prediction for the whole row, wiping out 14 of 17 March months (and,
+# by the identical mechanism, 23 further single-year months fed by an
+# unusually short predecessor month).
+#
+# The fix (`stk_drif_month_features()`) pulls a genuine trailing
+# `lb`-trading-day window per ticker, spanning calendar-month boundaries as
+# needed, instead of confining the window to one calendar month.
+
+local_env <- new.env(parent = globalenv())
+suppressWarnings(
+  sys.source(
+    here::here("R/plan_stock_backtest.R"),
+    envir = local_env,
+    keep.source = FALSE
+  )
+)
+stk_drif_month_features <- local_env$stk_drif_month_features
+
+# ── Fixture: a short (19-trading-day) February preceded by 10 days of
+#    January history, so a full 21-day trailing window requires reaching
+#    back across the calendar-month boundary. ────────────────────────────
+make_jan_feb_fixture <- function(tickers = c("AAA", "BBB"), n_jan = 10L, n_feb = 19L) {
+  jan_days <- as.Date("2013-01-02") + seq_len(n_jan) - 1L
+  feb_days <- as.Date("2013-02-01") + seq_len(n_feb) - 1L
+  mar_first <- as.Date("2013-03-04")
+
+  set.seed(1L)
+  daily <- purrr::map_dfr(tickers, function(tk) {
+    dplyr::bind_rows(
+      tibble::tibble(ticker = tk, date = c(jan_days, feb_days),
+                      daily_ret = rnorm(n_jan + n_feb, 0, 0.01)),
+      tibble::tibble(ticker = tk, date = mar_first, daily_ret = 0.001)
+    )
+  })
+  daily <- daily |>
+    dplyr::mutate(ym = format(date, "%Y-%m")) |>
+    dplyr::arrange(ticker, date)
+
+  monthly <- tibble::tibble(
+    ticker = tickers, ym = "2013-03",
+    monthly_ret = seq(0.01, by = 0.01, length.out = length(tickers))
+  )
+
+  list(daily = daily, monthly = monthly, jan_days = jan_days, feb_days = feb_days)
+}
+
+# ── Test 1: full lb-day window achieved by spanning Jan into Feb ────────
+
+test_that("trailing window spans the calendar-month boundary when February is short (#641)", {
+  f <- make_jan_feb_fixture()
+  feat <- stk_drif_month_features(f$daily, "2013-03", f$monthly, lb = 21L, min_days = 10L)
+
+  expect_equal(nrow(feat), 2L)
+  expect_true(all(paste0("c", 1:21) %in% names(feat)))
+  expect_true(all(paste0("r", 1:21) %in% names(feat)))
+  expect_false(anyNA(as.matrix(feat[, paste0("c", 1:21)])))
+  expect_false(anyNA(as.matrix(feat[, paste0("r", 1:21)])))
+})
+
+test_that("chrono column c1 is the OLDEST day and c{lb} is the most recent day before cutoff", {
+  f <- make_jan_feb_fixture()
+  feat <- stk_drif_month_features(f$daily, "2013-03", f$monthly, lb = 21L, min_days = 10L)
+
+  aaa_daily <- f$daily |>
+    dplyr::filter(ticker == "AAA", date < as.Date("2013-03-04")) |>
+    dplyr::arrange(date)
+  # Trailing 21 days: the last 21 rows of aaa_daily (29 total: 10 Jan + 19 Feb).
+  window <- utils::tail(aaa_daily, 21L)
+
+  aaa_feat <- feat |> dplyr::filter(ticker == "AAA")
+  expect_equal(unname(as.numeric(aaa_feat[["c1"]])), window$daily_ret[1L])
+  expect_equal(unname(as.numeric(aaa_feat[["c21"]])), window$daily_ret[21L])
+})
+
+# ── Test 2: without prior-month history, window is truncated (not NA) ───
+
+test_that("with no history before the short month, c-columns beyond available days are simply absent", {
+  f <- make_jan_feb_fixture(n_jan = 0L)  # only February exists -- 19 days
+  feat <- stk_drif_month_features(f$daily, "2013-03", f$monthly, lb = 21L, min_days = 10L)
+
+  expect_equal(nrow(feat), 2L)
+  expect_true("c19" %in% names(feat))
+  expect_false("c20" %in% names(feat))
+  expect_false("c21" %in% names(feat))
+  expect_false(anyNA(as.matrix(feat[, paste0("c", 1:19)])))
+})
+
+# ── Test 3: ticker below min_days is dropped ─────────────────────────────
+
+test_that("a ticker with fewer than min_days trailing trading days is dropped", {
+  feb_days <- as.Date("2013-02-01") + 0:18   # 19 days -- plenty for AAA
+  thin_days <- as.Date("2013-02-15") + 0:3   # only 4 days -- below min_days for BBB
+  mar_first <- as.Date("2013-03-04")
+
+  set.seed(2L)
+  daily <- dplyr::bind_rows(
+    tibble::tibble(ticker = "AAA", date = feb_days, daily_ret = rnorm(length(feb_days), 0, 0.01)),
+    tibble::tibble(ticker = "AAA", date = mar_first, daily_ret = 0.001),
+    tibble::tibble(ticker = "BBB", date = thin_days, daily_ret = rnorm(length(thin_days), 0, 0.01)),
+    tibble::tibble(ticker = "BBB", date = mar_first, daily_ret = 0.002)
+  ) |>
+    dplyr::mutate(ym = format(date, "%Y-%m")) |>
+    dplyr::arrange(ticker, date)
+
+  monthly <- tibble::tibble(ticker = c("AAA", "BBB"), ym = "2013-03", monthly_ret = c(0.01, 0.02))
+
+  feat <- stk_drif_month_features(daily, "2013-03", monthly, lb = 21L, min_days = 10L)
+  expect_false("BBB" %in% feat$ticker)
+  expect_true("AAA" %in% feat$ticker)
+})
+
+# ── Test 4: target month absent from daily entirely -> zero rows, not NULL ──
+
+test_that("a target month with no trading dates in daily returns zero rows, not NULL", {
+  f <- make_jan_feb_fixture()
+  feat <- stk_drif_month_features(f$daily, "2099-01", f$monthly, lb = 21L, min_days = 10L)
+  expect_s3_class(feat, "data.frame")
+  expect_equal(nrow(feat), 0L)
+})
+
+# ── Test 5: function signature is stable (catches API drift) ────────────
+
+test_that("stk_drif_month_features signature is stable (catches API drift)", {
+  expect_snapshot(args(stk_drif_month_features))
+})


### PR DESCRIPTION
## Summary

Part 1 of #641: `stk_drif_portfolio` has zero March rows across the entire
sample. This PR fixes the root cause upstream in the Stock DRIF feature
construction. **Part 2 (the `inner_join` chain in `R/plan_portfolio_opt.R`)
is out of scope here and is being fixed in a separate, concurrent PR.**

## Root cause (evidence-based, not speculative)

`stk_drif_features()` (`R/plan_stock_backtest.R`) built its 21-trading-day
lookback window from **only the single preceding calendar month**:

```r
prior <- daily |> filter(ym == prev_m) |> group_by(ticker) |> filter(n() >= 10) |> ...
```

February supplies only **19-21 trading days a year** (confirmed across all
22 years present in the built `_targets` store: max_days is 20 in 18/22
years, 21 in only 4/22 — the leap years 2008/2012/2016/2024, and even then
median is still only 20). `lookback_days = 21`, so the `c20`/`c21` (and
`r20`/`r21`) feature columns came out **NA for nearly every ticker**
whenever the target month was March.

`predict.glmnet()` propagates any NA feature to an NA prediction for the
**entire row**, so `stk_drif_signal` produced `predicted_ret = NA` for
essentially every stock in March — wiping the month out at the
`filter(!is.na(predicted_ret))` step in `stk_drif_portfolio`.

Diagnosis (read-only queries against the built store):

| Stage | March coverage |
|---|---|
| `stk_drif_signal` raw (before NA filter) | 17/17 years have a March `ym` value |
| `stk_drif_signal` after `!is.na(predicted_ret)` | only **3/17** years (2012, 2016, 2024 — the leap-year Februaries) |
| `stk_drif_portfolio` (after ADV + min-stocks guard) | **0/17** — even the 3 survivors only had 26-29 stocks, below the `n_stocks >= n_deciles * 5 = 50` gate |

The same mechanism intermittently wiped **23 further single-year months**
(37 total lost, 14 of them March) whenever a target month's immediate
predecessor happened to have fewer than 21 trading days for a given ticker.

## Fix

New `stk_drif_month_features()` helper (`R/plan_stock_backtest.R`) pulls a
genuine **trailing 21-TRADING-DAY window per ticker**, spanning
calendar-month boundaries as needed, instead of confining the window to one
calendar month.

Verified with a synthetic short-February + prior-January fixture
(`tests/testthat/test-stk-drif-month-features.R`): the fix reaches back
across the month boundary and produces a complete, NA-free 21-day window
where the old code left `c20`/`c21` NA for every ticker.

## Fail loudly, don't drop silently

Per the issue's ask and `data-validation-timeseries`, every previously-silent
month loss is now reported via `cli_warn`:

- `stk_drif_features()`: target months that produced zero feature rows.
- `stk_drif_signal()`: per-month skip reason (insufficient training rows /
  `cv.glmnet` failure / no feature rows) aggregated into one warning.
- `stk_drif_portfolio()`: months dropped by the `predicted_ret` NA filter,
  and months dropped by the min-stocks guard (with stock counts).

## Coverage assertion (QA gate S11)

`check_month_coverage()` in `R/plan_qa_gates.R`, wired as
`qa_stk_drif_month_coverage`:

1. Aborts if any calendar month 1-12 is entirely absent from
   `stk_drif_portfolio`.
2. Aborts if `stk_drif_portfolio`'s row count covers less than 60% of its
   own `[min(ym), max(ym)]` calendar-month span.

This gate would have caught the #641 regression at build time.

## Row-count shortfall (129 vs `stk_max_portfolio`'s 255)

Two components, not one:

1. `min_train = 60`-month expanding window truncates the first ~5 years —
   195 raw candidate months (matches the diagnosis: `stk_drif_signal` has
   exactly 195 unique `ym` values before any NA filtering).
2. The NA cascade above then wiped 37 of those 195 months entirely
   (pre-fix).

The remaining ~29-month gap (195 → 129) is the ADV/min-stocks investability
filter — legitimate, intentional filtering, now reported loudly instead of
silently.

## What is verified vs. not verified

**Verified:**
- Unit tests (`tests/testthat/test-stk-drif-month-features.R`,
  `tests/testthat/test-stk-drif-month-coverage.R`) pass against a synthetic
  repro of the exact bug (short February + prior January).
- `parse("_targets.R")` and a `tar_manifest()` dry-run (758 targets, all
  names resolve, `qa_stk_drif_month_coverage` present) against a throwaway
  store — confirms no wiring/dependency errors.
- `scripts/verify.sh` (root + package suite): **PASS**. Root suite 3/3
  baseline failures match exactly, 0 skip. Package suite 1/1 baseline
  failure matches exactly, skips are pre-existing environment-related
  (`alphavantager` not installed, `HD_TEST_LIVE` opt-in) and unrelated to
  this change.

**NOT verified** (task scope forbids mutating the shared `_targets` store,
so `tar_make()` was never run): whether the real pipeline, end to end,
actually restores all 12 calendar months in `stk_drif_portfolio` and by how
much the row count recovers. The fix is confirmed by unit test against a
synthetic fixture and by read-only diagnosis against the existing (pre-fix)
built store — not by re-running the real pipeline. A `tar_make()` on this
branch, followed by re-running the diagnostic queries in the issue, would
settle it definitively.

## Test plan

- [x] `scripts/verify.sh` — PASS (baseline-only failures, no regressions)
- [x] New unit tests for `stk_drif_month_features()` (6 tests) and
      `check_month_coverage()` (7 tests) — all pass
- [x] `tar_manifest()` dry-run confirms the QA gate target wires correctly
- [ ] `tar_make()` on this branch (not run — out of scope; see above)

Closes part 1 of #641.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
