### PR TITLE
feat(cost): derive borrow_status registry + borrow-rate sensitivity sweep (#664, #665)

### DIFF
--- a/R/plan_cost_convention.R
+++ b/R/plan_cost_convention.R
@@ -38,11 +38,244 @@
 #   but no borrow cost is modelled for it (`cost_source_ref` states which).
 # `cost_source_ref`: "file:line" of the code this claim was verified
 #   against.
+#
+# ─────────────────────────────────────────────────────────────────────────
+# #664: `borrow_rate_annual == NA` conflates two very different states --
+# "no short leg, borrow correctly not applicable" and "short leg exists,
+# borrow genuinely unmodelled" -- and the distinction previously lived only
+# as free prose in `cost_source_ref`, which nothing can filter, sort, count,
+# or gate on (fail-loud-not-null.md). `borrow_status` below makes it
+# machine-readable.
+#
+# BORROW_STATUS_ALLOWED is the single source of truth for the vocabulary
+# (same pattern as PERIOD_LABELS_ALLOWED, R/plan_partitions.R):
+#   - "not_applicable"     -- long-only or overlay; genuinely no short leg.
+#   - "modelled"            -- short leg exists; borrow_rate_annual is set.
+#   - "unmodelled"           -- short leg exists; NO borrow cost charged --
+#                              the defect class #664 exists to surface.
+#   - "embedded_in_source"   -- the short leg is inside a pre-computed factor
+#                              return series (e.g. HML), not separately
+#                              financeable by our own code.
+#   - "inherited"            -- a meta-portfolio blending already-net
+#                              constituent returns; borrow (if any) is a
+#                              property of the constituents, not this row.
+#   - "not_tradeable"        -- registry states this is not a tradeable
+#                              strategy at all (no cost model of any kind).
+BORROW_STATUS_ALLOWED <- c(
+  "not_applicable", "modelled", "unmodelled",
+  "embedded_in_source", "inherited", "not_tradeable"
+)
+
+# Documented borrow_status overrides (#664). `strategy_names$directionality`
+# plus borrow_rate_annual presence/absence is sufficient to derive
+# not_applicable / modelled / unmodelled for MOST rows (see
+# derive_borrow_status() below) -- but four rows need a status that
+# directionality alone cannot distinguish. Each override is verified against
+# source at the commit this file was authored against, same convention as
+# `cost_source_ref` above:
+#
+#   - "Value (HML)": directionality is long_only (this strategy's own
+#     construction never holds a separately-tradeable short position), but
+#     the HML factor value ITSELF nets a long-value/short-growth spread
+#     inside the pre-computed Fama-French series (R/plan_ev_ebit.R:33,79) --
+#     "embedded_in_source", not "not_applicable".
+#   - "PSO Optimal": directionality is long_only (blend weights are all
+#     >= 0), but it is a meta-portfolio over already-net constituent returns
+#     (R/plan_portfolio_opt.R), several of which ARE long_short with their
+#     own borrow_status -- "inherited", not "not_applicable".
+#   - "Avoid Worst": directionality is "overlay" like Risk State/TOM, but
+#     unlike those two it has NO cost model of any kind implemented in code
+#     (R/plan_avoid_worst.R:5, "NOT a tradeable strategy") -- "not_tradeable",
+#     distinct from an overlay that simply never needs to borrow.
+#   - "Managed Futures": directionality is long_short (the TSM sleeve does
+#     take short positions), but futures financing is embedded in the
+#     futures price itself, not a separately-financeable equity-style
+#     short-borrow cost (R/plan_managed_futures.R). This is a JUDGEMENT
+#     CALL, not a verified absence like the other three rows -- flagged in
+#     the PR body for review rather than asserted as settled fact.
+BORROW_STATUS_OVERRIDES <- tibble::tibble(
+  strategy = c("Value (HML)", "PSO Optimal", "Avoid Worst", "Managed Futures"),
+  borrow_status_override = c(
+    "embedded_in_source", "inherited", "not_tradeable", "not_applicable"
+  )
+)
+
+#' Derive each strategy's borrow_status from directionality + rate presence (#664)
+#'
+#' Pure, vectorised, unit-testable. Fails loud (fail-loud-not-null.md) rather
+#' than defaulting to NA: an unrecognised directionality, a missing
+#' directionality with no override, or an override outside
+#' BORROW_STATUS_ALLOWED all `cli_abort()`.
+#'
+#' @param strategy Character vector. Strategy display names, used only in
+#'   error messages.
+#' @param directionality Character vector (same length as `strategy`). Values
+#'   from `strategy_names$directionality` (R/plan_strategy_names.R):
+#'   long_only, long_short, market_neutral, overlay -- or NA if the strategy
+#'   has no `strategy_names` row (see the OLMAR-1 fill in the
+#'   `strategy_cost_convention` target below) and no override.
+#' @param has_borrow_rate Logical vector (same length). `TRUE` where
+#'   `borrow_rate_annual` is non-NA in the cost registry.
+#' @param override Character vector (same length), or NA where no override
+#'   applies. Values from BORROW_STATUS_OVERRIDES take priority over the
+#'   directionality-based derivation.
+#' @return Character vector of borrow_status values, each a member of
+#'   BORROW_STATUS_ALLOWED.
+#' @noRd
+derive_borrow_status <- function(strategy, directionality, has_borrow_rate,
+                                  override = NA_character_) {
+  n <- length(strategy)
+  if (length(directionality) != n || length(has_borrow_rate) != n) {
+    cli::cli_abort(c(
+      "x" = "derive_borrow_status(): strategy, directionality, has_borrow_rate must be the same length."
+    ))
+  }
+  if (length(override) == 1L) override <- rep(override, n)
+  if (length(override) != n) {
+    cli::cli_abort(c("x" = "derive_borrow_status(): override must have length 1 or {n}."))
+  }
+
+  vapply(seq_len(n), function(i) {
+    ov <- override[i]
+    if (!is.na(ov)) {
+      if (!ov %in% BORROW_STATUS_ALLOWED) {
+        cli::cli_abort(c(
+          "x" = "{.val {strategy[i]}}: override borrow_status {.val {ov}} is not in the allowed set.",
+          "i" = "Allowed values: {paste(BORROW_STATUS_ALLOWED, collapse = ', ')}."
+        ))
+      }
+      return(ov)
+    }
+
+    d <- directionality[i]
+    if (is.na(d)) {
+      cli::cli_abort(c(
+        "x" = "{.val {strategy[i]}}: cannot derive borrow_status -- directionality is NA and no override is set.",
+        "i" = "Add a row to strategy_names (R/plan_strategy_names.R) or an entry to BORROW_STATUS_OVERRIDES (R/plan_cost_convention.R)."
+      ))
+    }
+    if (d %in% c("long_only", "overlay")) {
+      return("not_applicable")
+    }
+    if (d %in% c("long_short", "market_neutral")) {
+      return(if (isTRUE(has_borrow_rate[i])) "modelled" else "unmodelled")
+    }
+    cli::cli_abort(c(
+      "x" = "{.val {strategy[i]}}: unrecognised directionality {.val {d}}.",
+      "i" = "Allowed values: long_only, long_short, market_neutral, overlay."
+    ))
+  }, character(1L))
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# #665 (quantification only): borrow-rate sensitivity sweep.
+#
+# REPORTING ONLY. Nothing here feeds `leaderboard` / `all_metrics` / any
+# published return -- it answers "what WOULD Sharpe/CAGR be at borrow rate
+# X", holding trade costs, signal, and weights fixed. See
+# `borrow_sensitivity_sweep` target below for how each strategy's PRE-BORROW
+# monthly return series is assembled.
+
+#' Recompute CAGR/Sharpe/vol at a swept annual borrow rate (#665)
+#'
+#' The borrow charge is applied at `rate / 12` per month against
+#' `short_notional_frac` of NAV -- the convention every borrow-charging
+#' strategy in this codebase already uses for a monthly-rebalanced,
+#' dollar-neutral decile long-short book (verified: R/plan_stock_backtest.R
+#' `portfolio_longshort()`, `borrow_cost <- borrow_rate_annual / 12`;
+#' R/plan_mom_prepeak.R:224-228, weight = +-1/n_leg per leg, i.e. 100% leg
+#' notional; packages/historicaldata/R/commodities_mean_reversion.R:185,
+#' same +-1/n_leg convention). CAGR/vol/Sharpe formulas mirror
+#' `calc_backtest_metrics()` (R/plan_stock_backtest.R:431) with the
+#' risk-free adjustment omitted -- this function reports RELATIVE deltas
+#' across borrow rates for a single strategy, so a constant rf term would
+#' cancel in `sharpe_delta` and is left out for simplicity (noted, not
+#' silently assumed away).
+#'
+#' @param monthly_ret_pre_borrow Numeric vector, monthly portfolio returns
+#'   BEFORE any borrow charge (trade costs already deducted). No NA allowed
+#'   -- filter upstream.
+#' @param borrow_rates_annual Numeric vector of annual borrow rates to sweep.
+#'   MUST include 0 (the baseline `sharpe_delta` is computed against).
+#' @param short_notional_frac Numeric scalar in `[0, 1]`. Fraction of NAV
+#'   held short each period. Default `1` (100%, per the verified convention
+#'   above).
+#' @return Tibble: borrow_rate_annual, cagr, vol, sharpe, sharpe_delta
+#'   (sharpe at this rate minus sharpe at rate 0).
+#' @noRd
+compute_borrow_sensitivity <- function(monthly_ret_pre_borrow,
+                                        borrow_rates_annual = c(0, 0.03, 0.10, 0.25),
+                                        short_notional_frac = 1) {
+  if (!is.numeric(monthly_ret_pre_borrow) || length(monthly_ret_pre_borrow) < 12L) {
+    cli::cli_abort(c(
+      "x" = "compute_borrow_sensitivity() requires >= 12 monthly returns.",
+      "i" = "Got {length(monthly_ret_pre_borrow)}."
+    ))
+  }
+  if (anyNA(monthly_ret_pre_borrow)) {
+    cli::cli_abort(c(
+      "x" = "compute_borrow_sensitivity(): monthly_ret_pre_borrow contains NA.",
+      "i" = "Filter NA out before calling -- never coerced or dropped silently here."
+    ))
+  }
+  if (!is.numeric(short_notional_frac) || length(short_notional_frac) != 1L ||
+      is.na(short_notional_frac) || short_notional_frac < 0 || short_notional_frac > 1) {
+    cli::cli_abort(c(
+      "x" = "short_notional_frac must be a single numeric value in [0, 1].",
+      "i" = "Got {short_notional_frac}."
+    ))
+  }
+  if (!0 %in% borrow_rates_annual) {
+    cli::cli_abort(c(
+      "x" = "borrow_rates_annual must include 0 -- it is the sharpe_delta baseline.",
+      "i" = "Got: {paste(borrow_rates_annual, collapse = ', ')}."
+    ))
+  }
+
+  n <- length(monthly_ret_pre_borrow)
+
+  rows <- purrr::map_dfr(borrow_rates_annual, function(rate) {
+    monthly_charge <- short_notional_frac * rate / 12
+    r       <- monthly_ret_pre_borrow - monthly_charge
+    ann_ret <- prod(1 + r)^(12 / n) - 1
+    ann_vol <- stats::sd(r) * sqrt(12)
+    sharpe  <- ann_ret / ann_vol
+    tibble::tibble(
+      borrow_rate_annual = rate, cagr = ann_ret, vol = ann_vol, sharpe = sharpe
+    )
+  })
+
+  sharpe_at_zero <- rows$sharpe[rows$borrow_rate_annual == 0][1]
+  rows$sharpe_delta <- rows$sharpe - sharpe_at_zero
+  rows
+}
+
+#' Apply compute_borrow_sensitivity() across a named list of strategies (#665)
+#'
+#' @param returns_by_strategy Named list of numeric vectors: PRE-BORROW
+#'   monthly returns per strategy (may contain NA -- filtered per-strategy).
+#' @param borrow_rates_annual Numeric vector to sweep.
+#' @return Tibble: strategy, borrow_rate_annual, cagr, vol, sharpe, sharpe_delta.
+#' @noRd
+build_borrow_sensitivity_table <- function(returns_by_strategy,
+                                            borrow_rates_annual = c(0, 0.03, 0.10, 0.25)) {
+  if (!is.list(returns_by_strategy) || length(returns_by_strategy) == 0L ||
+      is.null(names(returns_by_strategy)) || any(!nzchar(names(returns_by_strategy)))) {
+    cli::cli_abort(c(
+      "x" = "build_borrow_sensitivity_table(): returns_by_strategy must be a non-empty NAMED list."
+    ))
+  }
+  purrr::imap_dfr(returns_by_strategy, function(r, strategy) {
+    r <- r[!is.na(r)]
+    sweep <- compute_borrow_sensitivity(r, borrow_rates_annual)
+    dplyr::mutate(sweep, strategy = strategy, .before = 1L)
+  })
+}
 
 plan_cost_convention <- function() {
   list(
     targets::tar_target(strategy_cost_convention, {
-      tibble::tibble(
+      base <- tibble::tibble(
         strategy = c(
           "Factor MAX", "Factor DRIF",
           "Stock MAX", "Stock DRIF", "XGB DRIF",
@@ -103,6 +336,119 @@ plan_cost_convention <- function() {
           "R/plan_portfolio_opt.R (no cost_per_trade/cost_bps field found; w <- w/sum(w) blends already cost-net constituent returns; see R/plan_exposure.R source_ref for the same meta-portfolio caveat on gross exposure)"
         )
       )
+
+      # ── #664: derive borrow_status ────────────────────────────────────
+      # strategy_names is the single source of truth for directionality
+      # (R/plan_strategy_names.R). Join on strategy == short_name -- the
+      # same join key strategy_gross_convention (R/plan_exposure.R) uses.
+      #
+      # OLMAR-1 has no row in strategy_names (#626/#629 known join gap) --
+      # filled explicitly (long-only simplex projection, R/plan_olmar.R:30)
+      # rather than left NA (fail-loud-not-null.md): a silently-NA
+      # directionality would make derive_borrow_status() abort below, which
+      # is correct for a GENUINELY unknown strategy but wrong for a known,
+      # documented gap.
+      sn_lookup <- dplyr::transmute(
+        strategy_names,
+        strategy = short_name,
+        directionality = as.character(directionality)
+      )
+
+      with_direction <- base |>
+        dplyr::left_join(sn_lookup, by = "strategy") |>
+        dplyr::mutate(
+          directionality = dplyr::if_else(
+            strategy == "OLMAR-1", "long_only", directionality
+          )
+        ) |>
+        dplyr::left_join(BORROW_STATUS_OVERRIDES, by = "strategy")
+
+      with_status <- with_direction |>
+        dplyr::mutate(
+          borrow_status = derive_borrow_status(
+            strategy        = strategy,
+            directionality  = directionality,
+            has_borrow_rate = !is.na(borrow_rate_annual),
+            override        = borrow_status_override
+          )
+        ) |>
+        dplyr::select(-directionality, -borrow_status_override)
+
+      # Visible at every tar_make() (fail-loud-not-null.md: an unrecognised /
+      # unmodelled state must be visible, never silently absorbed).
+      unmodelled <- with_status$strategy[with_status$borrow_status == "unmodelled"]
+      if (length(unmodelled) > 0L) {
+        cli::cli_warn(c(
+          "!" = paste0(
+            length(unmodelled), " strategy/strategies have a short leg with ",
+            "NO borrow cost modelled (#664):"
+          ),
+          setNames(sprintf("  %s", unmodelled), rep("i", length(unmodelled))),
+          "i" = paste0(
+            "See the borrow_status column of strategy_cost_convention ",
+            "(R/plan_cost_convention.R) and the borrow_sensitivity_sweep ",
+            "target for the CAGR/Sharpe impact at borrow != 0 (#665)."
+          )
+        ))
+      }
+
+      with_status
+    }),
+
+    # ── #665 (quantification only): borrow-rate sensitivity sweep ───────
+    #
+    # REPORTING ONLY -- see build_borrow_sensitivity_table() /
+    # compute_borrow_sensitivity() roxygen above. Does NOT feed leaderboard,
+    # all_metrics, or any published return. Covers the 4 currently-
+    # "unmodelled" strategies (their whole edge is at stake if a borrow cost
+    # is ever added) plus the 4 currently-"modelled" strategies (so a reader
+    # can see how sensitive the already-costed strategies are to the flat
+    # 0.03 rate being wrong -- see the `# MANUAL: no source` markers on that
+    # constant in R/plan_stock_backtest.R and R/plan_ltr_momentum.R).
+    #
+    # Each series is reconstructed as the PRE-BORROW monthly return:
+    #   - unmodelled strategies: their return series already has zero
+    #     borrow charge, so it is used as-is.
+    #   - modelled strategies: the currently-applied 0.03/12 monthly charge
+    #     is added back (port_ret + borrow_cost, or ls_ret_net + borrow for
+    #     LTR's pre-computed parquet columns) so the sweep starts from the
+    #     same zero-borrow baseline as the unmodelled strategies.
+    #
+    # CMR reports 3 lookback variants (1m/3m/6m); the leaderboard displays
+    # whichever has the best Sharpe (.norm_cmr(), R/plan_leaderboard.R) --
+    # the same "best lookback" selection is replicated here from cmr_summary
+    # so the swept strategy matches what is actually published.
+    targets::tar_target(borrow_sensitivity_sweep, {
+      cmr_best <- cmr_summary$lookback[which.max(cmr_summary$sharpe)]
+      cmr_port <- switch(cmr_best,
+        "1m" = cmr_portfolio_1m,
+        "3m" = cmr_portfolio_3m,
+        "6m" = cmr_portfolio_6m,
+        cli::cli_abort(c(
+          "x" = "borrow_sensitivity_sweep: unrecognised CMR lookback {.val {cmr_best}} selected by cmr_summary.",
+          "i" = "Allowed values: 1m, 3m, 6m (R/plan_commodities_mean_reversion.R)."
+        ))
+      )
+
+      returns_by_strategy <- list(
+        "Mom Pre-Peak"  = mom_prepeak_returns$ret_ls,
+        "Mom Post-Peak" = mom_postpeak_returns$ret_ls,
+        "Mom 12-2"      = mom_combined_returns$ret_ls,
+        "CMR"           = cmr_port$net_ret,
+        "Stock MAX"     = stk_max_portfolio$port_ret + stk_max_portfolio$borrow_cost,
+        "Stock DRIF"    = stk_drif_portfolio$port_ret + stk_drif_portfolio$borrow_cost,
+        "XGB DRIF"      = xgb_drif_portfolio$port_ret + xgb_drif_portfolio$borrow_cost,
+        "LTR"           = ltr_portfolio$ls_ret_net + ltr_portfolio$borrow
+      )
+
+      out <- build_borrow_sensitivity_table(returns_by_strategy)
+
+      cli::cli_inform(c("v" = paste0(
+        "borrow_sensitivity_sweep: ", dplyr::n_distinct(out$strategy),
+        " strategies x ", length(unique(out$borrow_rate_annual)),
+        " borrow rates (reporting only, #665; CMR variant = ", cmr_best, ")"
+      )))
+      out
     })
   )
 }

--- a/R/plan_ltr_momentum.R
+++ b/R/plan_ltr_momentum.R
@@ -25,6 +25,15 @@ plan_ltr_momentum <- function() {
         train_years         = 10L,          # years of training (not 15 — less data)
         retrain_freq        = "yearly",     # retrain annually
         cost_per_trade      = 0.0010,       # 10bps per trade (tighter for demo)
+        # MANUAL: no source -- 3% annualised borrow cost is a round-number
+        # assumption, not derived from a machine-readable borrow-rate series.
+        # NOTE: this ltr_params value is not itself consumed downstream in
+        # this file -- the value that actually drives ltr_portfolio's
+        # published return is the separate `borrow_cost_annual` constant in
+        # scripts/compute_ltr_model.R:33 (also marked). Per
+        # reproducible-ingestion (~/.claude/CLAUDE.md) and
+        # fail-loud-not-null.md this is technical debt: a follow-up issue
+        # should source a real equity-borrow series (#664/#665 PR body).
         borrow_rate_annual  = 0.03,
         max_monthly_ret     = 0.20,
         oos_start           = p$test_start,

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -969,6 +969,99 @@ check_portfolio_join_coverage <- function(port_returns) {
 }
 
 
+#' Assert every strategy's borrow_status is derivable, in the allowed
+#' vocabulary, and consistent with borrow_rate_annual (S16)
+#'
+#' Guards against the #664 defect class: `strategy_cost_convention`'s
+#' `borrow_rate_annual` column conflated "no short leg -- borrow correctly
+#' N/A" with "short leg exists, borrow genuinely unmodelled" as a single NA
+#' value, with the distinction recorded only as free prose in
+#' `cost_source_ref` that nothing could filter, sort, count, or gate on
+#' (fail-loud-not-null.md). `borrow_status` (derived by
+#' `derive_borrow_status()`, R/plan_cost_convention.R) makes the distinction
+#' machine-readable; this gate is the belt-and-braces check that the
+#' derivation actually held for every row -- no NA status, no status outside
+#' `BORROW_STATUS_ALLOWED`, and no row where the derived status contradicts
+#' whether a `borrow_rate_annual` is actually present (a `"modelled"` row
+#' with no rate, or a non-`"modelled"` row WITH a rate, is a contradiction
+#' and must abort).
+#'
+#' @param strategy_cost_convention Tibble with at least `strategy`,
+#'   `borrow_status`, `borrow_rate_annual` columns (the output of the
+#'   `strategy_cost_convention` target, R/plan_cost_convention.R).
+#' @return `TRUE` invisibly on success.
+#' @noRd
+check_borrow_status_registry <- function(strategy_cost_convention) {
+  required_cols <- c("strategy", "borrow_status", "borrow_rate_annual")
+  missing_cols <- setdiff(required_cols, names(strategy_cost_convention))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "strategy_cost_convention is missing {length(missing_cols)} required column(s): {missing_cols}.",
+      "i" = "check_borrow_status_registry() (S16) requires strategy, borrow_status, borrow_rate_annual."
+    ))
+  }
+
+  # ── Assertion 1: no NA borrow_status ─────────────────────────────────────
+  na_status <- strategy_cost_convention$strategy[is.na(strategy_cost_convention$borrow_status)]
+  if (length(na_status) > 0L) {
+    cli::cli_abort(c(
+      "x" = paste0(
+        "strategy_cost_convention has ", length(na_status),
+        " strategy/strategies with NA borrow_status (#664):"
+      ),
+      setNames(sprintf("  %s", na_status), rep("i", length(na_status))),
+      "i" = "Every strategy must resolve to a status in BORROW_STATUS_ALLOWED (R/plan_cost_convention.R) -- never NA."
+    ))
+  }
+
+  # ── Assertion 2: no out-of-vocabulary borrow_status ──────────────────────
+  bad_vocab <- unique(setdiff(strategy_cost_convention$borrow_status, BORROW_STATUS_ALLOWED))
+  if (length(bad_vocab) > 0L) {
+    cli::cli_abort(c(
+      "x" = paste0(
+        "strategy_cost_convention has borrow_status value(s) outside the allowed vocabulary: ",
+        paste(bad_vocab, collapse = ", ")
+      ),
+      "i" = paste0("Allowed values: ", paste(BORROW_STATUS_ALLOWED, collapse = ", "), ".")
+    ))
+  }
+
+  # ── Assertion 3: status must agree with whether a rate is recorded ──────
+  is_modelled   <- strategy_cost_convention$borrow_status == "modelled"
+  has_rate      <- !is.na(strategy_cost_convention$borrow_rate_annual)
+  contradiction <- is_modelled != has_rate
+  offenders <- strategy_cost_convention[contradiction,
+    c("strategy", "borrow_status", "borrow_rate_annual"), drop = FALSE]
+
+  if (nrow(offenders) > 0L) {
+    msgs <- purrr::pmap_chr(
+      offenders,
+      function(strategy, borrow_status, borrow_rate_annual) {
+        sprintf(
+          "  %s -- borrow_status = %s, borrow_rate_annual = %s",
+          strategy, borrow_status,
+          if (is.na(borrow_rate_annual)) "NA" else format(borrow_rate_annual)
+        )
+      }
+    )
+    cli::cli_abort(c(
+      "x" = paste0(
+        "strategy_cost_convention has ", nrow(offenders),
+        " row(s) where borrow_status contradicts borrow_rate_annual (#664):"
+      ),
+      setNames(msgs, rep("i", length(msgs))),
+      "i" = paste0(
+        "A \"modelled\" row must have a non-NA borrow_rate_annual; every ",
+        "other status must have NA -- fix the registry row or the ",
+        "derivation in R/plan_cost_convention.R."
+      )
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+
 # ---- QA gate plan ----
 
 plan_qa_gates <- function() {
@@ -1288,6 +1381,22 @@ plan_qa_gates <- function() {
         }
         cli::cli_inform(c("v" = "qa_no_published_validation_reads: S15 passed (no published document reads Validation)"))
         nrow(hits)
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: strategy_cost_convention's borrow_status is derivable, in the
+    # allowed vocabulary, and consistent with borrow_rate_annual (S16) --
+    # guards against the #664 defect class where borrow_rate_annual == NA
+    # conflated "no short leg" with "short leg exists, borrow genuinely
+    # unmodelled" into a single value that nothing could filter, sort,
+    # count, or gate on.
+    targets::tar_target(
+      qa_borrow_status_registry,
+      command = {
+        check_borrow_status_registry(strategy_cost_convention)
+        cli::cli_inform(c("v" = "qa_borrow_status_registry: S16 passed (all borrow_status values derivable, in vocabulary, and consistent with borrow_rate_annual)"))
+        TRUE
       },
       cue = targets::tar_cue(mode = "always")
     )

--- a/R/plan_stock_backtest.R
+++ b/R/plan_stock_backtest.R
@@ -466,7 +466,12 @@ plan_stock_backtest <- function() {
         oos_start = p$test_start,
         # Cost model (Options 1, 4, 5)
         cost_per_trade = 0.005,       # 0.50% per trade (Option 1: higher than 0.10%)
-        borrow_rate_annual = 0.03,    # 3% annualised borrow cost for shorts (Option 5)
+        # MANUAL: no source -- 3% annualised borrow cost for shorts (Option 5)
+        # is a round-number assumption, not derived from a machine-readable
+        # borrow-rate series. Per reproducible-ingestion (~/.claude/CLAUDE.md)
+        # and fail-loud-not-null.md this is technical debt: a follow-up issue
+        # should source a real equity-borrow series (#664/#665 PR body).
+        borrow_rate_annual = 0.03,
         max_monthly_ret = 0.20,       # Winsorise at ±20% (Option 2)
         hrp_lookback_months = 36L,    # HRP covariance lookback for stock-level long-short
         adv_pct_cap = 0.10,           # ADV participation cap: 10% of ADV-weighted share × n

--- a/scripts/compute_ltr_model.R
+++ b/scripts/compute_ltr_model.R
@@ -30,6 +30,14 @@ train_years <- 10L
 min_stocks <- 30L
 n_quantiles <- 10L
 cost_per_trade <- 0.0010  # 10bps
+# MANUAL: no source -- 3% annualised borrow cost is a round-number
+# assumption, not derived from a machine-readable borrow-rate series. This
+# is the constant that actually drives ltr_portfolio's published return
+# (via ls_ret_net below); R/plan_ltr_momentum.R:28 carries the same value
+# in ltr_params for documentation but does not consume it downstream. Per
+# reproducible-ingestion (~/.claude/CLAUDE.md) and fail-loud-not-null.md
+# this is technical debt: a follow-up issue should source a real
+# equity-borrow series (#664/#665 PR body).
 borrow_cost_annual <- 0.03  # 3% for shorts
 oos_start <- as.Date("2020-01-01")
 

--- a/tests/testthat/_snaps/borrow-sensitivity-sweep.md
+++ b/tests/testthat/_snaps/borrow-sensitivity-sweep.md
@@ -1,0 +1,39 @@
+# compute_borrow_sensitivity requires >= 12 months
+
+    Code
+      compute_borrow_sensitivity(rep(0.01, 6L))
+    Condition
+      Error in `compute_borrow_sensitivity()`:
+      x compute_borrow_sensitivity() requires >= 12 monthly returns.
+      i Got 6.
+
+# compute_borrow_sensitivity aborts on NA input rather than dropping it silently
+
+    Code
+      compute_borrow_sensitivity(bad)
+    Condition
+      Error in `compute_borrow_sensitivity()`:
+      x compute_borrow_sensitivity(): monthly_ret_pre_borrow contains NA.
+      i Filter NA out before calling -- never coerced or dropped silently here.
+
+# compute_borrow_sensitivity's cagr/vol match an independent formula recomputation
+
+    Code
+      print(out, n = Inf)
+    Output
+      # A tibble: 4 x 5
+        borrow_rate_annual    cagr    vol sharpe sharpe_delta
+                     <dbl>   <dbl>  <dbl>  <dbl>        <dbl>
+      1               0     0.141  0.0445  3.18         0    
+      2               0.03  0.108  0.0445  2.43        -0.751
+      3               0.1   0.0335 0.0445  0.754       -2.43 
+      4               0.25 -0.111  0.0445 -2.49        -5.67 
+
+# build_borrow_sensitivity_table requires a non-empty named list
+
+    Code
+      build_borrow_sensitivity_table(list())
+    Condition
+      Error in `build_borrow_sensitivity_table()`:
+      x build_borrow_sensitivity_table(): returns_by_strategy must be a non-empty NAMED list.
+

--- a/tests/testthat/_snaps/borrow-status-registry.md
+++ b/tests/testthat/_snaps/borrow-status-registry.md
@@ -1,0 +1,48 @@
+# check_borrow_status_registry throws on NA borrow_status
+
+    Code
+      check_borrow_status_registry(bad)
+    Condition
+      Error in `check_borrow_status_registry()`:
+      x strategy_cost_convention has 1 strategy/strategies with NA borrow_status (#664):
+      i  CMR
+      i Every strategy must resolve to a status in BORROW_STATUS_ALLOWED (R/plan_cost_convention.R) -- never NA.
+
+# check_borrow_status_registry throws on an out-of-vocabulary status
+
+    Code
+      check_borrow_status_registry(bad)
+    Condition
+      Error in `check_borrow_status_registry()`:
+      x strategy_cost_convention has borrow_status value(s) outside the allowed vocabulary: bogus_status
+      i Allowed values: not_applicable, modelled, unmodelled, embedded_in_source, inherited, not_tradeable.
+
+# check_borrow_status_registry throws when a modelled row has no rate
+
+    Code
+      check_borrow_status_registry(bad)
+    Condition
+      Error in `check_borrow_status_registry()`:
+      x strategy_cost_convention has 1 row(s) where borrow_status contradicts borrow_rate_annual (#664):
+      i  Stock MAX -- borrow_status = modelled, borrow_rate_annual = NA
+      i A "modelled" row must have a non-NA borrow_rate_annual; every other status must have NA -- fix the registry row or the derivation in R/plan_cost_convention.R.
+
+# check_borrow_status_registry throws when a non-modelled row HAS a rate
+
+    Code
+      check_borrow_status_registry(bad)
+    Condition
+      Error in `check_borrow_status_registry()`:
+      x strategy_cost_convention has 1 row(s) where borrow_status contradicts borrow_rate_annual (#664):
+      i  CMR -- borrow_status = unmodelled, borrow_rate_annual = 0.05
+      i A "modelled" row must have a non-NA borrow_rate_annual; every other status must have NA -- fix the registry row or the derivation in R/plan_cost_convention.R.
+
+# check_borrow_status_registry throws when required columns are missing
+
+    Code
+      check_borrow_status_registry(bad)
+    Condition
+      Error in `check_borrow_status_registry()`:
+      x strategy_cost_convention is missing 1 required column(s): borrow_rate_annual.
+      i check_borrow_status_registry() (S16) requires strategy, borrow_status, borrow_rate_annual.
+

--- a/tests/testthat/_snaps/borrow-status.md
+++ b/tests/testthat/_snaps/borrow-status.md
@@ -1,0 +1,27 @@
+# an override outside BORROW_STATUS_ALLOWED aborts
+
+    Code
+      derive_borrow_status("Bogus", "long_only", FALSE, override = "not_a_real_status")
+    Condition
+      Error in `FUN()`:
+      x "Bogus": override borrow_status "not_a_real_status" is not in the allowed set.
+      i Allowed values: not_applicable, modelled, unmodelled, embedded_in_source, inherited, not_tradeable.
+
+# NA directionality with no override aborts, naming the strategy
+
+    Code
+      derive_borrow_status("OLMAR-1", NA_character_, FALSE)
+    Condition
+      Error in `FUN()`:
+      x "OLMAR-1": cannot derive borrow_status -- directionality is NA and no override is set.
+      i Add a row to strategy_names (R/plan_strategy_names.R) or an entry to BORROW_STATUS_OVERRIDES (R/plan_cost_convention.R).
+
+# an unrecognised directionality value aborts, naming the allowed set
+
+    Code
+      derive_borrow_status("Weird", "some_other_value", FALSE)
+    Condition
+      Error in `FUN()`:
+      x "Weird": unrecognised directionality "some_other_value".
+      i Allowed values: long_only, long_short, market_neutral, overlay.
+

--- a/tests/testthat/test-borrow-sensitivity-sweep.R
+++ b/tests/testthat/test-borrow-sensitivity-sweep.R
@@ -1,0 +1,109 @@
+testthat::local_edition(3)
+# Tests for compute_borrow_sensitivity() / build_borrow_sensitivity_table() (#665)
+#
+# REPORTING-ONLY functions defined in R/plan_cost_convention.R -- nothing
+# they compute feeds leaderboard/all_metrics/any published return. Tests
+# verify the borrow-rate sweep arithmetic on toy fixtures and the required
+# invariants: sharpe_delta == 0 at borrow_rate_annual == 0, sharpe strictly
+# decreases as the borrow rate increases (subtracting a constant charge
+# leaves volatility unchanged but lowers the mean), and NA / too-short /
+# out-of-range inputs abort loudly rather than silently coercing.
+
+source(here::here("R/plan_cost_convention.R"))
+
+# 24 months of a toy strategy return series -- small positive drift + noise
+# so cagr/vol/sharpe are all well-defined (vol > 0) and reproducible.
+set.seed(42)
+toy_ret <- rep(0.01, 24L) + stats::rnorm(24L, sd = 0.01)
+
+# ── Input validation (fail-loud-not-null.md) ────────────────────────────
+
+test_that("compute_borrow_sensitivity requires >= 12 months", {
+  expect_error(compute_borrow_sensitivity(rep(0.01, 6L)), regexp = "12")
+  expect_snapshot(error = TRUE, compute_borrow_sensitivity(rep(0.01, 6L)))
+})
+
+test_that("compute_borrow_sensitivity aborts on NA input rather than dropping it silently", {
+  bad <- toy_ret
+  bad[3] <- NA_real_
+  expect_error(compute_borrow_sensitivity(bad), regexp = "NA")
+  expect_snapshot(error = TRUE, compute_borrow_sensitivity(bad))
+})
+
+test_that("compute_borrow_sensitivity requires 0 in borrow_rates_annual (sharpe_delta baseline)", {
+  expect_error(
+    compute_borrow_sensitivity(toy_ret, borrow_rates_annual = c(0.03, 0.10)),
+    regexp = "0"
+  )
+})
+
+test_that("compute_borrow_sensitivity rejects an out-of-range short_notional_frac", {
+  expect_error(
+    compute_borrow_sensitivity(toy_ret, short_notional_frac = 1.5),
+    regexp = "\\[0, 1\\]"
+  )
+  expect_error(
+    compute_borrow_sensitivity(toy_ret, short_notional_frac = -0.1),
+    regexp = "\\[0, 1\\]"
+  )
+})
+
+# ── Core arithmetic ──────────────────────────────────────────────────────
+
+test_that("sharpe_delta is exactly 0 at borrow_rate_annual == 0", {
+  out <- compute_borrow_sensitivity(toy_ret)
+  expect_equal(out$sharpe_delta[out$borrow_rate_annual == 0], 0)
+})
+
+test_that("sharpe strictly decreases as borrow rate increases", {
+  # Subtracting a larger constant monthly charge lowers the mean but leaves
+  # sd() unchanged, so sharpe = ann_ret / ann_vol must strictly decrease as
+  # the swept rate increases -- true for ANY non-degenerate return series.
+  out <- compute_borrow_sensitivity(toy_ret, borrow_rates_annual = c(0, 0.03, 0.10, 0.25))
+  expect_true(all(diff(out$sharpe) < 0))
+  expect_true(all(diff(out$sharpe_delta) < 0))
+})
+
+test_that("short_notional_frac = 0 makes the sweep a no-op (no short exposure to charge)", {
+  out <- compute_borrow_sensitivity(toy_ret, short_notional_frac = 0)
+  expect_true(all(out$sharpe_delta == 0))
+  expect_true(all(out$cagr == out$cagr[1]))
+})
+
+test_that("compute_borrow_sensitivity's cagr/vol match an independent formula recomputation", {
+  out <- compute_borrow_sensitivity(toy_ret, borrow_rates_annual = c(0, 0.03, 0.10, 0.25))
+  for (rate in c(0, 0.03, 0.10, 0.25)) {
+    r <- toy_ret - rate / 12
+    row <- out[out$borrow_rate_annual == rate, ]
+    expect_equal(row$cagr, prod(1 + r)^(12 / length(r)) - 1, tolerance = 1e-12)
+    expect_equal(row$vol,  stats::sd(r) * sqrt(12),           tolerance = 1e-12)
+  }
+
+  # Snapshot: catches format/column drift.
+  expect_snapshot(print(out, n = Inf))
+})
+
+# ── build_borrow_sensitivity_table: multi-strategy assembly ──────────────
+
+test_that("build_borrow_sensitivity_table requires a non-empty named list", {
+  expect_error(build_borrow_sensitivity_table(list()), regexp = "non-empty")
+  expect_error(build_borrow_sensitivity_table(list(1:5)), regexp = "non-empty")
+  expect_snapshot(error = TRUE, build_borrow_sensitivity_table(list()))
+})
+
+test_that("build_borrow_sensitivity_table combines multiple strategies and filters NA per-strategy", {
+  strat_a <- toy_ret
+  strat_b <- c(NA_real_, toy_ret)  # leading NA -- must be filtered, not propagated
+
+  out <- build_borrow_sensitivity_table(list("Strategy A" = strat_a, "Strategy B" = strat_b))
+
+  expect_setequal(out$strategy, c("Strategy A", "Strategy B"))
+  expect_equal(nrow(out), 2L * length(c(0, 0.03, 0.10, 0.25)))
+  expect_true(all(!is.na(out$sharpe)))
+
+  # Both strategies swept over the identical rate grid.
+  expect_equal(
+    sort(unique(out$borrow_rate_annual[out$strategy == "Strategy A"])),
+    sort(unique(out$borrow_rate_annual[out$strategy == "Strategy B"]))
+  )
+})

--- a/tests/testthat/test-borrow-status-registry.R
+++ b/tests/testthat/test-borrow-status-registry.R
@@ -1,0 +1,81 @@
+testthat::local_edition(3)
+# Tests for check_borrow_status_registry() — QA gate S16 (#664)
+#
+# The function is defined in R/plan_qa_gates.R and depends on
+# BORROW_STATUS_ALLOWED, defined in R/plan_cost_convention.R (single source
+# of truth for the borrow_status vocabulary). Tests exercise the gate
+# directly without running tar_make().
+#
+# Background (#664): borrow_status is DERIVED (derive_borrow_status(),
+# tested in test-borrow-status.R), but the registry itself could still drift
+# out of sync -- a hand-edited borrow_rate_annual without a matching status
+# update, or a future override that doesn't match BORROW_STATUS_ALLOWED.
+# This gate is the belt-and-braces check on the assembled
+# strategy_cost_convention target.
+
+source(here::here("R/plan_cost_convention.R"))
+source(here::here("R/plan_qa_gates.R"))
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+good <- tibble::tibble(
+  strategy            = c("Stock MAX", "CMR", "Factor MAX"),
+  borrow_status       = c("modelled", "unmodelled", "not_applicable"),
+  borrow_rate_annual  = c(0.03, NA_real_, NA_real_)
+)
+
+# ── Pass case ────────────────────────────────────────────────────────────
+
+test_that("check_borrow_status_registry passes on a consistent registry", {
+  expect_true(check_borrow_status_registry(good))
+})
+
+# ── Assertion 1: no NA borrow_status ────────────────────────────────────
+
+test_that("check_borrow_status_registry throws on NA borrow_status", {
+  bad <- good
+  bad$borrow_status[bad$strategy == "CMR"] <- NA_character_
+  expect_error(check_borrow_status_registry(bad), regexp = "CMR")
+  expect_snapshot(error = TRUE, check_borrow_status_registry(bad))
+})
+
+# ── Assertion 2: out-of-vocabulary status ───────────────────────────────
+
+test_that("check_borrow_status_registry throws on an out-of-vocabulary status", {
+  bad <- good
+  bad$borrow_status[bad$strategy == "Factor MAX"] <- "bogus_status"
+  expect_error(check_borrow_status_registry(bad), regexp = "bogus_status")
+  expect_snapshot(error = TRUE, check_borrow_status_registry(bad))
+})
+
+# ── Assertion 3: contradiction between status and rate presence ─────────
+# This is the exact defect shape named in the task: a "modelled" row with no
+# rate, or a non-"modelled" row WITH a rate, must abort.
+
+test_that("check_borrow_status_registry throws when a modelled row has no rate", {
+  bad <- good
+  bad$borrow_rate_annual[bad$strategy == "Stock MAX"] <- NA_real_
+  expect_error(check_borrow_status_registry(bad), regexp = "Stock MAX")
+  expect_snapshot(error = TRUE, check_borrow_status_registry(bad))
+})
+
+test_that("check_borrow_status_registry throws when a non-modelled row HAS a rate", {
+  bad <- good
+  bad$borrow_rate_annual[bad$strategy == "CMR"] <- 0.05
+  expect_error(check_borrow_status_registry(bad), regexp = "CMR")
+  expect_snapshot(error = TRUE, check_borrow_status_registry(bad))
+})
+
+test_that("check_borrow_status_registry throws when a not_applicable row HAS a rate", {
+  bad <- good
+  bad$borrow_rate_annual[bad$strategy == "Factor MAX"] <- 0.02
+  expect_error(check_borrow_status_registry(bad), regexp = "Factor MAX")
+})
+
+# ── Required columns ─────────────────────────────────────────────────────
+
+test_that("check_borrow_status_registry throws when required columns are missing", {
+  bad <- dplyr::select(good, -borrow_rate_annual)
+  expect_error(check_borrow_status_registry(bad), regexp = "borrow_rate_annual")
+  expect_snapshot(error = TRUE, check_borrow_status_registry(bad))
+})

--- a/tests/testthat/test-borrow-status.R
+++ b/tests/testthat/test-borrow-status.R
@@ -1,0 +1,180 @@
+testthat::local_edition(3)
+# Tests for derive_borrow_status() (#664)
+#
+# The function and its supporting constants (BORROW_STATUS_ALLOWED,
+# BORROW_STATUS_OVERRIDES) are defined in R/plan_cost_convention.R. Tests
+# exercise the pure function directly without running tar_make().
+#
+# Background (#664): strategy_cost_convention's borrow_rate_annual column
+# conflated "no short leg -- borrow correctly N/A" with "short leg exists,
+# borrow genuinely unmodelled" as a single NA value, with the distinction
+# recorded only as free prose in cost_source_ref that nothing could filter,
+# sort, count, or gate on. borrow_status makes the distinction
+# machine-readable; derive_borrow_status() is how each row's status is
+# computed from strategy_names$directionality + borrow_rate_annual presence
+# (plus a small, documented override table for rows directionality alone
+# cannot distinguish).
+
+source(here::here("R/plan_cost_convention.R"))
+
+# ── Straightforward cases: directionality + rate presence is sufficient ────
+
+test_that("long_short with a rate resolves to modelled", {
+  expect_equal(
+    derive_borrow_status("Stock MAX", "long_short", TRUE),
+    "modelled"
+  )
+})
+
+test_that("long_short with NO rate resolves to unmodelled", {
+  expect_equal(
+    derive_borrow_status("CMR", "long_short", FALSE),
+    "unmodelled"
+  )
+})
+
+test_that("long_only resolves to not_applicable regardless of rate presence", {
+  expect_equal(derive_borrow_status("Factor MAX", "long_only", FALSE), "not_applicable")
+  expect_equal(derive_borrow_status("Factor MAX", "long_only", TRUE),  "not_applicable")
+})
+
+test_that("overlay resolves to not_applicable", {
+  expect_equal(derive_borrow_status("TOM", "overlay", FALSE), "not_applicable")
+})
+
+test_that("market_neutral behaves like long_short", {
+  expect_equal(derive_borrow_status("Toy", "market_neutral", TRUE),  "modelled")
+  expect_equal(derive_borrow_status("Toy", "market_neutral", FALSE), "unmodelled")
+})
+
+# ── The 4 known unmodelled strategies are detected as such (#664) ──────────
+
+test_that("the 4 known unmodelled strategies (short leg, no borrow charge) are detected", {
+  unmodelled_strategies <- c("Mom Pre-Peak", "Mom Post-Peak", "Mom 12-2", "CMR")
+  status <- derive_borrow_status(
+    strategy        = unmodelled_strategies,
+    directionality  = rep("long_short", 4L),
+    has_borrow_rate = rep(FALSE, 4L)
+  )
+  expect_equal(status, rep("unmodelled", 4L))
+})
+
+# ── Overrides take priority over directionality-derived status ─────────────
+
+test_that("a valid override wins over the directionality-based derivation", {
+  expect_equal(
+    derive_borrow_status("Value (HML)", "long_only", FALSE, override = "embedded_in_source"),
+    "embedded_in_source"
+  )
+  # Even if directionality/rate would otherwise say something different.
+  expect_equal(
+    derive_borrow_status("Weird", "long_short", TRUE, override = "not_tradeable"),
+    "not_tradeable"
+  )
+})
+
+test_that("an override outside BORROW_STATUS_ALLOWED aborts", {
+  expect_error(
+    derive_borrow_status("Bogus", "long_only", FALSE, override = "not_a_real_status"),
+    regexp = "Bogus"
+  )
+  expect_snapshot(
+    error = TRUE,
+    derive_borrow_status("Bogus", "long_only", FALSE, override = "not_a_real_status")
+  )
+})
+
+# ── Fail-loud: NA directionality with no override aborts (never silently NA) ─
+
+test_that("NA directionality with no override aborts, naming the strategy", {
+  expect_error(
+    derive_borrow_status("OLMAR-1", NA_character_, FALSE),
+    regexp = "OLMAR-1"
+  )
+  expect_snapshot(
+    error = TRUE,
+    derive_borrow_status("OLMAR-1", NA_character_, FALSE)
+  )
+})
+
+test_that("an unrecognised directionality value aborts, naming the allowed set", {
+  expect_error(
+    derive_borrow_status("Weird", "some_other_value", FALSE),
+    regexp = "some_other_value"
+  )
+  expect_snapshot(
+    error = TRUE,
+    derive_borrow_status("Weird", "some_other_value", FALSE)
+  )
+})
+
+test_that("mismatched vector lengths abort", {
+  expect_error(
+    derive_borrow_status(c("A", "B"), "long_only", c(TRUE, FALSE)),
+    regexp = "same length"
+  )
+})
+
+# ── Full 17-strategy registry resolves exactly as documented in #664 ───────
+#
+# directionality values below are taken directly from strategy_names
+# (R/plan_strategy_names.R) as of this PR's authoring commit, with OLMAR-1
+# filled per the documented #626/#629 join-gap workaround (matches the
+# strategy_cost_convention target's own fill). BORROW_STATUS_OVERRIDES is
+# read from the real source file, not re-typed, so a change to the override
+# table is caught by this test.
+
+test_that("all 17 strategies resolve to the expected borrow_status (#664)", {
+  strategy <- c(
+    "Factor MAX", "Factor DRIF", "Stock MAX", "Stock DRIF", "XGB DRIF",
+    "LTR", "OLMAR-1", "TOM", "CMR", "Risk State", "Avoid Worst",
+    "Mom Pre-Peak", "Mom Post-Peak", "Mom 12-2",
+    "Value (HML)", "Managed Futures", "PSO Optimal"
+  )
+  directionality <- c(
+    "long_only", "long_only", "long_short", "long_short", "long_short",
+    "long_short", "long_only", "overlay", "long_short", "overlay", "overlay",
+    "long_short", "long_short", "long_short",
+    "long_only", "long_short", "long_only"
+  )
+  has_borrow_rate <- c(
+    FALSE, FALSE, TRUE, TRUE, TRUE,
+    TRUE, FALSE, FALSE, FALSE, FALSE, FALSE,
+    FALSE, FALSE, FALSE,
+    FALSE, FALSE, FALSE
+  )
+  override <- BORROW_STATUS_OVERRIDES$borrow_status_override[
+    match(strategy, BORROW_STATUS_OVERRIDES$strategy)
+  ]
+
+  status <- derive_borrow_status(strategy, directionality, has_borrow_rate, override)
+
+  expected <- c(
+    "not_applicable", "not_applicable",           # Factor MAX, Factor DRIF
+    "modelled", "modelled", "modelled", "modelled", # Stock MAX/DRIF, XGB DRIF, LTR
+    "not_applicable",                              # OLMAR-1
+    "not_applicable",                              # TOM
+    "unmodelled",                                  # CMR
+    "not_applicable",                              # Risk State
+    "not_tradeable",                               # Avoid Worst
+    "unmodelled", "unmodelled", "unmodelled",      # Mom Pre-Peak/Post-Peak/12-2
+    "embedded_in_source",                          # Value (HML)
+    "not_applicable",                              # Managed Futures (judgement call)
+    "inherited"                                    # PSO Optimal
+  )
+  expect_equal(status, expected)
+
+  # And the 4 unmodelled strategies named by the issue are exactly these:
+  expect_equal(
+    strategy[status == "unmodelled"],
+    c("CMR", "Mom Pre-Peak", "Mom Post-Peak", "Mom 12-2")
+  )
+})
+
+test_that("BORROW_STATUS_ALLOWED contains exactly the 6 documented statuses", {
+  expect_setequal(
+    BORROW_STATUS_ALLOWED,
+    c("not_applicable", "modelled", "unmodelled",
+      "embedded_in_source", "inherited", "not_tradeable")
+  )
+})


### PR DESCRIPTION
## Summary

Closes the quantification-agnostic half of #664 in full, plus the sensitivity-sweep half of #665. **No strategy's construction, weights, or returns change anywhere in this PR** — `strategy_cost_convention`'s existing columns are untouched byte-for-byte; only a new `borrow_status` column and a new, isolated reporting target are added.

### Part 1 (#664) — `borrow_status` column

`strategy_cost_convention$borrow_rate_annual == NA` conflated two states into one value that nothing could filter/sort/count/gate on: "no short leg, borrow correctly N/A" vs "short leg exists, borrow genuinely unmodelled" (previously only distinguishable by reading `cost_source_ref` prose).

`borrow_status` is **derived**, not hand-typed, via `derive_borrow_status()` (`R/plan_cost_convention.R`) from `strategy_names$directionality` + presence/absence of `borrow_rate_annual`, plus 4 documented overrides for rows directionality alone can't disambiguate:

| strategy | directionality | rate? | derived `borrow_status` |
|---|---|---|---|
| Factor MAX | long_only | — | not_applicable |
| Factor DRIF | long_only | — | not_applicable |
| Stock MAX | long_short | 0.03 | modelled |
| Stock DRIF | long_short | 0.03 | modelled |
| XGB DRIF | long_short | 0.03 | modelled |
| LTR | long_short | 0.03 | modelled |
| OLMAR-1 | long_only *(filled, see below)* | — | not_applicable |
| TOM | overlay | — | not_applicable |
| **CMR** | long_short | — | **unmodelled** |
| Risk State | overlay | — | not_applicable |
| Avoid Worst | overlay *(override)* | — | **not_tradeable** |
| **Mom Pre-Peak** | long_short | — | **unmodelled** |
| **Mom Post-Peak** | long_short | — | **unmodelled** |
| **Mom 12-2** | long_short | — | **unmodelled** |
| Value (HML) | long_only *(override)* | — | **embedded_in_source** |
| Managed Futures | long_short *(override)* | — | not_applicable *(judgement call, see below)* |
| PSO Optimal | long_only *(override)* | — | **inherited** |

**OLMAR-1 join gap (#626/#629):** `strategy_names` has no `olmar` row, so the join to `directionality` produces NA for OLMAR-1. Filled explicitly with `directionality = "long_only"` (matches `R/plan_olmar.R:30`, "long-only simplex projection") rather than left NA — an unfilled NA would correctly abort in `derive_borrow_status()` (fail-loud-not-null.md), which is the right behaviour for a *genuinely* unknown strategy but wrong for this *documented* gap.

**Managed Futures — judgement call, flagged for review:** classified `not_applicable` on the reasoning that futures financing is embedded in the futures price itself, not a separately-financeable equity-style short-borrow cost (`R/plan_managed_futures.R`). Unlike the other 3 overrides (each a verified absence in source), this one is an assumption about how futures margin/financing economics differ from equity short-borrow economics — I could not verify it against a citation in this codebase. Please sanity-check.

**Visibility + gate:**
- `cli_warn()` at every `tar_make()` lists every `unmodelled` strategy.
- QA gate **S16** (`check_borrow_status_registry()`, `R/plan_qa_gates.R`) asserts: no NA `borrow_status`; every value in `BORROW_STATUS_ALLOWED`; and no contradiction against `borrow_rate_annual` (a `"modelled"` row with no rate, or any other status WITH a rate, aborts).

### Part 2 (#665, quantification only) — borrow-rate sensitivity sweep

New `borrow_sensitivity_sweep` target (`R/plan_cost_convention.R`) — **reporting only, does not feed `leaderboard`/`all_metrics`/any published return**. Reports Sharpe/CAGR/`sharpe_delta` at borrow ∈ {0%, 3%, 10%, 25%} annual for:

- the 4 `unmodelled` strategies (Mom Pre-Peak, Mom Post-Peak, Mom 12-2, CMR) — this is the number the issue calls "the single most informative number": how much of their edge survives a realistic short-financing assumption.
- the 4 `modelled` strategies (Stock MAX, Stock DRIF, XGB DRIF, LTR) — so a reader can see how sensitive the already-costed strategies are to the flat 0.03 assumption being wrong.

**Short notional = 100%.** Verified across every affected strategy's construction (not assumed): `portfolio_longshort()` (`R/plan_stock_backtest.R`, feeds Stock MAX/DRIF, XGB DRIF) already applies `borrow_cost <- borrow_rate_annual / 12` flat, independent of any separate notional scaling; `.mom_prepeak_form_portfolio()` (`R/plan_mom_prepeak.R:224-228`) assigns `weight = -1/n_short` per short position (short leg sums to 100%); `hd_commodity_mr_portfolio()` (`packages/historicaldata/R/commodities_mean_reversion.R:185`) uses the identical `-1/n_short` convention. So the sweep applies `rate/12` monthly against the existing pre-borrow return series — the same convention every borrow-charging strategy in this codebase already uses.

**Pre-borrow series reconstruction** (no strategy code touched, only reading already-computed columns):
- unmodelled strategies: return series already has zero borrow charge (`mom_prepeak_returns$ret_ls`, `mom_postpeak_returns$ret_ls`, `mom_combined_returns$ret_ls`, `cmr_port$net_ret`) — used as-is.
- modelled strategies: the currently-applied 0.03/12 monthly charge is added back — `stk_max_portfolio$port_ret + stk_max_portfolio$borrow_cost` (same pattern for Stock DRIF, XGB DRIF), and `ltr_portfolio$ls_ret_net + ltr_portfolio$borrow` (LTR's pre-computed parquet already carries both `ls_ret_net` and the separate `borrow` column, verified via `scripts/compute_ltr_model.R:143-150`).
- CMR reports 3 lookback variants; the leaderboard publishes whichever has best Sharpe (`.norm_cmr()`, `R/plan_leaderboard.R`) — the sweep replicates that same "best lookback" selection from `cmr_summary` so the swept strategy matches what's actually shown.

**I could not run `tar_make()`** to verify this target actually builds (store conflict with the main checkout, and I was instructed not to run it). Every target/column name referenced was checked against source (cited above), but the wiring itself is unverified against a real pipeline run — flagging per instructions rather than silently narrowing scope. The pure function `compute_borrow_sensitivity()` / `build_borrow_sensitivity_table()` it calls is fully unit tested against synthetic fixtures.

Excluded from this PR (per scope): CAGR/vol/Sharpe formulas omit the risk-free adjustment `calc_backtest_metrics()` uses — noted in the roxygen; since the sweep only reports *relative* deltas across borrow rates for a single strategy, a constant rf term cancels in `sharpe_delta` and was left out for simplicity.

### Part 3 — `# MANUAL: no source` markers

Per the reproducible-ingestion rule, marked the hardcoded `borrow_rate_annual = 0.03` at:
- `R/plan_stock_backtest.R` (`stk_params`, actually consumed by Stock MAX/DRIF, XGB DRIF)
- `R/plan_ltr_momentum.R` (`ltr_params`, **not actually consumed downstream** in that file — noted in the marker)
- `scripts/compute_ltr_model.R` (`borrow_cost_annual`, the constant that **actually** drives LTR's published return — also newly marked, since it wasn't named in the original task but is the real source of the number)

No value changed. A follow-up issue to source a real equity-borrow-rate series should be filed (not filed here, per instructions).

## Test plan

- [x] `parse("_targets.R")` succeeds
- [x] `scripts/verify.sh` (full mode, foreground) — see summary below
- [x] New unit tests for `derive_borrow_status()` including the full 17-strategy resolution table, an explicit assertion that the 4 known unmodelled strategies (CMR, Mom Pre-Peak, Mom Post-Peak, Mom 12-2) are detected, and a contradictory-row (`modelled` + no rate) abort test for S16
- [x] New unit tests for `compute_borrow_sensitivity()` / `build_borrow_sensitivity_table()` (input validation, sharpe_delta baseline, monotonic sharpe decrease, independent-formula cross-check)
- [x] `expect_snapshot(error = TRUE, ...)` coverage for every new `cli_abort()`; `_snaps/` committed

```
::VERIFY:ROOT_SUMMARY:: total=448 failed=3 skipped=0
::VERIFY:PKG_SUMMARY::  total=693 failed=1 skipped=15
=== scripts/verify.sh: PASS ===
```

Root failure/skip counts match the documented baseline exactly (3 pre-existing failures, 0 skip); root total rose 418 → 448 from the 30 new assertions in this PR's 3 new test files. Package suite untouched (693/1/15, identical to baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
