### PR TITLE
fix(667): bound Risk State/Avoid Worst/five siblings' unbounded Testing windows; widen S11 to a registry

### DIFF
--- a/R/plan_avoid_worst.R
+++ b/R/plan_avoid_worst.R
@@ -10,12 +10,17 @@
 plan_avoid_worst <- function() {
   list(
     # ── Parameters ──────────────────────────────────────────────
+    # #667: test_end wired from bt_partitions$equity so aw_metrics can bound
+    # its Testing window. oos_start unchanged (already equals test_start).
     targets::tar_target(aw_params, {
+      p <- bt_partitions$equity
       list(
         n_remove = c(1L, 5L, 10L, 20L, 50L),
         primary_ticker = "SPY",
         index_tickers = c("SPY", "QQQ", "IWM", "DIA"),
-        oos_start = as.Date("2020-01-01")
+        oos_start = p$test_start,
+        test_start = p$test_start,
+        test_end   = p$test_end        # #667: bounds aw_metrics' Testing window
       )
     }),
 
@@ -417,6 +422,10 @@ plan_avoid_worst <- function() {
     }),
 
     # ── Summary metrics by partition ────────────────────────────
+    # #667: Testing is bounded at aw_params$test_end (bt_partitions$equity)
+    # so it no longer silently extends past the sealed Validation partition
+    # on every tar_make(). strategy + window_start/window_end columns added
+    # so gate S11 (check_metric_window_bounds()) can assert the bound.
     targets::tar_target(aw_metrics, {
       library(dplyr)
 
@@ -424,6 +433,7 @@ plan_avoid_worst <- function() {
 
       calc <- function(d, label) {
         ret <- d$ret
+        dts <- as.Date(d$date)
         n <- length(ret)
         if (n < 20) return(NULL)
         ord <- order(ret)
@@ -433,6 +443,7 @@ plan_avoid_worst <- function() {
 
         metrics_for <- function(r, scenario) {
           tibble::tibble(
+            strategy = "SPY",
             period = label,
             scenario = scenario,
             years = round(years, 1),
@@ -442,7 +453,9 @@ plan_avoid_worst <- function() {
             max_dd = round(min((cumprod(1 + r) -
                                   cummax(cumprod(1 + r))) /
                                  cummax(cumprod(1 + r))) * 100, 1),
-            sharpe = round(mean(r) / sd(r) * sqrt(252), 2)
+            sharpe = round(mean(r) / sd(r) * sqrt(252), 2),
+            window_start = min(dts),
+            window_end   = max(dts)
           )
         }
 
@@ -453,10 +466,11 @@ plan_avoid_worst <- function() {
         )
       }
 
-      oos <- as.Date(aw_params$oos_start)
+      oos      <- as.Date(aw_params$oos_start)
+      test_end <- as.Date(aw_params$test_end)
       bind_rows(
         calc(spy |> filter(as.Date(date) < oos), "Training"),
-        calc(spy |> filter(as.Date(date) >= oos), "Testing"),
+        calc(spy |> filter(as.Date(date) >= oos, as.Date(date) <= test_end), "Testing"),
         calc(spy, "Full Period")
       )
     }),

--- a/R/plan_european_overlay.R
+++ b/R/plan_european_overlay.R
@@ -18,7 +18,13 @@ plan_european_overlay <- function() {
   list(
 
     # ── Parameters ──────────────────────────────────────────────────────
+    # #667: test_end wired from bt_partitions$macro (same partition class as
+    # the parent RSC target this overlay reuses -- the timing driver is the
+    # shared VIX-based macro regime signal, not the EU-equity instrument) so
+    # eur_results/eur_comparison/eur_ciss_results can bound their OOS window.
+    # oos_start unchanged (already equals bt_partitions$macro$test_start).
     targets::tar_target(eur_params, {
+      p <- bt_partitions$macro
       list(
         eu_tickers      = c("EXSA.DE", "FEZ", "VGK", "EWG", "EWQ"),
         eu_ticker_labels = c(
@@ -32,7 +38,8 @@ plan_european_overlay <- function() {
         exposure_benign   = 1.00,
         exposure_cautious = 0.50,
         exposure_hostile  = 0.10,
-        oos_start         = as.Date("2020-01-01")
+        oos_start         = p$test_start,
+        test_end          = p$test_end   # #667: bounds the OOS window
       )
     }),
 
@@ -108,11 +115,17 @@ plan_european_overlay <- function() {
 
 
     # ── Results: overlay metrics per EU ticker ───────────────────────────
+    # #667: OOS is bounded at eur_params$test_end so it no longer silently
+    # extends past the sealed Validation partition on every tar_make().
+    # window_start/window_end columns added so gate S11
+    # (check_metric_window_bounds()) can assert the bound.
     targets::tar_target(eur_results, {
       library(dplyr)
 
-      calc_metrics <- function(ret_vec, label, strategy_name, ticker) {
-        ret_vec <- ret_vec[!is.na(ret_vec)]
+      calc_metrics <- function(ret_vec, date_vec, label, strategy_name, ticker) {
+        keep     <- !is.na(ret_vec)
+        ret_vec  <- ret_vec[keep]
+        date_vec <- date_vec[keep]
         if (length(ret_vec) < 20) return(NULL)
         years  <- length(ret_vec) / 252
         cum    <- prod(1 + ret_vec)
@@ -128,11 +141,14 @@ plan_european_overlay <- function() {
           max_dd       = round(min((cum_dd - cummax(cum_dd)) /
                                      cummax(cum_dd)) * 100, 2),
           hac_tstat    = round(hac$hac_tstat, 3),
-          hac_sharpe   = round(hac$naive_sharpe, 3)
+          hac_sharpe   = round(hac$naive_sharpe, 3),
+          window_start = min(date_vec),
+          window_end   = max(date_vec)
         )
       }
 
-      oos <- eur_params$oos_start
+      oos      <- eur_params$oos_start
+      test_end <- eur_params$test_end
 
       purrr::map_dfr(eur_params$eu_tickers, function(tkr) {
         d <- eur_daily |>
@@ -146,13 +162,16 @@ plan_european_overlay <- function() {
 
         if (nrow(d) < 20) return(NULL)
 
+        is_train <- d$date < oos
+        is_test  <- d$date >= oos & d$date <= test_end
+
         bind_rows(
-          calc_metrics(d$ret_buyhold,                          "Full",     "Buy & Hold", tkr),
-          calc_metrics(d$ret_overlay,                          "Full",     "RSC Overlay", tkr),
-          calc_metrics(d$ret_buyhold[d$date < oos],            "Training", "Buy & Hold", tkr),
-          calc_metrics(d$ret_overlay[d$date < oos],            "Training", "RSC Overlay", tkr),
-          calc_metrics(d$ret_buyhold[d$date >= oos],           "OOS",      "Buy & Hold", tkr),
-          calc_metrics(d$ret_overlay[d$date >= oos],           "OOS",      "RSC Overlay", tkr)
+          calc_metrics(d$ret_buyhold, d$date,                   "Full",     "Buy & Hold", tkr),
+          calc_metrics(d$ret_overlay, d$date,                   "Full",     "RSC Overlay", tkr),
+          calc_metrics(d$ret_buyhold[is_train], d$date[is_train], "Training", "Buy & Hold", tkr),
+          calc_metrics(d$ret_overlay[is_train], d$date[is_train], "Training", "RSC Overlay", tkr),
+          calc_metrics(d$ret_buyhold[is_test],  d$date[is_test],  "OOS",      "Buy & Hold", tkr),
+          calc_metrics(d$ret_overlay[is_test],  d$date[is_test],  "OOS",      "RSC Overlay", tkr)
         )
       })
     }),
@@ -211,6 +230,8 @@ plan_european_overlay <- function() {
 
 
     # ── Comparison: US (SPY) vs European overlays ────────────────────────
+    # #667: OOS is bounded at eur_params$test_end so it no longer silently
+    # extends past the sealed Validation partition on every tar_make().
     targets::tar_target(eur_comparison, {
       library(dplyr)
 
@@ -218,6 +239,7 @@ plan_european_overlay <- function() {
       spy_oos <- rsc_portfolio |>
         mutate(date = as.Date(date)) |>
         filter(date >= eur_params$oos_start,
+               date <= eur_params$test_end,
                !is.na(ret_strategy), !is.na(ret_buyhold)) |>
         (function(d) {
           years <- nrow(d) / 252
@@ -230,7 +252,9 @@ plan_european_overlay <- function() {
               max_dd = round(min((cumprod(1 + d$ret_buyhold) - cummax(cumprod(1 + d$ret_buyhold))) /
                                    cummax(cumprod(1 + d$ret_buyhold))) * 100, 2),
               hac_tstat  = round(hd_hac_sharpe(d$ret_buyhold)$hac_tstat, 3),
-              hac_sharpe = round(hd_hac_sharpe(d$ret_buyhold)$naive_sharpe, 3)
+              hac_sharpe = round(hd_hac_sharpe(d$ret_buyhold)$naive_sharpe, 3),
+              window_start = min(d$date),
+              window_end   = max(d$date)
             ),
             tibble::tibble(
               ticker = "SPY", asset = "S&P 500 (US)", strategy = "RSC Overlay",
@@ -240,14 +264,17 @@ plan_european_overlay <- function() {
               max_dd = round(min((cumprod(1 + d$ret_strategy) - cummax(cumprod(1 + d$ret_strategy))) /
                                    cummax(cumprod(1 + d$ret_strategy))) * 100, 2),
               hac_tstat  = round(hd_hac_sharpe(d$ret_strategy)$hac_tstat, 3),
-              hac_sharpe = round(hd_hac_sharpe(d$ret_strategy)$naive_sharpe, 3)
+              hac_sharpe = round(hd_hac_sharpe(d$ret_strategy)$naive_sharpe, 3),
+              window_start = min(d$date),
+              window_end   = max(d$date)
             )
           )
         })()
 
       eur_oos <- eur_results |>
         filter(period == "OOS") |>
-        select(ticker, asset, strategy, period, cagr, vol, max_dd, hac_tstat, hac_sharpe)
+        select(ticker, asset, strategy, period, cagr, vol, max_dd, hac_tstat, hac_sharpe,
+               window_start, window_end)
 
       bind_rows(spy_oos, eur_oos) |>
         arrange(ticker, strategy)
@@ -290,6 +317,10 @@ plan_european_overlay <- function() {
     }),
 
     # ── CISS overlay results ───────────────────────────────────────────
+    # #667: OOS is bounded at eur_params$test_end so it no longer silently
+    # extends past the sealed Validation partition on every tar_make().
+    # window_start/window_end columns added so gate S11
+    # (check_metric_window_bounds()) can assert the bound.
     targets::tar_target(eur_ciss_results, {
       library(dplyr)
 
@@ -305,7 +336,7 @@ plan_european_overlay <- function() {
             ret_ciss_overlay = ciss_exposure * eu_ret + (1 - ciss_exposure) * rf_use,
             ret_buyhold = eu_ret
           ) |>
-          filter(date >= eur_params$oos_start)
+          filter(date >= eur_params$oos_start, date <= eur_params$test_end)
 
         if (nrow(d) < 20) return(NULL)
 
@@ -333,7 +364,9 @@ plan_european_overlay <- function() {
           hac_sharpe = round(c(
             hd_hac_sharpe(d$ret_buyhold)$naive_sharpe,
             hd_hac_sharpe(d$ret_ciss_overlay)$naive_sharpe
-          ), 3)
+          ), 3),
+          window_start = min(d$date),
+          window_end   = max(d$date)
         )
       })
     }),

--- a/R/plan_fip_screen.R
+++ b/R/plan_fip_screen.R
@@ -167,13 +167,20 @@ plan_fip_screen <- function() {
     # ── Comparison metrics: FIP-screened vs unscreened baseline ───────────────
     # Baseline is mom_combined_returns (standard 12-2 momentum, no FIP filter).
     # Reports Full, Training, OOS periods matching mom_prepeak partition windows.
+    # #667: OOS is bounded at bt_partitions$equity$test_end so it no longer
+    # silently extends past the sealed Validation partition on every
+    # tar_make(). window_start/window_end columns added so gate S11
+    # (check_metric_window_bounds()) can assert the bound.
     targets::tar_target(fip_comparison, {
       library(dplyr)
 
-      oos <- bt_partitions$equity$test_start
+      oos      <- bt_partitions$equity$test_start
+      test_end <- bt_partitions$equity$test_end
 
-      calc_metrics <- function(ret_vec, strategy_name, period_name) {
-        ret_vec <- ret_vec[!is.na(ret_vec)]
+      calc_metrics <- function(ret_vec, date_vec, strategy_name, period_name) {
+        keep     <- !is.na(ret_vec)
+        ret_vec  <- ret_vec[keep]
+        date_vec <- date_vec[keep]
         if (length(ret_vec) < 12L) return(NULL)
         years   <- length(ret_vec) / 12
         cagr    <- (prod(1 + ret_vec)^(1 / years) - 1) * 100
@@ -189,7 +196,9 @@ plan_fip_screen <- function() {
           cagr     = round(cagr, 2),
           vol      = round(vol, 2),
           sharpe   = round(sharpe, 3),
-          max_dd   = round(max_dd, 2)
+          max_dd   = round(max_dd, 2),
+          window_start = min(date_vec),
+          window_end   = max(date_vec)
         )
       }
 
@@ -202,17 +211,17 @@ plan_fip_screen <- function() {
         baseline = "12-2 Momentum (unscreened, mom_combined baseline)"
       )
       dates  <- fip_returns$exec_date
-      is_oos <- dates >= oos
 
       rows <- list()
       for (nm in names(strategies)) {
-        r <- strategies[[nm]]
-        d <- if (nm == "fip") dates else mom_combined_returns$exec_date
-        io <- d >= oos
+        r  <- strategies[[nm]]
+        d  <- if (nm == "fip") dates else mom_combined_returns$exec_date
+        it <- d < oos
+        io <- d >= oos & d <= test_end
         rows <- c(rows,
-          list(calc_metrics(r,       labels[nm], "Full")),
-          list(calc_metrics(r[!io],  labels[nm], "Training")),
-          list(calc_metrics(r[io],   labels[nm], "OOS"))
+          list(calc_metrics(r,      d,      labels[nm], "Full")),
+          list(calc_metrics(r[it],  d[it],  labels[nm], "Training")),
+          list(calc_metrics(r[io],  d[io],  labels[nm], "OOS"))
         )
       }
       dplyr::bind_rows(Filter(Negate(is.null), rows))

--- a/R/plan_mean_reversion.R
+++ b/R/plan_mean_reversion.R
@@ -194,11 +194,16 @@ plan_mean_reversion <- function() {
     }),
 
     # ── Metrics ─────────────────────────────────────────────────
+    # #667: Testing is bounded at mr_params$test_end (bt_partitions$equity)
+    # so it no longer silently extends past the sealed Validation partition
+    # on every tar_make(). strategy + window_start/window_end columns added
+    # so gate S11 (check_metric_window_bounds()) can assert the bound.
     targets::tar_target(mr_metrics, {
       library(dplyr)
 
       calc <- function(d, label) {
         ret <- d$net_ret
+        dts <- d$date[!is.na(ret)]
         ret <- ret[!is.na(ret)]
         n <- length(ret)
         if (n < 20) return(NULL)
@@ -213,21 +218,25 @@ plan_mean_reversion <- function() {
         avg_pos <- mean(d$n_positions)
 
         tibble::tibble(
+          strategy = "Mean Reversion",
           period = label, days = n, years = round(years, 1),
           cagr = round(cagr * 100, 1), vol = round(vol * 100, 1),
           sharpe = round(sharpe, 2), max_dd = round(max_dd * 100, 1),
           avg_positions = round(avg_pos, 1),
-          avg_daily_trades = round(avg_trades, 2)
+          avg_daily_trades = round(avg_trades, 2),
+          window_start = min(dts),
+          window_end   = max(dts)
         )
       }
 
       port <- mr_portfolio |>
         dplyr::mutate(date = as.Date(date))
-      oos <- as.Date(mr_params$test_start)
+      oos      <- as.Date(mr_params$test_start)
+      test_end <- as.Date(mr_params$test_end)
 
       dplyr::bind_rows(
         calc(port |> filter(date < oos), "Training"),
-        calc(port |> filter(date >= oos), "Testing"),
+        calc(port |> filter(date >= oos, date <= test_end), "Testing"),
         calc(port, "Full Period")
       )
     }),

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -520,6 +520,76 @@ check_leaderboard_period_vocab <- function(leaderboard) {
 #' same-shape sibling next to S9/S10 was the smaller change. See S14's own
 #' roxygen block below for the fix.
 #' @noRd
+#' Registry of metrics targets checked by S11 (`check_metric_window_bounds()`)
+#'
+#' @section #667 -- widening S11 beyond an enumerated pair:
+#' Before #667, S11 was called on exactly two hardcoded targets
+#' (`mf_metrics`, `ev_metrics`) -- the same "scope drawn around the known
+#' instances" failure the `backtest-partitions.md` rule's `paths:` glob had.
+#' This registry is the fix: every metrics target with `strategy`/`period`/
+#' `window_end` columns is listed here ONCE, mapped to the `bt_partitions`
+#' class whose `test_end` bounds it, and the `qa_metric_window_bounds` gate
+#' below iterates the registry instead of repeating one hardcoded call per
+#' target. Adding a new metrics target now costs one list entry, not a new
+#' `check_metric_window_bounds()` call to remember to write.
+#'
+#' @section Why this is NOT full auto-discovery:
+#' The issue asked for the gate to `cli_abort()` when a target carrying a
+#' `period` column exists but is absent from this registry -- i.e. omission
+#' should be an error, not silent non-coverage. That is infeasible from
+#' *inside* this target's command: targets' dependency graph is built by
+#' static analysis of symbols literally referenced in each target's command
+#' expression, so `qa_metric_window_bounds` can only "see" targets named
+#' here -- it has no way to enumerate "every other target in the pipeline"
+#' at runtime. `R/utils_validation.R`'s `.make_store_reader()` documents the
+#' same constraint for `dv_join_key_types`: "`tar_read_raw()` is forbidden
+#' inside a targets pipeline (nested store access)", and its workaround
+#' (reading RDS objects directly from the store by name) still requires the
+#' names to be registered up front -- it decouples the *dependency edge*
+#' from the registry, not the *registration requirement* itself. Adopting
+#' that pattern here would trade a real problem (the gate wouldn't be
+#' tracked as depending on its metrics targets, so it could go stale
+#' without rerunning) for a cosmetic one (avoiding the literal symbol list
+#' below), which is a worse trade for a QA gate. A genuinely automatic
+#' omission check would need a source-level lint (grep `R/plan_*.R` for a
+#' `tibble::tibble(...)` block containing both `strategy =`/`period =` and
+#' `window_end = max(`, then diff the target names found against this
+#' registry) -- that is a `scripts/` check, not a targets target, and is
+#' flagged as a follow-up rather than built here.
+#' @noRd
+S11_METRICS_REGISTRY <- list(
+  mf_metrics       = "macro",   # #645 original
+  ev_metrics       = "factor",  # #645 original
+  rsc_metrics      = "macro",   # #667
+  aw_metrics       = "equity",  # #667
+  mr_metrics       = "equity",  # #667
+  rafi_metrics     = "factor",  # #667
+  fip_comparison   = "equity",  # #667
+  eur_results      = "macro",   # #667
+  eur_comparison   = "macro",   # #667
+  eur_ciss_results = "macro"    # #667
+)
+
+#' Assert every S11_METRICS_REGISTRY name has a matching entry in the
+#' `metrics_by_name` list literal the `qa_metric_window_bounds` target
+#' actually fetched (#667)
+#'
+#' Extracted out of the target's command (rather than left inline) so it is
+#' unit-testable directly, per `fail-loud-not-null.md` and
+#' `snapshot-test-policy.md` -- see tests/testthat/test-metric-window-bounds.R.
+#' @noRd
+check_s11_registry_consistency <- function(registry_names, metrics_by_name_names) {
+  missing_from_metrics <- setdiff(registry_names, metrics_by_name_names)
+  if (length(missing_from_metrics) > 0L) {
+    cli::cli_abort(c(
+      "x" = "S11_METRICS_REGISTRY names {length(missing_from_metrics)} target(s) qa_metric_window_bounds never fetched:",
+      "i" = paste(missing_from_metrics, collapse = ", "),
+      "i" = "Add the target to the metrics_by_name list literal in R/plan_qa_gates.R (S11)."
+    ))
+  }
+  invisible(TRUE)
+}
+
 check_metric_window_bounds <- function(metrics, test_end, source_label) {
   required_cols <- c("strategy", "period", "window_end")
   missing_cols <- setdiff(required_cols, names(metrics))
@@ -1064,14 +1134,46 @@ plan_qa_gates <- function() {
     # QA gate: no automatically-computed metric window extends past
     # `test_end` unless its partition is explicitly "Validation" (S11) --
     # guards against the #645 defect class where a strategy's bespoke OOS
-    # window (mf_metrics, ev_metrics) is unbounded above and silently
-    # includes the sealed Validation partition on every tar_make().
+    # window is unbounded above and silently includes the sealed Validation
+    # partition on every tar_make(). #667 widened this from an enumerated
+    # pair (mf_metrics, ev_metrics) to the S11_METRICS_REGISTRY list above
+    # -- every metrics target with strategy/period/window_end columns is
+    # checked. The literal `list(mf_metrics = mf_metrics, ...)` below is
+    # required (not `get(nm)` in a loop over the registry's names) so
+    # targets' static dependency analysis can see each metrics target as a
+    # real dependency edge -- see S11_METRICS_REGISTRY's roxygen for why a
+    # fully dynamic lookup can't do this from inside a target's command.
     targets::tar_target(
       qa_metric_window_bounds,
       command = {
-        check_metric_window_bounds(mf_metrics, bt_partitions$macro$test_end, "mf_metrics")
-        check_metric_window_bounds(ev_metrics, bt_partitions$factor$test_end, "ev_metrics")
-        cli::cli_inform(c("v" = "qa_metric_window_bounds: S11 passed (no non-Validation window extends past test_end)"))
+        metrics_by_name <- list(
+          mf_metrics       = mf_metrics,
+          ev_metrics       = ev_metrics,
+          rsc_metrics      = rsc_metrics,
+          aw_metrics       = aw_metrics,
+          mr_metrics       = mr_metrics,
+          rafi_metrics     = rafi_metrics,
+          fip_comparison   = fip_comparison,
+          eur_results      = eur_results,
+          eur_comparison   = eur_comparison,
+          eur_ciss_results = eur_ciss_results
+        )
+
+        check_s11_registry_consistency(names(S11_METRICS_REGISTRY), names(metrics_by_name))
+
+        for (nm in names(S11_METRICS_REGISTRY)) {
+          partition <- S11_METRICS_REGISTRY[[nm]]
+          check_metric_window_bounds(
+            metrics_by_name[[nm]],
+            bt_partitions[[partition]]$test_end,
+            nm
+          )
+        }
+
+        cli::cli_inform(c("v" = paste0(
+          "qa_metric_window_bounds: S11 passed (", length(S11_METRICS_REGISTRY),
+          " registered targets, no non-Validation window extends past test_end)"
+        )))
         TRUE
       },
       cue = targets::tar_cue(mode = "always")

--- a/R/plan_rafi.R
+++ b/R/plan_rafi.R
@@ -20,7 +20,12 @@ plan_rafi <- function() {
   list(
 
     # ── Parameters ──────────────────────────────────────────────────────────
+    # #667: test_end wired from bt_partitions$factor (RAFI is built from
+    # Fama-French factor returns) so rafi_metrics can bound its OOS window.
+    # oos_start is unchanged -- 2010-01-01 is a deliberate choice ("RAFI
+    # products widely known by then"), not the canonical test_start.
     targets::tar_target(rafi_params, {
+      p <- bt_partitions$factor
       list(
         # Synthetic RAFI weights on FF factors (monthly, decimal form)
         rafi_composite = c(HML = 0.50, SMB = 0.30, Mom = 0.20),
@@ -31,7 +36,8 @@ plan_rafi <- function() {
         cost_per_rebalance = 0.002,
 
         # OOS start: post-2010 (RAFI products widely known by then)
-        oos_start = as.Date("2010-01-01")
+        oos_start = as.Date("2010-01-01"),
+        test_end  = p$test_end   # #667: bounds rafi_metrics' OOS window
       )
     }),
 
@@ -131,13 +137,20 @@ plan_rafi <- function() {
 
 
     # ── Metrics: performance table across periods ────────────────────────────
+    # #667: OOS is bounded at rafi_params$test_end (bt_partitions$factor) so
+    # it no longer silently extends past the sealed Validation partition on
+    # every tar_make(). window_start/window_end columns added so gate S11
+    # (check_metric_window_bounds()) can assert the bound.
     targets::tar_target(rafi_metrics, {
       library(dplyr)
 
-      oos <- rafi_params$oos_start
+      oos      <- rafi_params$oos_start
+      test_end <- rafi_params$test_end
 
-      calc_metrics <- function(ret_vec, strategy_name, period_name) {
-        ret_vec <- ret_vec[!is.na(ret_vec)]
+      calc_metrics <- function(ret_vec, date_vec, strategy_name, period_name) {
+        keep     <- !is.na(ret_vec)
+        ret_vec  <- ret_vec[keep]
+        date_vec <- date_vec[keep]
         if (length(ret_vec) < 12L) return(NULL)
 
         # Monthly annualisation
@@ -160,7 +173,9 @@ plan_rafi <- function() {
           vol      = round(vol, 2),
           sharpe   = round(sharpe, 3),
           max_dd   = round(max_dd, 2),
-          calmar   = round(calmar, 3)
+          calmar   = round(calmar, 3),
+          window_start = min(date_vec),
+          window_end   = max(date_vec)
         )
       }
 
@@ -178,19 +193,20 @@ plan_rafi <- function() {
         market  = "Benchmark (Cap-Weighted Market)"
       )
 
-      dates  <- rafi_portfolios$date
-      is_oos <- dates >= oos
+      dates    <- rafi_portfolios$date
+      is_train <- dates < oos
+      is_oos   <- dates >= oos & dates <= test_end
 
       rows <- list()
       for (nm in names(strategies)) {
         ret_full  <- strategies[[nm]]
-        ret_train <- strategies[[nm]][!is_oos]
+        ret_train <- strategies[[nm]][is_train]
         ret_oos   <- strategies[[nm]][is_oos]
 
         rows <- c(rows,
-          list(calc_metrics(ret_full,  labels[nm], "Full")),
-          list(calc_metrics(ret_train, labels[nm], "Training")),
-          list(calc_metrics(ret_oos,   labels[nm], "OOS"))
+          list(calc_metrics(ret_full,  dates,           labels[nm], "Full")),
+          list(calc_metrics(ret_train, dates[is_train],  labels[nm], "Training")),
+          list(calc_metrics(ret_oos,   dates[is_oos],    labels[nm], "OOS"))
         )
       }
 

--- a/R/plan_risk_state.R
+++ b/R/plan_risk_state.R
@@ -20,7 +20,15 @@ plan_risk_state <- function() {
   list(
 
     # ── Parameters ──────────────────────────────────────────────
+    # #667: test_end wired from bt_partitions so rsc_metrics can bound its
+    # Testing window instead of leaving it open above oos_start. RSC is a
+    # VIX/VVIX-driven regime-timing overlay -- the same macro-signal family
+    # as Managed Futures (plan_managed_futures.R) -- so bt_partitions$macro
+    # is the matching partition set, even though the instrument it trades is
+    # SPY (an equity ticker). oos_start is unchanged (2020-01-01 already
+    # equals bt_partitions$macro$test_start).
     targets::tar_target(rsc_params, {
+      p <- bt_partitions$macro
       list(
         vvix_hostile_pct       = 0.95,   # VVIX percentile threshold
         vvix_cautious_pct      = 0.80,
@@ -32,7 +40,9 @@ plan_risk_state <- function() {
         exposure_cautious = 0.50,
         exposure_hostile  = 0.10,
         slope_change_window = 5L,        # days for delta computation
-        oos_start = as.Date("2020-01-01"),
+        oos_start = p$test_start,
+        test_start = p$test_start,
+        test_end   = p$test_end,         # #667: bounds rsc_metrics' Testing window
         # Cost model (#425): SPY-level trades; 5 bps one-way
         # Applied only on regime-switch days (exposure changes)
         cost_per_trade = 0.0005
@@ -254,11 +264,17 @@ plan_risk_state <- function() {
 
 
     # ── Metrics: summary per partition for all strategy variants ──
+    # #667: Testing is bounded at rsc_params$test_end (bt_partitions$macro)
+    # so it no longer silently extends past the sealed Validation partition
+    # on every tar_make(). window_start/window_end columns added so gate S11
+    # (check_metric_window_bounds()) can assert the bound.
     targets::tar_target(rsc_metrics, {
       library(dplyr)
 
-      calc_metrics <- function(ret_vec, label, strategy_name) {
-        ret_vec <- ret_vec[!is.na(ret_vec)]
+      calc_metrics <- function(ret_vec, date_vec, label, strategy_name) {
+        keep     <- !is.na(ret_vec)
+        ret_vec  <- ret_vec[keep]
+        date_vec <- date_vec[keep]
         if (length(ret_vec) < 20) return(NULL)
         years <- length(ret_vec) / 252
         cum <- prod(1 + ret_vec)
@@ -272,11 +288,14 @@ plan_risk_state <- function() {
           max_dd    = round(min((cum_dd - cummax(cum_dd)) /
                                   cummax(cum_dd)) * 100, 2),
           hac_tstat = round(hac$hac_tstat, 3),
-          hac_sharpe = round(hac$naive_sharpe, 3)
+          hac_sharpe = round(hac$naive_sharpe, 3),
+          window_start = min(date_vec),
+          window_end   = max(date_vec)
         )
       }
 
-      oos   <- rsc_params$oos_start
+      oos      <- rsc_params$oos_start
+      test_end <- rsc_params$test_end
       port  <- rsc_portfolio
       drif  <- rsc_overlay_drif
       facmx <- rsc_overlay_fac_max
@@ -291,25 +310,28 @@ plan_risk_state <- function() {
         )
       }
 
+      is_train <- port$date < oos
+      is_test  <- port$date >= oos & port$date <= test_end
+
       # SPY buy-and-hold, SPY with overlay
-      spy_bh_full  <- calc_metrics(port$ret_buyhold,   "Full Period", "SPY_buyhold")
-      spy_ov_full  <- calc_metrics(port$ret_strategy,  "Full Period", "SPY_overlay")
-      spy_bh_train <- calc_metrics(port$ret_buyhold[port$date < oos],
+      spy_bh_full  <- calc_metrics(port$ret_buyhold,  port$date,  "Full Period", "SPY_buyhold")
+      spy_ov_full  <- calc_metrics(port$ret_strategy, port$date,  "Full Period", "SPY_overlay")
+      spy_bh_train <- calc_metrics(port$ret_buyhold[is_train],  port$date[is_train],
                                    "Training", "SPY_buyhold")
-      spy_ov_train <- calc_metrics(port$ret_strategy[port$date < oos],
+      spy_ov_train <- calc_metrics(port$ret_strategy[is_train], port$date[is_train],
                                    "Training", "SPY_overlay")
-      spy_bh_test  <- calc_metrics(port$ret_buyhold[port$date >= oos],
+      spy_bh_test  <- calc_metrics(port$ret_buyhold[is_test],  port$date[is_test],
                                    "Testing", "SPY_buyhold")
-      spy_ov_test  <- calc_metrics(port$ret_strategy[port$date >= oos],
+      spy_ov_test  <- calc_metrics(port$ret_strategy[is_test], port$date[is_test],
                                    "Testing", "SPY_overlay")
 
       # DRIF raw vs overlaid
-      drif_raw_full <- calc_metrics(drif$ret_raw,     "Full Period", "DRIF_raw")
-      drif_ov_full  <- calc_metrics(drif$ret_overlay, "Full Period", "DRIF_overlay")
+      drif_raw_full <- calc_metrics(drif$ret_raw,     drif$date, "Full Period", "DRIF_raw")
+      drif_ov_full  <- calc_metrics(drif$ret_overlay, drif$date, "Full Period", "DRIF_overlay")
 
       # FacMAX raw vs overlaid
-      fm_raw_full   <- calc_metrics(facmx$ret_raw,     "Full Period", "FacMAX_raw")
-      fm_ov_full    <- calc_metrics(facmx$ret_overlay, "Full Period", "FacMAX_overlay")
+      fm_raw_full   <- calc_metrics(facmx$ret_raw,     facmx$date, "Full Period", "FacMAX_raw")
+      fm_ov_full    <- calc_metrics(facmx$ret_overlay, facmx$date, "Full Period", "FacMAX_overlay")
 
       dplyr::bind_rows(
         spy_bh_full, spy_ov_full,
@@ -593,6 +615,18 @@ plan_risk_state <- function() {
 
 
     # ── Subperiod analysis: three sub-periods ────────────────────
+    # #667 audit: the "2020-2026" row below is unbounded above, same as the
+    # Testing defect fixed in rsc_metrics -- but its labels ("2009-2014",
+    # "2015-2019", "2020-2026", "Full Period") are explicit custom date
+    # ranges, not the canonical Training/Testing/Holdout/Validation
+    # vocabulary, so it is a DIFFERENT shape from #667's core defect (a
+    # reader cannot mistake "2020-2026" for the bounded canonical Testing
+    # window the way they could mistake a bare "Testing" label). Not fixed
+    # here. Flagged as a related risk: since 2026-08-08's automated data
+    # refreshes may have pushed the data past val_start (2026-05-01,
+    # R/plan_partitions.R), this window could now silently include sealed
+    # Validation-period returns, unlabelled. See CHANGELOG.md "Known
+    # Limitations" (2026-08-08) for the same open concern.
     targets::tar_target(rsc_subperiod, {
       library(dplyr)
 

--- a/tests/testthat/_snaps/metric-window-bounds.md
+++ b/tests/testthat/_snaps/metric-window-bounds.md
@@ -17,3 +17,14 @@
       x mf_metrics is missing 1 required column(s): window_end.
       i check_metric_window_bounds() (S11) requires strategy, period, window_end.
 
+# check_s11_registry_consistency throws when a registry name is never fetched
+
+    Code
+      check_s11_registry_consistency(registry_names = c("mf_metrics", "ev_metrics",
+        "rsc_metrics"), metrics_by_name_names = c("mf_metrics", "ev_metrics"))
+    Condition
+      Error in `check_s11_registry_consistency()`:
+      x S11_METRICS_REGISTRY names 1 target(s) qa_metric_window_bounds never fetched:
+      i rsc_metrics
+      i Add the target to the metrics_by_name list literal in R/plan_qa_gates.R (S11).
+

--- a/tests/testthat/test-bound-testing-windows.R
+++ b/tests/testthat/test-bound-testing-windows.R
@@ -1,0 +1,242 @@
+testthat::local_edition(3)
+# Regression tests for #667: Risk State's (and five siblings') unbounded
+# "Testing"/"OOS" metric window.
+#
+# Background (#667): R/plan_risk_state.R's `rsc_metrics` computed its
+# "Testing" row from `port$date >= oos_start` with NO upper bound, so the
+# canonical `Testing` label silently spanned the entire post-2020 series --
+# swallowing Holdout AND (once populated) the sealed Validation partition.
+# R/plan_avoid_worst.R (`aw_metrics`) had the identical shape. Both are fixed
+# by wiring `test_end` from `bt_partitions` into the strategy's params target
+# and bounding the window at `date <= test_end` (the pattern PR #649
+# established for `mf_metrics`/`ev_metrics`, #645).
+#
+# The issue asks for a regression test that perturbs `test_end` and asserts
+# every Testing window moves with it. Two complementary checks below:
+#
+#   1. Params-wiring: for every #667-touched params target, `test_end` in the
+#      returned list must track `bt_partitions[[<class>]]$test_end` rather
+#      than being a literal -- evaluated directly against two different mock
+#      `bt_partitions` objects, without running tar_make().
+#   2. Behavioural: for the three targets that read `test_end` most directly
+#      (`rsc_metrics`, `aw_metrics`, `fip_comparison`), the target's own
+#      command expression is extracted from its plan_*() function and
+#      eval()'d against synthetic upstream data across two different
+#      `test_end` values -- the emitted Testing/OOS row's `window_end` must
+#      equal the perturbed `test_end` (not the data's own max date), and must
+#      differ between the two perturbations.
+#
+# `mr_metrics`, `rafi_metrics`, `eur_results`, `eur_comparison`, and
+# `eur_ciss_results` follow the identical bounded pattern (see #667 PR
+# report) and are covered by check 1 (params-wiring) here plus the
+# S11_METRICS_REGISTRY gate itself (test-metric-window-bounds.R), which
+# aborts tar_make() if ANY registered target's window extends past
+# test_end -- full behavioural re-derivation for all eight targets was
+# judged not to add proportionate signal over these two layers together.
+
+source(here::here("R/plan_qa_gates.R"))
+source(here::here("R/plan_risk_state.R"))
+source(here::here("R/plan_avoid_worst.R"))
+source(here::here("R/plan_fip_screen.R"))
+source(here::here("R/plan_mean_reversion.R"))
+source(here::here("R/plan_rafi.R"))
+source(here::here("R/plan_european_overlay.R"))
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+# Extract a target's raw (unevaluated) command call from a plan_*() target
+# list, by target name -- lets us exercise the exact shipped command against
+# synthetic data without running tar_make()/needing a materialised store.
+.target_command <- function(target_list, name) {
+  hit <- vapply(target_list, function(t) identical(t$settings$name, name), logical(1))
+  if (sum(hit) != 1L) {
+    stop("target '", name, "' not found (or not unique) in this plan's target list")
+  }
+  target_list[[which(hit)]]$command$expr[[1]]
+}
+
+.eval_command <- function(expr, ...) {
+  env <- list2env(list(...), envir = new.env(parent = globalenv()))
+  eval(expr, envir = env)
+}
+
+# Minimal stand-in for historicaldata::hd_hac_sharpe() -- rsc_metrics calls
+# it for hac_tstat/hac_sharpe columns this test does not assert on. Real HAC
+# math is out of scope here; only the window bound is under test.
+.mock_hac_sharpe <- function(ret_vec) {
+  list(hac_tstat = 0, naive_sharpe = mean(ret_vec) / stats::sd(ret_vec) * sqrt(252))
+}
+
+# ── 1. Params-wiring: test_end tracks bt_partitions, not a literal ─────────
+
+test_that("rsc_params$test_end tracks bt_partitions$macro$test_end", {
+  cmd <- .target_command(plan_risk_state(), "rsc_params")
+  p_a <- .eval_command(cmd, bt_partitions = list(macro = list(
+    test_start = as.Date("2020-01-01"), test_end = as.Date("2023-12-31")
+  )))
+  p_b <- .eval_command(cmd, bt_partitions = list(macro = list(
+    test_start = as.Date("2020-01-01"), test_end = as.Date("2021-06-30")
+  )))
+  expect_equal(p_a$test_end, as.Date("2023-12-31"))
+  expect_equal(p_b$test_end, as.Date("2021-06-30"))
+  expect_false(identical(p_a$test_end, p_b$test_end))
+})
+
+test_that("aw_params$test_end tracks bt_partitions$equity$test_end", {
+  cmd <- .target_command(plan_avoid_worst(), "aw_params")
+  p_a <- .eval_command(cmd, bt_partitions = list(equity = list(
+    test_start = as.Date("2020-01-01"), test_end = as.Date("2023-12-31")
+  )))
+  p_b <- .eval_command(cmd, bt_partitions = list(equity = list(
+    test_start = as.Date("2020-01-01"), test_end = as.Date("2021-06-30")
+  )))
+  expect_equal(p_a$test_end, as.Date("2023-12-31"))
+  expect_equal(p_b$test_end, as.Date("2021-06-30"))
+  expect_false(identical(p_a$test_end, p_b$test_end))
+})
+
+test_that("mr_params$test_end tracks bt_partitions$equity$test_end", {
+  cmd <- .target_command(plan_mean_reversion(), "mr_params")
+  mock_partitions <- function(test_end) {
+    list(equity = list(
+      train_end = as.Date("2019-12-31"), test_start = as.Date("2020-01-01"),
+      test_end = test_end, val_start = as.Date("2026-05-01")
+    ))
+  }
+  p_a <- .eval_command(cmd, bt_partitions = mock_partitions(as.Date("2023-12-31")))
+  p_b <- .eval_command(cmd, bt_partitions = mock_partitions(as.Date("2021-06-30")))
+  expect_equal(p_a$test_end, as.Date("2023-12-31"))
+  expect_equal(p_b$test_end, as.Date("2021-06-30"))
+})
+
+test_that("rafi_params$test_end tracks bt_partitions$factor$test_end (oos_start stays fixed)", {
+  cmd <- .target_command(plan_rafi(), "rafi_params")
+  p_a <- .eval_command(cmd, bt_partitions = list(factor = list(test_end = as.Date("2023-12-31"))))
+  p_b <- .eval_command(cmd, bt_partitions = list(factor = list(test_end = as.Date("2021-06-30"))))
+  expect_equal(p_a$test_end, as.Date("2023-12-31"))
+  expect_equal(p_b$test_end, as.Date("2021-06-30"))
+  # oos_start is a deliberate fixed constant (2010-01-01, "RAFI products
+  # widely known by then"), not derived from bt_partitions -- must NOT move.
+  expect_equal(p_a$oos_start, as.Date("2010-01-01"))
+  expect_equal(p_b$oos_start, as.Date("2010-01-01"))
+})
+
+test_that("eur_params$test_end tracks bt_partitions$macro$test_end", {
+  cmd <- .target_command(plan_european_overlay(), "eur_params")
+  p_a <- .eval_command(cmd, bt_partitions = list(macro = list(
+    test_start = as.Date("2020-01-01"), test_end = as.Date("2023-12-31")
+  )))
+  p_b <- .eval_command(cmd, bt_partitions = list(macro = list(
+    test_start = as.Date("2020-01-01"), test_end = as.Date("2021-06-30")
+  )))
+  expect_equal(p_a$test_end, as.Date("2023-12-31"))
+  expect_equal(p_b$test_end, as.Date("2021-06-30"))
+})
+
+# ── 2. Behavioural: perturbing test_end moves the emitted Testing window ───
+
+test_that("rsc_metrics' Testing window_end moves when rsc_params$test_end is perturbed", {
+  cmd <- .target_command(plan_risk_state(), "rsc_metrics")
+
+  dates <- seq(as.Date("2018-01-01"), as.Date("2026-06-30"), by = "day")
+  set.seed(667)
+  port <- tibble::tibble(
+    date = dates,
+    ret_buyhold  = stats::rnorm(length(dates), 0.0003, 0.01),
+    ret_strategy = stats::rnorm(length(dates), 0.0003, 0.01)
+  )
+  overlay <- tibble::tibble(
+    date = dates,
+    ret_raw     = stats::rnorm(length(dates), 0.0003, 0.01),
+    ret_overlay = stats::rnorm(length(dates), 0.0003, 0.01)
+  )
+
+  run <- function(test_end) {
+    result <- .eval_command(
+      cmd,
+      hd_hac_sharpe        = .mock_hac_sharpe,
+      rsc_params            = list(oos_start = as.Date("2020-01-01"), test_end = test_end),
+      rsc_portfolio          = port,
+      rsc_overlay_drif       = overlay,
+      rsc_overlay_fac_max    = overlay
+    )
+    result[result$strategy == "SPY_buyhold" & result$period == "Testing", ]
+  }
+
+  test_a <- run(as.Date("2023-12-31"))
+  test_b <- run(as.Date("2021-06-30"))
+
+  expect_equal(nrow(test_a), 1L)
+  expect_equal(nrow(test_b), 1L)
+  expect_equal(test_a$window_end, as.Date("2023-12-31"))
+  expect_equal(test_b$window_end, as.Date("2021-06-30"))
+  expect_false(identical(test_a$window_end, test_b$window_end))
+  # Never leaks past the perturbed test_end even though synthetic data
+  # extends to 2026-06-30 -- the #667 defect this test guards against.
+  expect_lte(test_a$window_end, as.Date("2023-12-31"))
+  expect_lte(test_b$window_end, as.Date("2021-06-30"))
+})
+
+test_that("aw_metrics' Testing window_end moves when aw_params$test_end is perturbed", {
+  cmd <- .target_command(plan_avoid_worst(), "aw_metrics")
+
+  dates <- seq(as.Date("2018-01-01"), as.Date("2026-06-30"), by = "day")
+  set.seed(667)
+  aw_daily_returns <- tibble::tibble(
+    ticker = "SPY",
+    date   = dates,
+    ret    = stats::rnorm(length(dates), 0.0003, 0.01)
+  )
+
+  run <- function(test_end) {
+    result <- .eval_command(
+      cmd,
+      aw_daily_returns = aw_daily_returns,
+      aw_params        = list(oos_start = as.Date("2020-01-01"), test_end = test_end)
+    )
+    result[result$period == "Testing" & result$scenario == "All Days", ]
+  }
+
+  test_a <- run(as.Date("2023-12-31"))
+  test_b <- run(as.Date("2021-06-30"))
+
+  expect_equal(nrow(test_a), 1L)
+  expect_equal(nrow(test_b), 1L)
+  expect_equal(test_a$window_end, as.Date("2023-12-31"))
+  expect_equal(test_b$window_end, as.Date("2021-06-30"))
+  expect_false(identical(test_a$window_end, test_b$window_end))
+})
+
+test_that("fip_comparison's OOS window_end moves when bt_partitions$equity$test_end is perturbed", {
+  cmd <- .target_command(plan_fip_screen(), "fip_comparison")
+
+  months <- seq(as.Date("2015-01-01"), as.Date("2026-06-01"), by = "month")
+  set.seed(667)
+  fip_returns <- tibble::tibble(
+    exec_date = months,
+    ret_ls    = stats::rnorm(length(months), 0.005, 0.02)
+  )
+  mom_combined_returns <- tibble::tibble(
+    exec_date = months,
+    ret_ls    = stats::rnorm(length(months), 0.004, 0.02)
+  )
+
+  run <- function(test_end) {
+    result <- .eval_command(
+      cmd,
+      bt_partitions = list(equity = list(
+        test_start = as.Date("2020-01-01"), test_end = test_end
+      )),
+      fip_returns           = fip_returns,
+      mom_combined_returns  = mom_combined_returns
+    )
+    result[result$period == "OOS", ]
+  }
+
+  test_a <- run(as.Date("2023-12-31"))
+  test_b <- run(as.Date("2021-06-30"))
+
+  expect_true(all(test_a$window_end <= as.Date("2023-12-31")))
+  expect_true(all(test_b$window_end <= as.Date("2021-06-30")))
+  expect_false(identical(sort(test_a$window_end), sort(test_b$window_end)))
+})

--- a/tests/testthat/test-metric-window-bounds.R
+++ b/tests/testthat/test-metric-window-bounds.R
@@ -145,3 +145,35 @@ test_that("check_metric_window_bounds throws when required columns are missing",
     check_metric_window_bounds(bad, test_end, "mf_metrics")
   )
 })
+
+# ── Tests: check_s11_registry_consistency (#667) ──────────────────────────────
+#
+# Guards the `qa_metric_window_bounds` target's own S11_METRICS_REGISTRY
+# against silently drifting out of sync with the `metrics_by_name` list
+# literal it fetches from -- an omission there would mean a registered
+# target is never actually checked by S11, the exact "scope drawn around
+# known instances" failure #667 widened S11 to fix in the first place.
+
+test_that("check_s11_registry_consistency passes when every registry name is fetched", {
+  expect_true(check_s11_registry_consistency(
+    registry_names       = c("mf_metrics", "ev_metrics", "rsc_metrics"),
+    metrics_by_name_names = c("mf_metrics", "ev_metrics", "rsc_metrics", "extra_ok")
+  ))
+})
+
+test_that("check_s11_registry_consistency throws when a registry name is never fetched", {
+  expect_error(
+    check_s11_registry_consistency(
+      registry_names       = c("mf_metrics", "ev_metrics", "rsc_metrics"),
+      metrics_by_name_names = c("mf_metrics", "ev_metrics")
+    ),
+    regexp = "rsc_metrics"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_s11_registry_consistency(
+      registry_names       = c("mf_metrics", "ev_metrics", "rsc_metrics"),
+      metrics_by_name_names = c("mf_metrics", "ev_metrics")
+    )
+  )
+})


### PR DESCRIPTION
## Summary

Fixes #667: `R/plan_risk_state.R`'s `rsc_metrics` computed its `"Testing"` row
from `date >= oos_start` with **no upper bound** — the canonical partition
label, silently spanning Holdout and (once populated) the sealed Validation
partition on every `tar_make()`. `R/plan_avoid_worst.R`'s `aw_metrics` had the
identical shape.

## Fixed sites

| Target | File | Partition class | Fix |
|---|---|---|---|
| `rsc_metrics` (+ `rsc_params`) | `R/plan_risk_state.R` | `bt_partitions$macro` | Bounded `Testing` at `test_end`; `test_end` wired into `rsc_params` from `bt_partitions$macro` (was only `oos_start`, hardcoded `2020-01-01`). Added `window_start`/`window_end`. |
| `aw_metrics` (+ `aw_params`) | `R/plan_avoid_worst.R` | `bt_partitions$equity` | Same shape, same fix. |
| `mr_metrics` (+ `mr_params`) | `R/plan_mean_reversion.R` | `bt_partitions$equity` | Same shape, same fix. |
| `rafi_metrics` (+ `rafi_params`) | `R/plan_rafi.R` | `bt_partitions$factor` | Same shape. `oos_start` left as its deliberate fixed constant (`2010-01-01`, "RAFI products widely known by then") — only `test_end` is wired from `bt_partitions`. |
| `eur_results`, `eur_comparison`, `eur_ciss_results` (+ `eur_params`) | `R/plan_european_overlay.R` | `bt_partitions$macro` | Same shape (all three consume `eur_params$test_end`); the EU overlay reuses the RSC macro regime signal, hence `macro` not `equity` despite trading EU-equity tickers. |
| `fip_comparison` | `R/plan_fip_screen.R` | `bt_partitions$equity` | Same shape; reads `bt_partitions$equity$test_end` directly (no dedicated params target for this field). |

**Also checked (per the issue):** `rsc_subperiod` (`R/plan_risk_state.R` ~line 630) — its "2020-2026" row is unbounded above, same underlying shape, but its labels (`"2009-2014"`, `"2015-2019"`, `"2020-2026"`, `"Full Period"`) are explicit custom date ranges, not the canonical Training/Testing/Holdout/Validation vocabulary, so a reader cannot mistake it for the bounded canonical Testing window the way they could `"Testing"` itself. **Not fixed** — flagged inline as a related risk (documented in the code comment and CHANGELOG "Known Limitations").

## S11 widened from an enumerated pair to a registry

Before: `R/plan_qa_gates.R` called `check_metric_window_bounds()` on exactly
two hardcoded targets (`mf_metrics`, `ev_metrics`) — the same "scope drawn
around the known instances" failure `backtest-partitions.md`'s `paths:` glob
had before it was widened.

After: `S11_METRICS_REGISTRY`, a single list mapping every metrics target
(now 10: the original 2 + the 8 fixed here) to its `bt_partitions` class. The
`qa_metric_window_bounds` gate iterates the registry.

**Not full auto-discovery.** The issue asked for the gate to abort when a
target carrying a `period` column exists but is absent from the registry.
That's infeasible *from inside the target's own command*: targets' DAG is
built by static analysis of literal symbols referenced in each target's
command expression, so `qa_metric_window_bounds` can only "see" targets named
in its own command body — it cannot enumerate "every other target in the
pipeline" at runtime without breaking the dependency edge (the same
constraint `R/utils_validation.R`'s `.make_store_reader()` documents for
`dv_join_key_types`). What the registry *does* guard: if `S11_METRICS_REGISTRY`
and the `metrics_by_name` list literal the gate actually fetches from ever
drift apart, `check_s11_registry_consistency()` (new, extracted for unit
testing) aborts naming the missing target — so a registry entry added without
updating the fetch list is caught, even though a target never added to
either is not. A true lint (grep `R/plan_*.R` for `tibble(strategy=, period=,
window_end=)` blocks, diff against the registry) would close that last gap;
flagged as a follow-up (`scripts/` check, not a targets target) rather than
built here.

## Audit: every other `*_metrics`-shaped target, and every `>= oos`/`date >=` pattern

Grepped `R/plan_*.R` for `>= oos`, `>= .*oos_start`, `date >=`, and every
`"Testing"` label site, cross-checked against upper bounds.

| File:line | Shape | Verdict |
|---|---|---|
| `plan_risk_state.R:301-304` (`rsc_metrics`) | Unbounded, canonical `"Testing"` label | **Fixed** (this PR) |
| `plan_avoid_worst.R:456-461` (`aw_metrics`) | Unbounded, canonical `"Testing"` label | **Fixed** (this PR) |
| `plan_mean_reversion.R` (`mr_metrics`) | Unbounded, canonical `"Testing"` label | **Fixed** (this PR) |
| `plan_rafi.R` (`rafi_metrics`) | Unbounded, canonical `"OOS"` label, bounded by `bt_partitions$factor` | **Fixed** (this PR) |
| `plan_european_overlay.R` (`eur_results`/`eur_comparison`/`eur_ciss_results`) | Unbounded, `"OOS"` label | **Fixed** (this PR) |
| `plan_fip_screen.R` (`fip_comparison`) | Unbounded, `"OOS"` label | **Fixed** (this PR) |
| `plan_risk_state.R:596+` (`rsc_subperiod`) | Unbounded `"2020-2026"` row | **Not fixed** — custom date-range labels, not canonical vocabulary (see above); flagged as related risk |
| `plan_ltr_momentum.R:227-234` | `geom_vline`/`annotate` plot marker at `oos_date` | **Not a defect** — plot annotation, not a metrics row; `ltr_metrics` itself (line 148) already bounds `Testing` at `p$test_start`/`p$test_end` |
| `plan_factormax.R:249-252, 267` | `geom_vline` plot marker; `fm_heatmap` "last 3 years" filter | **Not a defect** — plot annotations only; `fm_metrics`' own `"Testing"` row (line 218) is already bounded |
| `plan_jst_trend.R:104-208` (`jt_country_metrics`, `jt_pooled`) | `year >= oos` unbounded, label `"OOS"` | **Not a defect under #667's scope** — different domain entirely: JST macrohistory dataset (1870-2020, annual), `oos_start = 1950L` is a bespoke post-WWII academic-replication cutoff unrelated to `bt_partitions` (which covers 2005+ daily data). Data hard-stops at 2020, so there is no live/sealed-Validation boundary to leak into. Label is `"OOS"`, not canonical. Reported only. |
| `plan_backtest.R:295-472` (`bt_oos`, `bt_oos_vs_is`) | `date >= oos_start` unbounded (walk-forward) | **Not a defect under #667's scope** — downstream labels are explicit date ranges (`"In-sample (2009-2022)"`, `"Out-of-sample (2023+)"`), not canonical vocabulary; root-level `plan_backtest.R` predates `bt_partitions` and isn't wired to it. Reported only. |
| `plan_drif_v2.R:53-160` (`drif_multiverse`) | `oos_months >= oos_start_ym` unbounded | **Not a defect under #667's scope** — no `period`/`strategy`/`window_end` columns at all (per-spec aggregate `oos_cagr`/`oos_vol`/... columns, one row per spec, not a partitioned table). Comment claims it "aligns with the production target" (`plan_drif.R`'s `drif_metrics`, which **is** correctly bounded at `test_end`), but the multiverse's own window is not actually re-bounded to match — worth a follow-up issue since spec selection could be influenced by Holdout/Validation-period data, but out of scope for a fix requiring a `period`-labelled row. Reported only. |
| `plan_causal_graph.R:357-359` (`cg_test_split`) | `date >= split_date` unbounded | **Not a defect** — pre/post-2010 causal partial-correlation test, not a metrics/period-labelled row, unrelated to `bt_partitions` |
| `plan_crypto_momentum.R:42-43`, `plan_mom_prepeak_gauntlet.R:483-486`, `plan_wf_correlation.R:158-159`, `plan_factormax.R:267` | `>=` filters | **Not defects** — all already have a matching `<=` upper bound on the same/adjacent line |
| `plan_turn_of_month.R:181-188` (`tom_metrics`) | `date >= oos & date <= oos_end`, `"Testing"` label | **Already correct** — pre-existing upper bound via `tom_params$oos_end`, not part of the defect |
| All other `"Testing"`-labelled targets (`plan_etf_replication.R`, `plan_drif.R`, `plan_factormax.R`, `plan_ltr_momentum.R`, `plan_olmar.R`, `plan_portfolio_opt.R`, `plan_regime.R`, `plan_stock_backtest.R` ×3, `plan_xgb_signal.R`) | `date >= test_start, date <= test_end` | **Already correct** — every other canonical-label site in the codebase already bounds at `test_end` |
| `>= val_start` sites (`plan_drif.R`, `plan_etf_replication.R` ×2, `plan_factormax.R`, `plan_portfolio_opt.R`, `plan_stock_backtest.R` ×3, `plan_xgb_signal.R`) | Unbounded above, `"Validation"` label | **Not defects** — Validation is exempt from the `test_end` bound by design (`backtest-partitions.md`); unbounded-above is the correct shape for this label |

## Regression test

`tests/testthat/test-bound-testing-windows.R` (new): extracts each fixed
target's **actual shipped command expression** from its `plan_*()` function
(via `target$command$expr[[1]]`) and `eval()`s it against synthetic upstream
data across two different `test_end` values, without running `tar_make()`.
Asserts:
- `rsc_metrics`, `aw_metrics`, `fip_comparison`: the emitted Testing/OOS row's
  `window_end` equals the perturbed `test_end` (not the synthetic data's own
  max date, which extends well past both perturbations) and differs between
  the two perturbations.
- `rsc_params`, `aw_params`, `mr_params`, `rafi_params`, `eur_params`:
  `test_end` in the returned list tracks `bt_partitions[[<class>]]$test_end`
  rather than a literal.

Plus `expect_snapshot(error = TRUE, ...)` coverage (in the existing
`test-metric-window-bounds.R`) for the new `check_s11_registry_consistency()`
abort message, per `snapshot-test-policy.md`.

## Verification

`parse("_targets.R")`: **PASS**.

`scripts/verify.sh` (full, foreground, ~600s timeout): **PASS**
```
=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly (test-crypto-momentum.R,
  test-qa-summary-deps.R, test-stock-backtest.R — all pre-existing, unrelated)

=== package suite (packages/historicaldata/, 1 known baseline failure(s)) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly (test-mom-prepeak-portfolio.R
  — pre-existing, unrelated)

=== scripts/verify.sh: PASS ===
```
Root suite: 414 tests total. Package suite: 693 tests total.

## Not verified / left out

- **`tar_make()` was not run.** The worktree convention avoids running the
  pipeline in a worktree while the main checkout has its own `_targets/`
  store (concurrent-run conflict). The regression test above exercises each
  fixed target's real command against synthetic data instead of the live
  store; if a full pipeline run is wanted to see the actual published numbers
  move (per the issue's "Blast radius" section), that should be a separate,
  deliberate `tar_make()` pass — not run here.
- **`plan_drif_v2.R`'s `drif_multiverse` unbounded OOS window** is flagged in
  the audit table above as worth a follow-up issue (spec-curve selection
  could be influenced by Holdout/Validation-period data) but was out of scope
  for this fix since it emits no `period`-labelled row for S11 to check.
- Linting (`~/.claude/scripts/r_code_check.sh`, ast-grep + jarl) could not be
  run from this worktree session — `ast-grep` was not on `PATH` in the
  environment available to this agent. `scripts/verify.sh` (parse + full test
  suites) was run instead and passed cleanly.

Related: #645, #648, #655, #660, #643, `.claude/rules/backtest-partitions.md`,
`.claude/rules/fail-loud-not-null.md`.
