### PR TITLE
fix(673): bound rsc_subperiod at holdout_end before any equity refresh; make S11 registry check bidirectional

### DIFF
--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -520,6 +520,7 @@ check_leaderboard_period_vocab <- function(leaderboard) {
 #' same-shape sibling next to S9/S10 was the smaller change. See S14's own
 #' roxygen block below for the fix.
 #' @noRd
+
 #' Registry of metrics targets checked by S11 (`check_metric_window_bounds()`)
 #'
 #' @section #667 -- widening S11 beyond an enumerated pair:
@@ -570,13 +571,20 @@ S11_METRICS_REGISTRY <- list(
   eur_ciss_results = "macro"    # #667
 )
 
-#' Assert every S11_METRICS_REGISTRY name has a matching entry in the
-#' `metrics_by_name` list literal the `qa_metric_window_bounds` target
-#' actually fetched (#667)
+#' Assert `S11_METRICS_REGISTRY` and the `metrics_by_name` list literal the
+#' `qa_metric_window_bounds` target actually fetched agree EXACTLY (#667, #673)
 #'
 #' Extracted out of the target's command (rather than left inline) so it is
 #' unit-testable directly, per `fail-loud-not-null.md` and
 #' `snapshot-test-policy.md` -- see tests/testthat/test-metric-window-bounds.R.
+#'
+#' #673 made this bidirectional. It originally checked only
+#' `setdiff(registry, fetched)` -- a registry entry never fetched. The mirror
+#' case was silent: a target added to the `metrics_by_name` literal but
+#' forgotten in the registry is simply never iterated, so S11 skips it and the
+#' gate still reports PASS. That is the `fail-loud-not-null.md` shape applied
+#' to the guard itself -- an omission producing a plausible pass rather than an
+#' error, which is precisely what S11 exists to prevent one level down.
 #' @noRd
 check_s11_registry_consistency <- function(registry_names, metrics_by_name_names) {
   missing_from_metrics <- setdiff(registry_names, metrics_by_name_names)
@@ -587,6 +595,16 @@ check_s11_registry_consistency <- function(registry_names, metrics_by_name_names
       "i" = "Add the target to the metrics_by_name list literal in R/plan_qa_gates.R (S11)."
     ))
   }
+
+  missing_from_registry <- setdiff(metrics_by_name_names, registry_names)
+  if (length(missing_from_registry) > 0L) {
+    cli::cli_abort(c(
+      "x" = "qa_metric_window_bounds fetched {length(missing_from_registry)} target(s) absent from S11_METRICS_REGISTRY, so S11 never checked them:",
+      "i" = paste(missing_from_registry, collapse = ", "),
+      "i" = "Add each to S11_METRICS_REGISTRY in R/plan_qa_gates.R, mapped to its bt_partitions class (equity/macro/factor)."
+    ))
+  }
+
   invisible(TRUE)
 }
 

--- a/R/plan_risk_state.R
+++ b/R/plan_risk_state.R
@@ -43,6 +43,10 @@ plan_risk_state <- function() {
         oos_start = p$test_start,
         test_start = p$test_start,
         test_end   = p$test_end,         # #667: bounds rsc_metrics' Testing window
+        # #673: bounds rsc_subperiod's trailing slice. Holdout, not test_end --
+        # that target deliberately spans Testing AND Holdout; only Validation
+        # must stay out. See the comment above rsc_subperiod.
+        holdout_end = p$holdout_end,
         # Cost model (#425): SPY-level trades; 5 bps one-way
         # Applied only on regime-switch days (exposure changes)
         cost_per_trade = 0.0005
@@ -615,18 +619,35 @@ plan_risk_state <- function() {
 
 
     # ── Subperiod analysis: three sub-periods ────────────────────
-    # #667 audit: the "2020-2026" row below is unbounded above, same as the
-    # Testing defect fixed in rsc_metrics -- but its labels ("2009-2014",
-    # "2015-2019", "2020-2026", "Full Period") are explicit custom date
-    # ranges, not the canonical Training/Testing/Holdout/Validation
-    # vocabulary, so it is a DIFFERENT shape from #667's core defect (a
-    # reader cannot mistake "2020-2026" for the bounded canonical Testing
-    # window the way they could mistake a bare "Testing" label). Not fixed
-    # here. Flagged as a related risk: since 2026-08-08's automated data
-    # refreshes may have pushed the data past val_start (2026-05-01,
-    # R/plan_partitions.R), this window could now silently include sealed
-    # Validation-period returns, unlabelled. See CHANGELOG.md "Known
-    # Limitations" (2026-08-08) for the same open concern.
+    # #667 audit / #673 fix. The trailing slice was `date >= 2020-01-01` with
+    # no upper bound. That is a DIFFERENT shape from #667's core defect -- the
+    # labels here are explicit custom date ranges, not the canonical
+    # Training/Testing/Holdout/Validation vocabulary, so no reader mistakes
+    # this for the bounded canonical Testing window -- which is why #667/PR
+    # #672 correctly left it alone. But unbounded is unbounded: #673 measured
+    # equity_daily's boundary at 2026-04-13, below val_start (2026-05-01), so
+    # the slice held no sealed data at that moment. It held none only because
+    # equity_daily has NO SCHEDULED REFRESH (#673): the boundary is stationary
+    # because the fetcher is unscheduled, not because it has yet to catch up.
+    # The first run of scripts/fetch_equity.py would have carried it past
+    # val_start and pulled sealed Validation returns in here, unlabelled, on
+    # the next tar_make() -- and that fetch is the PREREQUISITE for the
+    # one-shot evaluation in scripts/evaluate_validation.R. The protection
+    # would have vanished in the same action that needed it. Now bounded at
+    # holdout_end so the refresh is safe whenever it happens.
+    #
+    # Bound is holdout_end (2026-04-30), NOT test_end (2023-12-31): this is a
+    # descriptive breakdown that spans Testing and Holdout on purpose, and
+    # Holdout is observed-not-sealed per backtest-partitions.md. Validation is
+    # the only line that must not be crossed. Bounding at test_end would
+    # amputate two years of legitimate data.
+    #
+    # Do NOT add rsc_subperiod to S11_METRICS_REGISTRY (R/plan_qa_gates.R).
+    # S11 asserts window_end <= test_end; this target's window legitimately
+    # runs to holdout_end, so registering it would make the gate reject a
+    # correct target. Its bespoke date-range labels are also outside the
+    # canonical vocabulary S11's exempt_periods list assumes. Different shape,
+    # deliberately unregistered.
     targets::tar_target(rsc_subperiod, {
       library(dplyr)
 
@@ -658,15 +679,24 @@ plan_risk_state <- function() {
       }
 
       port <- rsc_portfolio
+
+      # #673: inclusive [start, end] slice whose label is DERIVED from its own
+      # bounds, so the label cannot drift out of sync with the window when
+      # partition dates move (the "2020-2026" string was previously hardcoded
+      # next to a window that is now parameterised by holdout_end).
+      slice_years <- function(data, start, end) {
+        start <- as.Date(start)
+        end   <- as.Date(end)
+        calc_sp(
+          data |> filter(as.Date(date) >= start, as.Date(date) <= end),
+          paste0(format(start, "%Y"), "-", format(end, "%Y"))
+        )
+      }
+
       dplyr::bind_rows(
-        calc_sp(port |> filter(date >= as.Date("2009-01-01"),
-                               date <  as.Date("2015-01-01")),
-                "2009-2014"),
-        calc_sp(port |> filter(date >= as.Date("2015-01-01"),
-                               date <  as.Date("2020-01-01")),
-                "2015-2019"),
-        calc_sp(port |> filter(date >= as.Date("2020-01-01")),
-                "2020-2026"),
+        slice_years(port, "2009-01-01", "2014-12-31"),
+        slice_years(port, "2015-01-01", "2019-12-31"),
+        slice_years(port, "2020-01-01", rsc_params$holdout_end),
         calc_sp(port, "Full Period")
       )
     }),

--- a/tests/testthat/_snaps/metric-window-bounds.md
+++ b/tests/testthat/_snaps/metric-window-bounds.md
@@ -28,3 +28,14 @@
       i rsc_metrics
       i Add the target to the metrics_by_name list literal in R/plan_qa_gates.R (S11).
 
+# check_s11_registry_consistency throws when a fetched target is absent from the registry
+
+    Code
+      check_s11_registry_consistency(registry_names = c("mf_metrics", "ev_metrics"),
+      metrics_by_name_names = c("mf_metrics", "ev_metrics", "aw_metrics"))
+    Condition
+      Error in `check_s11_registry_consistency()`:
+      x qa_metric_window_bounds fetched 1 target(s) absent from S11_METRICS_REGISTRY, so S11 never checked them:
+      i aw_metrics
+      i Add each to S11_METRICS_REGISTRY in R/plan_qa_gates.R, mapped to its bt_partitions class (equity/macro/factor).
+

--- a/tests/testthat/test-bound-testing-windows.R
+++ b/tests/testthat/test-bound-testing-windows.R
@@ -240,3 +240,75 @@ test_that("fip_comparison's OOS window_end moves when bt_partitions$equity$test_
   expect_true(all(test_b$window_end <= as.Date("2021-06-30")))
   expect_false(identical(sort(test_a$window_end), sort(test_b$window_end)))
 })
+
+# ── 3. rsc_subperiod's trailing slice is bounded at holdout_end (#673) ──────
+#
+# rsc_subperiod is deliberately NOT in S11_METRICS_REGISTRY: its window
+# legitimately runs to holdout_end, past test_end, and its labels are bespoke
+# date ranges rather than the canonical vocabulary S11 assumes. So the gate
+# cannot guard it and this test is the only thing standing between a future
+# equity_daily refresh (#673 -- currently frozen at 2026-04-13, below
+# val_start) and sealed Validation returns silently entering that slice.
+
+test_that("rsc_params$holdout_end tracks bt_partitions$macro$holdout_end", {
+  cmd <- .target_command(plan_risk_state(), "rsc_params")
+  mock <- function(holdout_end) list(macro = list(
+    test_start  = as.Date("2020-01-01"),
+    test_end    = as.Date("2023-12-31"),
+    holdout_end = holdout_end
+  ))
+  p_a <- .eval_command(cmd, bt_partitions = mock(as.Date("2026-04-30")))
+  p_b <- .eval_command(cmd, bt_partitions = mock(as.Date("2025-06-30")))
+  expect_equal(p_a$holdout_end, as.Date("2026-04-30"))
+  expect_equal(p_b$holdout_end, as.Date("2025-06-30"))
+  expect_false(identical(p_a$holdout_end, p_b$holdout_end))
+})
+
+test_that("rsc_subperiod's trailing window stops at holdout_end, not the data's max date", {
+  cmd <- .target_command(plan_risk_state(), "rsc_subperiod")
+
+  # Portfolio deliberately runs to 2026-12-31 -- PAST every holdout_end tested
+  # below, standing in for a post-refresh equity_daily that has crossed
+  # val_start. If the slice were unbounded it would swallow all of it.
+  days <- seq(as.Date("2009-01-01"), as.Date("2026-12-31"), by = "day")
+  set.seed(673)
+  port <- tibble::tibble(
+    date         = days,
+    ret_strategy = stats::rnorm(length(days), 0.0004, 0.01),
+    ret_buyhold  = stats::rnorm(length(days), 0.0004, 0.012),
+    regime       = rep_len(c("benign", "cautious", "hostile"), length(days))
+  )
+
+  run <- function(holdout_end) {
+    .eval_command(
+      cmd,
+      rsc_portfolio  = port,
+      rsc_params     = list(holdout_end = holdout_end),
+      hd_hac_sharpe  = .mock_hac_sharpe
+    )
+  }
+
+  res_a <- run(as.Date("2026-04-30"))
+  res_b <- run(as.Date("2024-06-30"))
+
+  # The label is derived from the bounds, so it moves with them.
+  expect_true("2020-2026" %in% res_a$period)
+  expect_true("2020-2024" %in% res_b$period)
+
+  # ...and the earlier, fully-bounded slices are unaffected by holdout_end.
+  expect_true(all(c("2009-2014", "2015-2019", "Full Period") %in% res_a$period))
+  expect_true(all(c("2009-2014", "2015-2019", "Full Period") %in% res_b$period))
+
+  # The trailing slice must not be the same row under both bounds -- if it
+  # were unbounded, both runs would cover 2020-01-01..2026-12-31 identically.
+  row_a <- res_a[res_a$period == "2020-2026", ]
+  row_b <- res_b[res_b$period == "2020-2024", ]
+  expect_false(identical(row_a$vol, row_b$vol))
+
+  # "Full Period" is exempt by design (whole-sample aggregate) and still
+  # spans everything, so it is NOT expected to move with holdout_end.
+  expect_equal(
+    res_a[res_a$period == "Full Period", ]$vol,
+    res_b[res_b$period == "Full Period", ]$vol
+  )
+})

--- a/tests/testthat/test-metric-window-bounds.R
+++ b/tests/testthat/test-metric-window-bounds.R
@@ -146,25 +146,37 @@ test_that("check_metric_window_bounds throws when required columns are missing",
   )
 })
 
-# ── Tests: check_s11_registry_consistency (#667) ──────────────────────────────
+# ── Tests: check_s11_registry_consistency (#667, bidirectional #673) ─────────
 #
 # Guards the `qa_metric_window_bounds` target's own S11_METRICS_REGISTRY
 # against silently drifting out of sync with the `metrics_by_name` list
-# literal it fetches from -- an omission there would mean a registered
-# target is never actually checked by S11, the exact "scope drawn around
-# known instances" failure #667 widened S11 to fix in the first place.
+# literal it fetches from -- an omission on EITHER side means a target is
+# never actually checked by S11, the exact "scope drawn around known
+# instances" failure #667 widened S11 to fix in the first place.
+#
+# #673 made the check bidirectional. Note the pass-case fixture below no
+# longer carries an unmatched "extra_ok" entry: under the original
+# one-directional check a fetched-but-unregistered target passed silently,
+# which is the very hole #673 closed. The two lists must now agree exactly.
 
-test_that("check_s11_registry_consistency passes when every registry name is fetched", {
+test_that("check_s11_registry_consistency passes when registry and fetched list agree exactly", {
   expect_true(check_s11_registry_consistency(
-    registry_names       = c("mf_metrics", "ev_metrics", "rsc_metrics"),
-    metrics_by_name_names = c("mf_metrics", "ev_metrics", "rsc_metrics", "extra_ok")
+    registry_names        = c("mf_metrics", "ev_metrics", "rsc_metrics"),
+    metrics_by_name_names = c("mf_metrics", "ev_metrics", "rsc_metrics")
+  ))
+})
+
+test_that("check_s11_registry_consistency is order-insensitive", {
+  expect_true(check_s11_registry_consistency(
+    registry_names        = c("mf_metrics", "ev_metrics", "rsc_metrics"),
+    metrics_by_name_names = c("rsc_metrics", "mf_metrics", "ev_metrics")
   ))
 })
 
 test_that("check_s11_registry_consistency throws when a registry name is never fetched", {
   expect_error(
     check_s11_registry_consistency(
-      registry_names       = c("mf_metrics", "ev_metrics", "rsc_metrics"),
+      registry_names        = c("mf_metrics", "ev_metrics", "rsc_metrics"),
       metrics_by_name_names = c("mf_metrics", "ev_metrics")
     ),
     regexp = "rsc_metrics"
@@ -172,8 +184,30 @@ test_that("check_s11_registry_consistency throws when a registry name is never f
   expect_snapshot(
     error = TRUE,
     check_s11_registry_consistency(
-      registry_names       = c("mf_metrics", "ev_metrics", "rsc_metrics"),
+      registry_names        = c("mf_metrics", "ev_metrics", "rsc_metrics"),
       metrics_by_name_names = c("mf_metrics", "ev_metrics")
+    )
+  )
+})
+
+# The #673 direction: a target added to the metrics_by_name literal but
+# forgotten in S11_METRICS_REGISTRY. Under the original one-directional
+# check this passed silently and S11 simply never inspected that target --
+# an omission producing a plausible PASS instead of an error, which is the
+# `fail-loud-not-null.md` shape applied to the guard itself.
+test_that("check_s11_registry_consistency throws when a fetched target is absent from the registry", {
+  expect_error(
+    check_s11_registry_consistency(
+      registry_names        = c("mf_metrics", "ev_metrics"),
+      metrics_by_name_names = c("mf_metrics", "ev_metrics", "aw_metrics")
+    ),
+    regexp = "aw_metrics"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_s11_registry_consistency(
+      registry_names        = c("mf_metrics", "ev_metrics"),
+      metrics_by_name_names = c("mf_metrics", "ev_metrics", "aw_metrics")
     )
   )
 })


### PR DESCRIPTION
Three follow-ups to #667 / PR #672 (merged as `838d9bf`). Closes the ordering constraint identified in #673.

## 1. `rsc_subperiod` bounded at `holdout_end` — the urgent one

`R/plan_risk_state.R`. The trailing slice was `date >= as.Date("2020-01-01")` with no upper bound.

#667 / PR #672 correctly triaged this as a *different shape* from its core defect and left it alone: the labels here are bespoke date ranges (`"2009-2014"`, `"2020-2026"`), not the canonical `Training`/`Testing`/`Holdout`/`Validation` vocabulary, so no reader mistakes it for the bounded canonical Testing window. That reasoning was sound.

But unbounded is unbounded. #673 measured `equity_daily`'s boundary at **2026-04-13**, below `val_start` (2026-05-01), so the slice held no sealed data at that moment — and held none **only because `equity_daily` has no scheduled refresh**. The boundary is stationary because the fetcher is unscheduled, not because it has yet to catch up.

The first run of `scripts/fetch_equity.py` would have carried the boundary past `val_start` and pulled sealed Validation returns into this slice, unlabelled, on the next `tar_make()`. And that fetch is the *prerequisite* for the one-shot evaluation `scripts/evaluate_validation.R` exists to perform — the protection would have vanished in the same action that required it.

### Why `holdout_end`, not `test_end`

Bound is `holdout_end` (2026-04-30), **not** `test_end` (2023-12-31). This target is a descriptive sub-period breakdown that spans Testing *and* Holdout on purpose, and Holdout is observed-not-sealed per `backtest-partitions.md`. Validation is the only line that must not be crossed. Bounding at `test_end` would have amputated two years of legitimate data to fix a problem that does not exist there.

`holdout_end` is wired through `rsc_params` from `bt_partitions$macro`, following the `test_end` pattern PR #672 established — not hardcoded.

### Labels now derived from bounds

`"2020-2026"` was a hardcoded string sitting next to a window that is now parameterised — exactly the drift `strategy-name-consistency` exists to prevent. All three slices now derive their label from their own `[start, end]` bounds, so the label cannot fall out of sync when partition dates move. The regression test asserts this directly: at `holdout_end = 2024-06-30` the row is labelled `"2020-2024"`.

### Deliberately NOT in `S11_METRICS_REGISTRY`

Bounded at `holdout_end`, this target's `window_end` legitimately exceeds `test_end`, so S11 would **reject a correct target**. Its bespoke labels are also outside the canonical vocabulary S11's `exempt_periods` assumes. Registering it is the obvious-looking "consistency" move and it would break the gate — the reasoning is left in a comment at the target so the next reader does not make that inference.

This means S11 cannot guard this target, and the regression test in `tests/testthat/test-bound-testing-windows.R` is the only thing holding the bound. Its fixture deliberately runs to 2026-12-31 — past every `holdout_end` under test — standing in for a post-refresh `equity_daily`.

## 2. `check_s11_registry_consistency()` made bidirectional

It checked only `setdiff(registry_names, metrics_by_name_names)` — a registry entry never fetched. The mirror case was silent: a target added to the `metrics_by_name` list literal but forgotten in `S11_METRICS_REGISTRY` is never iterated, so S11 skips it entirely **and the gate still reports PASS**.

That is the [`fail-loud-not-null`](.claude/rules/fail-loud-not-null.md) shape applied to the guard itself — an omission producing a plausible pass instead of an error, which is precisely what S11 exists to prevent one level down.

Worth noting: the existing pass-case fixture carried an unmatched `"extra_ok"` entry and asserted `expect_true` — it was *encoding* the hole as intended behaviour. Updated so the two lists must agree exactly, plus an order-insensitivity test so the stricter check cannot be tripped by list ordering.

## 3. Doc block un-spliced

PR #672 appended the `S11_METRICS_REGISTRY` roxygen directly after the previous block's `#' @noRd` with no blank line, merging them. Net effect: the ~40-line S11-vs-S14 rationale written under #648 read as a preamble to the registry constant, and `check_metric_window_bounds()` — the function it describes — had no doc block at all.

Separator restored. No prose reworded on either side.

## Verification

`scripts/verify.sh` full run, foreground:

```
::VERIFY:ROOT_SUMMARY:: total=418 failed=3 skipped=0
::VERIFY:PKG_SUMMARY::  total=693 failed=1 skipped=15
PASS: _targets.R parses
PASS: testthat edition 3 active
PASS: failures match the known baseline exactly   (both suites)
=== scripts/verify.sh: PASS ===
```

Baseline on `838d9bf` immediately before these changes was root `414/3/0`, package `693/1/15`. Root rises to 418 from the four tests added here; the failure set and skip counts are unchanged.

## Not done

- `tar_make()` not run — store conflict with the main checkout. The bound is proven by evaluating `rsc_subperiod`'s real command expression against synthetic data across two `holdout_end` values, not by a pipeline run.
- The rest of #673 — scheduling `equity_daily`, the staleness surface, amending `R/plan_partitions.R:96` — is untouched. This PR closes only the ordering constraint: the refresh is now safe to perform whenever it happens.

Refs #673, #667.
