### PR TITLE
fix(669): adjusted -> adjusted_close schema mismatch across 12 hd_ohlcv() consumers

### DIFF
--- a/R/plan_avoid_worst.R
+++ b/R/plan_avoid_worst.R
@@ -27,7 +27,7 @@ plan_avoid_worst <- function() {
         d <- hd_ohlcv(tkr) |>
           arrange(date) |>
           mutate(
-            ret = adjusted / lag(adjusted) - 1,
+            ret = adjusted_close / lag(adjusted_close) - 1,
             ticker = tkr
           ) |>
           filter(!is.na(ret)) |>

--- a/R/plan_backtest.R
+++ b/R/plan_backtest.R
@@ -38,7 +38,7 @@ plan_backtest <- function() {
         dplyr::group_by(ticker, ym) |>
         dplyr::filter(date == max(date)) |>
         dplyr::ungroup() |>
-        dplyr::select(ticker, date, close, adjusted) |>
+        dplyr::select(ticker, date, close, adjusted_close) |>
         dplyr::arrange(ticker, date) |>
         dplyr::mutate(date = as.Date(date, tz = "UTC"))
     }),
@@ -48,7 +48,7 @@ plan_backtest <- function() {
       bt_prices |>
         dplyr::group_by(ticker) |>
         dplyr::arrange(date) |>
-        dplyr::mutate(ret = adjusted / dplyr::lag(adjusted) - 1) |>
+        dplyr::mutate(ret = adjusted_close / dplyr::lag(adjusted_close) - 1) |>
         dplyr::filter(!is.na(ret)) |>
         dplyr::ungroup() |>
         dplyr::mutate(date = as.Date(date, tz = "UTC"))

--- a/R/plan_circuit_breaker.R
+++ b/R/plan_circuit_breaker.R
@@ -247,7 +247,7 @@ plan_circuit_breaker <- function() {
         hd_ohlcv("SPY") |>
           mutate(date = as.Date(date)) |>
           arrange(date) |>
-          mutate(spy_ret = adjusted / lag(adjusted) - 1) |>
+          mutate(spy_ret = adjusted_close / lag(adjusted_close) - 1) |>
           filter(!is.na(spy_ret)) |>
           select(date, spy_ret),
         error = function(e) {

--- a/R/plan_etf_replication.R
+++ b/R/plan_etf_replication.R
@@ -49,10 +49,10 @@ plan_etf_replication <- function() {
       raw |>
         group_by(ticker) |>
         arrange(date) |>
-        mutate(daily_ret = adjusted / dplyr::lag(adjusted) - 1) |>
+        mutate(daily_ret = adjusted_close / dplyr::lag(adjusted_close) - 1) |>
         filter(!is.na(daily_ret)) |>
         ungroup() |>
-        select(ticker, date, daily_ret, close, adjusted) |>
+        select(ticker, date, daily_ret, close, adjusted_close) |>
         dplyr::mutate(date = as.Date(date, tz = "UTC"))
     }),
 
@@ -67,7 +67,7 @@ plan_etf_replication <- function() {
         ungroup() |>
         group_by(ticker) |>
         arrange(date) |>
-        mutate(monthly_ret = adjusted / dplyr::lag(adjusted) - 1) |>
+        mutate(monthly_ret = adjusted_close / dplyr::lag(adjusted_close) - 1) |>
         filter(!is.na(monthly_ret)) |>
         ungroup() |>
         select(ticker, date, ym, monthly_ret) |>

--- a/R/plan_factormax.R
+++ b/R/plan_factormax.R
@@ -318,7 +318,7 @@ plan_factormax <- function() {
         ungroup() |>
         group_by(ticker) |>
         arrange(date) |>
-        mutate(ret = adjusted / dplyr::lag(adjusted) - 1) |>
+        mutate(ret = adjusted_close / dplyr::lag(adjusted_close) - 1) |>
         filter(!is.na(ret)) |>
         ungroup() |>
         select(ticker, date, ym, ret)

--- a/R/plan_guardian.R
+++ b/R/plan_guardian.R
@@ -70,7 +70,7 @@ plan_guardian <- function() {
           ) |>
           dplyr::group_by(year_month) |>
           dplyr::summarise(
-            spy_return = (dplyr::last(adjusted) / dplyr::first(adjusted) - 1) * 100,
+            spy_return = (dplyr::last(adjusted_close) / dplyr::first(adjusted_close) - 1) * 100,
             .groups = "drop"
           )
       }, error = function(e) {

--- a/R/plan_integration.R
+++ b/R/plan_integration.R
@@ -60,7 +60,7 @@ plan_integration <- function() {
         hd_ohlcv("SPY") |>
           dplyr::arrange(date) |>
           dplyr::mutate(
-            return = (adjusted / dplyr::lag(adjusted)) - 1
+            return = (adjusted_close / dplyr::lag(adjusted_close)) - 1
           ) |>
           dplyr::select(date, return) |>
           dplyr::filter(!is.na(return))
@@ -82,11 +82,11 @@ plan_integration <- function() {
 
         # Get benchmark asset returns (SPY, TLT, GLD, DBC)
         benchmark_assets <- hd_ohlcv(c("SPY", "TLT", "GLD", "DBC")) |>
-          dplyr::select(date, ticker, adjusted) |>
+          dplyr::select(date, ticker, adjusted_close) |>
           dplyr::arrange(ticker, date) |>
           dplyr::group_by(ticker) |>
           dplyr::mutate(
-            return = (adjusted / dplyr::lag(adjusted)) - 1
+            return = (adjusted_close / dplyr::lag(adjusted_close)) - 1
           ) |>
           dplyr::filter(!is.na(return)) |>
           dplyr::select(date, ticker, return) |>
@@ -113,7 +113,7 @@ plan_integration <- function() {
         # but that's 50+ tickers and slow for demo
         equity_data <- hd_ohlcv("SPY") |>
           dplyr::mutate(ticker = "SPY") |>
-          dplyr::select(date, ticker, open, high, low, close, adjusted, volume)
+          dplyr::select(date, ticker, open, high, low, close, adjusted_close, volume)
 
         calculate_adv(equity_data, window_days = 20)
       }

--- a/R/plan_nyt_sentiment.R
+++ b/R/plan_nyt_sentiment.R
@@ -146,7 +146,7 @@ plan_nyt_sentiment <- function() {
         hd_ohlcv("SPY") |>
           mutate(date = as.Date(date)) |>
           arrange(date) |>
-          mutate(daily_ret = adjusted / dplyr::lag(adjusted) - 1) |>
+          mutate(daily_ret = adjusted_close / dplyr::lag(adjusted_close) - 1) |>
           filter(!is.na(daily_ret)),
         error = function(e) {
           cli::cli_warn("Could not load SPY data: {e$message}")

--- a/R/plan_olmar.R
+++ b/R/plan_olmar.R
@@ -54,7 +54,7 @@ plan_olmar <- function() {
         tryCatch({
           hd_ohlcv(tkr, from = as.character(olmar_params$start_date)) |>
             dplyr::arrange(date) |>
-            dplyr::select(date, adjusted) |>
+            dplyr::select(date, adjusted_close) |>
             dplyr::mutate(date = as.Date(date, tz = "UTC"),
                           ticker = tkr)
         }, error = function(e) {
@@ -74,7 +74,7 @@ plan_olmar <- function() {
 
       # Pivot to wide: rows = date, cols = ticker
       wide <- dplyr::bind_rows(raw) |>
-        tidyr::pivot_wider(names_from = ticker, values_from = adjusted) |>
+        tidyr::pivot_wider(names_from = ticker, values_from = adjusted_close) |>
         dplyr::arrange(date)
 
       # Drop tickers that have too little history

--- a/R/plan_quiz.R
+++ b/R/plan_quiz.R
@@ -41,7 +41,7 @@ plan_quiz <- function() {
         tryCatch({
           d <- hd_ohlcv(tkr) |>
             dplyr::arrange(date) |>
-            dplyr::mutate(ret = adjusted / dplyr::lag(adjusted) - 1) |>
+            dplyr::mutate(ret = adjusted_close / dplyr::lag(adjusted_close) - 1) |>
             dplyr::filter(!is.na(ret))
           d |> dplyr::select(date, ret)
         }, error = function(e) NULL)

--- a/R/plan_risk_state.R
+++ b/R/plan_risk_state.R
@@ -47,7 +47,7 @@ plan_risk_state <- function() {
       # SPY daily returns
       spy <- hd_ohlcv("SPY") |>
         arrange(date) |>
-        mutate(spy_ret = adjusted / lag(adjusted) - 1) |>
+        mutate(spy_ret = adjusted_close / lag(adjusted_close) - 1) |>
         filter(!is.na(spy_ret)) |>
         select(date, spy_ret)
 

--- a/R/plan_vix_macro_overlay.R
+++ b/R/plan_vix_macro_overlay.R
@@ -37,7 +37,7 @@ plan_vix_macro_overlay <- function() {
           hd_ohlcv(tkr) |>
             mutate(date = as.Date(date)) |>
             arrange(date) |>
-            mutate(ret = adjusted / lag(adjusted) - 1, ticker = tkr) |>
+            mutate(ret = adjusted_close / lag(adjusted_close) - 1, ticker = tkr) |>
             filter(!is.na(ret)) |>
             select(date, ticker, ret) |>
             left_join(vix, by = "date")

--- a/packages/historicaldata/R/query.R
+++ b/packages/historicaldata/R/query.R
@@ -30,6 +30,43 @@
   }
   invisible(NULL)
 }
+# ── Schema contract guard (#669) ──────────────────────────────────────────
+
+#' Assert the canonical adjusted-price column survived the read-time alias
+#'
+#' Fires a classed error ("hd_schema_drift") when a dataset that promises
+#' an adjusted_close column in its [hd_datasets()] schema does not actually
+#' have one after the adjusted -> adjusted_close backward-compat rename in
+#' [hd_ohlcv_single()] / [hd_lazy()]. Without this guard, an upstream schema
+#' change that the rename does not anticipate is silently absorbed here and
+#' only surfaces later as a "column doesn't exist" error at an arbitrary
+#' downstream consumer -- exactly what happened for ~10 weeks in issue #669,
+#' where adjusted_close diverged from adjusted across call sites with no
+#' error raised at the access boundary.
+#'
+#' @param col_names Character vector of column names already read from the
+#'   source, after the read-time alias has run.
+#' @param dataset Dataset name (from [hd_datasets()]), used in the error.
+#' @return Invisibly NULL when the contract holds or the dataset does not
+#'   promise an adjusted_close column.
+#' @noRd
+.hd_assert_price_schema <- function(col_names, dataset) {
+  ds <- hd_datasets()[[dataset]]
+  promises_adjusted_close <- !is.null(ds) && "adjusted_close" %in% ds[["schema"]]
+  if (!promises_adjusted_close) return(invisible(NULL))
+  if ("adjusted_close" %in% col_names) return(invisible(NULL))
+  cli::cli_abort(
+    c(
+      "x" = "{.val {dataset}} promises an {.val adjusted_close} column but it is missing after the read-time alias.",
+      "i" = "Columns present: {.val {col_names}}.",
+      "i" = "The underlying parquet's adjusted-price column has apparently been renamed to something the {.fn hd_ohlcv}/{.fn hd_lazy} alias does not recognise.",
+      ">" = "Update the {.val adjusted} -> {.val adjusted_close} alias in {.fn hd_ohlcv_single} / {.fn hd_lazy} to match the new upstream column name."
+    ),
+    class = "hd_schema_drift",
+    call = rlang::caller_env()
+  )
+}
+
 
 # ── Survivorship-bias guard ───────────────────────────────────────────────────
 
@@ -194,7 +231,10 @@ hd_ohlcv_single <- function(ticker, dataset, from, to, local, collect) {
   col_names <- names(schema0)
   if ("adjusted" %in% col_names && !("adjusted_close" %in% col_names)) {
     lf <- lf |> dplyr::rename(adjusted_close = adjusted)
+    col_names[col_names == "adjusted"] <- "adjusted_close"
   }
+
+  .hd_assert_price_schema(col_names, dataset)
 
   # Date-filter type matching for duckplyr (#453)
   # The HF equity_daily parquet stores 'date' as TIMESTAMP_NS. DuckDB throws an
@@ -288,7 +328,10 @@ hd_lazy <- function(dataset = "equity_daily", local = FALSE) {
   col_names <- lf |> head(0) |> dplyr::collect() |> names()
   if ("adjusted" %in% col_names && !("adjusted_close" %in% col_names)) {
     lf <- lf |> dplyr::rename(adjusted_close = adjusted)
+    col_names[col_names == "adjusted"] <- "adjusted_close"
   }
+
+  .hd_assert_price_schema(col_names, dataset)
 
   lf
 }

--- a/packages/historicaldata/tests/testthat/_snaps/hd-ohlcv-adjusted-close-contract.md
+++ b/packages/historicaldata/tests/testthat/_snaps/hd-ohlcv-adjusted-close-contract.md
@@ -1,0 +1,12 @@
+# .hd_assert_price_schema() fires when adjusted_close is missing for a dataset that promises it (#669)
+
+    Code
+      historicaldata:::.hd_assert_price_schema(c("date", "open", "close", "volume"),
+      "equity_daily")
+    Condition
+      Error:
+      x "equity_daily" promises an "adjusted_close" column but it is missing after the read-time alias.
+      i Columns present: "date", "open", "close", and "volume".
+      i The underlying parquet's adjusted-price column has apparently been renamed to something the `hd_ohlcv()`/`hd_lazy()` alias does not recognise.
+      > Update the "adjusted" -> "adjusted_close" alias in `hd_ohlcv_single()` / `hd_lazy()` to match the new upstream column name.
+

--- a/packages/historicaldata/tests/testthat/test-hd-ohlcv-adjusted-close-contract.R
+++ b/packages/historicaldata/tests/testthat/test-hd-ohlcv-adjusted-close-contract.R
@@ -1,0 +1,66 @@
+# Regression tests for issue #669: hd_ohlcv()/hd_lazy() must always present
+# the canonical adjusted_close column, even when the underlying parquet
+# still uses the legacy adjusted name (as both the live equity_daily
+# parquet and the bundled sample fixture currently do -- see
+# test-sample-data.R "equity sample columns match the registry schema
+# (legacy 'adjusted' name)". Consumers must select adjusted_close, never bare
+# "adjusted" -- see R/plan_backtest.R and friends at the repo root, all fixed
+# in #669 to reference the canonical name.
+
+test_that("hd_ohlcv() presents adjusted_close, never bare 'adjusted' (#669)", {
+  local_sample_data()
+
+  result <- hd_ohlcv("AAPL", from = "2024-01-02", to = "2024-01-08")
+  expect_true("adjusted_close" %in% names(result))
+  expect_false("adjusted" %in% names(result))
+})
+
+test_that("a consumer selecting adjusted_close from hd_ohlcv() succeeds (#669)", {
+  local_sample_data()
+
+  # Mirrors R/plan_backtest.R's bt_prices target after the #669 fix: select
+  # the canonical column and compute a lagged return.
+  result <- hd_ohlcv("AAPL", from = "2024-01-02") |>
+    dplyr::arrange(date) |>
+    dplyr::mutate(ret = adjusted_close / dplyr::lag(adjusted_close) - 1) |>
+    dplyr::filter(!is.na(ret))
+
+  expect_true(nrow(result) > 0)
+  expect_true(all(is.finite(result$ret)))
+})
+
+test_that("hd_lazy() presents adjusted_close after collect() (#669)", {
+  local_sample_data()
+
+  result <- hd_lazy("equity_daily") |>
+    dplyr::filter(ticker == "AAPL") |>
+    dplyr::collect()
+
+  expect_true("adjusted_close" %in% names(result))
+  expect_false("adjusted" %in% names(result))
+})
+
+test_that(".hd_assert_price_schema() fires when adjusted_close is missing for a dataset that promises it (#669)", {
+  expect_snapshot(
+    error = TRUE,
+    historicaldata:::.hd_assert_price_schema(c("date", "open", "close", "volume"), "equity_daily")
+  )
+})
+
+test_that(".hd_assert_price_schema() is silent when adjusted_close is present (#669)", {
+  expect_no_error(
+    historicaldata:::.hd_assert_price_schema(c("date", "adjusted_close"), "equity_daily")
+  )
+})
+
+test_that(".hd_assert_price_schema() is silent for datasets that do not promise adjusted_close (#669)", {
+  expect_no_error(
+    historicaldata:::.hd_assert_price_schema(c("date", "open", "close", "volume"), "crypto_daily")
+  )
+})
+
+test_that(".hd_assert_price_schema() is silent for an unknown dataset (defensive default) (#669)", {
+  expect_no_error(
+    historicaldata:::.hd_assert_price_schema(c("date"), "not_a_real_dataset")
+  )
+})

--- a/tests/testthat/_snaps/adjusted-close-schema.md
+++ b/tests/testthat/_snaps/adjusted-close-schema.md
@@ -1,0 +1,11 @@
+# .hd_assert_price_schema() aborts when a promised dataset is missing adjusted_close
+
+    Code
+      .hd_assert_price_schema(c("date", "open", "close", "volume"), "equity_daily")
+    Condition
+      Error:
+      x "equity_daily" promises an "adjusted_close" column but it is missing after the read-time alias.
+      i Columns present: "date", "open", "close", and "volume".
+      i The underlying parquet's adjusted-price column has apparently been renamed to something the `hd_ohlcv()`/`hd_lazy()` alias does not recognise.
+      > Update the "adjusted" -> "adjusted_close" alias in `hd_ohlcv_single()` / `hd_lazy()` to match the new upstream column name.
+

--- a/tests/testthat/test-adjusted-close-schema.R
+++ b/tests/testthat/test-adjusted-close-schema.R
@@ -1,0 +1,72 @@
+testthat::local_edition(3)
+
+# Regression tests for issue #669: pipeline errors from an adjusted vs
+# adjusted_close schema mismatch, broken for ~10 weeks and masked by
+# target caching. hd_ohlcv()/hd_lazy() apply a read-time alias so callers
+# always see adjusted_close; twelve root-level plan_*.R consumers had
+# drifted to reference the pre-#325 bare adjusted name instead and were
+# fixed here. See also the hd_ohlcv()-level hermetic contract tests in
+# packages/historicaldata/tests/testthat/test-hd-ohlcv-adjusted-close-contract.R.
+#
+# .hd_assert_price_schema() lives in packages/historicaldata/R/query.R and
+# depends only on base R + cli (no duckplyr) -- sourced directly here,
+# same pattern as test-cov-routing.R, to keep this file hermetic and
+# independent of whether duckplyr is loadable in this test environment.
+source(here::here("packages/historicaldata/R/registry.R"))
+source(here::here("packages/historicaldata/R/query.R"))
+
+# ── Static regression guard: no fixed plan file may reintroduce a bare
+# adjusted symbol reference (#669) ─────────────────────────────────────
+
+test_that("fixed plan_*.R files reference adjusted_close, never bare adjusted (#669)", {
+  fixed_files <- c(
+    "R/plan_backtest.R", "R/plan_etf_replication.R", "R/plan_avoid_worst.R",
+    "R/plan_circuit_breaker.R", "R/plan_factormax.R", "R/plan_guardian.R",
+    "R/plan_integration.R", "R/plan_nyt_sentiment.R", "R/plan_olmar.R",
+    "R/plan_risk_state.R", "R/plan_quiz.R", "R/plan_vix_macro_overlay.R"
+  )
+  for (f in fixed_files) {
+    exprs <- parse(here::here(f))
+    syms <- unlist(lapply(exprs, function(e) all.names(e, unique = TRUE)))
+    expect_false("adjusted" %in% syms, label = paste("bare adjusted symbol in", f))
+    expect_true("adjusted_close" %in% syms, label = paste("expected adjusted_close symbol in", f))
+  }
+})
+
+# ── hd_datasets() contract: equity_daily promises adjusted_close ───────
+
+test_that("hd_datasets() equity_daily schema promises adjusted_close (#669)", {
+  ds <- hd_datasets()
+  expect_true("adjusted_close" %in% ds[["equity_daily"]][["schema"]])
+  expect_false("adjusted" %in% ds[["equity_daily"]][["schema"]])
+})
+
+# ── .hd_assert_price_schema(): the access-boundary schema guard (#669) ──
+
+test_that(".hd_assert_price_schema() aborts when a promised dataset is missing adjusted_close", {
+  expect_snapshot(
+    error = TRUE,
+    .hd_assert_price_schema(c("date", "open", "close", "volume"), "equity_daily")
+  )
+})
+
+test_that(".hd_assert_price_schema() aborts carry the hd_schema_drift class", {
+  cnd <- tryCatch(
+    .hd_assert_price_schema(c("date"), "equity_daily"),
+    error = function(e) e
+  )
+  expect_true(inherits(cnd, "hd_schema_drift"))
+})
+
+test_that(".hd_assert_price_schema() is silent when adjusted_close is present", {
+  expect_no_error(.hd_assert_price_schema(c("date", "adjusted_close"), "equity_daily"))
+})
+
+test_that(".hd_assert_price_schema() is silent for datasets that do not promise adjusted_close", {
+  expect_no_error(.hd_assert_price_schema(c("date", "open", "close", "volume"), "crypto_daily"))
+  expect_no_error(.hd_assert_price_schema(c("date", "value", "series_id"), "macro_daily"))
+})
+
+test_that(".hd_assert_price_schema() is silent for an unknown dataset (defensive default)", {
+  expect_no_error(.hd_assert_price_schema(c("date"), "not_a_real_dataset"))
+})


### PR DESCRIPTION
## Summary

Fixes #669: `bt_prices`, `bt_returns`, `etf_daily` (and 10 more previously-unflagged targets) referenced a bare `adjusted` column after calling `hd_ohlcv()`, which has presented the canonical `adjusted_close` column since #325. `olmar_prices`'s "no tickers returned data" error is the **same bug**, masked by a per-ticker `tryCatch` that silently dropped every ticker and surfaced a misleading network-access message.

## Root-cause mapping (established before any fix)

| Access path | Column presented | Why |
|---|---|---|
| `hd_ohlcv()` / `hd_lazy()` (package functions) | `adjusted_close` | Read-time alias renames the raw parquet's `adjusted` -> `adjusted_close` at query time (#325) |
| Raw parquet read directly (`duckplyr::read_parquet_duckdb(hd_datasets()[["equity_daily"]]$url)`), bypassing `hd_ohlcv()`/`hd_lazy()` | `adjusted` | The live HuggingFace `equity_daily.parquet` still literally has a column named `adjusted` — confirmed empirically; the doc comment claiming the raw parquet itself is `adjusted_close` is inaccurate for the currently-deployed file |

`ltr_universe` and `stk_universe`/`stk_monthly` read the raw parquet directly and correctly select `adjusted` — they were never broken. Every consumer that calls `hd_ohlcv()`/`hd_lazy()` and then selects `adjusted` is broken, because the alias always fires. `adjusted` and `adjusted_close` are the **same quantity** — the alias is a `dplyr::rename()`, not a recomputation — so renaming call sites changes no numbers.

## Fix

**Option (a) chosen**: rename each `hd_ohlcv()`/`hd_lazy()` consumer's `adjusted` reference to `adjusted_close`. Option (b) (normalise further at the access boundary) was rejected because the access boundary already normalises correctly — the bug is in twelve consumers that never got updated when #325 shipped, not in the boundary itself.

Auditing every `hd_ohlcv()` call site (not just the two files named in the issue) found **twelve** broken references across **ten** files — most previously unflagged and would have failed on their next cache invalidation:

- `R/plan_backtest.R` (`bt_prices`, `bt_returns`) — named in the issue
- `R/plan_etf_replication.R` (`etf_daily`, `etf_monthly`) — named in the issue
- `R/plan_avoid_worst.R` (`aw_daily_returns`)
- `R/plan_circuit_breaker.R` (`cb_vs_spy`)
- `R/plan_factormax.R`
- `R/plan_guardian.R` (`gdn_vs_spy`)
- `R/plan_integration.R` (`spy_returns`, `multi_asset_returns`, `equity_with_adv`)
- `R/plan_nyt_sentiment.R`
- `R/plan_olmar.R` (`olmar_prices`)
- `R/plan_risk_state.R` (`rsc_data`)
- `R/plan_quiz.R`
- `R/plan_vix_macro_overlay.R`

## `olmar_prices` diagnosis

Not a separate network problem. `plan_olmar.R` wraps each `hd_ohlcv(tkr, ...)` call in a `tryCatch` that converts *any* error (including the schema-mismatch `select()` error) into a `cli_warn` + dropped ticker. Since every ticker hit the identical schema error, all were dropped, and the final `length(raw) == 0L` branch fired the misleading "Check network access to HuggingFace parquet store." message. Reproduced directly: `hd_ohlcv("SPY", ...) |> select(date, adjusted)` raises `Column 'adjusted' doesn't exist` — no network involved. Fixed by the same rename.

## Schema-drift guard (access-boundary contract)

Added `.hd_assert_price_schema()`, called from both `hd_ohlcv_single()` and `hd_lazy()` immediately after the alias runs. It aborts with a classed `hd_schema_drift` error if a dataset that promises `adjusted_close` in its `hd_datasets()` schema does not have it after the alias — so a *future* upstream rename the alias doesn't anticipate fails loudly at the source, not silently at some consumer months later. Silent for datasets that don't promise the column (crypto_daily, macro_daily, etc.) and for unknown dataset names (defensive default).

## Periodic full-rebuild check (not built here, per scope)

Feasible: a scheduled `tar_make()` against an empty/invalidated store (e.g. weekly, `_targets` dir wiped first) would have caught this within a day rather than ~10 weeks. Cost is mostly wall-clock (full historical-data rebuild) and would need to run somewhere with the HF network path available — a GH Actions job or a local launchd job in the `housekeeping-framework` pattern. Left as a follow-up.

## Verification

- Empirically confirmed the pre-fix failure on the **orchestrator's checkout** (`main`) via the narrowly-authorised named-target build:
  ```
  ✖ etf_daily errored — object 'adjusted' not found
  ✖ bt_prices errored — Column `adjusted` doesn't exist
  ✖ olmar_prices errored — no tickers returned data. Check network access to HuggingFace parquet store.
  ```
  This confirms the current (pre-fix) failure state exactly as reported in #669. My fix is **not** present in the orchestrator's checkout — testing it end-to-end there would be a scope breach (writes outside my worktree). The fix is verified statically (parse checks on every changed file) and empirically by reproducing each fixed target's exact logic against live `hd_ohlcv()` data (no errors) and by the new hermetic test suites below.
- `scripts/verify.sh` — **PASS**, quoted verbatim:
  ```
  === root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
  SKIP count this run: 0
  PASS: failures match the known baseline exactly:
    [baseline, expected] test-crypto-momentum.R::C1: ...
    [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
    [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)

  === package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
  SKIP count this run: 15
  PASS: failures match the known baseline exactly:
    [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

  === scripts/verify.sh: PASS ===
  ```

## What remains unverified

- The narrow-authorisation named-target build could only be run **before** the fix (on the orchestrator's unmodified `main`) — the fix itself has not been exercised through `tar_make()` against the real `docs/_targets` store. Recommend the orchestrator re-run `targets::tar_make(names = c("bt_prices","bt_returns","etf_daily","olmar_prices"))` after merge to confirm the targets build cleanly end-to-end.
- The periodic full-rebuild check is scoped out (see above) — filed as a follow-up idea, not built.

## Test plan

- [x] `scripts/verify.sh` passes with baselines unchanged (quoted above)
- [x] New root-suite tests (`tests/testthat/test-adjusted-close-schema.R`, hermetic, `testthat::local_edition(3)`): AST-based regression guard (no bare `adjusted` symbol in the 12 fixed files) + `.hd_assert_price_schema()` unit tests, including an `expect_snapshot(error = TRUE, ...)` for the new `cli_abort` message
- [x] New package-suite tests (`packages/historicaldata/tests/testthat/test-hd-ohlcv-adjusted-close-contract.R`, hermetic via `local_sample_data()` — the bundled sample fixture also uses the legacy `adjusted` name, exercising the same alias path as the live parquet): `hd_ohlcv()`/`hd_lazy()` present `adjusted_close`; a consumer selecting it succeeds; `.hd_assert_price_schema()` behaviour, snapshotted
- [x] `_snaps/` committed alongside the new test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
