### PR TITLE
fix(leaderboard): seal the Validation partition on the automatic path (#648)

### DIFF
--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -281,6 +281,30 @@ plan_leaderboard <- function() {
         all_metrics <- bind_rows(all_metrics, port_row)
       }
 
+      # ── Seal the Validation partition (#648) ──────────────────────────────
+      # Several source metrics targets (fm_metrics, drif_metrics,
+      # stk_max_metrics, stk_drif_metrics, xgb_drif_metrics, ltr_metrics,
+      # port_metrics) compute a "Validation" period row internally, in their
+      # OWN plan file, for their own reasons (e.g. R/plan_factormax.R:202
+      # `calc_metrics(val_data, "Validation")`). Those rows flow into
+      # `all_metrics` above completely unfiltered via `add_meta()`/`bind_rows()`
+      # and `port_row` -- this is a wider instance of the same
+      # `backtest-partitions.md` seal-breach #648 is about, and those source
+      # targets are intentionally NOT modified here (out of #648's scope --
+      # flagged as a follow-up; several also surface Validation values
+      # directly in vignette prose, e.g. docs/stock-backtest.qmd, which is a
+      # separate display-side leak this issue does not touch).
+      #
+      # This target (`leaderboard`) must not RE-EXPOSE those rows regardless
+      # of which upstream source produced them: drop every row labelled
+      # "Validation" the moment the base rows are assembled, before any of
+      # the cost/join/augmentation logic below runs. Without this, removing
+      # the (now redundant) `Validation` slice from `slice_portfolio()` below
+      # would only stop the COST columns (net_cagr, cum_pnl, cvar_95) from
+      # being computed for Validation -- the base cagr/vol/sharpe/max_dd rows
+      # would still leak through from fm_metrics et al.
+      all_metrics <- all_metrics |> filter(period != "Validation")
+
       # ── Cost metrics (net_cagr, cum_pnl, cvar_95) ─────────────────
       # Compute per strategy per period from raw portfolio returns.
       # cost: 0.20% round-trip per month (full turnover assumed).
@@ -305,11 +329,19 @@ plan_leaderboard <- function() {
       }
 
       # Each portfolio target and its return column (as string) and period slicing params
+      #
+      # NOTE (#648): this function previously also sliced a `Validation`
+      # window (`port_df$date >= params$val_start`) and computed cost metrics
+      # for it on every `tar_make()` -- an automatic-computation violation of
+      # `backtest-partitions.md` ("Validation metrics are NOT computed
+      # automatically"). That slice is removed: the automatic path now only
+      # ever produces Training / Testing / Full Period cost rows. A one-shot
+      # Validation evaluation, when authorised, belongs in
+      # scripts/evaluate_validation.R (never invoked by tar_make()), not here.
       slice_portfolio <- function(port_df, ret_col_name, params) {
         ret <- list(
           Training     = port_df[port_df$date <= params$is_end, ][[ret_col_name]],
           Testing      = port_df[port_df$date >= params$test_start & port_df$date <= params$test_end, ][[ret_col_name]],
-          Validation   = port_df[port_df$date >= params$val_start, ][[ret_col_name]],
           `Full Period` = port_df[[ret_col_name]]
         )
         bind_rows(lapply(names(ret), function(p) {

--- a/R/plan_partitions.R
+++ b/R/plan_partitions.R
@@ -27,6 +27,22 @@
 # in the allowed set, and no `.norm_*` helper in R/plan_leaderboard.R may
 # rename OOS to Testing. Only "Full" -> "Full Period" is a safe rename
 # (pure spelling difference for the same concept — see #643).
+#
+# "Validation" stays in the allowed set (#648 decision) even though the
+# `leaderboard` target's own automatic path may no longer emit a row with
+# this label (R/plan_leaderboard.R strips it at `all_metrics` assembly,
+# guarded by the S14 gate in R/plan_qa_gates.R). PERIOD_LABELS_ALLOWED names
+# the VOCABULARY, not WHERE a label may be computed — those are separate
+# concerns. "Validation" remains legitimate vocabulary because:
+#   1. Several source metrics targets (fm_metrics, drif_metrics,
+#      stk_max_metrics, stk_drif_metrics, xgb_drif_metrics, ltr_metrics,
+#      port_metrics) still compute it in their own right for their own
+#      consumers (e.g. docs/stock-backtest.qmd prose) — out of #648's scope.
+#   2. scripts/evaluate_validation.R, the sanctioned manual one-shot
+#      evaluation route required by backtest-partitions.md, produces rows
+#      labelled "Validation" by design.
+# Removing it from this constant would make both of the above fail S10
+# (check_leaderboard_period_vocab) / any future vocab check applied to them.
 PERIOD_LABELS_ALLOWED <- c(
   "Training", "Testing", "Validation", "Full Period", "OOS"
 )

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -488,18 +488,25 @@ check_leaderboard_period_vocab <- function(leaderboard) {
 #' @section Scope note (#648):
 #' This function is scoped to window BOUNDS on `mf_metrics`/`ev_metrics`
 #' only. #648 identified a systematic, wider version of the same seal-breach
-#' pattern: `slice_portfolio()` in R/plan_leaderboard.R computes an explicit
-#' `Validation` slice on every `tar_make()` for 7 strategies -- not a bounds
-#' violation (those rows are correctly labelled `"Validation"`), but an
-#' automatic-computation violation (`backtest-partitions.md`: "Validation
-#' metrics are NOT computed automatically by tar_make()"). That is a
+#' pattern: `slice_portfolio()` in R/plan_leaderboard.R computed an explicit
+#' `Validation` slice on every `tar_make()` for several strategies -- not a
+#' bounds violation (those rows were correctly labelled `"Validation"`), but
+#' an automatic-computation violation (`backtest-partitions.md`: "Validation
+#' metrics are NOT computed automatically by tar_make()"). That was a
 #' different check -- "no row may be automatically labelled Validation at
-#' all" -- and is out of scope here; #648 handles it separately. If it is
-#' later folded into this same S11 gate, `metrics` already carries `period`,
-#' so a `"no period == 'Validation' row present"` assertion could be added
-#' as a second, independent check inside this function (or as a sibling
-#' function called from the same `qa_metric_window_bounds` target) without
-#' needing to change this function's signature.
+#' all" -- from this function's "no window may silently extend past
+#' test_end".
+#'
+#' #648 was fixed as a SIBLING gate, `check_leaderboard_no_validation_rows()`
+#' (S14), rather than folded into this function, because the two operate on
+#' different shapes: this function takes a single source metrics target
+#' (`mf_metrics`/`ev_metrics`) with a `window_end` column and asserts a
+#' bound; S14 takes the assembled, multi-strategy `leaderboard` target
+#' (same shape as S9/S10) and asserts a label is entirely absent. Forcing
+#' both checks through one function signature would have required either a
+#' new optional `window_end`-less mode or a second call convention -- a
+#' same-shape sibling next to S9/S10 was the smaller change. See S14's own
+#' roxygen block below for the fix.
 #' @noRd
 check_metric_window_bounds <- function(metrics, test_end, source_label) {
   required_cols <- c("strategy", "period", "window_end")
@@ -536,6 +543,78 @@ check_metric_window_bounds <- function(metrics, test_end, source_label) {
       "i" = paste0(
         "Bound the window at test_end in the source metrics target, or ",
         "relabel the period \"Validation\" if the window is intentionally sealed."
+      )
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+
+#' Assert the leaderboard target never emits an automatically-computed
+#' "Validation" row (S14)
+#'
+#' Guards against the #648 defect class: `backtest-partitions.md` requires
+#' Validation metrics to never be computed automatically by `tar_make()` --
+#' only via an explicit manual target or script, exactly once, as a sealed
+#' one-shot evaluation. Two independent sources fed Validation rows into the
+#' `leaderboard` target before #648:
+#'   1. `slice_portfolio()` in R/plan_leaderboard.R computed a `Validation`
+#'      cost-metric slice on every `tar_make()` for six strategies.
+#'   2. Several source metrics targets (fm_metrics, drif_metrics,
+#'      stk_max_metrics, stk_drif_metrics, xgb_drif_metrics, ltr_metrics,
+#'      port_metrics) independently compute a `Validation` row in their own
+#'      plan file, which flowed into `all_metrics` completely unfiltered.
+#' Both are addressed at #648 by dropping every `period == "Validation"` row
+#' the moment `all_metrics` is assembled in R/plan_leaderboard.R -- this gate
+#' is the belt-and-braces check that the `leaderboard` target itself never
+#' re-exposes one, regardless of which upstream source (existing or future)
+#' reintroduces it.
+#'
+#' This is a distinct check from S11 (`check_metric_window_bounds()`): S11
+#' asserts a per-strategy source metrics target's own bespoke window never
+#' extends past `test_end` UNLESS it is correctly labelled "Validation" (a
+#' bounds check on a single source target with a `window_end` column). This
+#' gate asserts the opposite direction on the assembled, multi-strategy
+#' `leaderboard` target: no row may be labelled "Validation" at all, because
+#' that target's whole path is automatic. See S11's `@section Scope note
+#' (#648)` for why these are two gates rather than one.
+#'
+#' Note: the source metrics targets listed above (fm_metrics et al.) still
+#' compute Validation rows for their OWN purposes -- that is out of #648's
+#' scope (those targets are not modified here) and several also surface
+#' Validation values directly in vignette prose (e.g. docs/stock-backtest.qmd),
+#' which is a separate, wider display-side leak not covered by this gate.
+#' This gate only guarantees the `leaderboard` target's own output.
+#'
+#' @param leaderboard Tibble with at least `strategy`, `period` columns (the
+#'   output of the `leaderboard` targets pipeline target).
+#' @return `TRUE` invisibly on success.
+#' @noRd
+check_leaderboard_no_validation_rows <- function(leaderboard) {
+  required_cols <- c("strategy", "period")
+  missing_cols <- setdiff(required_cols, names(leaderboard))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "Leaderboard is missing {length(missing_cols)} required column(s): {missing_cols}.",
+      "i" = "check_leaderboard_no_validation_rows() (S14) requires strategy, period."
+    ))
+  }
+
+  offenders <- unique(leaderboard$strategy[leaderboard$period == "Validation"])
+
+  if (length(offenders) > 0L) {
+    cli::cli_abort(c(
+      "x" = paste0(
+        "Leaderboard has ", length(offenders),
+        " strategy/strategies with an automatically-computed {.val Validation} row, #648:"
+      ),
+      setNames(sprintf("  %s", offenders), rep("i", length(offenders))),
+      "i" = paste0(
+        "Validation metrics must NOT be computed automatically by tar_make() ",
+        "(.claude/rules/backtest-partitions.md). Drop the Validation row at ",
+        "the point it enters R/plan_leaderboard.R's `all_metrics`, or use ",
+        "scripts/evaluate_validation.R for a one-shot manual evaluation."
       )
     ))
   }
@@ -942,6 +1021,23 @@ plan_qa_gates <- function() {
       command = {
         check_portfolio_join_coverage(port_returns)
         cli::cli_inform(c("v" = "qa_portfolio_join_coverage: S13 passed (no calendar-month gaps in port_returns)"))
+        TRUE
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: leaderboard never emits an automatically-computed Validation
+    # row (S14) — guards against the #648 defect class where
+    # `slice_portfolio()` in R/plan_leaderboard.R and several source metrics
+    # targets (fm_metrics, drif_metrics, stk_max_metrics, stk_drif_metrics,
+    # xgb_drif_metrics, ltr_metrics, port_metrics) fed a "Validation" period
+    # row into the leaderboard on every tar_make() — an automatic-computation
+    # violation of the sealed-partition rule (backtest-partitions.md).
+    targets::tar_target(
+      qa_leaderboard_no_validation,
+      command = {
+        check_leaderboard_no_validation_rows(leaderboard)
+        cli::cli_inform(c("v" = "qa_leaderboard_no_validation: S14 passed (no automatically-computed Validation row in leaderboard)"))
         TRUE
       },
       cue = targets::tar_cue(mode = "always")

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -312,7 +312,12 @@ if (!is.null(lb)) {
 
 ```{r}
 if (!is.null(lb)) {
-  # NEVER show Validation data — sealed envelope (backtest-partitions rule)
+  # NEVER show Validation data — sealed envelope (backtest-partitions rule).
+  # As of #648, the `leaderboard` target itself no longer emits Validation
+  # rows (R/plan_leaderboard.R strips them at assembly), so the
+  # `filter(period != "Validation")` below is now belt-and-braces rather
+  # than the sole control -- kept so this display never regresses even if
+  # a future upstream change reintroduces a Validation row.
   params <- safe_tar_read("stk_params")
 
   # Create years lookup

--- a/scripts/evaluate_validation.R
+++ b/scripts/evaluate_validation.R
@@ -1,0 +1,144 @@
+# Manual, one-shot Validation-partition evaluation (#648)
+#
+# ============================================================================
+# READ THIS BEFORE RUNNING
+# ============================================================================
+#
+# `.claude/rules/backtest-partitions.md` requires that Validation metrics are
+# NEVER computed automatically by `tar_make()` — only via an explicit manual
+# target or script, run ONCE, as a final one-shot evaluation before a
+# production decision:
+#
+#   "Once you look at validation results and change the strategy, the
+#    validation partition becomes another test set — the seal is broken."
+#
+# This script IS that sanctioned manual route. It is intentionally NOT
+# sourced by docs/_targets.R and is NEVER invoked by `tar_make()` — running
+# it is a deliberate act, not a pipeline side-effect. Confirm before running:
+#
+#   1. You are making (or directly informing) a production go/no-go decision
+#      for the strategies below — not idle curiosity, not "just checking".
+#   2. You have NOT already seen these Validation numbers this cycle (if you
+#      have, e.g. from a scratch `tar_read()`, the seal for THAT cycle is
+#      already broken — see JohnGavin/historical#648's own disclosure).
+#   3. You will NOT tune, reselect, or otherwise change the strategy after
+#      seeing these numbers. If you do, this is no longer a Validation
+#      partition — it has become another Testing partition, and any future
+#      claim of "sealed one-shot evaluation" for these strategies is false.
+#
+# If any of the above is not true, STOP. Do not run this script.
+#
+# Usage:
+#   Rscript scripts/evaluate_validation.R
+#
+# Requires a built targets store (docs/_targets or _targets) containing
+# bt_partitions, fm_portfolio, drif_portfolio, stk_max_portfolio,
+# stk_drif_portfolio, xgb_drif_portfolio, port_returns, port_optimal_weights.
+# It only READS the store — it never calls tar_make().
+# ============================================================================
+
+library(targets)
+library(dplyr)
+library(cli)
+
+source(here::here("R/utils_metrics.R"))
+
+store <- if (dir.exists("docs/_targets")) "docs/_targets" else "_targets"
+
+cli_h1("Manual Validation Evaluation (#648) — SEALED PARTITION")
+cli_alert_warning(paste0(
+  "Running this script consumes the one-shot Validation seal for every ",
+  "strategy below, per .claude/rules/backtest-partitions.md. If you have ",
+  "not read the header comment in this file, stop and read it now."
+))
+cat("Store:", store, "\n\n")
+
+bt_partitions <- tar_read_raw("bt_partitions", store = store)
+
+# COST_PER_MONTH mirrors R/plan_leaderboard.R's calc_cost_metrics() — kept
+# in sync manually since that function is a private closure inside the
+# `leaderboard` target and not exported. If the convention there changes,
+# update this value too.
+COST_PER_MONTH <- 0.002
+
+calc_cost_metrics <- function(ret) {
+  ret <- ret[!is.na(ret)]
+  n <- length(ret)
+  if (n == 0L) {
+    return(tibble(net_cagr = NA_real_, cum_pnl = NA_real_, cvar_95 = NA_real_))
+  }
+  net_ret <- ret * (1 - COST_PER_MONTH)
+  net_cagr <- prod(1 + net_ret)^(12 / n) - 1
+  cum_pnl_net <- prod(1 + net_ret) - 1
+  q05 <- quantile(ret, 0.05)
+  cvar_95 <- mean(ret[ret <= q05])
+  tibble(net_cagr = net_cagr, cum_pnl = cum_pnl_net, cvar_95 = cvar_95)
+}
+
+# One Validation row for a strategy's portfolio-return series, bounded at
+# val_start with no upper bound — matches R/plan_leaderboard.R's
+# `slice_portfolio()` convention (`date >= params$val_start`).
+validation_row <- function(strategy, port_df, ret_col_name, val_start) {
+  if (is.null(port_df) || !ret_col_name %in% names(port_df)) {
+    cli_alert_danger("{strategy}: source portfolio target missing or lacks column {.field {ret_col_name}} — skipped.")
+    return(NULL)
+  }
+  val_data <- port_df[port_df$date >= val_start, ]
+  ret <- val_data[[ret_col_name]]
+  ann <- annualise_returns(ret, periods_per_year = 12L)
+  cost <- calc_cost_metrics(ret)
+  tibble(
+    strategy = strategy,
+    period = "Validation",
+    months = ann$n,
+    cagr = ann$cagr, vol = ann$vol, sharpe = ann$sharpe, max_dd = ann$max_dd,
+    net_cagr = cost$net_cagr, cum_pnl = cost$cum_pnl, cvar_95 = cost$cvar_95
+  )
+}
+
+fm_portfolio       <- tryCatch(tar_read_raw("fm_portfolio", store = store), error = function(e) NULL)
+drif_portfolio     <- tryCatch(tar_read_raw("drif_portfolio", store = store), error = function(e) NULL)
+stk_max_portfolio  <- tryCatch(tar_read_raw("stk_max_portfolio", store = store), error = function(e) NULL)
+stk_drif_portfolio <- tryCatch(tar_read_raw("stk_drif_portfolio", store = store), error = function(e) NULL)
+xgb_drif_portfolio <- tryCatch(tar_read_raw("xgb_drif_portfolio", store = store), error = function(e) NULL)
+port_returns          <- tryCatch(tar_read_raw("port_returns", store = store), error = function(e) NULL)
+port_optimal_weights  <- tryCatch(tar_read_raw("port_optimal_weights", store = store), error = function(e) NULL)
+
+val_start_factor <- bt_partitions$factor$val_start
+val_start_equity <- bt_partitions$equity$val_start
+
+rows <- list(
+  validation_row("Factor MAX",  fm_portfolio,       "portfolio_ret", val_start_factor),
+  validation_row("Factor DRIF", drif_portfolio,     "portfolio_ret", val_start_factor),
+  validation_row("Stock MAX",   stk_max_portfolio,  "port_ret",      val_start_equity),
+  validation_row("Stock DRIF",  stk_drif_portfolio, "port_ret",      val_start_equity),
+  validation_row("XGB DRIF",    xgb_drif_portfolio, "port_ret",      val_start_equity)
+)
+
+# PSO Optimal — derive from port_returns + the optimal weights, mirroring
+# R/plan_leaderboard.R's own PSO Optimal cost-slice construction.
+if (!is.null(port_returns) && !is.null(port_optimal_weights)) {
+  w <- port_optimal_weights
+  strat_cols <- names(w)
+  opt_returns_df <- port_returns |>
+    filter(if_all(all_of(strat_cols), ~ !is.na(.x))) |>
+    mutate(opt_ret = as.numeric(as.matrix(pick(all_of(strat_cols))) %*% w))
+  rows[[length(rows) + 1L]] <- validation_row(
+    "PSO Optimal", opt_returns_df, "opt_ret", val_start_equity
+  )
+} else {
+  cli_alert_warning("PSO Optimal: port_returns or port_optimal_weights missing from store — skipped.")
+}
+
+validation_metrics <- bind_rows(rows)
+
+cli_h2("Validation partition results — SEALED, one-shot")
+print(validation_metrics)
+
+cli_alert_warning(paste0(
+  "These numbers now count as SEEN. Do not tune, reselect, or otherwise ",
+  "change any of the strategies above based on this output — doing so ",
+  "breaks the seal (.claude/rules/backtest-partitions.md)."
+))
+
+invisible(validation_metrics)

--- a/tests/testthat/_snaps/leaderboard-no-validation.md
+++ b/tests/testthat/_snaps/leaderboard-no-validation.md
@@ -1,0 +1,31 @@
+# check_leaderboard_no_validation_rows throws when one strategy has a Validation row
+
+    Code
+      check_leaderboard_no_validation_rows(one_validation_row_leaderboard)
+    Condition
+      Error in `check_leaderboard_no_validation_rows()`:
+      x Leaderboard has 1 strategy/strategies with an automatically-computed "Validation" row, #648:
+      i  Stock DRIF
+      i Validation metrics must NOT be computed automatically by tar_make() (.claude/rules/backtest-partitions.md). Drop the Validation row at the point it enters R/plan_leaderboard.R's `all_metrics`, or use scripts/evaluate_validation.R for a one-shot manual evaluation.
+
+# check_leaderboard_no_validation_rows names every offending strategy
+
+    Code
+      check_leaderboard_no_validation_rows(multi_validation_leaderboard)
+    Condition
+      Error in `check_leaderboard_no_validation_rows()`:
+      x Leaderboard has 3 strategy/strategies with an automatically-computed "Validation" row, #648:
+      i  Factor MAX
+      i  Stock DRIF
+      i  XGB DRIF
+      i Validation metrics must NOT be computed automatically by tar_make() (.claude/rules/backtest-partitions.md). Drop the Validation row at the point it enters R/plan_leaderboard.R's `all_metrics`, or use scripts/evaluate_validation.R for a one-shot manual evaluation.
+
+# check_leaderboard_no_validation_rows throws when required columns are missing
+
+    Code
+      check_leaderboard_no_validation_rows(bad)
+    Condition
+      Error in `check_leaderboard_no_validation_rows()`:
+      x Leaderboard is missing 1 required column(s): period.
+      i check_leaderboard_no_validation_rows() (S14) requires strategy, period.
+

--- a/tests/testthat/test-leaderboard-no-validation.R
+++ b/tests/testthat/test-leaderboard-no-validation.R
@@ -1,0 +1,104 @@
+testthat::local_edition(3)
+# Tests for check_leaderboard_no_validation_rows() — QA gate S14 (#648)
+#
+# The function is defined in R/plan_qa_gates.R. Tests exercise the gate
+# directly without running tar_make().
+#
+# Background (#648): `slice_portfolio()` in R/plan_leaderboard.R computed an
+# explicit "Validation" cost-metric slice on every tar_make() for six
+# strategies, and several source metrics targets (fm_metrics, drif_metrics,
+# stk_max_metrics, stk_drif_metrics, xgb_drif_metrics, ltr_metrics,
+# port_metrics) independently fed a "Validation" row into the leaderboard's
+# `all_metrics`, unfiltered -- an automatic-computation violation of
+# `.claude/rules/backtest-partitions.md` ("Validation metrics are NOT
+# computed automatically by tar_make()"). This gate catches a recurrence of
+# either source: any "Validation" row reaching the assembled `leaderboard`
+# target's own output.
+
+source(here::here("R/plan_qa_gates.R"))
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+good_leaderboard <- tibble::tibble(
+  strategy = c(
+    "Factor MAX", "Factor MAX", "Factor MAX",
+    "Stock DRIF", "Stock DRIF", "Stock DRIF"
+  ),
+  period = c(
+    "Training", "Testing", "Full Period",
+    "Training", "Testing", "Full Period"
+  )
+)
+
+# One strategy has a Validation row -- the #648 regression itself: a source
+# metrics target (or slice_portfolio()) fed a Validation row through
+# unfiltered.
+one_validation_row_leaderboard <- tibble::tibble(
+  strategy = c(
+    "Factor MAX", "Factor MAX", "Factor MAX",
+    "Stock DRIF", "Stock DRIF", "Stock DRIF", "Stock DRIF"
+  ),
+  period = c(
+    "Training", "Testing", "Full Period",
+    "Training", "Testing", "Full Period", "Validation"
+  )
+)
+
+# Multiple strategies leaking Validation rows -- the actual #648 evidence
+# shape (7 strategies with a Validation row in the built store).
+multi_validation_leaderboard <- tibble::tibble(
+  strategy = c(
+    "Factor MAX", "Factor MAX", "Stock DRIF", "Stock DRIF", "XGB DRIF"
+  ),
+  period = c(
+    "Full Period", "Validation", "Full Period", "Validation", "Validation"
+  )
+)
+
+# ── Tests: passes when no Validation row is present ──────────────────────────
+
+test_that("check_leaderboard_no_validation_rows passes when no strategy has a Validation row", {
+  expect_true(check_leaderboard_no_validation_rows(good_leaderboard))
+})
+
+# ── Tests: throws when a Validation row leaks through ────────────────────────
+
+test_that("check_leaderboard_no_validation_rows throws when one strategy has a Validation row", {
+  expect_error(
+    check_leaderboard_no_validation_rows(one_validation_row_leaderboard),
+    regexp = "Stock DRIF"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_no_validation_rows(one_validation_row_leaderboard)
+  )
+})
+
+test_that("check_leaderboard_no_validation_rows names every offending strategy", {
+  expect_error(
+    check_leaderboard_no_validation_rows(multi_validation_leaderboard),
+    regexp = "Factor MAX"
+  )
+  expect_error(
+    check_leaderboard_no_validation_rows(multi_validation_leaderboard),
+    regexp = "XGB DRIF"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_no_validation_rows(multi_validation_leaderboard)
+  )
+})
+
+# ── Tests: required columns ───────────────────────────────────────────────────
+
+test_that("check_leaderboard_no_validation_rows throws when required columns are missing", {
+  bad <- dplyr::select(good_leaderboard, -period)
+  expect_error(
+    check_leaderboard_no_validation_rows(bad),
+    regexp = "period"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_no_validation_rows(bad)
+  )
+})


### PR DESCRIPTION
## Summary

- Fixes #648. `slice_portfolio()` in `R/plan_leaderboard.R` computed an explicit `Validation` cost-metric slice on every `tar_make()` for six strategies — an automatic-computation violation of `.claude/rules/backtest-partitions.md` ("Validation metrics are NOT computed automatically by tar_make()").
- **Tracing every consumer surfaced a wider issue than the literal defect the issue named.** Several source metrics targets — `fm_metrics` (`R/plan_factormax.R`), `drif_metrics` (`R/plan_drif.R`), `stk_max_metrics`/`stk_drif_metrics`/`xgb_drif_metrics` (`R/plan_stock_backtest.R`), `ltr_metrics` (`R/plan_ltr_momentum.R`), `port_metrics` (`R/plan_portfolio_opt.R`) — already compute their own `Validation` row internally and feed it into `all_metrics`/`leaderboard` completely **unfiltered** via `add_meta()`/`bind_rows()`. Removing only the `slice_portfolio()` slice would **not** have removed the 7 `Validation` rows the issue's own evidence table shows in `tar_read(leaderboard)` — those base `cagr`/`vol`/`sharpe`/`max_dd` rows come from the sources above, not from `slice_portfolio()` (which only adds `net_cagr`/`cum_pnl`/`cvar_95` cost columns via a `left_join`, which cannot create new rows).

## What changed

1. **`R/plan_leaderboard.R`**
   - Removed the `Validation` slice from `slice_portfolio()` (the literal defect named in #648).
   - Added `all_metrics <- all_metrics |> filter(period != "Validation")` immediately after the base rows (including PSO Optimal) are assembled, before any cost/join/augmentation logic runs. This is what actually makes the `leaderboard` target's own output free of Validation rows regardless of which upstream source produced them.
   - The upstream source targets (`fm_metrics` et al.) are **NOT modified** — that is out of #648's scope. Several of them already surface Validation values directly in vignette prose (e.g. `docs/stock-backtest.qmd` lines 121, 127, 132–134, 148, 286, 429, 542 read `m$sharpe[m$period=="Validation"]` etc. with no filter) — **this is a separate, wider display-side leak, not fixed here.** Flagging for a follow-up issue.

2. **`scripts/evaluate_validation.R`** (new) — the sanctioned manual one-shot route `backtest-partitions.md` requires. Never sourced by `docs/_targets.R` or root `_targets.R` (confirmed by grep). Prints a prominent warning citing the rule before and after computing, and documents at the top exactly when it is legitimate to run.

3. **`R/plan_qa_gates.R`** — new QA gate S14, `check_leaderboard_no_validation_rows(leaderboard)`, wired as `qa_leaderboard_no_validation`. Asserts the assembled `leaderboard` target never contains a `period == "Validation"` row. I chose a **sibling to S9/S10** rather than folding into S11 (`check_metric_window_bounds`), because S11 operates on a single-strategy metrics tibble with a `window_end` column (a bounds check), while this needs the assembled multi-strategy `leaderboard` shape (`strategy`, `period` only) — same shape as S9/S10, different shape from S11. Amended S11's own `@section Scope note (#648)` to point at S14 instead of leaving the question open.

4. **`R/plan_partitions.R`** — documented, rather than silently decided, that `PERIOD_LABELS_ALLOWED` **keeps** `"Validation"`. The constant names the vocabulary, not where a label may be computed; the source targets above and the new manual script both still legitimately produce `"Validation"` rows.

5. **`docs/leaderboard.qmd:315`** — updated the comment above the `filter(period != "Validation")` at line 339 to describe reality: that filter is now belt-and-braces (the `leaderboard` target itself is sealed), not the sole control. The partition-definition reference table at `:979` was left as-is — it describes the partition scheme itself (dates + purpose), not computed metrics, and was already accurate.

6. **`tests/testthat/test-leaderboard-no-validation.R`** (new, `local_edition(3)`) + `_snaps/leaderboard-no-validation.md` — snapshot coverage for the new gate's `cli_abort` messages, per `snapshot-test-policy`.

## Explicitly out of scope (not touched)

- The digest snapshot parquet purge (#655) — `packages/historicaldata/inst/extdata/digest/` untouched.
- The "`Full Period` spans validation" question raised in the issue's second comment — that's a rule-level decision (whether a whole-sample aggregate that includes the sealed window is permitted), not code. Not decided here; flagging for a `.claude/rules/backtest-partitions.md` clause as the issue itself suggests.
- The wider Validation leak in `fm_metrics`/`drif_metrics`/`stk_max_metrics`/`stk_drif_metrics`/`xgb_drif_metrics`/`ltr_metrics`/`port_metrics` and their direct display in `docs/stock-backtest.qmd` — discovered while tracing consumers, arguably a bigger version of #648, but out of the scope I was given. Recommend a follow-up issue.

## Verification

`scripts/verify.sh` (foreground, full mode) — **PASS**:

```
PASS: _targets.R parses (verified tree: .../fix/648-seal-validation-partition worktree)
PASS: testthat edition 3 active

=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

=== scripts/verify.sh: PASS ===
```

Root suite total=351 (up from baseline, includes the 4 new S14 tests, all passing). Package suite total=686, unchanged failure/skip set.

**Not verified — I could not run `tar_make()`** (out of scope per dispatch: read-only on the built store). So I cannot show `tar_read(leaderboard)` actually losing its 7 Validation rows in a fresh build. The fix is verified by:
- Static trace of every code path that feeds `all_metrics`/`leaderboard` (confirmed via grep across `R/`, `docs/`, `tests/`).
- Unit tests on the new gate function in isolation (it correctly fails on fixtures shaped like the real leak and passes on clean fixtures).
- `parse("_targets.R")` succeeding with the new target wired in.

A `tar_make()` + `tar_read(leaderboard)` check confirming zero Validation rows in a real build is the natural next verification step, for whoever runs the pipeline next.

## Test plan

- [x] `scripts/verify.sh` full mode — PASS, matches known baselines exactly
- [x] New QA gate has unit tests + snapshot coverage
- [ ] `tar_make()` + `tar_read(leaderboard)` confirms 0 Validation rows (not run — read-only scope)
- [ ] Reviewer decision on the two flagged follow-ups (wider source-target leak; Full Period rule clause)
