### PR TITLE
fix(660): re-cut backtest partitions into four tiers (Training/Testing/Holdout/Validation)

### DIFF
--- a/.claude/rules/backtest-partitions.md
+++ b/.claude/rules/backtest-partitions.md
@@ -16,20 +16,21 @@ paths:
   - "vignettes/*.qmd"
   - "scripts/evaluate_validation.R"
 ---
-# Rule: Mandatory Train/Test/Validation Partitions for Backtests
+# Rule: Mandatory Train/Test/Holdout/Validation Partitions for Backtests
 
 ## When This Applies
 Any project that backtests a trading strategy, signal, or model.
 
-## CRITICAL: Three Partitions, Not Two
+## CRITICAL: Four Partitions, Not Two
 
-Every backtest MUST use a 3-way temporal split:
+Every backtest MUST use a temporal split with, at minimum, Training/Testing/Validation. This project additionally uses a fourth tier, **Holdout**, added at [#660](https://github.com/JohnGavin/historical/issues/660) — see that section below for why.
 
-| Partition | Purpose | When to use |
-|-----------|---------|-------------|
-| **Training** | Model fitting, signal estimation, expanding window | During development |
-| **Testing** | Calibration, hyperparameter tuning, strategy comparison | During development |
-| **Validation** | Final one-shot evaluation | ONCE, before production |
+| Partition | Purpose | When to use | Sealed? |
+|-----------|---------|-------------|---------|
+| **Training** | Model fitting, signal estimation, expanding window | During development | n/a |
+| **Testing** | Calibration, hyperparameter tuning, strategy comparison | During development | n/a |
+| **Holdout** | Observed data retained for evaluation, with a stated discount | Ongoing, automatic | **NO — observed, never sealed** |
+| **Validation** | Final one-shot evaluation | ONCE, before production | **YES** |
 
 A 2-way split (IS/OOS) is insufficient — "OOS" gets used for both tuning AND evaluation, which is snooping.
 
@@ -42,17 +43,38 @@ plan_partitions <- function() {
   list(targets::tar_target(bt_partitions, {
     list(
       equity = list(
-        train_start = as.Date("2005-01-01"),
-        train_end   = as.Date("2019-12-31"),
-        test_start  = as.Date("2020-01-01"),
-        test_end    = as.Date("2022-12-31"),
-        val_start   = as.Date("2023-01-01"),
-        val_end     = as.Date("2026-12-31")
+        train_start   = as.Date("2005-01-01"),
+        train_end     = as.Date("2019-12-31"),
+        test_start    = as.Date("2020-01-01"),
+        test_end      = as.Date("2023-12-31"),
+        holdout_start = as.Date("2024-01-01"),
+        holdout_end   = as.Date("2026-04-30"),
+        val_start     = as.Date("2026-05-01"),
+        val_end       = as.Date("2026-12-31")
       )
     )
   }))
 }
 ```
+
+## Holdout: Observed, Not Sealed ([#660](https://github.com/JohnGavin/historical/issues/660))
+
+**Holdout is observed data, deliberately retained for evaluation; it is NOT sealed and must never be described as such.**
+
+### Why this tier exists
+
+The original two-way Testing/Validation split (`test_end = 2022-12-31`, `val_start = 2023-01-01`) was burned: [#660](https://github.com/JohnGavin/historical/issues/660) found `docs/stock-backtest.qmd` publishing Validation figures in prose and drawing a strategy conclusion from them — a violation of the Reasoning clause below. Fixing the display ([#660](https://github.com/JohnGavin/historical/issues/660)/PR #662) and the computation ([#648](https://github.com/JohnGavin/historical/issues/648)/PR #659) did not un-observe the partition itself: the seal is a claim about what has been read, and by the time those PRs landed, the 2023-2026 span had already been read and reasoned from.
+
+Every month from 2024-01 to the data boundary (2026-04-15 equity, 2026-02-27 factor as of #660) sits inside the block that was published, so no re-slicing of *existing* data yields a genuinely clean window — the entire 2024-2026 span is observed. The only unobserved data is **2026-05-01 onwards**: the first month past the current data boundary. That is why the re-cut moves `val_start` there rather than to any earlier date, and introduces `Holdout` to cover the 2024-2026 span honestly instead of either (a) pretending it is still sealed, or (b) discarding two years of otherwise-usable evaluation data.
+
+### What Holdout is and is not
+
+- Holdout **is** computed automatically by `tar_make()` — deliberately, unlike Validation. There is no seal to preserve here; hiding it would gain nothing.
+- Holdout **is** usable for evaluation, with a stated discount relative to a genuinely untouched sample — it has been read once (by whoever wrote the #660-era prose) and should be weighted accordingly, not treated as pristine.
+- Holdout is **NOT** a one-shot result. It may be recomputed, inspected, and discussed repeatedly — that is the point of separating it from Validation.
+- Holdout must **NEVER** be labelled "sealed", "sealed partition", or "one-shot evaluation" on any published surface. Doing so would repeat the exact #660 defect one tier down.
+- QA gate S11 (`check_metric_window_bounds()`, R/plan_qa_gates.R) exempts `"Holdout"` from the `test_end` bound, the same way it exempts `"Validation"` and `"Full Period"` — Holdout's whole purpose is to extend past `test_end`.
+- QA gate S14 (`check_leaderboard_no_validation_rows()`) is **unchanged in intent**: it still rejects only `"Validation"` rows. Holdout rows are allowed on the automatic path — that is the entire point of the tier.
 
 ## Validation Is Sealed
 
@@ -64,6 +86,7 @@ The seal is a claim about **what has been observed**, not about where a number i
 - Validation requires an explicit manual target or script, never invoked by the pipeline
 - A metric window that is *unbounded above* computes validation whether or not it says so — bound every automatic window at `test_end` (QA gate S11)
 - Guard it: no automatically-computed metrics target may emit a row labelled `Validation` (QA gate S14)
+- **Holdout is the one deliberate exception to "not computed automatically"** — it is allowed on the automatic path because it was never sealed in the first place (see the "Holdout: Observed, Not Sealed" section above). Do not read this bullet as licence to compute Validation automatically; Holdout and Validation are different partitions with different rules
 
 ### 2. Storage
 
@@ -101,6 +124,10 @@ It was four lines and constrained only computation. On 2026-08-05 four independe
 
 A rule that names one failure mode will be satisfied by code exhibiting the other three. See [`fail-loud-not-null`](fail-loud-not-null.md) for the general form of this pattern.
 
+### The re-cut ([#660](https://github.com/JohnGavin/historical/issues/660) resolution)
+
+The `stock-backtest.qmd` prose leak above was the fourth leak in the same session, and the most severe: it was a *reasoning* violation, not just a display one. Removing the printed values (the display-side fix) could not undo the fact that the 2023-2026 partition had already been read and reasoned from — the seal on that specific span was permanently broken. The project chose [option 2 from the issue](https://github.com/JohnGavin/historical/issues/660): reclassify the burned span as a fourth tier, `Holdout`, and cut a new, genuinely untouched `Validation` window starting at the first month past the current data boundary (2026-05-01). See the "Holdout: Observed, Not Sealed" section above for the full boundary rationale.
+
 ## Metrics Labelling
 
 Every metrics table MUST label the partition:
@@ -109,6 +136,7 @@ Every metrics table MUST label the partition:
 bind_rows(
   calc_metrics(train_data, "Training"),
   calc_metrics(test_data, "Testing"),
+  calc_metrics(holdout_data, "Holdout"),
   calc_metrics(val_data, "Validation"),
   calc_metrics(all_data, "Full Period")
 )

--- a/R/plan_drif.R
+++ b/R/plan_drif.R
@@ -308,9 +308,14 @@ plan_drif <- function() {
         )
       }
 
+      # #666: Holdout (2024-01-01..2026-04-30, observed but not sealed) --
+      # so the Holdout row emitted by slice_portfolio() in R/plan_leaderboard.R
+      # finds a matching base row here and survives the left_join instead of
+      # being silently dropped (the #660 KNOWN GAP).
       bind_rows(
         calc_metrics(drif_portfolio |> filter(date <= drif_params$is_end), "Training"),
         calc_metrics(drif_portfolio |> filter(date >= drif_params$test_start, date <= drif_params$test_end), "Testing"),
+        calc_metrics(drif_portfolio |> filter(date >= drif_params$holdout_start, date <= drif_params$holdout_end), "Holdout"),
         calc_metrics(drif_portfolio |> filter(date >= drif_params$val_start), "Validation"),
         calc_metrics(drif_portfolio, "Full Period")
       )

--- a/R/plan_drif.R
+++ b/R/plan_drif.R
@@ -22,6 +22,8 @@ plan_drif <- function() {
         is_end = p$train_end,
         test_start = p$test_start,
         test_end = p$test_end,
+        holdout_start = p$holdout_start,  # #660: observed, not sealed
+        holdout_end = p$holdout_end,
         val_start = p$val_start,
         val_end = p$val_end,
         oos_start = p$test_start,

--- a/R/plan_factormax.R
+++ b/R/plan_factormax.R
@@ -19,6 +19,8 @@ plan_factormax <- function() {
         is_end = p$train_end,
         test_start = p$test_start,
         test_end = p$test_end,
+        holdout_start = p$holdout_start,  # #660: observed, not sealed
+        holdout_end = p$holdout_end,
         val_start = p$val_start,
         val_end = p$val_end,
         oos_start = p$test_start,      # backwards compat
@@ -170,6 +172,16 @@ plan_factormax <- function() {
 
       calc_metrics <- function(df, label) {
         n <- nrow(df)
+        # #660: val_start moves to 2026-05-01 (first month past the current
+        # data boundary), so the Validation slice below is empty against
+        # today's data (0 rows) -- without this guard, n=0 would propagate
+        # through 1^Inf/NA arithmetic and emit a spurious row instead of
+        # silently contributing nothing, unlike every sibling calc_metrics()/
+        # calc_backtest_metrics() in this codebase (R/plan_drif.R,
+        # R/plan_stock_backtest.R, R/plan_etf_replication.R,
+        # R/plan_portfolio_opt.R, R/plan_ltr_momentum.R all already guard
+        # at n < 12 or n < 6).
+        if (n < 12) return(NULL)
         ann_ret <- prod(1 + df$portfolio_ret)^(12/n) - 1
         ann_vol <- sd(df$portfolio_ret) * sqrt(12)
         sharpe <- (ann_ret - mean(df$rf_ret) * 12) / ann_vol

--- a/R/plan_factormax.R
+++ b/R/plan_factormax.R
@@ -206,11 +206,17 @@ plan_factormax <- function() {
 
       train_data <- fm_portfolio |> filter(date <= fm_params$is_end)
       test_data <- fm_portfolio |> filter(date >= fm_params$test_start, date <= fm_params$test_end)
+      # #666: Holdout (2024-01-01..2026-04-30, observed but not sealed) --
+      # so the Holdout row emitted by slice_portfolio() in R/plan_leaderboard.R
+      # finds a matching base row here and survives the left_join instead of
+      # being silently dropped (the #660 KNOWN GAP).
+      holdout_data <- fm_portfolio |> filter(date >= fm_params$holdout_start, date <= fm_params$holdout_end)
       val_data <- fm_portfolio |> filter(date >= fm_params$val_start)
 
       bind_rows(
         calc_metrics(train_data, "Training"),
         calc_metrics(test_data, "Testing"),
+        calc_metrics(holdout_data, "Holdout"),
         calc_metrics(val_data, "Validation"),
         calc_metrics(fm_portfolio, "Full Period")
       )

--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -335,13 +335,36 @@ plan_leaderboard <- function() {
       # for it on every `tar_make()` -- an automatic-computation violation of
       # `backtest-partitions.md` ("Validation metrics are NOT computed
       # automatically"). That slice is removed: the automatic path now only
-      # ever produces Training / Testing / Full Period cost rows. A one-shot
-      # Validation evaluation, when authorised, belongs in
+      # ever produces Training / Testing / Holdout / Full Period cost rows. A
+      # one-shot Validation evaluation, when authorised, belongs in
       # scripts/evaluate_validation.R (never invoked by tar_make()), not here.
+      #
+      # NOTE (#660): `Holdout` is added below (2024-01-01..2026-04-30,
+      # R/plan_partitions.R `bt_partitions`) -- it is computed automatically
+      # by design (observed, not sealed; see backtest-partitions.md's Holdout
+      # subsection), unlike Validation above.
+      #
+      # KNOWN GAP (#660, flagged not fixed -- out of this change's scope):
+      # `calc_cost_metrics()` never returns NULL (an empty window yields a
+      # row of NAs, not zero rows), so `cost_rows` below always gets a
+      # `period == "Holdout"` row per strategy. But the join two blocks down
+      # is `all_metrics |> left_join(cost_rows, by = c("strategy", "period"))`
+      # -- LEFT-driven by `all_metrics`, whose base rows come from the source
+      # metrics targets (stk_max_metrics, stk_drif_metrics, xgb_drif_metrics,
+      # fm_metrics, drif_metrics, port_metrics) via `calc_backtest_metrics()`
+      # / `calc_metrics()` / `calc_port_metrics()`. None of those functions
+      # compute a "Holdout" period today -- only Training/Testing/Validation
+      # (filtered)/Full Period. A right-side-only period value is silently
+      # dropped by `left_join()`, so the Holdout rows built here currently do
+      # NOT surface in the assembled `leaderboard` target or on
+      # docs/leaderboard.qmd's "By Partition" table. Making Holdout actually
+      # visible requires adding a Holdout slice to those source targets too
+      # -- a separate, wider change than this one; see the #660 PR report.
       slice_portfolio <- function(port_df, ret_col_name, params) {
         ret <- list(
           Training     = port_df[port_df$date <= params$is_end, ][[ret_col_name]],
           Testing      = port_df[port_df$date >= params$test_start & port_df$date <= params$test_end, ][[ret_col_name]],
+          Holdout      = port_df[port_df$date >= params$holdout_start & port_df$date <= params$holdout_end, ][[ret_col_name]],
           `Full Period` = port_df[[ret_col_name]]
         )
         bind_rows(lapply(names(ret), function(p) {

--- a/R/plan_ltr_momentum.R
+++ b/R/plan_ltr_momentum.R
@@ -31,6 +31,8 @@ plan_ltr_momentum <- function() {
         is_end              = p$train_end,
         test_start          = p$test_start,
         test_end            = p$test_end,
+        holdout_start       = p$holdout_start,  # #666: observed, not sealed
+        holdout_end         = p$holdout_end,
         val_start           = p$val_start,
         xgb_params = list(
           max_depth    = 5L,
@@ -176,10 +178,16 @@ plan_ltr_momentum <- function() {
 
       port <- ltr_portfolio
 
+      # #666: Holdout (2024-01-01..2026-04-30, observed but not sealed) --
+      # so the Holdout row emitted by slice_portfolio() in R/plan_leaderboard.R
+      # finds a matching base row here and survives the left_join instead of
+      # being silently dropped (the #660 KNOWN GAP).
       bind_rows(Filter(Negate(is.null), list(
         compute_ltr_metrics(port |> filter(as.Date(date) <= p$is_end),         "Training"),
         compute_ltr_metrics(port |> filter(as.Date(date) >= p$test_start,
                                             as.Date(date) <= p$test_end),       "Testing"),
+        compute_ltr_metrics(port |> filter(as.Date(date) >= p$holdout_start,
+                                            as.Date(date) <= p$holdout_end),    "Holdout"),
         compute_ltr_metrics(port |> filter(as.Date(date) >= p$val_start),      "Validation"),
         compute_ltr_metrics(port,                                               "Full Period")
       )))

--- a/R/plan_partitions.R
+++ b/R/plan_partitions.R
@@ -1,11 +1,44 @@
-# Shared backtesting partitions: train / test / validation
+# Shared backtesting partitions: train / test / holdout / validation
 #
 # Single source of truth for date boundaries across all strategies.
 # Validation data is LOCKED — not computed automatically.
 #
 # Training:   model fitting, expanding window signal estimation
 # Testing:    calibration, hyperparameter tuning, strategy comparison
+# Holdout:    observed data retained for evaluation — NOT sealed (#660)
 # Validation: final one-shot evaluation (sealed envelope)
+#
+# ── Four-tier re-cut (#660) ─────────────────────────────────────────────────
+# The original two-way Testing/Validation split (test_end = 2022-12-31,
+# val_start = 2023-01-01) was burned: #660 found docs/stock-backtest.qmd
+# publishing Validation figures in prose and drawing a strategy conclusion
+# from them (fixed at #660/PR #662 and #648/PR #659, but the *partition
+# itself* stayed observed once it was read and reasoned about — see
+# `.claude/rules/backtest-partitions.md` "Reasoning" clause).
+#
+# Every month from 2024-01 to the data end (2026-04-15 equity, 2026-02-27
+# factor as of #660) sits inside the block that was read, so no re-slicing
+# of EXISTING data yields a clean window — the entire 2024-2026 span is
+# observed. The only genuinely unobserved data is 2026-05-01 onwards: the
+# first month past the current data boundary. That is why `val_start` moves
+# there rather than to any earlier date.
+#
+# The re-cut adds a fourth tier, `Holdout`, absorbing the burned 2023-2026
+# span:
+#   Training  -- unchanged (train_start .. train_end)
+#   Testing   -- test_start .. 2023-12-31 (absorbs the burned 2023, which
+#                used to be the first year of the old Validation partition)
+#   Holdout   -- 2024-01-01 .. 2026-04-30 (observed, computed automatically,
+#                usable for evaluation WITH A STATED DISCOUNT because it has
+#                been read; NEVER describe it as sealed)
+#   Validation -- 2026-05-01 onwards (genuinely untouched; will be EMPTY
+#                until new data arrives past the current boundary)
+#
+# Holdout is NOT a replacement for Validation's sealing guarantee. It exists
+# because the four-part seal (computation / storage / display / reasoning,
+# `.claude/rules/backtest-partitions.md`) can only be honoured for data that
+# has never been observed -- and the 2024-2026 block no longer qualifies.
+# Holdout is the honest label for "observed, not sealed, still informative."
 
 # ── Canonical period vocabulary (#643) ──────────────────────────────────────
 # Single source of truth for every value the `period` column is allowed to
@@ -16,17 +49,34 @@
 #
 # "OOS" is INTENTIONALLY separate from "Testing" — they are not synonyms:
 #   - "Testing" is the canonical, bounded window in `bt_partitions` above
-#     (currently 2020-01-01..2022-12-31 for every asset class).
+#     (2020-01-01..2023-12-31 for every asset class as of #660 -- widened by
+#     one year to absorb the burned 2023 that used to open the old
+#     Validation partition; see the "Four-tier re-cut (#660)" comment above).
 #   - "OOS" labels a strategy-local out-of-sample split defined by its own
 #     `oos_start` parameter with NO end bound (e.g. R/plan_ev_ebit.R and
 #     R/plan_managed_futures.R both use `dates >= 2010-01-01`, which spans
-#     the canonical Training tail (2010-2019), all of Testing (2020-2022),
-#     and all of Validation (2023+) in one undifferentiated block).
+#     the canonical Training tail, all of Testing, all of Holdout, and (once
+#     any exists) all of Validation in one undifferentiated block). Because
+#     "OOS" is bounded above at `test_end` (#645, QA gate S11), moving
+#     `test_end` to 2023-12-31 widens every OOS window by one year too --
+#     see the #660 PR report for the full list of strategies whose published
+#     OOS numbers move as a result.
 # Renaming "OOS" to "Testing" would misrepresent that wider, strategy-defined
 # sample as the shared cross-strategy test partition — so both labels stay
 # in the allowed set, and no `.norm_*` helper in R/plan_leaderboard.R may
 # rename OOS to Testing. Only "Full" -> "Full Period" is a safe rename
 # (pure spelling difference for the same concept — see #643).
+#
+# "Holdout" was added in #660 for the new observed-but-unsealed tier
+# (2024-01-01..2026-04-30). It is computed automatically by tar_make() --
+# unlike Validation, this is by design (see the "Four-tier re-cut (#660)"
+# comment above) -- and is exempt from the QA gate S11 `test_end` bound in
+# R/plan_qa_gates.R (`check_metric_window_bounds()`) for the same reason
+# "Full Period" is: it is a partition whose whole purpose is to extend past
+# `test_end`, not a bespoke window that has silently grown to swallow the
+# sealed partition. It is NOT required per-strategy (unlike "Full Period",
+# which the S10 gate requires); a strategy may report Holdout metrics or
+# not, same as OOS/Testing.
 #
 # "Validation" stays in the allowed set (#648 decision) even though the
 # `leaderboard` target's own automatic path may no longer emit a row with
@@ -43,8 +93,15 @@
 #      labelled "Validation" by design.
 # Removing it from this constant would make both of the above fail S10
 # (check_leaderboard_period_vocab) / any future vocab check applied to them.
+# As of #660, this window (val_start = 2026-05-01) is EMPTY against the
+# current data boundary (2026-04-15 equity, 2026-02-27 factor) -- that is
+# expected, not a bug; every `calc_metrics()`/`calc_backtest_metrics()`-style
+# helper that feeds a "Validation" row returns NULL below its minimum
+# observation count, so an empty window silently contributes zero rows
+# rather than erroring or emitting a spurious NA row (verified per source
+# target as part of #660; see the PR report for the full list).
 PERIOD_LABELS_ALLOWED <- c(
-  "Training", "Testing", "Validation", "Full Period", "OOS"
+  "Training", "Testing", "Holdout", "Validation", "Full Period", "OOS"
 )
 
 plan_partitions <- function() {
@@ -53,30 +110,36 @@ plan_partitions <- function() {
       list(
         # Equity / stock-level strategies (data from ~2005)
         equity = list(
-          train_start = as.Date("2005-01-01"),
-          train_end   = as.Date("2019-12-31"),
-          test_start  = as.Date("2020-01-01"),
-          test_end    = as.Date("2022-12-31"),
-          val_start   = as.Date("2023-01-01"),
-          val_end     = as.Date("2026-12-31")
+          train_start   = as.Date("2005-01-01"),
+          train_end     = as.Date("2019-12-31"),
+          test_start    = as.Date("2020-01-01"),
+          test_end      = as.Date("2023-12-31"),
+          holdout_start = as.Date("2024-01-01"),
+          holdout_end   = as.Date("2026-04-30"),
+          val_start     = as.Date("2026-05-01"),
+          val_end       = as.Date("2026-12-31")
         ),
         # Factor-level strategies (data from 1963)
         factor = list(
-          train_start = as.Date("1968-01-01"),  # 60-month min window from 1963
-          train_end   = as.Date("2019-12-31"),
-          test_start  = as.Date("2020-01-01"),
-          test_end    = as.Date("2022-12-31"),
-          val_start   = as.Date("2023-01-01"),
-          val_end     = as.Date("2026-12-31")
+          train_start   = as.Date("1968-01-01"),  # 60-month min window from 1963
+          train_end     = as.Date("2019-12-31"),
+          test_start    = as.Date("2020-01-01"),
+          test_end      = as.Date("2023-12-31"),
+          holdout_start = as.Date("2024-01-01"),
+          holdout_end   = as.Date("2026-04-30"),
+          val_start     = as.Date("2026-05-01"),
+          val_end       = as.Date("2026-12-31")
         ),
         # Macro defense rotation (data from 2007)
         macro = list(
-          train_start = as.Date("2007-04-01"),
-          train_end   = as.Date("2019-12-31"),
-          test_start  = as.Date("2020-01-01"),
-          test_end    = as.Date("2022-12-31"),
-          val_start   = as.Date("2023-01-01"),
-          val_end     = as.Date("2026-12-31")
+          train_start   = as.Date("2007-04-01"),
+          train_end     = as.Date("2019-12-31"),
+          test_start    = as.Date("2020-01-01"),
+          test_end      = as.Date("2023-12-31"),
+          holdout_start = as.Date("2024-01-01"),
+          holdout_end   = as.Date("2026-04-30"),
+          val_start     = as.Date("2026-05-01"),
+          val_end       = as.Date("2026-12-31")
         )
       )
     })

--- a/R/plan_portfolio_opt.R
+++ b/R/plan_portfolio_opt.R
@@ -303,9 +303,15 @@ plan_portfolio_opt <- function() {
         )
       }
 
+      # #666: Holdout (2024-01-01..2026-04-30, observed but not sealed) --
+      # so the "PSO Optimal" Holdout base row (R/plan_leaderboard.R's
+      # `port_row`) exists to match the pso_cost Holdout row emitted by
+      # slice_portfolio() and survives the left_join instead of being
+      # silently dropped (the #660 KNOWN GAP).
       bind_rows(
         calc_port_metrics(port_combined |> filter(date <= stk_params$is_end), "Training"),
         calc_port_metrics(port_combined |> filter(date >= stk_params$test_start, date <= stk_params$test_end), "Testing"),
+        calc_port_metrics(port_combined |> filter(date >= stk_params$holdout_start, date <= stk_params$holdout_end), "Holdout"),
         calc_port_metrics(port_combined |> filter(date >= stk_params$val_start), "Validation"),
         calc_port_metrics(port_combined, "Full Period")
       )

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -386,6 +386,9 @@ check_leaderboard_metric_ranges <- function(leaderboard) {
 #'      vocabulary. "OOS" is deliberately its own label, distinct from
 #'      "Testing" -- see the `PERIOD_LABELS_ALLOWED` comment in
 #'      R/plan_partitions.R for why the two windows are not interchangeable.
+#'      "Holdout" (#660) is accepted the same way "OOS" is: a strategy MAY
+#'      report a Holdout row or not -- assertion 1 only requires "Full
+#'      Period", never "Holdout" -- so a strategy without one still passes.
 #'
 #' @param leaderboard Tibble with at least `strategy` and `period` columns
 #'   (the output of the `leaderboard` targets pipeline target).
@@ -462,10 +465,18 @@ check_leaderboard_period_vocab <- function(leaderboard) {
 #' (R/plan_partitions.R `bt_partitions`, `backtest-partitions` rule) on every
 #' `tar_make()`.
 #'
-#' Two period labels are exempt from the `test_end` bound, both by design of
+#' Three period labels are exempt from the `test_end` bound, all by design of
 #' `backtest-partitions.md`:
 #'   - `"Validation"` -- the sealed partition itself; its whole purpose is to
 #'     extend past `test_end`.
+#'   - `"Holdout"` -- the observed-but-unsealed tier added in #660
+#'     (2024-01-01..2026-04-30). `test_end` moved back to 2023-12-31 as part
+#'     of the same change (absorbing the burned 2023 into Testing), so
+#'     Holdout's `window_end` legitimately sits past `test_end` on every
+#'     `tar_make()` -- that is the entire point of the tier, not a #645-style
+#'     leak. Unlike Validation, Holdout IS computed automatically; see
+#'     `.claude/rules/backtest-partitions.md`'s Holdout subsection for why
+#'     that is by design rather than a seal breach.
 #'   - `"Full"` / `"Full Period"` -- the rule's own canonical reference
 #'     implementation lists `calc_metrics(all_data, "Full Period")` alongside
 #'     Training/Testing/Validation as an accepted, full-sample summary that is
@@ -473,7 +484,8 @@ check_leaderboard_period_vocab <- function(leaderboard) {
 #'     definition -- it is not a bespoke evaluation/test window like `"OOS"`.
 #'     Every other strategy on the leaderboard already reports a Full Period
 #'     row this way; only a genuinely bespoke window (not itself the sealed
-#'     partition or the full-sample summary) is what #645 is about.
+#'     partition, the Holdout tier, or the full-sample summary) is what #645
+#'     is about.
 #'
 #' @param metrics A tibble with at least `strategy`, `period`, `window_end`
 #'   columns (the output of a strategy metrics target, e.g. `mf_metrics` or
@@ -518,7 +530,7 @@ check_metric_window_bounds <- function(metrics, test_end, source_label) {
     ))
   }
 
-  exempt_periods <- c("Validation", "Full", "Full Period")
+  exempt_periods <- c("Validation", "Holdout", "Full", "Full Period")
 
   is_offender <- !is.na(metrics$window_end) &
     !(metrics$period %in% exempt_periods) &
@@ -586,6 +598,15 @@ check_metric_window_bounds <- function(metrics, test_end, source_label) {
 #' Validation values directly in vignette prose (e.g. docs/stock-backtest.qmd),
 #' which is a separate, wider display-side leak not covered by this gate.
 #' This gate only guarantees the `leaderboard` target's own output.
+#'
+#' @section Holdout is deliberately unaffected (#660):
+#' This gate checks ONLY for `period == "Validation"`. The `"Holdout"` label
+#' added in #660 (R/plan_partitions.R, 2024-01-01..2026-04-30) is an
+#' automatically-computed, observed-but-unsealed tier -- it is EXPECTED to
+#' reach the `leaderboard` target and must never be rejected here. Widening
+#' this gate to reject Holdout would misapply the Validation seal to a
+#' partition that was never sealed in the first place; see
+#' `.claude/rules/backtest-partitions.md`'s Holdout subsection.
 #'
 #' @param leaderboard Tibble with at least `strategy`, `period` columns (the
 #'   output of the `leaderboard` targets pipeline target).

--- a/R/plan_stock_backtest.R
+++ b/R/plan_stock_backtest.R
@@ -459,6 +459,8 @@ plan_stock_backtest <- function() {
         is_end = p$train_end,
         test_start = p$test_start,
         test_end = p$test_end,
+        holdout_start = p$holdout_start,  # #660: observed, not sealed
+        holdout_end = p$holdout_end,
         val_start = p$val_start,
         val_end = p$val_end,
         oos_start = p$test_start,

--- a/R/plan_stock_backtest.R
+++ b/R/plan_stock_backtest.R
@@ -778,9 +778,14 @@ plan_stock_backtest <- function() {
       library(dplyr)
 
       p <- stk_max_portfolio
+      # #666: Holdout (2024-01-01..2026-04-30, observed but not sealed) --
+      # so the Holdout row emitted by slice_portfolio() in R/plan_leaderboard.R
+      # finds a matching base row here and survives the left_join instead of
+      # being silently dropped (the #660 KNOWN GAP).
       bind_rows(
         calc_backtest_metrics(p |> filter(date <= stk_params$is_end), "Training"),
         calc_backtest_metrics(p |> filter(date >= stk_params$test_start, date <= stk_params$test_end), "Testing"),
+        calc_backtest_metrics(p |> filter(date >= stk_params$holdout_start, date <= stk_params$holdout_end), "Holdout"),
         calc_backtest_metrics(p |> filter(date >= stk_params$val_start), "Validation"),
         calc_backtest_metrics(p, "Full Period")
       ) |> mutate(survivorship_biased = TRUE)  # stk_universe is survivorship-biased; see #150
@@ -1095,9 +1100,14 @@ plan_stock_backtest <- function() {
     targets::tar_target(stk_drif_metrics, {
       library(dplyr)
       p <- stk_drif_portfolio
+      # #666: Holdout (2024-01-01..2026-04-30, observed but not sealed) --
+      # so the Holdout row emitted by slice_portfolio() in R/plan_leaderboard.R
+      # finds a matching base row here and survives the left_join instead of
+      # being silently dropped (the #660 KNOWN GAP).
       bind_rows(
         calc_backtest_metrics(p |> filter(date <= stk_params$is_end), "Training"),
         calc_backtest_metrics(p |> filter(date >= stk_params$test_start, date <= stk_params$test_end), "Testing"),
+        calc_backtest_metrics(p |> filter(date >= stk_params$holdout_start, date <= stk_params$holdout_end), "Holdout"),
         calc_backtest_metrics(p |> filter(date >= stk_params$val_start), "Validation"),
         calc_backtest_metrics(p, "Full Period")
       ) |> mutate(survivorship_biased = TRUE)  # stk_universe is survivorship-biased; see #150

--- a/R/plan_xgb_signal.R
+++ b/R/plan_xgb_signal.R
@@ -143,9 +143,14 @@ plan_xgb_signal <- function() {
     targets::tar_target(xgb_drif_metrics, {
       library(dplyr)
       p <- xgb_drif_portfolio
+      # #666: Holdout (2024-01-01..2026-04-30, observed but not sealed) --
+      # so the Holdout row emitted by slice_portfolio() in R/plan_leaderboard.R
+      # finds a matching base row here and survives the left_join instead of
+      # being silently dropped (the #660 KNOWN GAP).
       bind_rows(
         calc_backtest_metrics(p |> filter(date <= stk_params$is_end), "Training"),
         calc_backtest_metrics(p |> filter(date >= stk_params$test_start, date <= stk_params$test_end), "Testing"),
+        calc_backtest_metrics(p |> filter(date >= stk_params$holdout_start, date <= stk_params$holdout_end), "Holdout"),
         calc_backtest_metrics(p |> filter(date >= stk_params$val_start), "Validation"),
         calc_backtest_metrics(p, "Full Period")
       ) |> mutate(survivorship_biased = TRUE)  # stk_universe is survivorship-biased; see #150

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -321,24 +321,40 @@ if (!is.null(lb)) {
   params <- safe_tar_read("stk_params")
 
   # Create years lookup
+  #
+  # "Holdout" (#660, 2024-01-01..2026-04-30) is included here for
+  # forward-compatibility with `period_order` below, but as of #660 the
+  # assembled `leaderboard` target does not yet emit any row with this
+  # label -- the source metrics targets (stk_max_metrics, stk_drif_metrics,
+  # xgb_drif_metrics, fm_metrics, drif_metrics, port_metrics) only compute
+  # Training/Testing/(Validation, filtered)/Full Period, so the Holdout cost
+  # rows built in R/plan_leaderboard.R's `slice_portfolio()` are dropped by
+  # its LEFT join before reaching `lb`. This row is therefore currently
+  # inert (matches zero rows) -- see the #660 PR report for the follow-up
+  # needed to surface it.
   years_map <- tibble(
-    period = c("Training", "Testing", "Full Period"),
+    period = c("Training", "Testing", "Holdout", "Full Period"),
     Years = if (!is.null(params)) {
       c(
         paste0(format(as.Date(params$start_date), "%Y"), "-", format(as.Date(params$is_end), "%Y")),
         paste0(format(as.Date(params$test_start), "%Y"), "-", format(as.Date(params$test_end), "%Y")),
+        paste0(format(as.Date(params$holdout_start), "%Y"), "-", format(as.Date(params$holdout_end), "%Y")),
         paste0(format(as.Date(params$start_date), "%Y"), "-", format(as.Date(params$test_end), "%Y"))
       )
     } else {
-      c("—", "—", "—")
+      c("—", "—", "—", "—")
     }
   )
 
   # Explicit period display order (NOT alphabetical, per rule): Testing,
-  # Full Period, Training. Implemented via factor levels so dplyr::arrange()
-  # sorts by this order rather than alphabetically ("Full Period" < "Testing"
-  # < "Training").
-  period_order <- c("Testing", "Full Period", "Training")
+  # Holdout, Full Period, Training. Testing and Holdout are adjacent because
+  # Holdout is the more recent, more-informative-but-unsealed evaluation
+  # window that directly follows Testing chronologically; Full Period and
+  # Training close out the table the same way they always have (#660).
+  # Implemented via factor levels so dplyr::arrange() sorts by this order
+  # rather than alphabetically ("Full Period" < "Holdout" < "Testing" <
+  # "Training").
+  period_order <- c("Testing", "Holdout", "Full Period", "Training")
 
   by_part <- lb |>
     filter(period != "Validation") |>
@@ -359,7 +375,7 @@ if (!is.null(lb)) {
     select(Strategy = strategy, Period, Sharpe, Years, CAGR, Vol, `Max DD`, `CVaR 95%`)
 
   # Bespoke DT call (not hd_dt()): rows above are already sorted by Period
-  # (Testing / Full Period / Training) then Sharpe descending. hd_dt()'s
+  # (Testing / Holdout / Full Period / Training) then Sharpe descending. hd_dt()'s
   # fixed options list has no `order` entry, so DT would apply its default
   # initial sort (column 0 ascending = Strategy) and silently undo the sort
   # above -- `order = list()` (empty array) disables DT's initial sort and
@@ -372,7 +388,7 @@ if (!is.null(lb)) {
     caption = htmltools::tags$caption(
       style = "caption-side: top; text-align: left; font-weight: bold;",
       class = "dt-caption",
-      "All strategies × Training and Testing partitions, ordered Testing / Full Period / Training then by Sharpe (descending). Years column shows date ranges. Validation partition is sealed — not shown until production deployment."
+      "All strategies × Training, Testing, and Holdout partitions, ordered Testing / Holdout / Full Period / Training then by Sharpe (descending). Years column shows date ranges. Holdout (2024-2026) is observed, not sealed -- treat it with a discount relative to a genuinely untouched sample (#660). Validation partition is sealed and genuinely untouched (2026-05-01 onwards) — not shown until production deployment."
     ),
     rownames = FALSE,
     filter = "top",
@@ -980,18 +996,27 @@ Per `backtesting-assumptions` rule, all strategies use:
 ```{r}
 params <- safe_tar_read("stk_params")
 if (!is.null(params)) {
+  # Four-tier re-cut (#660): Holdout is the observed-but-unsealed tier that
+  # absorbs the 2024-2026 span burned by #660 (docs/stock-backtest.qmd
+  # published Validation figures and drew a strategy conclusion from them).
+  # It is computed automatically, unlike Validation -- see
+  # .claude/rules/backtest-partitions.md.
   param_df <- tibble(
-    Partition = c("Training", "Testing", "Validation"),
+    Partition = c("Training", "Testing", "Holdout", "Validation"),
     Period = c(
       paste(params$start_date, "to", params$is_end),
       paste(params$test_start, "to", params$test_end),
+      paste(params$holdout_start, "to", params$holdout_end),
       paste(params$val_start, "to", "present")
     ),
-    Purpose = c("Model fitting, expanding window signal estimation",
-                "Calibration, hyperparameter tuning, strategy comparison",
-                "SEALED — not computed or shown until production deployment")
+    Purpose = c(
+      "Model fitting, expanding window signal estimation",
+      "Calibration, hyperparameter tuning, strategy comparison",
+      "OBSERVED, NOT SEALED — usable for evaluation with a stated discount; never a one-shot result (#660)",
+      "SEALED — not computed or shown until production deployment"
+    )
   )
-  hd_dt(param_df, "Shared partitions across all strategies. Validation is sealed: metrics are NOT computed until a one-shot production decision.")
+  hd_dt(param_df, "Shared partitions across all strategies. Holdout is observed but not sealed (#660). Validation is sealed: metrics are NOT computed until a one-shot production decision.")
 }
 ```
 

--- a/scripts/evaluate_validation.R
+++ b/scripts/evaluate_validation.R
@@ -1,8 +1,19 @@
-# Manual, one-shot Validation-partition evaluation (#648)
+# Manual, one-shot Validation-partition evaluation (#648, boundary moved #660)
 #
 # ============================================================================
 # READ THIS BEFORE RUNNING
 # ============================================================================
+#
+# #660 re-cut the partitions: `val_start` (R/plan_partitions.R bt_partitions)
+# moved from 2023-01-01 to 2026-05-01 -- the 2024-2026 span that used to open
+# Validation was burned (docs/stock-backtest.qmd published figures from it
+# and drew a strategy conclusion; see #660) and is now the `Holdout` tier
+# instead (observed, NOT sealed -- see .claude/rules/backtest-partitions.md).
+# 2026-05-01 is the first month past the current data boundary (2026-04-15
+# equity, 2026-02-27 factor as of #660), so THIS SCRIPT WILL PRINT AN EMPTY
+# (all-NA) Validation table until new data arrives past that boundary. That
+# is expected, not a bug -- do not treat an empty run as "nothing to
+# report"; it means the seal is intact because there is nothing yet to seal.
 #
 # `.claude/rules/backtest-partitions.md` requires that Validation metrics are
 # NEVER computed automatically by `tar_make()` — only via an explicit manual
@@ -131,6 +142,24 @@ if (!is.null(port_returns) && !is.null(port_optimal_weights)) {
 }
 
 validation_metrics <- bind_rows(rows)
+
+# #660: val_start (2026-05-01) is the first month past the current data
+# boundary, so this window is expected to be empty today -- warn explicitly
+# rather than letting an all-NA table look like "nothing to report" or a
+# silent failure. `validation_row()` always returns a row (months = 0, all
+# other columns NA) even for a zero-observation slice, so check `months`
+# rather than `nrow()`.
+if (nrow(validation_metrics) > 0L &&
+    all(is.na(validation_metrics$months) | validation_metrics$months == 0L)) {
+  cli_alert_warning(paste0(
+    "Validation window (", format(val_start_equity), " onwards) has ZERO ",
+    "observations for every strategy -- this is EXPECTED, not an error. ",
+    "2026-05-01 is the first month past the current data boundary ",
+    "(equity/factor data currently ends ~2026-04-15 / ~2026-02-27, #660). ",
+    "The all-NA table below reflects that, not a broken query. Re-run this ",
+    "script once new data extends past the Validation boundary."
+  ))
+}
 
 cli_h2("Validation partition results — SEALED, one-shot")
 print(validation_metrics)

--- a/tests/testthat/_snaps/leaderboard-period-vocab.md
+++ b/tests/testthat/_snaps/leaderboard-period-vocab.md
@@ -17,7 +17,7 @@
       Error in `check_leaderboard_period_vocab()`:
       x Leaderboard period column has 1 value(s) outside the canonical vocabulary:
       i  Full-Sample -- used by: Managed Futures
-      i Allowed values (R/plan_partitions.R PERIOD_LABELS_ALLOWED): Training, Testing, Validation, Full Period, OOS.
+      i Allowed values (R/plan_partitions.R PERIOD_LABELS_ALLOWED): Training, Testing, Holdout, Validation, Full Period, OOS.
       i Normalise the label in the strategy's .norm_* helper in R/plan_leaderboard.R (#643).
 
 # check_leaderboard_period_vocab throws when required columns are missing

--- a/tests/testthat/test-empty-validation-window.R
+++ b/tests/testthat/test-empty-validation-window.R
@@ -1,0 +1,99 @@
+testthat::local_edition(3)
+# Tests that the #660 partition re-cut does not break metrics targets whose
+# "Validation" slice becomes EMPTY against the current data boundary.
+#
+# Background (#660): `val_start` (R/plan_partitions.R bt_partitions) moved to
+# 2026-05-01 -- the first month past the current data boundary (2026-04-15
+# equity, 2026-02-27 factor as of #660). Every `calc_metrics()` /
+# `calc_backtest_metrics()`-style helper that feeds a "Validation" row must
+# handle a zero-row window without erroring and without emitting a spurious
+# NA-filled row.
+#
+# R/plan_factormax.R's `calc_metrics()` (used by the `fm_metrics` target) was
+# missing this guard -- unlike every sibling helper in R/plan_drif.R,
+# R/plan_stock_backtest.R, R/plan_etf_replication.R, R/plan_portfolio_opt.R,
+# and R/plan_ltr_momentum.R, which all already return NULL below their
+# minimum observation count. #660 added the same `if (n < 12) return(NULL)`
+# guard there. This file verifies the fix end-to-end via the real
+# `fm_metrics` target's own command expression (not a hand-copied re
+# implementation of `calc_metrics()`, which could silently drift from the
+# source).
+
+source(here::here("R/plan_partitions.R"))
+source(here::here("R/plan_factormax.R"))
+source(here::here("R/plan_stock_backtest.R"))
+
+bt_partitions <- eval(plan_partitions()[[1]]$command$expr)
+
+.get_target_expr <- function(plan_targets, target_name) {
+  nms <- vapply(plan_targets, function(t) t$settings$name, character(1))
+  idx <- which(nms == target_name)
+  testthat::expect_length(idx, 1L)
+  plan_targets[[idx]]$command$expr
+}
+
+# ── fm_metrics (#660 fix: missing n < 12 guard) ────────────────────────────────
+
+test_that("fm_metrics does not error when the Validation window is empty", {
+  p <- bt_partitions$factor
+  fm_params <- list(
+    is_end = p$train_end, test_start = p$test_start, test_end = p$test_end,
+    holdout_start = p$holdout_start, holdout_end = p$holdout_end,
+    val_start = p$val_start, val_end = p$val_end
+  )
+  # Synthetic monthly data covering Training + Testing only -- nothing at or
+  # past val_start (2026-05-01), mirroring the real current data boundary.
+  dates <- seq(as.Date("2018-01-15"), as.Date("2023-12-15"), by = "month")
+  set.seed(1)
+  fm_portfolio <- tibble::tibble(
+    date = dates,
+    portfolio_ret = stats::rnorm(length(dates), 0.01, 0.02),
+    rf_ret = 0.001,
+    benchmark_ret = stats::rnorm(length(dates), 0.008, 0.02)
+  )
+
+  expr <- .get_target_expr(plan_factormax(), "fm_metrics")
+  env <- new.env()
+  env$fm_portfolio <- fm_portfolio
+  env$fm_params <- fm_params
+
+  expect_no_error(result <- eval(expr, envir = env))
+  expect_false("Validation" %in% result$period)
+  expect_setequal(result$period, c("Training", "Testing", "Full Period"))
+  # No NA-filled spurious row: every numeric column on every row is finite.
+  numeric_cols <- names(result)[vapply(result, is.numeric, logical(1))]
+  expect_true(all(vapply(result[numeric_cols], function(x) all(is.finite(x)), logical(1))))
+})
+
+# ── calc_backtest_metrics (already guarded; regression-proofing) ─────────────
+# Shared by stk_max_metrics / stk_drif_metrics / xgb_drif_metrics -- this
+# top-level function already had the `n < 12` guard before #660, verified
+# here directly since it is NOT a target-local closure.
+
+test_that("calc_backtest_metrics returns NULL (not a spurious row) for an empty window", {
+  empty_df <- dplyr::tibble(
+    date = as.Date(character()), port_ret = numeric(),
+    rf_ret = numeric(), n_long = integer(), n_short = integer()
+  )
+  expect_null(calc_backtest_metrics(empty_df, "Validation"))
+})
+
+test_that("calc_backtest_metrics returns NULL below the 12-observation minimum", {
+  short_df <- dplyr::tibble(
+    date = as.Date("2026-05-01") + 0:5 * 30, port_ret = rep(0.01, 6),
+    rf_ret = rep(0.001, 6), n_long = rep(10L, 6), n_short = rep(10L, 6)
+  )
+  expect_null(calc_backtest_metrics(short_df, "Validation"))
+})
+
+test_that("calc_backtest_metrics returns a row when the window has >= 12 observations", {
+  ok_df <- dplyr::tibble(
+    date = seq(as.Date("2020-01-15"), by = "month", length.out = 12),
+    port_ret = rep(0.01, 12), rf_ret = rep(0.001, 12),
+    n_long = rep(10L, 12), n_short = rep(10L, 12)
+  )
+  result <- calc_backtest_metrics(ok_df, "Testing")
+  expect_false(is.null(result))
+  expect_equal(result$period, "Testing")
+  expect_equal(result$months, 12L)
+})

--- a/tests/testthat/test-holdout-source-metrics-666.R
+++ b/tests/testthat/test-holdout-source-metrics-666.R
@@ -1,0 +1,307 @@
+testthat::local_edition(3)
+# Tests for #666: add a "Holdout" period row to the seven source-metrics
+# targets so slice_portfolio()'s Holdout cost-metric slice in
+# R/plan_leaderboard.R (added by #660, previously unmatched -- the "KNOWN
+# GAP" documented at that function's definition) finds a base row to
+# left_join() onto and actually reaches the leaderboard.
+#
+# Targets covered: fm_metrics, drif_metrics, stk_max_metrics,
+# stk_drif_metrics, xgb_drif_metrics, ltr_metrics, port_metrics.
+#
+# `tar_target()` command bodies are quoted expressions, not plain functions,
+# so these tests extract each target's real `command$expr` from its
+# `plan_*()` list (same technique as test-partitions-recut.R) and evaluate
+# it against synthetic upstream data -- this exercises the actual target
+# body, catching a regression in the real plan file, not a hand-copied
+# re-implementation of it.
+
+source(here::here("R/plan_partitions.R"))
+source(here::here("R/plan_factormax.R"))
+source(here::here("R/plan_drif.R"))
+source(here::here("R/plan_stock_backtest.R"))
+source(here::here("R/plan_xgb_signal.R"))
+source(here::here("R/plan_ltr_momentum.R"))
+source(here::here("R/plan_portfolio_opt.R"))
+
+.eval_bt_partitions <- function() {
+  targets_list <- plan_partitions()
+  eval(targets_list[[1]]$command$expr)
+}
+bt_partitions <- .eval_bt_partitions()
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+#' Extract the quoted `command$expr` for a named target out of a plan_*() list
+.tar_expr <- function(targets_list, name) {
+  nm  <- vapply(targets_list, function(t) t$settings$name, character(1))
+  idx <- which(nm == name)
+  testthat::expect_length(idx, 1L)  # fails loudly if the target was renamed/removed
+  targets_list[[idx]]$command$expr
+}
+
+#' Evaluate a target's command expr against a named list of upstream objects
+.eval_target <- function(expr, vars) {
+  eval(expr, envir = list2env(vars, parent = globalenv()))
+}
+
+# Full-span monthly series: 2018-01 .. 2026-04, so Training/Testing/Holdout
+# all have >= 12 months of data (equity/factor Holdout is 2024-01..2026-04-30,
+# 28 calendar months -- comfortably above every helper's n < 12 guard).
+.make_monthly_dates <- function(from = "2018-01-31", to = "2026-04-30") {
+  seq.Date(as.Date(from), as.Date(to), by = "month")
+}
+
+.make_factor_portfolio <- function(dates = .make_monthly_dates()) {
+  n <- length(dates)
+  set.seed(1L)
+  tibble::tibble(
+    date          = dates,
+    portfolio_ret = stats::rnorm(n, 0.006, 0.03),
+    benchmark_ret = stats::rnorm(n, 0.004, 0.03),
+    rf_ret        = rep(0.0003, n)
+  )
+}
+
+.make_stock_portfolio <- function(dates = .make_monthly_dates()) {
+  n <- length(dates)
+  set.seed(2L)
+  tibble::tibble(
+    date     = dates,
+    port_ret = stats::rnorm(n, 0.006, 0.03),
+    rf_ret   = rep(0.0003, n),
+    n_long   = rep(20L, n),
+    n_short  = rep(20L, n)
+  )
+}
+
+.make_port_combined <- function(dates = .make_monthly_dates()) {
+  n <- length(dates)
+  set.seed(3L)
+  tibble::tibble(
+    date        = dates,
+    optimal_ret = stats::rnorm(n, 0.006, 0.03),
+    hrp_ret     = stats::rnorm(n, 0.005, 0.03),
+    equalwt_ret = stats::rnorm(n, 0.005, 0.03),
+    rf_ret      = rep(0.0003, n)
+  )
+}
+
+.params_for <- function(cls, extra = list()) {
+  p <- bt_partitions[[cls]]
+  utils::modifyList(
+    list(
+      is_end        = p$train_end,
+      test_start    = p$test_start,
+      test_end      = p$test_end,
+      holdout_start = p$holdout_start,
+      holdout_end   = p$holdout_end,
+      val_start     = p$val_start,
+      val_end       = p$val_end
+    ),
+    extra
+  )
+}
+
+.months_in_window <- function(dates, start, end) sum(dates >= start & dates <= end)
+
+# ── fm_metrics (factor class, calc_metrics helper) ────────────────────────────
+
+fm_expr      <- .tar_expr(plan_factormax(), "fm_metrics")
+fm_params    <- .params_for("factor")
+fm_portfolio <- .make_factor_portfolio()
+fm_result    <- .eval_target(fm_expr, list(fm_params = fm_params, fm_portfolio = fm_portfolio))
+
+test_that("fm_metrics: Holdout is in the period set", {
+  expect_true("Holdout" %in% fm_result$period)
+})
+
+test_that("fm_metrics: Holdout window matches bt_partitions$factor", {
+  hd <- fm_result[fm_result$period == "Holdout", ]
+  expect_equal(nrow(hd), 1L)
+  expect_equal(
+    hd$months,
+    .months_in_window(fm_portfolio$date, bt_partitions$factor$holdout_start, bt_partitions$factor$holdout_end)
+  )
+})
+
+test_that("fm_metrics: empty Holdout slice yields no row and no error", {
+  short_portfolio <- .make_factor_portfolio(.make_monthly_dates(to = "2023-12-31"))  # ends before holdout_start
+  result <- expect_no_error(
+    .eval_target(fm_expr, list(fm_params = fm_params, fm_portfolio = short_portfolio))
+  )
+  expect_false("Holdout" %in% result$period)
+})
+
+# ── drif_metrics (factor class, calc_metrics helper) ──────────────────────────
+
+drif_expr      <- .tar_expr(plan_drif(), "drif_metrics")
+drif_params    <- .params_for("factor")
+drif_portfolio <- .make_factor_portfolio()
+drif_result    <- .eval_target(drif_expr, list(drif_params = drif_params, drif_portfolio = drif_portfolio))
+
+test_that("drif_metrics: Holdout is in the period set", {
+  expect_true("Holdout" %in% drif_result$period)
+})
+
+test_that("drif_metrics: Holdout window matches bt_partitions$factor", {
+  hd <- drif_result[drif_result$period == "Holdout", ]
+  expect_equal(nrow(hd), 1L)
+  expect_equal(
+    hd$months,
+    .months_in_window(drif_portfolio$date, bt_partitions$factor$holdout_start, bt_partitions$factor$holdout_end)
+  )
+})
+
+# ── stk_max_metrics / stk_drif_metrics / xgb_drif_metrics (equity class,
+#    shared calc_backtest_metrics() helper defined top-level in
+#    R/plan_stock_backtest.R) ───────────────────────────────────────────────
+
+stk_params <- .params_for("equity")
+
+test_that("stk_max_metrics: Holdout is in the period set and window matches", {
+  expr <- .tar_expr(plan_stock_backtest(), "stk_max_metrics")
+  stk_max_portfolio <- .make_stock_portfolio()
+  result <- .eval_target(expr, list(stk_params = stk_params, stk_max_portfolio = stk_max_portfolio))
+
+  hd <- result[result$period == "Holdout", ]
+  expect_equal(nrow(hd), 1L)
+  expect_equal(
+    hd$months,
+    .months_in_window(stk_max_portfolio$date, bt_partitions$equity$holdout_start, bt_partitions$equity$holdout_end)
+  )
+})
+
+test_that("stk_max_metrics: short Holdout slice (below the n<12 guard) yields no row and no error", {
+  expr <- .tar_expr(plan_stock_backtest(), "stk_max_metrics")
+  # Holdout window has only 6 months of data -- below calc_backtest_metrics()'s n < 12 guard.
+  short_dates <- .make_monthly_dates(to = "2024-06-30")
+  stk_max_portfolio <- .make_stock_portfolio(short_dates)
+  result <- expect_no_error(
+    .eval_target(expr, list(stk_params = stk_params, stk_max_portfolio = stk_max_portfolio))
+  )
+  expect_false("Holdout" %in% result$period)
+})
+
+test_that("stk_drif_metrics: Holdout is in the period set and window matches", {
+  expr <- .tar_expr(plan_stock_backtest(), "stk_drif_metrics")
+  stk_drif_portfolio <- .make_stock_portfolio()
+  result <- .eval_target(expr, list(stk_params = stk_params, stk_drif_portfolio = stk_drif_portfolio))
+
+  hd <- result[result$period == "Holdout", ]
+  expect_equal(nrow(hd), 1L)
+  expect_equal(
+    hd$months,
+    .months_in_window(stk_drif_portfolio$date, bt_partitions$equity$holdout_start, bt_partitions$equity$holdout_end)
+  )
+})
+
+test_that("xgb_drif_metrics: Holdout is in the period set and window matches", {
+  expr <- .tar_expr(plan_xgb_signal(), "xgb_drif_metrics")
+  xgb_drif_portfolio <- .make_stock_portfolio()
+  result <- .eval_target(expr, list(stk_params = stk_params, xgb_drif_portfolio = xgb_drif_portfolio))
+
+  hd <- result[result$period == "Holdout", ]
+  expect_equal(nrow(hd), 1L)
+  expect_equal(
+    hd$months,
+    .months_in_window(xgb_drif_portfolio$date, bt_partitions$equity$holdout_start, bt_partitions$equity$holdout_end)
+  )
+})
+
+# ── ltr_metrics (equity class, local compute_ltr_metrics() helper) ───────────
+
+test_that("ltr_params carries holdout_start/holdout_end sourced from bt_partitions$equity (#666)", {
+  ltr_expr <- .tar_expr(plan_ltr_momentum(), "ltr_params")
+  result <- .eval_target(ltr_expr, list(bt_partitions = bt_partitions))
+  expect_equal(result$holdout_start, bt_partitions$equity$holdout_start)
+  expect_equal(result$holdout_end, bt_partitions$equity$holdout_end)
+})
+
+test_that("ltr_metrics: Holdout is in the period set and window matches", {
+  expr <- .tar_expr(plan_ltr_momentum(), "ltr_metrics")
+  ltr_params <- .params_for("equity")
+  ltr_portfolio <- .make_stock_portfolio()
+  result <- .eval_target(expr, list(ltr_params = ltr_params, ltr_portfolio = ltr_portfolio))
+
+  hd <- result[result$period == "Holdout", ]
+  expect_equal(nrow(hd), 1L)
+  expect_equal(
+    hd$months,
+    .months_in_window(ltr_portfolio$date, bt_partitions$equity$holdout_start, bt_partitions$equity$holdout_end)
+  )
+})
+
+test_that("ltr_metrics: short Holdout slice yields no row and no error", {
+  expr <- .tar_expr(plan_ltr_momentum(), "ltr_metrics")
+  ltr_params <- .params_for("equity")
+  short_dates <- .make_monthly_dates(to = "2024-06-30")
+  ltr_portfolio <- .make_stock_portfolio(short_dates)
+  result <- expect_no_error(
+    .eval_target(expr, list(ltr_params = ltr_params, ltr_portfolio = ltr_portfolio))
+  )
+  expect_false("Holdout" %in% result$period)
+})
+
+# ── port_metrics (equity class, local calc_port_metrics() helper) ────────────
+
+test_that("port_metrics: Holdout is in the period set and window matches", {
+  expr <- .tar_expr(plan_portfolio_opt(), "port_metrics")
+  port_combined <- .make_port_combined()
+  result <- .eval_target(expr, list(stk_params = stk_params, port_combined = port_combined))
+
+  hd <- result[result$period == "Holdout", ]
+  expect_equal(nrow(hd), 1L)
+  expect_equal(
+    hd$months,
+    .months_in_window(port_combined$date, bt_partitions$equity$holdout_start, bt_partitions$equity$holdout_end)
+  )
+})
+
+test_that("port_metrics: short Holdout slice yields no row and no error", {
+  expr <- .tar_expr(plan_portfolio_opt(), "port_metrics")
+  short_dates <- .make_monthly_dates(to = "2024-06-30")
+  port_combined <- .make_port_combined(short_dates)
+  result <- expect_no_error(
+    .eval_target(expr, list(stk_params = stk_params, port_combined = port_combined))
+  )
+  expect_false("Holdout" %in% result$period)
+})
+
+# ── No "Validation" row is newly introduced by this change ───────────────────
+# This change adds ONLY a "Holdout" slice to each target -- it must not also
+# add or duplicate a "Validation" row (each target's existing Validation
+# slice, if any, is untouched and out of #666's scope; see
+# test-leaderboard-no-validation.R for the leaderboard-level S14 gate that
+# strips Validation from the automatic tar_make() path regardless).
+
+test_that("none of the seven targets emit more than one row per period label", {
+  results <- list(
+    fm   = fm_result,
+    drif = drif_result
+  )
+  for (nm in names(results)) {
+    r <- results[[nm]]
+    dup_periods <- r$period[duplicated(r$period)]
+    expect_length(dup_periods, 0L)
+  }
+})
+
+# ── holdout_start/holdout_end threading matches bt_partitions exactly ────────
+# (the "join now succeeds" static argument: slice_portfolio() in
+# R/plan_leaderboard.R keys its own Holdout slice off `params$holdout_start`/
+# `params$holdout_end` on the SAME params objects (fm_params, drif_params,
+# stk_params) used here -- so both sides of the eventual left_join key off
+# an identical [holdout_start, holdout_end] window by construction.)
+
+test_that("fm_params/drif_params/stk_params Holdout boundaries equal bt_partitions (#666 join precondition)", {
+  fm_p   <- .eval_target(.tar_expr(plan_factormax(), "fm_params"), list(bt_partitions = bt_partitions))
+  drif_p <- .eval_target(.tar_expr(plan_drif(), "drif_params"), list(bt_partitions = bt_partitions))
+  stk_p  <- .eval_target(.tar_expr(plan_stock_backtest(), "stk_params"), list(bt_partitions = bt_partitions))
+
+  expect_equal(fm_p$holdout_start, bt_partitions$factor$holdout_start)
+  expect_equal(fm_p$holdout_end,   bt_partitions$factor$holdout_end)
+  expect_equal(drif_p$holdout_start, bt_partitions$factor$holdout_start)
+  expect_equal(drif_p$holdout_end,   bt_partitions$factor$holdout_end)
+  expect_equal(stk_p$holdout_start, bt_partitions$equity$holdout_start)
+  expect_equal(stk_p$holdout_end,   bt_partitions$equity$holdout_end)
+})

--- a/tests/testthat/test-leaderboard-no-validation.R
+++ b/tests/testthat/test-leaderboard-no-validation.R
@@ -55,10 +55,28 @@ multi_validation_leaderboard <- tibble::tibble(
   )
 )
 
+# A leaderboard with "Holdout" rows (#660) but no "Validation" row -- the
+# tier this gate must NOT reject, since Holdout is observed-but-unsealed and
+# allowed on the automatic path by design (backtest-partitions.md).
+holdout_leaderboard <- tibble::tibble(
+  strategy = c(
+    "Factor MAX", "Factor MAX", "Factor MAX", "Factor MAX",
+    "Stock DRIF", "Stock DRIF", "Stock DRIF", "Stock DRIF"
+  ),
+  period = c(
+    "Training", "Testing", "Holdout", "Full Period",
+    "Training", "Testing", "Holdout", "Full Period"
+  )
+)
+
 # ── Tests: passes when no Validation row is present ──────────────────────────
 
 test_that("check_leaderboard_no_validation_rows passes when no strategy has a Validation row", {
   expect_true(check_leaderboard_no_validation_rows(good_leaderboard))
+})
+
+test_that("check_leaderboard_no_validation_rows permits Holdout rows (#660) -- not the same tier as Validation", {
+  expect_true(check_leaderboard_no_validation_rows(holdout_leaderboard))
 })
 
 # ── Tests: throws when a Validation row leaks through ────────────────────────

--- a/tests/testthat/test-leaderboard-period-vocab.R
+++ b/tests/testthat/test-leaderboard-period-vocab.R
@@ -109,11 +109,34 @@ test_that("check_leaderboard_period_vocab throws when required columns are missi
   )
 })
 
+# ── 'Holdout' acceptance (#660) ───────────────────────────────────────────────
+
+# A strategy WITH a Holdout row -- must not be rejected as an unknown label.
+holdout_leaderboard <- tibble::tibble(
+  strategy = c("Factor MAX", "Factor MAX", "Factor MAX", "Factor MAX"),
+  period   = c("Training", "Testing", "Holdout", "Full Period")
+)
+
+# A strategy WITHOUT a Holdout row -- Holdout is optional per strategy, same
+# as "OOS"/"Testing"; only "Full Period" is mandatory (assertion 1).
+no_holdout_leaderboard <- tibble::tibble(
+  strategy = c("Value (HML)", "Value (HML)", "Value (HML)"),
+  period   = c("Training", "Testing", "Full Period")
+)
+
+test_that("check_leaderboard_period_vocab accepts 'Holdout' as canonical vocabulary", {
+  expect_true(check_leaderboard_period_vocab(holdout_leaderboard))
+})
+
+test_that("check_leaderboard_period_vocab does not require every strategy to have a Holdout row", {
+  expect_true(check_leaderboard_period_vocab(no_holdout_leaderboard))
+})
+
 # ── PERIOD_LABELS_ALLOWED itself ─────────────────────────────────────────────
 
-test_that("PERIOD_LABELS_ALLOWED contains the 5 expected canonical labels", {
+test_that("PERIOD_LABELS_ALLOWED contains the 6 expected canonical labels (#660 adds Holdout)", {
   expect_setequal(
     PERIOD_LABELS_ALLOWED,
-    c("Training", "Testing", "Validation", "Full Period", "OOS")
+    c("Training", "Testing", "Holdout", "Validation", "Full Period", "OOS")
   )
 })

--- a/tests/testthat/test-metric-window-bounds.R
+++ b/tests/testthat/test-metric-window-bounds.R
@@ -57,6 +57,26 @@ full_period_metrics <- tibble::tibble(
   window_end   = as.Date(c("2022-06-30", "2026-01-31"))
 )
 
+# The "Holdout" tier (#660): observed but NOT sealed, computed automatically,
+# and its whole purpose (like Validation and Full Period) is to extend past
+# test_end -- it must be exempt from the bound the same way those two are.
+holdout_metrics <- tibble::tibble(
+  strategy     = c("TS-Mom L/S", "TS-Mom L/S"),
+  period       = c("OOS", "Holdout"),
+  window_start = as.Date(c("2010-01-01", "2024-01-01")),
+  window_end   = as.Date(c("2022-06-30", "2026-04-30"))
+)
+
+# A genuine #645-style regression must still be caught even after the #660
+# Holdout exemption is added -- an OOS window that extends past test_end and
+# is NOT labelled Holdout or Validation must still abort.
+unbounded_oos_with_holdout_metrics <- tibble::tibble(
+  strategy     = c("TS-Mom L/S", "TS-Mom L/S", "TS-Mom L/S"),
+  period       = c("OOS", "Holdout", "Full Period"),
+  window_start = as.Date(c("2010-01-01", "2024-01-01", "2005-01-01")),
+  window_end   = as.Date(c("2026-04-30", "2026-04-30", "2026-04-30"))
+)
+
 # ── Tests: bounded window passes ──────────────────────────────────────────────
 
 test_that("check_metric_window_bounds passes when all non-Validation windows are bounded at test_end", {
@@ -91,6 +111,25 @@ test_that("check_metric_window_bounds exempts period == 'Validation'", {
 
 test_that("check_metric_window_bounds exempts period == 'Full Period'", {
   expect_true(check_metric_window_bounds(full_period_metrics, test_end, "mf_metrics"))
+})
+
+# ── Tests: 'Holdout' exemption (#660) ─────────────────────────────────────────
+
+test_that("check_metric_window_bounds exempts period == 'Holdout'", {
+  expect_true(check_metric_window_bounds(holdout_metrics, test_end, "mf_metrics"))
+})
+
+test_that("check_metric_window_bounds still catches a genuine #645 regression when a Holdout row is also present", {
+  expect_error(
+    check_metric_window_bounds(unbounded_oos_with_holdout_metrics, test_end, "mf_metrics"),
+    regexp = "OOS"
+  )
+  # Holdout and Full Period rows in the same fixture must NOT be flagged --
+  # only the offending OOS row should appear in the error.
+  expect_error(
+    check_metric_window_bounds(unbounded_oos_with_holdout_metrics, test_end, "mf_metrics"),
+    regexp = "1 row"
+  )
 })
 
 # ── Tests: required columns ───────────────────────────────────────────────────

--- a/tests/testthat/test-partitions-recut.R
+++ b/tests/testthat/test-partitions-recut.R
@@ -1,0 +1,113 @@
+testthat::local_edition(3)
+# Tests for the #660 four-tier partition re-cut (Training / Testing /
+# Holdout / Validation) in R/plan_partitions.R `bt_partitions`.
+#
+# Background (#660): the original Testing/Validation split (test_end =
+# 2022-12-31, val_start = 2023-01-01) was burned -- docs/stock-backtest.qmd
+# published Validation figures in prose and drew a strategy conclusion from
+# them. Every month from 2024-01 to the data boundary (2026-04-15 equity,
+# 2026-02-27 factor as of #660) had already been read, so the fix reclassifies
+# that span as a new "Holdout" tier (observed, NOT sealed) and cuts a
+# genuinely untouched "Validation" window starting 2026-05-01 -- the first
+# month past the current data boundary.
+#
+# `bt_partitions` is a targets `command` expression, not a plain object, so
+# these tests evaluate the target's own quoted expression directly rather
+# than re-deriving the dates by hand -- a regression that changes the dates
+# in R/plan_partitions.R without updating this test will be caught either
+# way, but evaluating the real expression also catches a regression in the
+# *shape* (e.g. a renamed field) that a hand-copied fixture would miss.
+
+source(here::here("R/plan_partitions.R"))
+
+.eval_bt_partitions <- function() {
+  targets_list <- plan_partitions()
+  tgt <- targets_list[[1]]
+  eval(tgt$command$expr)
+}
+
+bt_partitions <- .eval_bt_partitions()
+
+# ── Tests: shape ──────────────────────────────────────────────────────────────
+
+test_that("bt_partitions has the three expected asset classes", {
+  expect_setequal(names(bt_partitions), c("equity", "factor", "macro"))
+})
+
+test_that("every asset class has all 8 boundary fields", {
+  expected_fields <- c(
+    "train_start", "train_end", "test_start", "test_end",
+    "holdout_start", "holdout_end", "val_start", "val_end"
+  )
+  for (cls in names(bt_partitions)) {
+    expect_setequal(names(bt_partitions[[cls]]), expected_fields)
+  }
+})
+
+# ── Tests: boundary values (#660) ──────────────────────────────────────────────
+
+test_that("test_end moved to 2023-12-31 for every asset class (absorbs the burned 2023)", {
+  for (cls in names(bt_partitions)) {
+    expect_equal(bt_partitions[[cls]]$test_end, as.Date("2023-12-31"), info = cls)
+  }
+})
+
+test_that("holdout_start/holdout_end are 2024-01-01/2026-04-30 for every asset class", {
+  for (cls in names(bt_partitions)) {
+    expect_equal(bt_partitions[[cls]]$holdout_start, as.Date("2024-01-01"), info = cls)
+    expect_equal(bt_partitions[[cls]]$holdout_end,   as.Date("2026-04-30"), info = cls)
+  }
+})
+
+test_that("val_start moved to 2026-05-01 (first month past the data boundary) for every asset class", {
+  for (cls in names(bt_partitions)) {
+    expect_equal(bt_partitions[[cls]]$val_start, as.Date("2026-05-01"), info = cls)
+  }
+})
+
+test_that("val_end is unchanged at 2026-12-31 for every asset class", {
+  for (cls in names(bt_partitions)) {
+    expect_equal(bt_partitions[[cls]]$val_end, as.Date("2026-12-31"), info = cls)
+  }
+})
+
+test_that("train_start/train_end are unchanged from before the re-cut", {
+  expect_equal(bt_partitions$equity$train_start, as.Date("2005-01-01"))
+  expect_equal(bt_partitions$factor$train_start, as.Date("1968-01-01"))
+  expect_equal(bt_partitions$macro$train_start,  as.Date("2007-04-01"))
+  for (cls in names(bt_partitions)) {
+    expect_equal(bt_partitions[[cls]]$train_end, as.Date("2019-12-31"), info = cls)
+  }
+})
+
+test_that("test_start is unchanged at 2020-01-01 for every asset class", {
+  for (cls in names(bt_partitions)) {
+    expect_equal(bt_partitions[[cls]]$test_start, as.Date("2020-01-01"), info = cls)
+  }
+})
+
+# ── Tests: ordering invariants (no gaps, no overlaps) ─────────────────────────
+
+test_that("the four tiers are contiguous with no gaps or overlaps, for every asset class", {
+  for (cls in names(bt_partitions)) {
+    p <- bt_partitions[[cls]]
+    expect_true(p$train_start <= p$train_end, info = cls)
+    expect_equal(p$test_start, p$train_end + 1, info = cls)
+    expect_true(p$test_start <= p$test_end, info = cls)
+    expect_equal(p$holdout_start, p$test_end + 1, info = cls)
+    expect_true(p$holdout_start <= p$holdout_end, info = cls)
+    expect_equal(p$val_start, p$holdout_end + 1, info = cls)
+    expect_true(p$val_start <= p$val_end, info = cls)
+  }
+})
+
+# ── Tests: Validation window is empty against the current data boundary ──────
+# (#660: 2026-05-01 is the first month past the data boundary -- 2026-04-15
+# equity / 2026-02-27 factor as of #660 -- so this is EXPECTED, not a defect.)
+
+test_that("the Validation window starts after the documented current data boundary", {
+  current_data_boundary_equity <- as.Date("2026-04-15")
+  current_data_boundary_factor <- as.Date("2026-02-27")
+  expect_true(bt_partitions$equity$val_start > current_data_boundary_equity)
+  expect_true(bt_partitions$factor$val_start > current_data_boundary_factor)
+})


### PR DESCRIPTION
## Summary

Re-cuts `bt_partitions` (R/plan_partitions.R) from Training/Testing/Validation into four tiers — **Training / Testing / Holdout / Validation** — per option 2 of #660.

The 2023-2026 Validation window was burned: `docs/stock-backtest.qmd` published its figures in prose and drew a strategy conclusion from them (#660), and every month of that span had already been read by the time the display fix (#660/PR #662) and computation fix (#648/PR #659) landed. No re-slicing of *existing* data yields a genuinely clean window, so the burned span becomes a new `Holdout` tier — observed, computed automatically, **never sealed** — and a new `Validation` window opens at 2026-05-01, the first month past the current data boundary.

## Final `bt_partitions` (all three classes: equity / factor / macro)

| field | old value | new value |
|---|---|---|
| `train_start` / `train_end` | unchanged | unchanged |
| `test_start` | `2020-01-01` | unchanged |
| `test_end` | `2022-12-31` | **`2023-12-31`** (absorbs the burned 2023) |
| `holdout_start` | — | **`2024-01-01`** (new) |
| `holdout_end` | — | **`2026-04-30`** (new) |
| `val_start` | `2023-01-01` | **`2026-05-01`** (first month past the data boundary) |
| `val_end` | `2026-12-31` | unchanged |

`PERIOD_LABELS_ALLOWED` adds `"Holdout"` (now 6 values).

## Gates touched

- **S10** (`check_leaderboard_period_vocab`) — no code change; dynamically reads `PERIOD_LABELS_ALLOWED`, so `Holdout` is accepted automatically. Roxygen updated: **Holdout is optional per strategy**, same as `OOS`/`Testing` — only `"Full Period"` is required (assertion 1 unchanged). Added tests for both cases.
- **S11** (`check_metric_window_bounds`) — `exempt_periods` gains `"Holdout"` alongside `"Validation"`/`"Full"`/`"Full Period"`, since Holdout's whole purpose is to extend past `test_end`. Added a regression test proving a genuine unbounded-OOS violation is still caught even when a legitimate Holdout row is present in the same fixture.
- **S14** (`check_leaderboard_no_validation_rows`) — **unchanged in intent**, per the task: it still rejects only `period == "Validation"`. Holdout rows are allowed through by design. Added a test confirming a leaderboard with Holdout rows (no Validation row) passes.
- **S15** (`check_no_published_validation_reads`) — not touched; its lexical scan only matches `period == "Validation"`, unaffected by Holdout.

## Display placement

`docs/leaderboard.qmd` "By Partition" table: `period_order <- c("Testing", "Holdout", "Full Period", "Training")` — Holdout placed immediately after Testing because it's the more recent, more informative (but discounted) evaluation window that follows Testing chronologically. Caption updated to name Holdout and state it is "observed, not sealed — treat it with a discount". The "Partitions" summary table near the end gets an explicit Holdout row with Purpose = "OBSERVED, NOT SEALED — usable for evaluation with a stated discount; never a one-shot result (#660)".

## Known gap — Holdout does not yet surface on the leaderboard (flagged, not fixed)

`slice_portfolio()` in `R/plan_leaderboard.R` now builds a Holdout cost-metric slice, but **these rows currently do not reach the assembled `leaderboard` target or `docs/leaderboard.qmd`**. The join is `all_metrics |> left_join(cost_rows, by = c("strategy", "period"))` — LEFT-driven by `all_metrics`, whose base rows come from `stk_max_metrics`/`stk_drif_metrics`/`xgb_drif_metrics`/`fm_metrics`/`drif_metrics`/`port_metrics` via `calc_backtest_metrics()`/`calc_metrics()`/`calc_port_metrics()`. None of those functions compute a `"Holdout"` period today (only Training/Testing/(Validation, filtered)/Full Period), so the Holdout rows built in `slice_portfolio()` are silently dropped by the join. Making Holdout actually visible requires adding a Holdout slice to those seven source targets too — a separate, wider change (7 more files) than the nine items in this task's scope. Documented inline at the exact join site and in `docs/leaderboard.qmd`'s `years_map` comment. **This needs a decision**: either authorize that follow-up or accept the Holdout tier is metadata-only (boundaries + gates correct) until then.

## Metrics whose published values move

**Widened by design (test_end 2022-12-31 → 2023-12-31, absorbs one real year):**
Every strategy with a canonical, bounded `"Testing"` row shifts — Factor MAX, Factor DRIF, Stock MAX, Stock DRIF, XGB DRIF, LTR, OLMAR-1, TOM, ETF DRIF A, ETF DRIF B, PSO Optimal (cost metrics). This is the intended primary effect of the re-cut, not a side effect.

**Widened as an accepted consequence (confirmed — the only two, per the task's own framing):**
- `Managed Futures` (R/plan_managed_futures.R, `mf_metrics`) — its `"OOS"` window is `dates >= oos_start` bounded above at `bt_partitions$macro$test_end` (#645) — now extends one year further.
- `Value (HML)` (R/plan_ev_ebit.R, `ev_metrics`) — same pattern, `bt_partitions$factor$test_end`.

Both strategies have **no `"Testing"` row at all** (only Training/OOS/Full) — verified by grep.

**Currently empty (expected, not a bug):**
- Every source target's `"Validation"` row (`fm_metrics`, `drif_metrics`, `stk_max_metrics`, `stk_drif_metrics`, `xgb_drif_metrics`, `etf_a_metrics`, `etf_b_metrics`, `ltr_metrics`, `port_metrics`) becomes a zero-observation window against `val_start = 2026-05-01` (current data ends ~2026-04-15 equity / ~2026-02-27 factor). Verified every such `calc_metrics`/`calc_backtest_metrics`/`calc_port_metrics`/`compute_ltr_metrics`/`calc_m` helper already returns `NULL` below its minimum-observation guard — **except** `R/plan_factormax.R`'s `calc_metrics()` (used by `fm_metrics`), which had no guard at all. **Fixed**: added the same `if (n < 12) return(NULL)` pattern used by every sibling helper, verified end-to-end against the real target expression (not a hand-copied reimplementation) — before the fix this would have propagated `1^Inf`/`NaN`/`Inf` arithmetic into a spurious row; after the fix it silently contributes zero rows, matching every other strategy.
- `scripts/evaluate_validation.R` now explicitly warns when the window is empty rather than silently printing an all-NA table.

## Additional consumer found, not in the task's list — flagged prominently, not fixed

`R/plan_risk_state.R`'s `rsc_metrics` target (feeds the leaderboard's **"Risk State"** row via `.norm_rsc()`) computes its `"Testing"` period as `port$ret_buyhold[port$date >= oos]` / `port$ret_strategy[port$date >= oos]` where `oos <- rsc_params$oos_start` (`2020-01-01`) — **unbounded above, no upper limit at all**. This is a #645-style leak that has *always* silently included the entire post-2020 span — including the old sealed Validation partition (2023-2026) — under the label `"Testing"` rather than `"OOS"`, so it evaded both the original #645 fix (which only looked at OOS-labeled windows) and S11 (`check_metric_window_bounds`), which isn't wired to `rsc_metrics` at all — and couldn't be, since `rsc_metrics`'s `calc_metrics()` doesn't produce a `window_end` column S11 requires. This predates #660 entirely and is not caused by this PR, but after this PR the same unbounded window will also silently swallow all of Holdout (2024-2026) and, later, Validation. Recommend a follow-up issue; not fixed here (out of this PR's declared scope — would need a new `window_end` column plus gate wiring).

## Verification

`scripts/verify.sh` (full mode, foreground) — **PASS**:

```
PASS: _targets.R parses
PASS: testthat edition 3 active
=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)
=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%
=== scripts/verify.sh: PASS ===
```

No new failures, no new skips, matches the documented baselines exactly. Two new test files (`test-partitions-recut.R` — 51 assertions on boundaries/ordering, `test-empty-validation-window.R` — 10 assertions including an end-to-end run of the real `fm_metrics` target expression with synthetic data) plus updates to the three existing gate test files (snapshot for `leaderboard-period-vocab.md` regenerated and diff-reviewed).

## What remains unverified

- **Cannot run `tar_make()`** (out of scope per dispatch) — so the rebuilt leaderboard carrying the widened Testing/OOS numbers and any Holdout rows (pending the join-gap follow-up above) is not shown here. All new test coverage exercises the real target *expressions* with synthetic data instead of the live pipeline.
- `docs/stock-backtest.qmd`'s own "Partitions" table (lines ~636-655, reads `stk_params` dynamically) will correctly reflect the new dates at render time but was **not** updated to add a Holdout row — it's outside this task's 9 enumerated files and is a benign boundary-date display, not a sealed-metric leak.
- ast-grep/jarl code-quality check (`~/.claude/scripts/r_code_check.sh`) could not run in this environment (`ast-grep not found in PATH`) — per project convention this tool is laptop-local only and skipped when missing elsewhere.

Closes #660.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
