### PR TITLE
fix(docs): unpublish sealed Validation metrics from stock-backtest.qmd (#660)

### DIFF
--- a/.claude/rules/backtest-partitions.md
+++ b/.claude/rules/backtest-partitions.md
@@ -50,19 +50,6 @@ plan_partitions <- function() {
 - Once you look at validation results and change the strategy, the validation partition becomes another test set — the seal is broken
 - Document in the vignette which partition each metric comes from
 
-**The seal covers display and reasoning, not only computation.** A source
-metrics target may legitimately compute a `"Validation"` row for other
-consumers (e.g. `scripts/evaluate_validation.R`) — that is not itself a
-violation. The violation is reading that row into a **published document**
-(a rendered `.qmd`, a table, a prose sentence) or drawing a **conclusion**
-from it (a Pros/Cons verdict, a "generalisation has/hasn't held" claim). Both
-are breaches of the seal even when no code change followed, because the
-partition's value depends on the values never having been looked at
-(#660). Every published document is scanned for a literal
-`period == "Validation"` read by the `qa_no_published_validation_reads`
-gate (S15, `R/plan_qa_gates.R`) — the sanctioned exception is
-`scripts/evaluate_validation.R`, the one-shot manual evaluation route.
-
 ## Metrics Labelling
 
 Every metrics table MUST label the partition:

--- a/.claude/rules/backtest-partitions.md
+++ b/.claude/rules/backtest-partitions.md
@@ -50,6 +50,19 @@ plan_partitions <- function() {
 - Once you look at validation results and change the strategy, the validation partition becomes another test set — the seal is broken
 - Document in the vignette which partition each metric comes from
 
+**The seal covers display and reasoning, not only computation.** A source
+metrics target may legitimately compute a `"Validation"` row for other
+consumers (e.g. `scripts/evaluate_validation.R`) — that is not itself a
+violation. The violation is reading that row into a **published document**
+(a rendered `.qmd`, a table, a prose sentence) or drawing a **conclusion**
+from it (a Pros/Cons verdict, a "generalisation has/hasn't held" claim). Both
+are breaches of the seal even when no code change followed, because the
+partition's value depends on the values never having been looked at
+(#660). Every published document is scanned for a literal
+`period == "Validation"` read by the `qa_no_published_validation_reads`
+gate (S15, `R/plan_qa_gates.R`) — the sanctioned exception is
+`scripts/evaluate_validation.R`, the one-shot manual evaluation route.
+
 ## Metrics Labelling
 
 Every metrics table MUST label the partition:

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -623,6 +623,68 @@ check_leaderboard_no_validation_rows <- function(leaderboard) {
 }
 
 
+#' Scan published documents for reads of the sealed Validation partition (S15)
+#'
+#' Guards against the #660 defect class: `docs/stock-backtest.qmd` read
+#' `period == "Validation"` directly from upstream source-metrics targets
+#' (`stk_drif_metrics`, `stk_max_metrics`, `fm_metrics`, `drif_metrics`,
+#' `etf_a_metrics`, `etf_b_metrics`) in inline R expressions and in
+#' unfiltered metrics tables -- publishing sealed one-shot evaluation
+#' figures in prose and table cells, and in one case (the Stock DRIF Cons
+#' cell) drawing a strategy conclusion from them. This entirely bypassed
+#' the `leaderboard` target and its S14 gate (`check_leaderboard_no_validation_rows()`),
+#' because these reads went straight to the source metrics targets, which
+#' still legitimately compute a Validation row for other consumers (that
+#' computation is out of scope here and is not touched by this gate).
+#'
+#' `.claude/rules/backtest-partitions.md` requires Validation to be sealed
+#' from *display and reasoning*, not only from automatic computation --
+#' S14's scope was the assembled `leaderboard` target only. This gate
+#' extends the seal to every published document by scanning for the
+#' literal `period == "Validation"` (or `period=="Validation"`) comparison,
+#' the idiom every #660 offending site shared.
+#'
+#' Known limitation (documented, not silently accepted): this is a lexical
+#' scan, like S1-S4 (`check_no_lead_ym()` et al.). A comparison built from a
+#' variable (e.g. `m$period == per` where `per` is later passed the string
+#' `"Validation"` at a call site) will NOT be caught by this pattern -- the
+#' #660 fix removed the one site in this codebase that did this (the
+#' `get_val()` helper in `docs/stock-backtest.qmd`'s headline callout) in
+#' favour of the literal idiom used everywhere else in the file, so no such
+#' site currently exists to miss.
+#'
+#' Exclusions (both required for the scan to be usable at all):
+#'   - `R/plan_qa_gates.R` itself -- this function's own roxygen block and
+#'     `check_leaderboard_no_validation_rows()` (S14) both name the literal
+#'     pattern `period == "Validation"` in comments/code; same
+#'     self-exclusion convention as `qa_look_ahead_bias` (S1-S4).
+#'   - `scripts/evaluate_validation.R` -- the sanctioned one-shot manual
+#'     evaluation route (#648). It does not currently use a `period ==`
+#'     comparison (it *assigns* `period = "Validation"` when building its
+#'     result rows), so today this exclusion is defensive rather than
+#'     load-bearing -- but the script's whole purpose is to read the
+#'     Validation partition, so it must never be flagged if its
+#'     implementation changes to filter its own output by period.
+#'
+#' Opt-out: append `# validation-read-safe` to a line reading Validation
+#' for a purpose that is not a published display of the metric (rare;
+#' document why in the comment).
+#'
+#' @param files Character vector of absolute file paths to scan (.qmd, .R).
+#' @return A tibble with columns file, line, code. Zero rows = no hits.
+#' @noRd
+check_no_published_validation_reads <- function(files) {
+  results <- purrr::map(files, function(f) {
+    lines <- readLines(f, warn = FALSE)
+    m <- grep("period\\s*==\\s*[\"']Validation[\"']", lines)
+    m <- m[!grepl("# validation-read-safe", lines[m], fixed = TRUE)]
+    if (length(m) == 0L) return(NULL)
+    tibble::tibble(file = f, line = m, code = lines[m])
+  })
+  dplyr::bind_rows(results)
+}
+
+
 #' Assert a monthly portfolio target has complete calendar-month coverage (S12)
 #'
 #' Guards against the #641 defect class: a systematic construction bug (a
@@ -1039,6 +1101,52 @@ plan_qa_gates <- function() {
         check_leaderboard_no_validation_rows(leaderboard)
         cli::cli_inform(c("v" = "qa_leaderboard_no_validation: S14 passed (no automatically-computed Validation row in leaderboard)"))
         TRUE
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: no published document reads the sealed Validation partition
+    # (S15) — guards against the #660 defect class where docs/stock-backtest.qmd
+    # read `period == "Validation"` directly from source-metrics targets in
+    # prose and unfiltered metrics tables, bypassing the leaderboard target
+    # (and its S14 gate) entirely. Extends S14's leaderboard-only scope to
+    # every published .qmd/.R, per the display-and-reasoning clause this
+    # issue adds to backtest-partitions.md. See check_no_published_validation_reads()
+    # roxygen for the two required exclusions (this file; scripts/evaluate_validation.R).
+    targets::tar_target(
+      qa_no_published_validation_reads,
+      command = {
+        scan_dirs <- c(here::here("docs"), here::here("R"), here::here("scripts"))
+        scan_dirs <- scan_dirs[dir.exists(scan_dirs)]
+        files <- unlist(lapply(scan_dirs, function(d) {
+          list.files(d, pattern = "\\.(qmd|R)$", full.names = TRUE, recursive = TRUE)
+        }))
+        files <- files[basename(files) != "plan_qa_gates.R"]
+        files <- files[basename(files) != "evaluate_validation.R"]
+
+        hits <- check_no_published_validation_reads(files)
+        if (nrow(hits) > 0L) {
+          msgs <- purrr::pmap_chr(
+            hits[, c("file", "line", "code")],
+            function(file, line, code) {
+              sprintf("  %s:%d -- %s", basename(file), line, trimws(code))
+            }
+          )
+          cli::cli_abort(c(
+            "x" = paste0(
+              "Published document(s) read the sealed Validation partition in ",
+              nrow(hits), " place(s), #660:"
+            ),
+            setNames(msgs, rep("i", length(msgs))),
+            "i" = paste0(
+              "Validation is sealed for display AND reasoning ",
+              "(.claude/rules/backtest-partitions.md) -- remove the read, or use ",
+              "scripts/evaluate_validation.R for the sanctioned one-shot evaluation."
+            )
+          ))
+        }
+        cli::cli_inform(c("v" = "qa_no_published_validation_reads: S15 passed (no published document reads Validation)"))
+        nrow(hits)
       },
       cue = targets::tar_cue(mode = "always")
     )

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -637,8 +637,8 @@ check_leaderboard_no_validation_rows <- function(leaderboard) {
 #' still legitimately compute a Validation row for other consumers (that
 #' computation is out of scope here and is not touched by this gate).
 #'
-#' `.claude/rules/backtest-partitions.md` requires Validation to be sealed
-#' from *display and reasoning*, not only from automatic computation --
+#' `.claude/rules/backtest-partitions.md` requires Validation to stay sealed
+#' everywhere it could leak -- not only in automatic computation --
 #' S14's scope was the assembled `leaderboard` target only. This gate
 #' extends the seal to every published document by scanning for the
 #' literal `period == "Validation"` (or `period=="Validation"`) comparison,
@@ -1110,8 +1110,8 @@ plan_qa_gates <- function() {
     # read `period == "Validation"` directly from source-metrics targets in
     # prose and unfiltered metrics tables, bypassing the leaderboard target
     # (and its S14 gate) entirely. Extends S14's leaderboard-only scope to
-    # every published .qmd/.R, per the display-and-reasoning clause this
-    # issue adds to backtest-partitions.md. See check_no_published_validation_reads()
+    # every published .qmd/.R, per the sealed-Validation requirement in
+    # backtest-partitions.md. See check_no_published_validation_reads()
     # roxygen for the two required exclusions (this file; scripts/evaluate_validation.R).
     targets::tar_target(
       qa_no_published_validation_reads,

--- a/docs/stock-backtest.qmd
+++ b/docs/stock-backtest.qmd
@@ -101,10 +101,13 @@ if (!is.null(stk_max) && !is.null(stk_drif) && !is.null(fac_max) && !is.null(fac
     make_row(stk_drif, "Stock DRIF"),
     make_row(fac_max, "Factor MAX"),
     make_row(fac_drif, "Factor DRIF")
-  )
+  ) |>
+    filter(Period != "Validation")
 
   hd_dt(all_metrics, paste0(
-    "All strategies by partition (Training / Testing / Validation / Full). ",
+    "All strategies by partition (Training / Testing / Full). ",
+    "Validation is sealed — not reported until a one-shot production evaluation ",
+    "(see `scripts/evaluate_validation.R`). ",
     "Factor-level links: Factor MAX, Factor DRIF. ",
     "Stock MAX and Stock DRIF draw on `stk_universe` (survivorship-biased — see issue #150)."
   ))
@@ -118,20 +121,20 @@ if (!is.null(stk_max) && !is.null(stk_drif) && !is.null(fac_max) && !is.null(fac
 | Finding | Evidence |
 |---------|----------|
 | Stock MAX full-period CAGR: `r { m <- safe_tar_read("stk_max_metrics"); v <- if(!is.null(m)) m$cagr[m$period=="Full Period"] else numeric(0); if(length(v)==1L) paste0(round(v*100,1),"%") else "N/A" }` | Vol: `r { m <- safe_tar_read("stk_max_metrics"); v <- if(!is.null(m)) m$vol[m$period=="Full Period"] else numeric(0); if(length(v)==1L) paste0(round(v*100,0),"%") else "N/A" }` — full-period Sharpe: `r { m <- safe_tar_read("stk_max_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Full Period"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` |
-| Factor DRIF full-period Sharpe: `r { m <- safe_tar_read("drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Full Period"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` | Full-period covers the entire sample including Training. Validation Sharpe: `r { m <- safe_tar_read("drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` |
+| Factor DRIF full-period Sharpe: `r { m <- safe_tar_read("drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Full Period"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` | Full-period covers the entire sample including Training. Validation Sharpe is sealed — not reported until a one-shot production evaluation (see `scripts/evaluate_validation.R`). |
 | Stock DRIF full-period CAGR is only `r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }` | Elastic net regularisation is very aggressive at stock level |
 
 **Out-of-Sample / Validation**
 
 ::: {.callout-warning}
-**Current Validation Sharpe (sealed partition):** `r { get_val <- function(tgt, col, per) { m <- safe_tar_read(tgt); v <- if (!is.null(m)) m[[col]][m$period == per] else numeric(0); if (length(v) == 1L) round(v, 2) else "N/A" }; paste0("Stock DRIF: ", get_val("stk_drif_metrics","sharpe","Validation"), " | Stock MAX: ", get_val("stk_max_metrics","sharpe","Validation"), " | Factor MAX: ", get_val("fm_metrics","sharpe","Validation"), " | Factor DRIF: ", get_val("drif_metrics","sharpe","Validation")) }`. Validation Sharpe values are shown above for each strategy. The Testing partition OOS results (below) reflect the calibration window used during strategy development, not the sealed evaluation.
+**Validation (sealed partition):** Validation Sharpe for these strategies is not reported on this page — it is sealed until a one-shot production evaluation (see `scripts/evaluate_validation.R`). The Testing partition OOS results (below) reflect the calibration window used during strategy development, not the sealed evaluation.
 :::
 
 | Finding | Evidence |
 |---------|----------|
-| Stock DRIF Testing-period Sharpe during elastic net development: `r { m <- safe_tar_read("stk_drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Testing"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` | Validation Sharpe is `r { m <- safe_tar_read("stk_drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` — `r { mt <- safe_tar_read("stk_drif_metrics"); vt <- if(!is.null(mt)) mt$sharpe[mt$period=="Testing"] else numeric(0); vv <- if(!is.null(mt)) mt$sharpe[mt$period=="Validation"] else numeric(0); if(length(vt)==1L && length(vv)==1L && is.finite(vt) && is.finite(vv)) { if(vv >= vt) "Validation Sharpe met or exceeded Testing." else "Validation Sharpe was lower than Testing." } else "Validation vs Testing comparison unavailable." }` |
-| Factor MAX Testing-period Sharpe: `r { m <- safe_tar_read("fm_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Testing"],2) else "N/A" }` | Single-signal approach at factor level; Validation Sharpe: `r { m <- safe_tar_read("fm_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` |
-| Stock MAX OOS CAGR looks extreme (`r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Testing"]*100,0),"%") else "N/A" }`) | Driven by COVID recovery + meme stocks — Validation CAGR: `r { m <- safe_tar_read("stk_max_metrics"); v <- if(!is.null(m)) m$cagr[m$period=="Validation"] else numeric(0); if(length(v)==1L) paste0(round(v*100,1),"%") else "N/A" }` |
+| Stock DRIF Testing-period Sharpe during elastic net development: `r { m <- safe_tar_read("stk_drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Testing"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` | Testing period reflects the calibration window used during development. Validation is sealed — not reported (see `scripts/evaluate_validation.R`). |
+| Factor MAX Testing-period Sharpe: `r { m <- safe_tar_read("fm_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Testing"],2) else "N/A" }` | Single-signal approach at factor level; Validation is sealed — not reported (see `scripts/evaluate_validation.R`). |
+| Stock MAX OOS CAGR looks extreme (`r { m <- safe_tar_read("stk_max_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Testing"]*100,0),"%") else "N/A" }`) | Driven by COVID recovery + meme stocks. Validation CAGR is sealed — not reported (see `scripts/evaluate_validation.R`). |
 
 **Risk**
 
@@ -145,7 +148,7 @@ if (!is.null(stk_max) && !is.null(stk_drif) && !is.null(fac_max) && !is.null(fac
 
 | Finding | Evidence |
 |---------|----------|
-| Full daily return distribution (42 features) carries more signal than single-day MAX on paper; whether this advantage persists in the Validation period requires checking the current metrics table | Factor-level Validation Sharpe: `r { m <- safe_tar_read("drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` vs Factor MAX Validation Sharpe: `r { m <- safe_tar_read("fm_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` |
+| Full daily return distribution (42 features) carries more signal than single-day MAX on paper | Whether this advantage persists cannot be assessed here — Validation is sealed and not reported (see `scripts/evaluate_validation.R`) |
 | Factor-level vs stock-level volatility comparison — see current metrics table | Classic diversification vs concentration tradeoff |
 
 # Stock MAX
@@ -194,10 +197,11 @@ if (!is.null(stk_max) && !is.null(stk_drif) && !is.null(fac_max) && !is.null(fac
 metrics <- safe_tar_read("stk_max_metrics")
 if (!is.null(metrics)) {
   display <- metrics |>
+    filter(period != "Validation") |>
     mutate(across(c(cagr, vol, max_dd), ~ paste0(round(. * 100, 1), "%")),
            sharpe = round(sharpe, 2),
            avg_long = round(avg_long), avg_short = round(avg_short))
-  hd_dt_wide(display, "Stock MAX metrics by partition.")
+  hd_dt_wide(display, "Stock MAX metrics by partition (Validation sealed — see scripts/evaluate_validation.R).")
 }
 ```
 
@@ -271,10 +275,11 @@ if (!is.null(metrics)) {
 metrics <- safe_tar_read("stk_drif_metrics")
 if (!is.null(metrics)) {
   display <- metrics |>
+    filter(period != "Validation") |>
     mutate(across(c(cagr, vol, max_dd), ~ paste0(round(. * 100, 1), "%")),
            sharpe = round(sharpe, 2),
            avg_long = round(avg_long), avg_short = round(avg_short))
-  hd_dt_wide(display, "Stock DRIF metrics by partition.")
+  hd_dt_wide(display, "Stock DRIF metrics by partition (Validation sealed — see scripts/evaluate_validation.R).")
 }
 ```
 
@@ -283,7 +288,7 @@ if (!is.null(metrics)) {
 | | Detail |
 |--|--------|
 | **Pros (long-only)** | Uses full daily return information (42 features <!-- structural: 21 chronological + 21 rank daily returns — part of strategy definition, not a computed metric -->). Elastic net prevents overfitting. During strategy development (Testing period), showed Testing Sharpe of `r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Testing"],2) else "N/A" }`. |
-| **Cons** | Weak in-sample long-short (`r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Training"]*100,1),"%") else "N/A" }` CAGR). Compute-intensive (10 min for 660 stocks × 600 months). High turnover. Validation Sharpe `r { m <- safe_tar_read("stk_drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }` — generalisation to sealed Validation has not held. |
+| **Cons** | Weak in-sample long-short (`r { m <- safe_tar_read("stk_drif_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Training"]*100,1),"%") else "N/A" }` CAGR). Compute-intensive (10 min for 660 stocks × 600 months). High turnover. Generalisation beyond the Testing partition has not been assessed — Validation is sealed and is not read here (see `scripts/evaluate_validation.R`). |
 | **Works well** | When the cross-section is large (more stocks = better elastic net training). Long-only implementation avoids cost drag of short leg. |
 | **Works badly** | Small universes (<100 stocks). Long-short after costs (D1-D10 spread insufficient to overcome 1.85%/month cost). |
 | **Factor exposure** | Lower factor loading than MAX (elastic net regularises out common factors). More likely to represent genuine alpha. |
@@ -400,9 +405,10 @@ Stock-level long-short strategies lose ~20%/yr after realistic costs (1.85%/mont
 metrics_a <- safe_tar_read("etf_a_metrics")
 if (!is.null(metrics_a)) {
   display <- metrics_a |>
+    filter(period != "Validation") |>
     mutate(across(c(cagr, long_cagr, vol, max_dd), ~ paste0(round(. * 100, 1), "%")),
            sharpe = round(sharpe, 2))
-  hd_dt_wide(display, "Approach A: DRIF applied directly to 9 factor ETF daily returns. Long-short (L/S) and long-only metrics. Cost: 0.10%/trade, 0.5%/yr borrow.")
+  hd_dt_wide(display, "Approach A: DRIF applied directly to 9 factor ETF daily returns. Long-short (L/S) and long-only metrics. Cost: 0.10%/trade, 0.5%/yr borrow. Validation sealed — see scripts/evaluate_validation.R.")
 }
 ```
 
@@ -412,9 +418,10 @@ if (!is.null(metrics_a)) {
 metrics_b <- safe_tar_read("etf_b_metrics")
 if (!is.null(metrics_b)) {
   display <- metrics_b |>
+    filter(period != "Validation") |>
     mutate(across(c(cagr, long_cagr, vol, max_dd), ~ paste0(round(. * 100, 1), "%")),
            sharpe = round(sharpe, 2))
-  hd_dt_wide(display, "Approach B: Academic factor DRIF signal mapped to ETFs via ETF_FACTOR_MAP. Mapping: HML→VLUE/VTV/IWD, Mom→MTUM, RMW→QUAL, etc.")
+  hd_dt_wide(display, "Approach B: Academic factor DRIF signal mapped to ETFs via ETF_FACTOR_MAP. Mapping: HML→VLUE/VTV/IWD, Mom→MTUM, RMW→QUAL, etc. Validation sealed — see scripts/evaluate_validation.R.")
 }
 ```
 
@@ -426,7 +433,7 @@ if (!is.null(metrics_b)) {
 | **Short leg is unprofitable** | A long-short: `r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }`. B long-short: `r { m <- safe_tar_read("etf_b_metrics"); if(!is.null(m)) paste0(round(m$cagr[m$period=="Full Period"]*100,1),"%") else "N/A" }`. ETFs all have market beta — shorting one is mostly shorting the market. |
 | **Approach A vs B** | A full-period Sharpe: `r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Full Period"],2) else "N/A" }`. B full-period Sharpe: `r { m <- safe_tar_read("etf_b_metrics"); if(!is.null(m)) round(m$sharpe[m$period=="Full Period"],2) else "N/A" }`. A max DD: `r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) paste0(round(m$max_dd[m$period=="Full Period"]*100,1),"%") else "N/A" }`. The VLUE/HML mapping (cor=0.34) in B adds noise. |
 | **Cost advantage is real** | ETF costs ~0.20%/month vs 1.85%/month stock-level. The long-only gross returns survive after costs. |
-| **Validation** | A long-only CAGR (Validation): `r { m <- safe_tar_read("etf_a_metrics"); if(!is.null(m)) paste0(round(m$long_cagr[m$period=="Validation"]*100,1),"%") else "N/A" }`. B long-only CAGR (Validation): `r { m <- safe_tar_read("etf_b_metrics"); if(!is.null(m)) paste0(round(m$long_cagr[m$period=="Validation"]*100,1),"%") else "N/A" }`. Caveat: overlaps a bull market. |
+| **Validation** | Sealed — not reported until a one-shot production evaluation (see `scripts/evaluate_validation.R`). |
 
 # Factor-Level Deep Dive {#factor-level-deep-dive}
 
@@ -461,10 +468,11 @@ Based on [Alpha Architect research](https://alphaarchitect.com/factor-max/){targ
 metrics <- safe_tar_read("fm_metrics")
 if (!is.null(metrics)) {
   display <- metrics |>
+    filter(period != "Validation") |>
     mutate(across(c(cagr, vol, max_dd, hit_rate, bench_cagr, bench_vol),
                   ~ paste0(round(. * 100, 1), "%"))) |>
     mutate(across(c(sharpe, bench_sharpe), ~ round(., 2)))
-  hd_dt(display, "Factor MAX strategy metrics: in-sample (1963-2019), out-of-sample (2020+), and full period.")
+  hd_dt(display, "Factor MAX strategy metrics: in-sample (1963-2019), out-of-sample (2020+), and full period. Validation sealed — see scripts/evaluate_validation.R.")
 }
 ```
 
@@ -539,17 +547,18 @@ Based on [Alpha Architect research](https://alphaarchitect.com/daily-stock-retur
 :::
 
 ::: {.callout-warning}
-**Current status (Validation period — sealed one-shot evaluation):** Sharpe `r { m <- safe_tar_read("drif_metrics"); v <- if(!is.null(m)) m$sharpe[m$period=="Validation"] else numeric(0); if(length(v)==1L) round(v,2) else "N/A" }`, CAGR `r { m <- safe_tar_read("drif_metrics"); v <- if(!is.null(m)) m$cagr[m$period=="Validation"] else numeric(0); if(length(v)==1L) paste0(round(v*100,1),"%") else "N/A" }`, max DD `r { m <- safe_tar_read("drif_metrics"); v <- if(!is.null(m)) m$max_dd[m$period=="Validation"] else numeric(0); if(length(v)==1L) paste0(round(v*100,1),"%") else "N/A" }`. The in-sample and Testing Sharpes reflect the development period; Validation is the unbiased live-performance estimate.
+**Validation (sealed partition):** Not reported here — DRIF Validation metrics are sealed until a one-shot production evaluation (see `scripts/evaluate_validation.R`). The in-sample and Testing Sharpes above reflect the development period only.
 :::
 
 ```{r}
 metrics <- safe_tar_read("drif_metrics")
 if (!is.null(metrics)) {
   display <- metrics |>
+    dplyr::filter(period != "Validation") |>
     dplyr::mutate(across(c(cagr, vol, max_dd, hit_rate, bench_cagr, bench_vol),
                   ~ paste0(round(. * 100, 1), "%"))) |>
     dplyr::mutate(across(c(sharpe, bench_sharpe), ~ round(., 2)))
-  hd_dt_wide(display, "DRIF strategy metrics: in-sample (1968-2019), out-of-sample (2020+), and full period. Uses 60-month minimum expanding window.")
+  hd_dt_wide(display, "DRIF strategy metrics: in-sample (1968-2019), out-of-sample (2020+), and full period. Uses 60-month minimum expanding window. Validation sealed — see scripts/evaluate_validation.R.")
 }
 ```
 

--- a/tests/testthat/_snaps/qa-no-published-validation-reads.md
+++ b/tests/testthat/_snaps/qa-no-published-validation-reads.md
@@ -1,0 +1,15 @@
+# check_no_published_validation_reads detects period=="Validation" (no spaces)
+
+    Code
+      names(hits)
+    Output
+      [1] "file" "line" "code"
+
+# qa_no_published_validation_reads scanner function signature is stable (catches API drift)
+
+    Code
+      args(check_no_published_validation_reads)
+    Output
+      function (files) 
+      NULL
+

--- a/tests/testthat/test-qa-no-published-validation-reads.R
+++ b/tests/testthat/test-qa-no-published-validation-reads.R
@@ -1,0 +1,155 @@
+testthat::local_edition(3)
+# Tests for check_no_published_validation_reads() — QA gate S15 (#660)
+#
+# The function is defined in R/plan_qa_gates.R. Tests exercise the gate
+# directly without running tar_make().
+#
+# Background (#660): docs/stock-backtest.qmd read `period == "Validation"`
+# directly from upstream source-metrics targets (stk_drif_metrics,
+# stk_max_metrics, fm_metrics, drif_metrics, etf_a_metrics, etf_b_metrics)
+# in inline R expressions and unfiltered metrics tables -- publishing
+# sealed one-shot evaluation figures in prose and table cells, and in one
+# case drawing a strategy conclusion from them. This bypassed the
+# `leaderboard` target and its S14 gate entirely, because the reads went
+# straight to the source metrics targets, which still legitimately compute
+# a Validation row for other consumers.
+
+source(here::here("R/plan_qa_gates.R"))
+
+# ── S15: literal `period == "Validation"` detection ──────────────────────────
+
+test_that("check_no_published_validation_reads detects period==\"Validation\" (no spaces)", {
+  tmp <- tempfile(fileext = ".qmd")
+  writeLines(
+    'Validation Sharpe: `r { m <- safe_tar_read("x"); m$sharpe[m$period=="Validation"] }`',
+    tmp
+  )
+  on.exit(unlink(tmp))
+  hits <- check_no_published_validation_reads(tmp)
+  expect_equal(nrow(hits), 1L)
+  expect_equal(hits$line, 1L)
+  # Schema snapshot: pins the returned tibble's column names (file/line/code).
+  expect_snapshot(names(hits))
+})
+
+test_that("check_no_published_validation_reads detects period == \"Validation\" (spaced)", {
+  tmp <- tempfile(fileext = ".R")
+  writeLines(
+    'offenders <- m[m$period == "Validation", ]',
+    tmp
+  )
+  on.exit(unlink(tmp))
+  hits <- check_no_published_validation_reads(tmp)
+  expect_equal(nrow(hits), 1L)
+})
+
+test_that("check_no_published_validation_reads detects single-quoted comparisons", {
+  tmp <- tempfile(fileext = ".R")
+  writeLines(
+    "v <- m$sharpe[m$period == 'Validation']",
+    tmp
+  )
+  on.exit(unlink(tmp))
+  hits <- check_no_published_validation_reads(tmp)
+  expect_equal(nrow(hits), 1L)
+})
+
+test_that("check_no_published_validation_reads respects # validation-read-safe opt-out marker", {
+  tmp <- tempfile(fileext = ".R")
+  writeLines(
+    'v <- m$sharpe[m$period == "Validation"]  # validation-read-safe: internal audit only',
+    tmp
+  )
+  on.exit(unlink(tmp))
+  hits <- check_no_published_validation_reads(tmp)
+  expect_equal(nrow(hits), 0L)
+})
+
+test_that("check_no_published_validation_reads ignores filter(period != \"Validation\")", {
+  tmp <- tempfile(fileext = ".qmd")
+  writeLines(
+    'display <- metrics |> filter(period != "Validation")',
+    tmp
+  )
+  on.exit(unlink(tmp))
+  hits <- check_no_published_validation_reads(tmp)
+  expect_equal(nrow(hits), 0L)
+})
+
+test_that("check_no_published_validation_reads ignores prose mentions of Validation with no comparison", {
+  tmp <- tempfile(fileext = ".qmd")
+  writeLines(
+    "**Validation (sealed partition):** Not reported here -- see scripts/evaluate_validation.R.",
+    tmp
+  )
+  on.exit(unlink(tmp))
+  hits <- check_no_published_validation_reads(tmp)
+  expect_equal(nrow(hits), 0L)
+})
+
+test_that("check_no_published_validation_reads ignores computing/labelling a Validation row", {
+  # R/plan_stock_backtest.R and siblings legitimately compute a Validation
+  # row for source metrics targets via calc_metrics(val_data, "Validation")
+  # -- a label argument, not a `period ==` comparison. Out of #660 scope.
+  tmp <- tempfile(fileext = ".R")
+  writeLines(
+    'calc_metrics(val_data |> filter(date >= params$val_start), "Validation")',
+    tmp
+  )
+  on.exit(unlink(tmp))
+  hits <- check_no_published_validation_reads(tmp)
+  expect_equal(nrow(hits), 0L)
+})
+
+test_that("check_no_published_validation_reads returns zero rows for a clean file", {
+  tmp <- tempfile(fileext = ".qmd")
+  writeLines(
+    c(
+      "Full-period Sharpe: `r round(m$sharpe[m$period==\"Full Period\"], 2)`",
+      "Testing Sharpe: `r round(m$sharpe[m$period==\"Testing\"], 2)`"
+    ),
+    tmp
+  )
+  on.exit(unlink(tmp))
+  hits <- check_no_published_validation_reads(tmp)
+  expect_equal(nrow(hits), 0L)
+})
+
+test_that("check_no_published_validation_reads names every offending file:line", {
+  tmp1 <- tempfile(fileext = ".qmd")
+  tmp2 <- tempfile(fileext = ".qmd")
+  writeLines('m$sharpe[m$period=="Validation"]', tmp1)
+  writeLines(c("prose line", 'm$cagr[m$period=="Validation"]'), tmp2)
+  on.exit({
+    unlink(tmp1)
+    unlink(tmp2)
+  })
+  hits <- check_no_published_validation_reads(c(tmp1, tmp2))
+  expect_equal(nrow(hits), 2L)
+  expect_true(tmp1 %in% hits$file)
+  expect_true(tmp2 %in% hits$file)
+  expect_equal(hits$line[hits$file == tmp2], 2L)
+})
+
+# ── Live tripwire: current docs/R/scripts tree must pass (same scan as S15) ──
+
+test_that("qa_no_published_validation_reads scanner function signature is stable (catches API drift)", {
+  expect_snapshot(args(check_no_published_validation_reads))
+})
+
+test_that("qa_no_published_validation_reads passes on the current docs/R/scripts tree", {
+  scan_dirs <- c(here::here("docs"), here::here("R"), here::here("scripts"))
+  scan_dirs <- scan_dirs[dir.exists(scan_dirs)]
+  files <- unlist(lapply(scan_dirs, function(d) {
+    list.files(d, pattern = "\\.(qmd|R)$", full.names = TRUE, recursive = TRUE)
+  }))
+  files <- files[basename(files) != "plan_qa_gates.R"]
+  files <- files[basename(files) != "evaluate_validation.R"]
+
+  hits <- check_no_published_validation_reads(files)
+  expect_equal(
+    nrow(hits),
+    0L,
+    info = paste(capture.output(print(hits)), collapse = "\n")
+  )
+})


### PR DESCRIPTION
## Summary

Fixes #660 — the display-and-reasoning half of the sealed-Validation leak that PR #659 (#648) did not cover. `docs/stock-backtest.qmd` read `period == "Validation"` directly from source metrics targets (bypassing the `leaderboard` target and its S14 gate) in prose expressions **and** in several unfiltered metrics tables, publishing sealed one-shot evaluation figures and, in one place, drawing a strategy conclusion from them.

This PR implements **option 1 only** (remove the display, keep partition boundaries as-is) plus the guards. It deliberately does **not** decide between options 2/3 from the issue (re-cut the Validation window vs. retire the sealed-validation claim) — that is a research-integrity call for the user, not an engineering one.

### What changed

- **Removed every inline Validation value** from `docs/stock-backtest.qmd`: the headline callout, four Evidence-table cells, the ETF Key Findings row, and the DRIF "current status" callout now state the metric is sealed and point to `scripts/evaluate_validation.R` instead of printing a number.
- **Rewrote the Stock DRIF Cons conclusion** (line 286 pre-fix) so it rests only on Training/Testing evidence ("generalisation ... has not been assessed") instead of asserting "generalisation to sealed Validation has not held" — the old wording laundered a conclusion drawn from data that should never have been read.
- **Filtered Validation out of six previously-unfiltered metrics tables** (combined Comparison table, Stock MAX, Stock DRIF, ETF Approach A/B, Factor MAX, Factor DRIF) — these displayed the sealed partition as a table row with no `period==` inline expression, so they weren't in the issue's original line list. Found during the audit.
- **Audited every `docs/*.qmd`, `archive/`, `scripts/`, and root README** for the same pattern. Only `leaderboard.qmd` and `momentum-prepeak.qmd` matched "Validation" at all: `leaderboard.qmd` was already compliant (filters Validation, has explicit sealed-partition comments); the `momentum-prepeak.qmd` hit is unrelated Cross-Validation/CPCV vocabulary, not the backtest partition.
- **Added QA gate S15** (`qa_no_published_validation_reads`, `R/plan_qa_gates.R`): scans `docs/*.qmd`, `R/*.R`, `scripts/*.R` for a literal `period == "Validation"` comparison and aborts on every `tar_make()`. Excludes `R/plan_qa_gates.R` itself (self-reference) and `scripts/evaluate_validation.R` (the sanctioned one-shot manual route).
- **Extended `.claude/rules/backtest-partitions.md`** with a clause: the seal covers *display and reasoning*, not only automatic computation — a source target computing a Validation row for `scripts/evaluate_validation.R` is fine; reading that row into a published document or a conclusion is not.

### Known limitation of S15 (documented in its roxygen)

S15 is a lexical scan, same family as the existing S1–S4 look-ahead-bias checks. It will not catch a comparison built from a variable (e.g. `m$period == per` where `per` is later passed `"Validation"` at a call site) — this repo had exactly one such site (the `get_val()` helper in the old headline callout), which this PR removes in favour of the literal idiom used everywhere else, so nothing currently escapes the scan.

## Verification

`scripts/verify.sh` run in full (parse + root suite + package suite):

```
PASS: _targets.R parses
PASS: testthat edition 3 active
=== root suite ===   total=362 failed=3 skipped=0   -- matches known baseline exactly
=== package suite === total=686 failed=1 skipped=15  -- matches known baseline exactly
=== scripts/verify.sh: PASS ===
```

New test file `tests/testthat/test-qa-no-published-validation-reads.R` (16 tests, snapshot-covered) run standalone: `FAIL 0 | WARN 0 | SKIP 0 | PASS 16`, including a live tripwire that scans the actual `docs/`, `R/`, `scripts/` tree for zero remaining hits.

**Not verified** (per dispatch constraints — no `tar_make()` or full-site render available in this worktree): the rendered HTML output of `docs/stock-backtest.qmd`. Static verification (grep for `period == "Validation"` / `period=="Validation"`) confirms zero remaining reads in any published document; the S15 gate target itself (`qa_no_published_validation_reads`) has not been executed inside `tar_make()`, only its underlying `check_no_published_validation_reads()` function via testthat.

## Test plan

- [ ] Reviewer re-reads lines that previously held raw Validation values (see diff) and confirms the rewritten prose does not reintroduce a laundered conclusion
- [ ] `tar_make()` run once with a built store to confirm `qa_no_published_validation_reads` (S15) passes end-to-end
- [ ] Render `docs/stock-backtest.qmd` and visually confirm no Validation figures appear
- [ ] User decides between options 2/3 from #660 (separate follow-up, not this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
