### PR TITLE
fix(sharpe): canonical rf-adjusted Sharpe helper; fix LTR and Risk State (#677 slice 1)

### DIFF
--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -65,13 +65,15 @@ plan_leaderboard <- function() {
       # comment above. Each helper below converts from its source's native
       # unit (fraction or percent) at this boundary.
 
-      # ltr_metrics has hac_sharpe instead of sharpe; no months column.
+      # ltr_metrics carries its own canonical `sharpe` (#677: (ann_ret -
+      # ann_rf) / ann_vol, via R/utils_metrics.R::sharpe_ratio_rf()) AS
+      # WELL AS `hac_sharpe` (a separate, HAC-adjusted statistic) -- no
+      # longer renamed/substituted, see plan_ltr_momentum.R:compute_ltr_metrics().
       # Source: R/plan_ltr_momentum.R:167-169 (compute_ltr_metrics) stores
       # cagr/vol/max_dd as PERCENT (round(x * 100, 1)) -- convert to fraction.
       .norm_ltr <- function(m) {
         if (is.null(m) || nrow(m) == 0) return(NULL)
         m |>
-          rename(sharpe = hac_sharpe) |>
           mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100)
       }
 
@@ -126,7 +128,11 @@ plan_leaderboard <- function() {
 
       # rsc_metrics contains multiple internal strategy variants (SPY_overlay,
       # DRIF_overlay, etc.). Pick only the SPY_overlay rows which represent the
-      # strategy's own performance.
+      # strategy's own performance. Those rows now carry a canonical `sharpe`
+      # (#677: (ann_ret - ann_rf) / ann_vol, via
+      # R/utils_metrics.R::sharpe_ratio_rf(), rf = rsc_portfolio$rf_daily) AS
+      # WELL AS `hac_sharpe` -- no longer renamed/substituted, see
+      # plan_risk_state.R:calc_metrics().
       # Source: R/plan_risk_state.R:270-273 stores cagr/vol/max_dd as PERCENT
       # (round(x * 100, 2)) -- convert to fraction.
       .norm_rsc <- function(m) {
@@ -134,7 +140,6 @@ plan_leaderboard <- function() {
         m |>
           filter(strategy == "SPY_overlay") |>
           select(-strategy) |>
-          rename(sharpe = hac_sharpe) |>
           mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100)
       }
 

--- a/R/plan_ltr_momentum.R
+++ b/R/plan_ltr_momentum.R
@@ -144,12 +144,39 @@ plan_ltr_momentum <- function() {
       cli::cli_inform(c(
         "v" = "LTR portfolio: {nrow(port)} months, {format(min(port$date), '%Y-%m')} to {format(max(port$date), '%Y-%m')}"
       ))
-      port |>
+      port <- port |>
         mutate(
           port_ret = ls_ret_net,
           port_cum = cumprod(1 + port_ret)
         ) |>
         dplyr::mutate(date = as.Date(date, tz = "UTC"))
+
+      # ── #677 defect B ──────────────────────────────────────────────────
+      # ltr_portfolio previously had no `rf_ret` column at all. Every
+      # downstream Sharpe computed against it (`ltr_subperiod$sharpe` via
+      # compute_sp_metrics() below, and `ltr_metrics$sharpe` via
+      # compute_ltr_metrics()) evaluated `mean(df$rf_ret, na.rm = TRUE)`
+      # against a NULL column, which returns NA silently -- every
+      # subperiod Sharpe was NA from the day this target was written,
+      # discovered only by accident (see fail-loud-not-null.md). Join the
+      # shared monthly risk-free series (`stk_rf`: ym, rf_ret --
+      # R/plan_stock_backtest.R) onto `ym`, and abort loud rather than let
+      # a partial join reintroduce the same silent-NA defect one level
+      # down.
+      port_ym_range <- range(port$ym)
+      port <- port |> left_join(stk_rf, by = "ym")
+
+      missing_rf_ym <- sort(port$ym[is.na(port$rf_ret)])
+      if (length(missing_rf_ym) > 0L) {
+        cli::cli_abort(c(
+          "x" = "{length(missing_rf_ym)} month{?s} in ltr_portfolio have no matching stk_rf risk-free rate.",
+          "i" = "Missing ym: {.val {missing_rf_ym}}.",
+          "i" = "ltr_portfolio spans {port_ym_range[1]}..{port_ym_range[2]}; stk_rf spans {min(stk_rf$ym)}..{max(stk_rf$ym)}.",
+          "i" = "Extend stk_rf's `from` date (R/plan_stock_backtest.R) or investigate the FF3 data source before trusting any downstream LTR Sharpe figure."
+        ))
+      }
+
+      port
     }),
 
 
@@ -169,6 +196,15 @@ plan_ltr_momentum <- function() {
         cum     <- cumprod(1 + df$port_ret)
         max_dd  <- min(cum / cummax(cum) - 1)
 
+        # #677: canonical, risk-free-adjusted Sharpe -- see
+        # R/utils_metrics.R::sharpe_ratio_rf(). This is the statistic used
+        # for cross-strategy leaderboard ranking (R/plan_leaderboard.R).
+        # `hac_sharpe` below is a SEPARATE, HAC-adjusted naive/arithmetic
+        # statistic -- both are kept as distinct columns; do not conflate
+        # them. `df$rf_ret` is guaranteed present and fully covered by the
+        # `ltr_portfolio` target's join + coverage check above.
+        sr <- sharpe_ratio_rf(df$port_ret, df$rf_ret, periods_per_year = 12L)
+
         hac <- tryCatch(hd_hac_sharpe(df$port_ret),
                         error = function(e) list(hac_tstat = NA_real_, naive_sharpe = NA_real_))
 
@@ -178,6 +214,7 @@ plan_ltr_momentum <- function() {
           cagr       = round(ann_ret * 100, 1),
           vol        = round(ann_vol * 100, 1),
           max_dd     = round(max_dd * 100, 1),
+          sharpe     = round(sr$sharpe, 2),
           hac_sharpe = round(hac$naive_sharpe, 2),
           hac_tstat  = round(hac$hac_tstat, 2),
           avg_long   = if ("n_long" %in% names(df)) round(mean(df$n_long, na.rm = TRUE)) else NA_integer_,
@@ -368,11 +405,17 @@ plan_ltr_momentum <- function() {
         nm <- nrow(df)
         if (nm < 6L) return(NULL)
         ann_ret <- prod(1 + df$port_ret)^(12 / nm) - 1
-        ann_vol <- sd(df$port_ret) * sqrt(12)
-        rf_ann  <- mean(df$rf_ret, na.rm = TRUE) * 12
         cum     <- cumprod(1 + df$port_ret)
         max_dd  <- min(cum / cummax(cum) - 1)
-        sharpe  <- if (ann_vol < 1e-8) NA_real_ else (ann_ret - rf_ann) / ann_vol
+
+        # #677 defect B: this used to be `mean(df$rf_ret, na.rm = TRUE)`
+        # against a column that did not exist on ltr_portfolio -- silently
+        # NA, so `sharpe` below was NA for every subperiod. `df$rf_ret` is
+        # now guaranteed present (ltr_portfolio's join + coverage check in
+        # this file), and sharpe_ratio_rf() aborts loud if it ever isn't.
+        sr      <- sharpe_ratio_rf(df$port_ret, df$rf_ret, periods_per_year = 12L)
+        ann_vol <- sr$ann_vol
+        sharpe  <- sr$sharpe
 
         hac <- tryCatch(hd_hac_sharpe(df$port_ret),
                         error = function(e) list(hac_tstat = NA_real_))
@@ -469,14 +512,17 @@ plan_ltr_momentum <- function() {
 
   # Record full-period metrics row
   # Units (#640): ltr_metrics stores cagr/vol/max_dd as PERCENT (round(x*100,1)
-  # above — the source #637 flagged as percent-native), hac_sharpe/hac_tstat
-  # are scale-free ratios, and months/avg_long/avg_short are counts.
+  # above — the source #637 flagged as percent-native), sharpe/hac_sharpe/
+  # hac_tstat are scale-free ratios (#677: `sharpe` is the new canonical,
+  # risk-free-adjusted column added alongside the pre-existing `hac_sharpe`
+  # -- both need a unit or hd_metric_record() aborts loud per #640), and
+  # months/avg_long/avg_short are counts.
   full_row <- ltr_metrics[ltr_metrics$period == "Full Period", , drop = FALSE]
   if (nrow(full_row) == 1L) {
     metric_cols <- setdiff(names(full_row), "period")
     ltr_units <- c(
       months = "count", cagr = "percent", vol = "percent", max_dd = "percent",
-      hac_sharpe = "ratio", hac_tstat = "ratio",
+      sharpe = "ratio", hac_sharpe = "ratio", hac_tstat = "ratio",
       avg_long = "count", avg_short = "count"
     )
     historicaldata::hd_metric_record(

--- a/R/plan_risk_state.R
+++ b/R/plan_risk_state.R
@@ -275,20 +275,39 @@ plan_risk_state <- function() {
     targets::tar_target(rsc_metrics, {
       library(dplyr)
 
-      calc_metrics <- function(ret_vec, date_vec, label, strategy_name) {
+      # #677: rf_vec is OPTIONAL here (unlike sharpe_ratio_rf() itself,
+      # which aborts on a NULL rf per fail-loud-not-null.md) because only
+      # SPY_buyhold/SPY_overlay have an aligned risk-free series wired in
+      # today (rsc_portfolio$rf_daily, from FF3 RF -- see rsc_data/
+      # rsc_signals above). DRIF_raw/DRIF_overlay/FacMAX_raw/FacMAX_overlay
+      # do not have a matching daily rf series joined onto their overlay
+      # return streams -- sourcing one is out of scope for #677 slice 1
+      # (see PR body). `sharpe` is deliberately left NA_real_ for those
+      # rows; `hac_sharpe` (HAC-adjusted, no rf) is retained for all rows
+      # and is unaffected by this change.
+      calc_metrics <- function(ret_vec, date_vec, label, strategy_name, rf_vec = NULL) {
         keep     <- !is.na(ret_vec)
         ret_vec  <- ret_vec[keep]
         date_vec <- date_vec[keep]
+        if (!is.null(rf_vec)) rf_vec <- rf_vec[keep]
         if (length(ret_vec) < 20) return(NULL)
         years <- length(ret_vec) / 252
         cum <- prod(1 + ret_vec)
         cum_dd <- cumprod(1 + ret_vec)
         hac <- hd_hac_sharpe(ret_vec)
+        # Canonical, risk-free-adjusted Sharpe (#677) -- see
+        # R/utils_metrics.R::sharpe_ratio_rf(). Distinct from hac_sharpe.
+        sharpe_val <- if (!is.null(rf_vec)) {
+          sharpe_ratio_rf(ret_vec, rf_vec, periods_per_year = 252L)$sharpe
+        } else {
+          NA_real_
+        }
         tibble::tibble(
           strategy  = strategy_name,
           period    = label,
           cagr      = round((cum^(1 / years) - 1) * 100, 2),
           vol       = round(sd(ret_vec) * sqrt(252) * 100, 2),
+          sharpe    = round(sharpe_val, 3),
           max_dd    = round(min((cum_dd - cummax(cum_dd)) /
                                   cummax(cum_dd)) * 100, 2),
           hac_tstat = round(hac$hac_tstat, 3),
@@ -318,16 +337,21 @@ plan_risk_state <- function() {
       is_test  <- port$date >= oos & port$date <= test_end
 
       # SPY buy-and-hold, SPY with overlay
-      spy_bh_full  <- calc_metrics(port$ret_buyhold,  port$date,  "Full Period", "SPY_buyhold")
-      spy_ov_full  <- calc_metrics(port$ret_strategy, port$date,  "Full Period", "SPY_overlay")
+      # rf_vec = port$rf_daily: FF3 daily RF, already lagged (t+1) and
+      # zero-filled for leading NAs at rsc_portfolio construction time
+      # (R/plan_risk_state.R rsc_portfolio target) -- safe to pass directly.
+      spy_bh_full  <- calc_metrics(port$ret_buyhold,  port$date,  "Full Period", "SPY_buyhold",
+                                   rf_vec = port$rf_daily)
+      spy_ov_full  <- calc_metrics(port$ret_strategy, port$date,  "Full Period", "SPY_overlay",
+                                   rf_vec = port$rf_daily)
       spy_bh_train <- calc_metrics(port$ret_buyhold[is_train],  port$date[is_train],
-                                   "Training", "SPY_buyhold")
+                                   "Training", "SPY_buyhold", rf_vec = port$rf_daily[is_train])
       spy_ov_train <- calc_metrics(port$ret_strategy[is_train], port$date[is_train],
-                                   "Training", "SPY_overlay")
+                                   "Training", "SPY_overlay", rf_vec = port$rf_daily[is_train])
       spy_bh_test  <- calc_metrics(port$ret_buyhold[is_test],  port$date[is_test],
-                                   "Testing", "SPY_buyhold")
+                                   "Testing", "SPY_buyhold", rf_vec = port$rf_daily[is_test])
       spy_ov_test  <- calc_metrics(port$ret_strategy[is_test], port$date[is_test],
-                                   "Testing", "SPY_overlay")
+                                   "Testing", "SPY_overlay", rf_vec = port$rf_daily[is_test])
 
       # DRIF raw vs overlaid
       drif_raw_full <- calc_metrics(drif$ret_raw,     drif$date, "Full Period", "DRIF_raw")
@@ -775,8 +799,10 @@ plan_risk_state <- function() {
 
   # Record SPY_overlay / Full Period metrics row (the primary RSC result)
   # Units (#640): rsc_metrics stores cagr/vol/max_dd as PERCENT
-  # (round(x*100, ...) in calc_metrics() above); hac_tstat/hac_sharpe are
-  # scale-free ratios.
+  # (round(x*100, ...) in calc_metrics() above); sharpe/hac_tstat/hac_sharpe
+  # are scale-free ratios (#677: `sharpe` is the new canonical,
+  # risk-free-adjusted column added alongside the pre-existing `hac_sharpe`
+  # -- both need a unit or hd_metric_record() aborts loud per #640).
   full_row <- rsc_metrics[
     rsc_metrics$strategy == "SPY_overlay" & rsc_metrics$period == "Full Period",
     , drop = FALSE
@@ -785,7 +811,7 @@ plan_risk_state <- function() {
     metric_cols <- setdiff(names(full_row), c("strategy", "period"))
     rsc_units <- c(
       cagr = "percent", vol = "percent", max_dd = "percent",
-      hac_tstat = "ratio", hac_sharpe = "ratio"
+      sharpe = "ratio", hac_tstat = "ratio", hac_sharpe = "ratio"
     )
     historicaldata::hd_metric_record(
       con, uu, full_row[, metric_cols, drop = FALSE], units = rsc_units

--- a/R/utils_metrics.R
+++ b/R/utils_metrics.R
@@ -81,3 +81,120 @@ annualise_returns <- function(ret, periods_per_year = 12L, na.rm = TRUE) {
     n      = n
   )
 }
+
+#' Canonical risk-free-adjusted Sharpe ratio — shared helper (#677)
+#'
+#' Computes \code{sharpe = (ann_ret - ann_rf) / ann_vol}, using geometric
+#' (compound) annualisation for the return -- the majority convention already
+#' used by \code{R/plan_factormax.R}, \code{R/plan_drif.R}, and
+#' \code{R/plan_alpha_decay.R}. This is a DIFFERENT basis from
+#' \code{annualise_returns()$sharpe} above, which is \code{cagr / vol} with
+#' NO risk-free deduction -- that is the deliberately separate "no-rf family"
+#' basis (\code{plan_managed_futures.R}, \code{plan_ev_ebit.R},
+#' \code{bootstrap_ci()}; see issue #677 slice 2). Do not conflate the two;
+#' migrating the no-rf family onto this helper is out of scope for #677
+#' slice 1 and is tracked separately.
+#'
+#' Per \code{.claude/rules/fail-loud-not-null.md}, this function ABORTS
+#' rather than silently treating a missing/absent risk-free input as zero:
+#' issue #677 defect B was exactly this failure mode --
+#' \code{mean(df$rf_ret, na.rm = TRUE)} against a column that did not exist
+#' returned \code{NA} silently, and every downstream Sharpe was \code{NA}
+#' from the day the target was written, discovered only by accident.
+#'
+#' @param ret Numeric vector of periodic returns (e.g., monthly).
+#' @param rf Numeric vector of periodic risk-free returns, position-aligned
+#'   with \code{ret} (same length, same periods, both already filtered to
+#'   the same observations by the caller). Must not be \code{NULL}.
+#' @param periods_per_year Integer. Default 12L (monthly). Use 252L for
+#'   daily returns.
+#' @param na.rm Logical. If \code{TRUE} (default), positions where either
+#'   \code{ret} or \code{rf} is \code{NA} are dropped (pairwise) before
+#'   computation.
+#'
+#' @return A named list with elements:
+#'   \describe{
+#'     \item{ann_ret}{Annualised return (geometric/compound).}
+#'     \item{ann_rf}{Annualised risk-free rate (arithmetic mean * periods_per_year).}
+#'     \item{ann_vol}{Annualised volatility (sd * sqrt(periods_per_year)).}
+#'     \item{sharpe}{(ann_ret - ann_rf) / ann_vol; NA when vol is zero or
+#'       fewer than 2 observations remain.}
+#'     \item{n}{Number of paired non-NA observations used.}
+#'   }
+#'
+#' @family backtest
+#' @export
+sharpe_ratio_rf <- function(ret, rf, periods_per_year = 12L, na.rm = TRUE) {
+  if (!is.numeric(ret)) {
+    cli::cli_abort(c(
+      "x" = "{.arg ret} must be a numeric vector.",
+      "i" = "Got {.cls {class(ret)}}."
+    ))
+  }
+  if (is.null(rf)) {
+    cli::cli_abort(c(
+      "x" = "{.arg rf} must not be NULL.",
+      "i" = "A missing risk-free series must never be treated as zero -- see fail-loud-not-null.md (#677 defect B).",
+      "i" = "Join a risk-free series (e.g. the {.code stk_rf} target: ym, rf_ret) onto your data before calling {.fn sharpe_ratio_rf}."
+    ))
+  }
+  if (!is.numeric(rf)) {
+    cli::cli_abort(c(
+      "x" = "{.arg rf} must be a numeric vector.",
+      "i" = "Got {.cls {class(rf)}}."
+    ))
+  }
+  if (length(ret) != length(rf)) {
+    cli::cli_abort(c(
+      "x" = "{.arg ret} and {.arg rf} must be the same length.",
+      "i" = "Got length {length(ret)} and {length(rf)}."
+    ))
+  }
+  if (!is.numeric(periods_per_year) || length(periods_per_year) != 1L ||
+      periods_per_year <= 0) {
+    cli::cli_abort(c(
+      "x" = "{.arg periods_per_year} must be a single positive number.",
+      "i" = "Got {periods_per_year}."
+    ))
+  }
+
+  if (isTRUE(na.rm)) {
+    keep <- !is.na(ret) & !is.na(rf)
+    ret  <- ret[keep]
+    rf   <- rf[keep]
+  }
+
+  n <- length(ret)
+  if (n < 2L) {
+    return(list(
+      ann_ret = NA_real_,
+      ann_rf  = NA_real_,
+      ann_vol = NA_real_,
+      sharpe  = NA_real_,
+      n       = n
+    ))
+  }
+
+  equity  <- cumprod(1 + ret)
+  ann_ret <- equity[n]^(periods_per_year / n) - 1
+  ann_vol <- stats::sd(ret) * sqrt(periods_per_year)
+  ann_rf  <- mean(rf) * periods_per_year
+
+  if (!is.finite(ann_vol)) {
+    cli::cli_abort(c(
+      "x" = "Computed annualised volatility is not finite.",
+      "i" = "Got {ann_vol}.",
+      "i" = "Check {.arg ret} for Inf/-Inf values before calling {.fn sharpe_ratio_rf}."
+    ))
+  }
+
+  sharpe <- if (ann_vol > 0) (ann_ret - ann_rf) / ann_vol else NA_real_
+
+  list(
+    ann_ret = ann_ret,
+    ann_rf  = ann_rf,
+    ann_vol = ann_vol,
+    sharpe  = sharpe,
+    n       = n
+  )
+}

--- a/tests/testthat/_snaps/utils-metrics.md
+++ b/tests/testthat/_snaps/utils-metrics.md
@@ -24,3 +24,67 @@
       function (ret, periods_per_year = 12L, na.rm = TRUE) 
       NULL
 
+# sharpe_ratio_rf: NULL rf aborts loud rather than defaulting to zero (#677 defect B)
+
+    Code
+      sharpe_ratio_rf(c(0.01, 0.02, 0.03), NULL)
+    Condition
+      Error in `sharpe_ratio_rf()`:
+      x `rf` must not be NULL.
+      i A missing risk-free series must never be treated as zero -- see fail-loud-not-null.md (#677 defect B).
+      i Join a risk-free series (e.g. the `stk_rf` target: ym, rf_ret) onto your data before calling `sharpe_ratio_rf()`.
+
+# sharpe_ratio_rf: non-numeric rf aborts
+
+    Code
+      sharpe_ratio_rf(c(0.01, 0.02, 0.03), c("a", "b", "c"))
+    Condition
+      Error in `sharpe_ratio_rf()`:
+      x `rf` must be a numeric vector.
+      i Got <character>.
+
+# sharpe_ratio_rf: non-numeric ret aborts
+
+    Code
+      sharpe_ratio_rf(c("a", "b"), c(0.001, 0.001))
+    Condition
+      Error in `sharpe_ratio_rf()`:
+      x `ret` must be a numeric vector.
+      i Got <character>.
+
+# sharpe_ratio_rf: length mismatch between ret and rf aborts
+
+    Code
+      sharpe_ratio_rf(c(0.01, 0.02, 0.03), c(0.001, 0.001))
+    Condition
+      Error in `sharpe_ratio_rf()`:
+      x `ret` and `rf` must be the same length.
+      i Got length 3 and 2.
+
+# sharpe_ratio_rf: invalid periods_per_year aborts
+
+    Code
+      sharpe_ratio_rf(c(0.01, 0.02), c(0.001, 0.001), periods_per_year = 0)
+    Condition
+      Error in `sharpe_ratio_rf()`:
+      x `periods_per_year` must be a single positive number.
+      i Got 0.
+
+# sharpe_ratio_rf: non-finite ret aborts on non-finite volatility
+
+    Code
+      sharpe_ratio_rf(c(0.01, Inf, 0.02), c(0.001, 0.001, 0.001))
+    Condition
+      Error in `sharpe_ratio_rf()`:
+      x Computed annualised volatility is not finite.
+      i Got NaN.
+      i Check `ret` for Inf/-Inf values before calling `sharpe_ratio_rf()`.
+
+# sharpe_ratio_rf: function signature is stable (catches API drift)
+
+    Code
+      args(sharpe_ratio_rf)
+    Output
+      function (ret, rf, periods_per_year = 12L, na.rm = TRUE) 
+      NULL
+

--- a/tests/testthat/test-holdout-source-metrics-666.R
+++ b/tests/testthat/test-holdout-source-metrics-666.R
@@ -22,6 +22,11 @@ source(here::here("R/plan_stock_backtest.R"))
 source(here::here("R/plan_xgb_signal.R"))
 source(here::here("R/plan_ltr_momentum.R"))
 source(here::here("R/plan_portfolio_opt.R"))
+# #677: ltr_metrics' compute_ltr_metrics() now calls sharpe_ratio_rf() (the
+# shared canonical Sharpe helper) -- source it so .eval_target()'s eval env
+# (parent = globalenv()) can resolve it, same as every other top-level
+# helper this file relies on being sourced.
+source(here::here("R/utils_metrics.R"))
 
 .eval_bt_partitions <- function() {
   targets_list <- plan_partitions()

--- a/tests/testthat/test-plan-ltr-momentum.R
+++ b/tests/testthat/test-plan-ltr-momentum.R
@@ -1,0 +1,174 @@
+testthat::local_edition(3)
+# Regression tests for #677 slice 1: canonical, risk-free-adjusted Sharpe
+# for LTR (R/plan_ltr_momentum.R).
+#
+# Two testing strategies are used, matching the two shapes of target in
+# this file:
+#
+#   1. Extraction (`ltr_metrics`, `ltr_subperiod`): these targets take
+#      `ltr_portfolio` (a plain tibble) as their only real input -- no file
+#      I/O -- so their exact shipped command expression is extracted from
+#      plan_ltr_momentum() and eval()'d against synthetic data, following
+#      the pattern established in test-bound-testing-windows.R (#667). This
+#      exercises the REAL shipped code, not a re-implementation.
+#
+#   2. Inline simulation (`ltr_portfolio`'s new rf_ret join + coverage
+#      check): `ltr_portfolio` itself reads a parquet file from data/raw/
+#      (gitignored, requires `nix develop . --command Rscript
+#      scripts/compute_ltr_model.R` to populate) that does not exist in a
+#      bare checkout, so its command cannot be eval()'d directly. Its
+#      join+coverage-check logic is instead reproduced faithfully inline,
+#      matching the project's established pattern for data-dependent
+#      targets (see tests/testthat/test-drif.R).
+
+source(here::here("R/plan_ltr_momentum.R"))
+source(here::here("R/utils_metrics.R"))
+
+# ── Helpers (mirrors test-bound-testing-windows.R) ──────────────────────
+
+.target_command <- function(target_list, name) {
+  hit <- vapply(target_list, function(t) identical(t$settings$name, name), logical(1))
+  if (sum(hit) != 1L) {
+    stop("target '", name, "' not found (or not unique) in this plan's target list")
+  }
+  target_list[[which(hit)]]$command$expr[[1]]
+}
+
+.eval_command <- function(expr, ...) {
+  env <- list2env(list(...), envir = new.env(parent = globalenv()))
+  eval(expr, envir = env)
+}
+
+# Minimal stand-in for historicaldata::hd_hac_sharpe() -- ltr_metrics/
+# ltr_subperiod call it for hac_sharpe/hac_tstat columns this test does not
+# assert on (real HAC math is out of scope here). Deliberately NOT
+# rf-adjusted, so it differs from the canonical sharpe under test.
+.mock_hac_sharpe <- function(ret_vec) {
+  list(hac_tstat = 0, naive_sharpe = mean(ret_vec) / stats::sd(ret_vec) * sqrt(12))
+}
+
+.toy_ltr_portfolio <- function(n_months = 60L, seed = 677L, rf_val = 0.0015) {
+  set.seed(seed)
+  dates <- seq(as.Date("2018-01-01"), by = "month", length.out = n_months)
+  tibble::tibble(
+    ym       = format(dates, "%Y-%m"),
+    date     = dates,
+    port_ret = stats::rnorm(n_months, mean = 0.006, sd = 0.03),
+    rf_ret   = rep(rf_val, n_months),
+    n_long   = 5L,
+    n_short  = 5L
+  )
+}
+
+# ── 1. ltr_portfolio: rf_ret join + coverage check (inline simulation) ───
+
+test_that("ltr_portfolio: full stk_rf coverage joins rf_ret with no NA", {
+  port <- tibble::tibble(ym = c("2020-01", "2020-02", "2020-03"))
+  stk_rf <- tibble::tibble(
+    ym = c("2020-01", "2020-02", "2020-03"),
+    rf_ret = c(0.001, 0.001, 0.001)
+  )
+
+  joined <- dplyr::left_join(port, stk_rf, by = "ym")
+  missing_rf_ym <- sort(joined$ym[is.na(joined$rf_ret)])
+
+  expect_length(missing_rf_ym, 0L)
+  expect_false(anyNA(joined$rf_ret))
+})
+
+test_that("ltr_portfolio: a gap in stk_rf coverage is detected -- what R/plan_ltr_momentum.R now cli_aborts on (#677 defect B)", {
+  port <- tibble::tibble(ym = c("2020-01", "2020-02", "2020-03"))
+  # stk_rf is missing 2020-02 -- the exact shape of the original defect
+  stk_rf <- tibble::tibble(ym = c("2020-01", "2020-03"), rf_ret = c(0.001, 0.001))
+
+  joined <- dplyr::left_join(port, stk_rf, by = "ym")
+  missing_rf_ym <- sort(joined$ym[is.na(joined$rf_ret)])
+
+  expect_equal(missing_rf_ym, "2020-02")
+  expect_gt(length(missing_rf_ym), 0L)
+})
+
+# ── 2. ltr_metrics: carries both `sharpe` and `hac_sharpe`, and they differ ──
+
+test_that("ltr_metrics: Full Period row has both sharpe and hac_sharpe, and they differ", {
+  cmd <- .target_command(plan_ltr_momentum(), "ltr_metrics")
+  port <- .toy_ltr_portfolio(n_months = 48L, rf_val = 0.0015)
+
+  result <- .eval_command(
+    cmd,
+    hd_hac_sharpe   = .mock_hac_sharpe,
+    sharpe_ratio_rf = sharpe_ratio_rf,
+    ltr_params = list(
+      is_end = as.Date("2019-12-31"), test_start = as.Date("2020-01-01"),
+      test_end = as.Date("2020-12-31"), holdout_start = as.Date("2021-01-01"),
+      holdout_end = as.Date("2021-06-30"), val_start = as.Date("2021-07-01")
+    ),
+    ltr_portfolio = port
+  )
+
+  full_row <- result[result$period == "Full Period", ]
+  expect_equal(nrow(full_row), 1L)
+  expect_true("sharpe" %in% names(full_row))
+  expect_true("hac_sharpe" %in% names(full_row))
+  expect_false(is.na(full_row$sharpe))
+  expect_false(is.na(full_row$hac_sharpe))
+  # rf-adjusted vs naive statistics are genuinely different quantities --
+  # they must not be equal (the pre-#677 bug was `sharpe` being a rename of
+  # `hac_sharpe`, i.e. always identical).
+  expect_false(isTRUE(all.equal(full_row$sharpe, full_row$hac_sharpe)))
+})
+
+test_that("ltr_metrics: aborts loud (not silent NA) if rf_ret is missing from ltr_portfolio (#677 defect B guard)", {
+  cmd <- .target_command(plan_ltr_momentum(), "ltr_metrics")
+  port <- .toy_ltr_portfolio(n_months = 48L) |> dplyr::select(-rf_ret)
+
+  expect_error(
+    .eval_command(
+      cmd,
+      hd_hac_sharpe   = .mock_hac_sharpe,
+      sharpe_ratio_rf = sharpe_ratio_rf,
+      ltr_params = list(
+        is_end = as.Date("2019-12-31"), test_start = as.Date("2020-01-01"),
+        test_end = as.Date("2020-12-31"), holdout_start = as.Date("2021-01-01"),
+        holdout_end = as.Date("2021-06-30"), val_start = as.Date("2021-07-01")
+      ),
+      ltr_portfolio = port
+    ),
+    class = "rlang_error"
+  )
+})
+
+# ── 3. ltr_subperiod: sharpe is not all-NA (defect B regression) ────────
+
+test_that("ltr_subperiod: sharpe is populated (not all-NA) when rf_ret is present -- #677 defect B", {
+  cmd <- .target_command(plan_ltr_momentum(), "ltr_subperiod")
+  port <- .toy_ltr_portfolio(n_months = 60L, rf_val = 0.0012)
+
+  result <- .eval_command(
+    cmd,
+    hd_hac_sharpe   = .mock_hac_sharpe,
+    sharpe_ratio_rf = sharpe_ratio_rf,
+    ltr_portfolio   = port
+  )
+
+  expect_equal(nrow(result), 3L)
+  # Pre-#677: `mean(df$rf_ret, na.rm = TRUE)` against a column that did not
+  # exist on ltr_portfolio returned NA silently, so every row here was NA.
+  expect_false(all(is.na(result$sharpe)))
+  expect_true(all(is.finite(result$sharpe)))
+})
+
+test_that("ltr_subperiod: aborts loud (not silent NA) if rf_ret is missing from ltr_portfolio (#677 defect B guard)", {
+  cmd <- .target_command(plan_ltr_momentum(), "ltr_subperiod")
+  port <- .toy_ltr_portfolio(n_months = 60L) |> dplyr::select(-rf_ret)
+
+  expect_error(
+    .eval_command(
+      cmd,
+      hd_hac_sharpe   = .mock_hac_sharpe,
+      sharpe_ratio_rf = sharpe_ratio_rf,
+      ltr_portfolio   = port
+    ),
+    class = "rlang_error"
+  )
+})

--- a/tests/testthat/test-plan-risk-state-sharpe.R
+++ b/tests/testthat/test-plan-risk-state-sharpe.R
@@ -1,0 +1,94 @@
+testthat::local_edition(3)
+# Regression tests for #677 slice 1: canonical, risk-free-adjusted Sharpe
+# for Risk State's SPY_overlay row (R/plan_risk_state.R). Complements
+# test-bound-testing-windows.R, which already extracts/eval()'s the
+# `rsc_metrics` command for the #667 window-bound regression -- this file
+# adds the same extraction pattern with an `rf_daily` column present, since
+# #667's synthetic `port` tibble does not include one (and does not need
+# to: it doesn't assert on sharpe).
+
+source(here::here("R/plan_risk_state.R"))
+source(here::here("R/utils_metrics.R"))
+
+# ── Helpers (mirrors test-bound-testing-windows.R) ──────────────────────
+
+.target_command <- function(target_list, name) {
+  hit <- vapply(target_list, function(t) identical(t$settings$name, name), logical(1))
+  if (sum(hit) != 1L) {
+    stop("target '", name, "' not found (or not unique) in this plan's target list")
+  }
+  target_list[[which(hit)]]$command$expr[[1]]
+}
+
+.eval_command <- function(expr, ...) {
+  env <- list2env(list(...), envir = new.env(parent = globalenv()))
+  eval(expr, envir = env)
+}
+
+# Minimal stand-in for historicaldata::hd_hac_sharpe() -- rsc_metrics calls
+# it for hac_tstat/hac_sharpe columns this test does not assert on.
+# Deliberately NOT rf-adjusted, so it differs from the canonical sharpe.
+.mock_hac_sharpe <- function(ret_vec) {
+  list(hac_tstat = 0, naive_sharpe = mean(ret_vec) / stats::sd(ret_vec) * sqrt(252))
+}
+
+.toy_rsc_inputs <- function(n_days = 500L, seed = 677L, rf_val = 0.0001) {
+  set.seed(seed)
+  dates <- seq(as.Date("2018-01-01"), by = "day", length.out = n_days)
+  port <- tibble::tibble(
+    date         = dates,
+    ret_buyhold  = stats::rnorm(n_days, 0.0003, 0.01),
+    ret_strategy = stats::rnorm(n_days, 0.0003, 0.008),
+    rf_daily     = rep(rf_val, n_days)
+  )
+  overlay <- tibble::tibble(
+    date        = dates,
+    ret_raw     = stats::rnorm(n_days, 0.0003, 0.01),
+    ret_overlay = stats::rnorm(n_days, 0.0003, 0.008)
+  )
+  list(port = port, overlay = overlay)
+}
+
+test_that("rsc_metrics: SPY_overlay Full Period row has both sharpe and hac_sharpe, and they differ", {
+  cmd <- .target_command(plan_risk_state(), "rsc_metrics")
+  inputs <- .toy_rsc_inputs(n_days = 500L, rf_val = 0.0001)
+
+  result <- .eval_command(
+    cmd,
+    hd_hac_sharpe       = .mock_hac_sharpe,
+    sharpe_ratio_rf     = sharpe_ratio_rf,
+    rsc_params          = list(oos_start = as.Date("2019-01-01"), test_end = as.Date("2019-06-30")),
+    rsc_portfolio       = inputs$port,
+    rsc_overlay_drif    = inputs$overlay,
+    rsc_overlay_fac_max = inputs$overlay
+  )
+
+  full_row <- result[result$strategy == "SPY_overlay" & result$period == "Full Period", ]
+  expect_equal(nrow(full_row), 1L)
+  expect_true("sharpe" %in% names(full_row))
+  expect_true("hac_sharpe" %in% names(full_row))
+  expect_false(is.na(full_row$sharpe))
+  expect_false(is.na(full_row$hac_sharpe))
+  expect_false(isTRUE(all.equal(full_row$sharpe, full_row$hac_sharpe)))
+})
+
+test_that("rsc_metrics: DRIF_raw/FacMAX_raw rows have NA sharpe (no rf series wired -- documented, deliberate default)", {
+  cmd <- .target_command(plan_risk_state(), "rsc_metrics")
+  inputs <- .toy_rsc_inputs(n_days = 500L)
+
+  result <- .eval_command(
+    cmd,
+    hd_hac_sharpe       = .mock_hac_sharpe,
+    sharpe_ratio_rf     = sharpe_ratio_rf,
+    rsc_params          = list(oos_start = as.Date("2019-01-01"), test_end = as.Date("2019-06-30")),
+    rsc_portfolio       = inputs$port,
+    rsc_overlay_drif    = inputs$overlay,
+    rsc_overlay_fac_max = inputs$overlay
+  )
+
+  no_rf_rows <- result[result$strategy %in% c("DRIF_raw", "DRIF_overlay", "FacMAX_raw", "FacMAX_overlay"), ]
+  expect_gt(nrow(no_rf_rows), 0L)
+  expect_true(all(is.na(no_rf_rows$sharpe)))
+  # hac_sharpe is unaffected -- still populated for these rows
+  expect_false(any(is.na(no_rf_rows$hac_sharpe)))
+})

--- a/tests/testthat/test-utils-metrics.R
+++ b/tests/testthat/test-utils-metrics.R
@@ -110,3 +110,141 @@ test_that("annualise_returns: invalid periods_per_year aborts", {
 test_that("annualise_returns: function signature is stable (catches API drift)", {
   expect_snapshot(args(annualise_returns))
 })
+
+# ── sharpe_ratio_rf() (#677) ─────────────────────────────────────────────
+
+test_that("sharpe_ratio_rf: known-value case matches hand computation", {
+  ret <- rep(0.01, 12)
+  rf  <- rep(0.0002, 12)
+  m <- sharpe_ratio_rf(ret, rf, periods_per_year = 12L)
+
+  expected_ann_ret <- 1.01^12 - 1
+  expected_ann_vol <- stats::sd(ret) * sqrt(12)
+  expected_ann_rf  <- mean(rf) * 12
+  expected_sharpe  <- (expected_ann_ret - expected_ann_rf) / expected_ann_vol
+
+  expect_equal(m$ann_ret, expected_ann_ret, tolerance = 1e-10)
+  expect_equal(m$ann_rf,  expected_ann_rf,  tolerance = 1e-10)
+  expect_equal(m$ann_vol, expected_ann_vol, tolerance = 1e-10)
+  # vol is 0 here (constant returns) -> sharpe NA, not Inf
+  expect_true(is.na(m$sharpe))
+  expect_equal(m$n, 12L)
+})
+
+test_that("sharpe_ratio_rf: non-zero-vol toy series gives a finite, rf-deducted Sharpe", {
+  ret <- rep(c(0.05, -0.03), 12)   # 24 months, alternating
+  rf  <- rep(0.001, 24)
+  m <- sharpe_ratio_rf(ret, rf, periods_per_year = 12L)
+
+  equity <- cumprod(1 + ret)
+  n <- 24
+  ann_ret_expected <- equity[n]^(12 / n) - 1
+  ann_vol_expected <- stats::sd(ret) * sqrt(12)
+  ann_rf_expected  <- mean(rf) * 12
+  sharpe_expected  <- (ann_ret_expected - ann_rf_expected) / ann_vol_expected
+
+  expect_equal(m$sharpe, sharpe_expected, tolerance = 1e-10)
+  expect_true(is.finite(m$sharpe))
+  expect_equal(m$n, 24L)
+})
+
+test_that("sharpe_ratio_rf: rf deduction lowers Sharpe vs a zero risk-free rate", {
+  ret <- rep(c(0.05, -0.03), 12)
+  rf_zero <- rep(0, 24)
+  rf_pos  <- rep(0.005, 24)   # meaningfully positive monthly rf
+
+  sharpe_zero_rf <- sharpe_ratio_rf(ret, rf_zero, periods_per_year = 12L)$sharpe
+  sharpe_pos_rf  <- sharpe_ratio_rf(ret, rf_pos,  periods_per_year = 12L)$sharpe
+
+  expect_true(sharpe_pos_rf < sharpe_zero_rf)
+})
+
+test_that("sharpe_ratio_rf: NULL rf aborts loud rather than defaulting to zero (#677 defect B)", {
+  expect_error(
+    sharpe_ratio_rf(c(0.01, 0.02, 0.03), NULL),
+    class = "rlang_error"
+  )
+  expect_snapshot(
+    error = TRUE,
+    sharpe_ratio_rf(c(0.01, 0.02, 0.03), NULL)
+  )
+})
+
+test_that("sharpe_ratio_rf: non-numeric rf aborts", {
+  expect_error(
+    sharpe_ratio_rf(c(0.01, 0.02, 0.03), c("a", "b", "c")),
+    class = "rlang_error"
+  )
+  expect_snapshot(
+    error = TRUE,
+    sharpe_ratio_rf(c(0.01, 0.02, 0.03), c("a", "b", "c"))
+  )
+})
+
+test_that("sharpe_ratio_rf: non-numeric ret aborts", {
+  expect_error(
+    sharpe_ratio_rf(c("a", "b"), c(0.001, 0.001)),
+    class = "rlang_error"
+  )
+  expect_snapshot(
+    error = TRUE,
+    sharpe_ratio_rf(c("a", "b"), c(0.001, 0.001))
+  )
+})
+
+test_that("sharpe_ratio_rf: length mismatch between ret and rf aborts", {
+  expect_error(
+    sharpe_ratio_rf(c(0.01, 0.02, 0.03), c(0.001, 0.001)),
+    class = "rlang_error"
+  )
+  expect_snapshot(
+    error = TRUE,
+    sharpe_ratio_rf(c(0.01, 0.02, 0.03), c(0.001, 0.001))
+  )
+})
+
+test_that("sharpe_ratio_rf: invalid periods_per_year aborts", {
+  expect_error(
+    sharpe_ratio_rf(c(0.01, 0.02), c(0.001, 0.001), periods_per_year = 0),
+    class = "rlang_error"
+  )
+  expect_snapshot(
+    error = TRUE,
+    sharpe_ratio_rf(c(0.01, 0.02), c(0.001, 0.001), periods_per_year = 0)
+  )
+})
+
+test_that("sharpe_ratio_rf: non-finite ret aborts on non-finite volatility", {
+  expect_error(
+    sharpe_ratio_rf(c(0.01, Inf, 0.02), c(0.001, 0.001, 0.001)),
+    class = "rlang_error"
+  )
+  expect_snapshot(
+    error = TRUE,
+    sharpe_ratio_rf(c(0.01, Inf, 0.02), c(0.001, 0.001, 0.001))
+  )
+})
+
+test_that("sharpe_ratio_rf: na.rm drops paired NAs positionally", {
+  ret <- c(0.01, NA, 0.02, 0.03, NA)
+  rf  <- c(0.001, 0.001, NA, 0.001, 0.001)
+  # After pairwise NA removal: positions 1 and 4 survive (ret[2], ret[5] NA
+  # in ret; ret[3] paired with NA rf) -- only 2 complete pairs, n < 2 is not
+  # true here since n==2, but let's assert the count directly.
+  m <- sharpe_ratio_rf(ret, rf, periods_per_year = 12L)
+  expect_equal(m$n, 2L)
+})
+
+test_that("sharpe_ratio_rf: fewer than 2 paired observations returns all NA (deliberate default)", {
+  m <- sharpe_ratio_rf(numeric(0), numeric(0))
+  expect_equal(m$n, 0L)
+  expect_true(is.na(m$sharpe))
+
+  m1 <- sharpe_ratio_rf(0.01, 0.001)
+  expect_equal(m1$n, 1L)
+  expect_true(is.na(m1$sharpe))
+})
+
+test_that("sharpe_ratio_rf: function signature is stable (catches API drift)", {
+  expect_snapshot(args(sharpe_ratio_rf))
+})


### PR DESCRIPTION
## Summary (#677 slice 1 of 4)

Adds `sharpe_ratio_rf()` — the canonical, shared Sharpe helper — and uses it to fix LTR and Risk State, the two strategies that had no real `sharpe` at all. Slices 2 (no-rf family: `managed_futures`/`ev_ebit`/`bootstrap_ci`), 3 (arithmetic family: `plan_backtest`/`commodities_mean_reversion`/`avoid_worst`), and 4 (gate S17) are deliberately out of scope here.

## The helper

`R/utils_metrics.R::sharpe_ratio_rf(ret, rf, periods_per_year = 12L, na.rm = TRUE)`:

```
sharpe = (ann_ret - ann_rf) / ann_vol
```

geometric numerator, risk-free deducted — already the majority convention (`plan_factormax.R:187`, `plan_drif.R:293`, `plan_alpha_decay.R:159`). It sits alongside the pre-existing `annualise_returns()` in the same file, which is a **deliberately different** basis (`cagr / vol`, no rf) — that is the "no-rf family" basis for slice 2 and is untouched.

Per `.claude/rules/fail-loud-not-null.md`, it `cli::cli_abort()`s rather than silently defaulting to zero on: `rf = NULL`, non-numeric `ret`/`rf`, a `ret`/`rf` length mismatch, or non-finite computed volatility. This is a direct response to defect B below, where a missing rf column silently produced `NA` for years.

## Defect B: `ltr_subperiod$sharpe` was silently NA, always

Confirmed on `main` before this change: `ltr_portfolio` has no `rf_ret` column at all. `compute_sp_metrics()` did `rf_ann <- mean(df$rf_ret, na.rm = TRUE) * 12` — `df$rf_ret` is `NULL`, `mean(NULL, na.rm=TRUE)` is `NA`, so every subperiod Sharpe was `NA` since the target was written, discovered only by accident.

Fix: `ltr_portfolio` now `left_join`s the shared monthly risk-free series `stk_rf` (`ym`, `rf_ret` — `R/plan_stock_backtest.R`) onto `ym`, and `cli_abort()`s if any month is left uncovered by the join (rather than silently reintroducing the same defect one level down). `stk_rf`'s source (`FF3` daily factors, `from = stk_params$start_date` = the same `bt_partitions$equity$train_start` LTR itself uses) should fully cover LTR's date range by construction — this is asserted at runtime, not just assumed.

## LTR and Risk State had no real `sharpe` column

`plan_leaderboard.R`'s `.norm_ltr()` and `.norm_rsc()` did `rename(sharpe = hac_sharpe)` — substituting a naive, non-rf-deducted HAC statistic for the canonical Sharpe. This is why **LTR ranked #1 on the leaderboard at a published 2.36**, while `cagr/vol` for LTR is **0.448**.

- `ltr_metrics` (`compute_ltr_metrics()`) and `ltr_subperiod` (`compute_sp_metrics()`) now compute a real `sharpe` via `sharpe_ratio_rf()`, using the now-guaranteed `rf_ret`.
- `rsc_metrics` (`calc_metrics()`) now accepts an optional `rf_vec`; `SPY_buyhold`/`SPY_overlay` rows pass `rsc_portfolio$rf_daily` (FF3 daily RF, already lagged t+1 and zero-filled at that target). `DRIF_raw`/`DRIF_overlay`/`FacMAX_raw`/`FacMAX_overlay` do **not** yet have an aligned rf series joined onto their overlay return streams — `sharpe` is deliberately left `NA` for those rows (documented in-code as a follow-up), `hac_sharpe` is unaffected. `.norm_rsc()` only consumes the `SPY_overlay` rows, so this is sufficient for the leaderboard fix.
- `hac_sharpe` is kept as its own column everywhere (not renamed away) — `.norm_ltr()`/`.norm_rsc()` no longer rename it.

## Expected impact

LTR's published Sharpe should fall from **2.36** to somewhat below the naive `cagr/vol` ratio of **0.448** (rf deduction pulls it down further) — this is the correction, not a regression, and should move LTR substantially off the #1 leaderboard rank. Risk State's SPY_overlay Sharpe will also change from the HAC-substituted value to the real rf-adjusted one.

**I could not verify the actual before/after numbers or rank change.** `ltr_portfolio` reads `data/raw/ltr_portfolio.parquet`, which is gitignored and requires `nix develop . --command Rscript scripts/compute_ltr_model.R` to populate — it does not exist in this worktree, and per the task instructions I did not run `tar_make()` (targets-store conflict with the main checkout). The orchestrator will need to rebuild and confirm the actual LTR/Risk-State Sharpe values and any leaderboard rank change after merge.

## Registry-writer fix (found while implementing, not in the original brief)

`.ltr_register_runs()` and `.rsc_register_runs()` (`R/plan_ltr_momentum.R`, `R/plan_risk_state.R`) pass a wide-form metrics row to `historicaldata::hd_metric_record()`, which requires every column to resolve to a declared unit (`#640`) and `cli_abort()`s on any column with no matching unit. Since `ltr_metrics`/`rsc_metrics` now carry a new `sharpe` column that wasn't in either function's `units` map, both registry writers would have aborted at runtime the first time they ran. Added `sharpe = "ratio"` to both unit maps.

## Tests

- `R/utils_metrics.R::sharpe_ratio_rf()`: known-value cases, rf-deduction-lowers-Sharpe sanity check, `expect_snapshot(error = TRUE, ...)` for every new `cli_abort` (NULL rf, non-numeric rf/ret, length mismatch, invalid `periods_per_year`, non-finite vol), na.rm pairwise-drop behaviour, n<2 deliberate-default behaviour, function-signature snapshot. `_snaps/utils-metrics.md` updated.
- `tests/testthat/test-plan-ltr-momentum.R` (new): inline simulation of the `ltr_portfolio` join+coverage-check (the real target can't be `eval()`'d directly — it reads a gitignored parquet); extraction-pattern tests (`.target_command()`/`.eval_command()`, same technique as `test-bound-testing-windows.R` / `test-holdout-source-metrics-666.R`) for `ltr_metrics` (asserts `sharpe` and `hac_sharpe` both present and differ; aborts loud if `rf_ret` is missing) and `ltr_subperiod` (asserts `sharpe` is not all-NA — the direct defect-B regression test; aborts loud if `rf_ret` is missing).
- `tests/testthat/test-plan-risk-state-sharpe.R` (new): same extraction pattern for `rsc_metrics` — `SPY_overlay` Full Period row has both `sharpe`/`hac_sharpe` and they differ; `DRIF_raw`/`FacMAX_raw` rows have `NA` sharpe (documented, deliberate) but retain `hac_sharpe`.
- `tests/testthat/test-holdout-source-metrics-666.R`: pre-existing test broke because it evaluates `ltr_metrics`'s real command against synthetic data without sourcing `R/utils_metrics.R` — added the missing `source()`. This is a direct, minimal consequence of `compute_ltr_metrics()` now depending on `sharpe_ratio_rf()`.
- Root tests start with `testthat::local_edition(3)`.

## `scripts/verify.sh`

Ran in foreground, `timeout: 600000`, actual output:

```
PASS: _targets.R parses (verified tree: .../fix/677-sharpe-basis)
PASS: testthat edition 3 active

=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

=== scripts/verify.sh: PASS ===
```

Root suite total rose from the `dd0992a` baseline of 448 to **468** (the ~20 new assertions above), same 3 pre-existing failures, 0 new skips. Package suite unchanged at 694/1/15.

## Left for later slices (per #677, deliberately not touched here)

- Slice 2: no-rf family (`plan_managed_futures.R`, `plan_ev_ebit.R`, `bootstrap_ci()`)
- Slice 3: arithmetic family (`plan_backtest`, `plan_commodities_mean_reversion.R`, `plan_avoid_worst.R`)
- Slice 4: gate S17 (would fail on half the board today, per the task brief)
- Risk State's `DRIF_raw`/`DRIF_overlay`/`FacMAX_raw`/`FacMAX_overlay` rows still have no rf-adjusted `sharpe` (documented `NA`, `hac_sharpe` retained) — sourcing an aligned rf series for those overlay return streams is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
