### PR TITLE
fix(ltr): restore pipeline — trim trailing rf-uncovered months instead of aborting (#677 follow-up)

### DIFF
--- a/R/plan_ltr_momentum.R
+++ b/R/plan_ltr_momentum.R
@@ -163,20 +163,7 @@ plan_ltr_momentum <- function() {
       # R/plan_stock_backtest.R) onto `ym`, and abort loud rather than let
       # a partial join reintroduce the same silent-NA defect one level
       # down.
-      port_ym_range <- range(port$ym)
-      port <- port |> left_join(stk_rf, by = "ym")
-
-      missing_rf_ym <- sort(port$ym[is.na(port$rf_ret)])
-      if (length(missing_rf_ym) > 0L) {
-        cli::cli_abort(c(
-          "x" = "{length(missing_rf_ym)} month{?s} in ltr_portfolio have no matching stk_rf risk-free rate.",
-          "i" = "Missing ym: {.val {missing_rf_ym}}.",
-          "i" = "ltr_portfolio spans {port_ym_range[1]}..{port_ym_range[2]}; stk_rf spans {min(stk_rf$ym)}..{max(stk_rf$ym)}.",
-          "i" = "Extend stk_rf's `from` date (R/plan_stock_backtest.R) or investigate the FF3 data source before trusting any downstream LTR Sharpe figure."
-        ))
-      }
-
-      port
+      .ltr_join_rf(port, stk_rf)
     }),
 
 
@@ -459,6 +446,78 @@ plan_ltr_momentum <- function() {
 # ── Internal helper ────────────────────────────────────────────────────────────
 # Prefixed .ltr_* (private; not exported from the package).
 # Mirrors .mom_prepeak_register_runs() from plan_mom_prepeak.R.
+
+#' Join the shared risk-free series onto an LTR portfolio, handling coverage
+#'
+#' Extracted from the `ltr_portfolio` target so the coverage policy is pure
+#' and unit-testable (the target itself reads a gitignored parquet, so it
+#' cannot be exercised portably).
+#'
+#' #677 defect B gave `ltr_portfolio` an `rf_ret` column for the first time;
+#' before that, `mean(df$rf_ret, na.rm = TRUE)` evaluated against a NULL
+#' column and every downstream Sharpe was silently `NA`.
+#'
+#' PR #678's first form then aborted on ANY uncovered month, which took the
+#' whole leaderboard down on its first real run: `ltr_portfolio` spanned
+#' 2005-01..2026-03 while `stk_rf` (Fama-French) spanned 2005-01..2026-02.
+#' That is not a defect — FF3 publishes with a lag, so the newest portfolio
+#' month routinely has no risk-free rate yet, and it recurs every month.
+#' Aborting turned an expected data-lag condition into a hard failure.
+#'
+#' Silently keeping `NA` rf is the defect this join exists to fix, so the
+#' policy distinguishes the two cases:
+#'   - **trailing** uncovered months (beyond `max(stk_rf$ym)`) — a
+#'     publication lag. TRIM them and `cli_warn`, naming the dropped months
+#'     and the effective end date, per `fail-loud-not-null.md`'s "Make the
+#'     drop observable". The drop is counted and reported, never silent.
+#'   - **interior** uncovered months (at or before `max(stk_rf$ym)`) — a real
+#'     hole in the FF3 series, not a lag. Still `cli_abort`.
+#'
+#' @param port Tibble with a `ym` column (the LTR portfolio).
+#' @param stk_rf Tibble with columns `ym`, `rf_ret`.
+#' @return `port` with `rf_ret` joined, trailing uncovered months removed.
+#' @noRd
+.ltr_join_rf <- function(port, stk_rf) {
+  required <- c("ym", "rf_ret")
+  missing_cols <- setdiff(required, names(stk_rf))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = ".ltr_join_rf(): stk_rf is missing {length(missing_cols)} required column{?s}: {.field {missing_cols}}.",
+      "i" = "Expected a tibble with ym and rf_ret (R/plan_stock_backtest.R)."
+    ))
+  }
+  if (!"ym" %in% names(port)) {
+    cli::cli_abort(c("x" = ".ltr_join_rf(): port has no {.field ym} column to join on."))
+  }
+
+  port_ym_range <- range(port$ym)
+  port <- dplyr::left_join(port, stk_rf, by = "ym")
+
+  missing_rf_ym <- sort(port$ym[is.na(port$rf_ret)])
+  if (length(missing_rf_ym) == 0L) return(port)
+
+  rf_max   <- max(stk_rf$ym)
+  interior <- missing_rf_ym[missing_rf_ym <= rf_max]
+
+  if (length(interior) > 0L) {
+    cli::cli_abort(c(
+      "x" = "{length(interior)} month{?s} inside stk_rf's own span have no risk-free rate.",
+      "i" = "Missing ym: {.val {interior}}.",
+      "i" = "stk_rf spans {min(stk_rf$ym)}..{rf_max}, so this is a HOLE in the series, not a publication lag.",
+      "i" = "Investigate the FF3 source (R/plan_stock_backtest.R) before trusting any LTR Sharpe figure."
+    ))
+  }
+
+  n_before <- nrow(port)
+  port <- dplyr::filter(port, !is.na(.data$rf_ret))
+  cli::cli_warn(c(
+    "!" = "Dropped {n_before - nrow(port)} trailing month{?s} from ltr_portfolio with no risk-free rate yet.",
+    "i" = "Dropped ym: {.val {missing_rf_ym}}.",
+    "i" = "ltr_portfolio spans {port_ym_range[1]}..{port_ym_range[2]}; stk_rf ends {rf_max} (Fama-French publication lag).",
+    "i" = "Every LTR metric is therefore computed through {rf_max}, not {port_ym_range[2]}."
+  ))
+  port
+}
 
 #' Register LTR backtest run in the strategy registry
 #'

--- a/tests/testthat/_snaps/plan-ltr-momentum.md
+++ b/tests/testthat/_snaps/plan-ltr-momentum.md
@@ -1,0 +1,20 @@
+# .ltr_join_rf abort messages are stable
+
+    Code
+      .ltr_join_rf(port, .mk_rf(c("2026-01", "2026-03")))
+    Condition
+      Error in `.ltr_join_rf()`:
+      x 1 month inside stk_rf's own span have no risk-free rate.
+      i Missing ym: "2026-02".
+      i stk_rf spans 2026-01..2026-03, so this is a HOLE in the series, not a publication lag.
+      i Investigate the FF3 source (R/plan_stock_backtest.R) before trusting any LTR Sharpe figure.
+
+---
+
+    Code
+      .ltr_join_rf(.mk_port("2026-01"), tibble::tibble(ym = "2026-01"))
+    Condition
+      Error in `.ltr_join_rf()`:
+      x .ltr_join_rf(): stk_rf is missing 1 required column: rf_ret.
+      i Expected a tibble with ym and rf_ret (R/plan_stock_backtest.R).
+

--- a/tests/testthat/test-plan-ltr-momentum.R
+++ b/tests/testthat/test-plan-ltr-momentum.R
@@ -172,3 +172,60 @@ test_that("ltr_subperiod: aborts loud (not silent NA) if rf_ret is missing from 
     class = "rlang_error"
   )
 })
+
+# ── .ltr_join_rf() coverage policy (#677 follow-up) ─────────────────────────
+#
+# PR #678 aborted on ANY uncovered month. On its first real run that took the
+# whole leaderboard down: ltr_portfolio spanned 2005-01..2026-03 while stk_rf
+# (Fama-French) ended 2026-02. FF3 publishes with a lag, so the newest month
+# routinely has no rf yet and this recurs monthly. The policy now distinguishes
+# a trailing lag (trim + loud warn) from an interior hole (still abort).
+
+.mk_port <- function(yms) tibble::tibble(ym = yms, port_ret = seq_along(yms) / 1000)
+.mk_rf   <- function(yms) tibble::tibble(ym = yms, rf_ret = rep(0.001, length(yms)))
+
+test_that(".ltr_join_rf attaches rf_ret with no NA when coverage is complete", {
+  out <- .ltr_join_rf(.mk_port(c("2026-01", "2026-02")), .mk_rf(c("2026-01", "2026-02")))
+  expect_equal(nrow(out), 2L)
+  expect_false(anyNA(out$rf_ret))
+})
+
+test_that(".ltr_join_rf trims a trailing uncovered month and warns (the #678 breakage)", {
+  port <- .mk_port(c("2026-01", "2026-02", "2026-03"))
+  rf   <- .mk_rf(c("2026-01", "2026-02"))
+
+  expect_warning(out <- .ltr_join_rf(port, rf), regexp = "2026-03")
+  # The uncovered month is REMOVED, not carried as NA -- carrying it is the
+  # defect B this join exists to fix.
+  expect_equal(nrow(out), 2L)
+  expect_false(anyNA(out$rf_ret))
+  expect_false("2026-03" %in% out$ym)
+})
+
+test_that(".ltr_join_rf warning names the effective end date, not just the drop", {
+  expect_warning(
+    .ltr_join_rf(.mk_port(c("2026-01", "2026-02", "2026-03")), .mk_rf(c("2026-01", "2026-02"))),
+    regexp = "2026-02"
+  )
+})
+
+test_that(".ltr_join_rf still aborts on an INTERIOR hole -- a real FF3 gap, not a lag", {
+  port <- .mk_port(c("2026-01", "2026-02", "2026-03"))
+  rf   <- .mk_rf(c("2026-01", "2026-03"))  # 2026-02 missing, inside the span
+
+  expect_error(.ltr_join_rf(port, rf), regexp = "2026-02")
+  expect_error(.ltr_join_rf(port, rf), regexp = "HOLE")
+})
+
+test_that(".ltr_join_rf aborts when stk_rf lacks required columns", {
+  expect_error(
+    .ltr_join_rf(.mk_port("2026-01"), tibble::tibble(ym = "2026-01")),
+    regexp = "rf_ret"
+  )
+})
+
+test_that(".ltr_join_rf abort messages are stable", {
+  port <- .mk_port(c("2026-01", "2026-02", "2026-03"))
+  expect_snapshot(error = TRUE, .ltr_join_rf(port, .mk_rf(c("2026-01", "2026-03"))))
+  expect_snapshot(error = TRUE, .ltr_join_rf(.mk_port("2026-01"), tibble::tibble(ym = "2026-01")))
+})


### PR DESCRIPTION
**`main` is currently broken.** PR #678's rf-coverage guard aborts the `ltr_portfolio` target on every run, taking `ltr_metrics`, `ltr_subperiod` and `leaderboard` down with it. This restores the pipeline.

## What broke

The guard aborted on **any** month with no matching `stk_rf` rate. On its first real pipeline run:

```
x 1 month in ltr_portfolio have no matching stk_rf risk-free rate.
i Missing ym: '2026-03'.
i ltr_portfolio spans 2005-01..2026-03; stk_rf spans 2005-01..2026-02.
```

That is not a data defect. **Fama-French publishes with a lag**, so the newest portfolio month routinely has no risk-free rate yet — and it will recur every month. The guard turned an expected, recurring condition into a hard pipeline failure.

## Two things this exposed

**`tar_make` exited 0.** The project sets `error = "continue"`, so four errored targets still produced a zero exit status. `tar_read(leaderboard)` then served the **stale, pre-#678** values — LTR still showing `sharpe = 2.36`, `ltr_subperiod` still `NA, NA, NA`. The fix looked like it had silently not applied. It was caught only because the rebuilt numbers were checked against a prediction and didn't move.

**`scripts/verify.sh` does not run `tar_make`.** #678 passed full verification — root 468/3/0, package 694/1/15, both baselines exact — while breaking the pipeline. Every gate in `scripts/verify.sh` is a `testthat` run; nothing exercises the DAG. A change can therefore be fully "verified" and still leave `main` unbuildable. That is [#669](https://github.com/JohnGavin/historical/issues/669)'s lesson recurring, and it is worth its own issue.

## The fix

Distinguish the two cases rather than treating all uncovered months alike:

| case | condition | action |
|---|---|---|
| **trailing** | uncovered months beyond `max(stk_rf$ym)` | **trim + `cli_warn`**, naming the dropped months *and* the effective end date |
| **interior** | uncovered months at/before `max(stk_rf$ym)` | **still `cli_abort`** — a real hole in the FF3 series, not a lag |

Trimming rather than keeping `NA` preserves the point of #677 defect B: the uncovered month is *removed*, never carried as a null that downstream code silently averages over. And the drop is counted and named on every run, per `fail-loud-not-null.md`'s "Make the drop observable" — this is a visible reduction in coverage, not a silent one.

The warning states the consequence explicitly, so a reader knows what window the metrics actually cover:

```
! Dropped 1 trailing month from ltr_portfolio with no risk-free rate yet.
i Dropped ym: "2026-03".
i ltr_portfolio spans 2005-01..2026-03; stk_rf ends 2026-02 (Fama-French publication lag).
i Every LTR metric is therefore computed through 2026-02, not 2026-03.
```

## Why the logic moved into a helper

Extracted from the `ltr_portfolio` target into `.ltr_join_rf()`. The target reads a gitignored parquet, so it cannot be exercised portably in tests — **which is exactly why #678's guard shipped without a test that would have caught this**. As a pure function the coverage policy is directly testable.

## Verification

Against **real data** in the main checkout (2026-08-17), not just fixtures:

```
port ym: 2005-01 .. 2026-03   rf ym: 2005-01 .. 2026-02
rows in: 255 -> out: 254 | any NA rf: FALSE | new max ym: 2026-02
```

`scripts/verify.sh`: **PASS** — root `total=474 failed=3 skipped=0` (was 468/3/0 on `1167311`; +6 new tests), package `total=694 failed=1 skipped=15` unchanged, both baselines matched exactly.

New tests: complete coverage joins cleanly; trailing trim removes the month and warns; the warning names the effective end date; an interior hole still aborts; missing `stk_rf` columns abort; snapshot coverage for both abort messages.

## Not done here

`tar_make()` was not run from this worktree (store conflict with the main checkout). The helper was instead exercised directly against the real `ltr_portfolio` parquet and the real `stk_rf` target, which reproduces the exact failing condition. A full rebuild and confirmation of the LTR Sharpe/rank change follows immediately after merge.

Refs #677.
