### PR TITLE
fix(sharpe): migrate no-rf family onto canonical sharpe_ratio_rf() (#677 slice 2)

### DIFF
--- a/R/plan_bootstrap_ci.R
+++ b/R/plan_bootstrap_ci.R
@@ -80,8 +80,38 @@ plan_bootstrap_ci <- function() {
     targets::tar_target(boot_metrics, {
       library(dplyr)
 
-      strat_names <- c("stk_max", "stk_drif", "fac_max", "fac_drif")
+      # Derive the strategy list from the data, NOT a hardcoded vector. The
+      # pre-#677 code used colnames(boot_monthly_returns |> select(-ym));
+      # adding the paired `<strat>_rf` columns broke that (an rf column would
+      # be treated as a strategy), and the first fix was to enumerate the
+      # four names literally. That is the "scope drawn around the known
+      # instances" pattern this repo keeps being bitten by (#667 S11's
+      # enumerated pair, PR #661's paths: glob, #674's one-directional
+      # registry check) -- a fifth strategy added to boot_monthly_returns
+      # would have been silently dropped from the bootstrap with nothing
+      # saying so. Derive by excluding the `_rf` suffix instead, and assert
+      # the pairing is complete (fail-loud-not-null.md).
+      # Derived from the draws matrix boot_metrics already holds, NOT from
+      # boot_monthly_returns -- reading the latter here would add a new DAG
+      # edge for nothing, since every draw carries the same columns.
+      all_cols    <- setdiff(colnames(boot_draws[[1]]), "ym")
+      strat_names <- all_cols[!grepl("_rf$", all_cols)]
       rf_names    <- paste0(strat_names, "_rf")
+
+      missing_rf <- setdiff(rf_names, all_cols)
+      if (length(missing_rf) > 0L) {
+        cli::cli_abort(c(
+          "x" = "{length(missing_rf)} strateg{?y/ies} in boot_monthly_returns have no paired risk-free column:",
+          "i" = "Missing: {.field {missing_rf}}.",
+          "i" = "Every `<strategy>` column must have a matching `<strategy>_rf` (see boot_monthly_returns above, #677)."
+        ))
+      }
+      if (length(strat_names) == 0L) {
+        cli::cli_abort(c(
+          "x" = "boot_monthly_returns has no strategy columns (only ym and/or _rf columns).",
+          "i" = "Check the select() in boot_monthly_returns (R/plan_bootstrap_ci.R)."
+        ))
+      }
 
       # Compute rf-adjusted Sharpe, CAGR, max DD for a return + rf pair
       calc_boot_metrics <- function(ret, rf) {

--- a/R/plan_bootstrap_ci.R
+++ b/R/plan_bootstrap_ci.R
@@ -19,13 +19,28 @@ plan_bootstrap_ci <- function() {
     }),
 
     # Collect monthly returns per strategy into wide format
+    #
+    # #677 slice 2: also carry each strategy's own risk-free series --
+    # already joined onto its portfolio target upstream (stk_max_portfolio,
+    # stk_drif_portfolio, fm_portfolio, drif_portfolio all carry `rf_ret`)
+    # -- so the bootstrap Sharpe below uses the SAME rf-adjusted definition
+    # as the leaderboard (sharpe_ratio_rf(), R/utils_metrics.R). Without
+    # this, boot_ci_summary's "does the Sharpe CI cross zero" flag was
+    # computed on an inflated no-rf Sharpe (cagr/vol with implied rf =
+    # exactly 0.00%, the same formula signature flagged in #677), which is
+    # systematically more lenient than the rf-adjusted Sharpe published
+    # for the same strategy elsewhere on the leaderboard -- a decision
+    # judged on this file's own terms rather than migrated reflexively:
+    # this IS a statistical-inference display (does the strategy's Sharpe
+    # differ from zero), so it must use the same basis as what it is
+    # implicitly being compared against.
     targets::tar_target(boot_monthly_returns, {
       library(dplyr)
 
-      stk_max <- stk_max_portfolio |> select(ym, stk_max = port_ret)
-      stk_drif <- stk_drif_portfolio |> select(ym, stk_drif = port_ret)
-      fac_max <- fm_portfolio |> select(ym, fac_max = portfolio_ret)
-      fac_drif <- drif_portfolio |> select(ym, fac_drif = portfolio_ret)
+      stk_max  <- stk_max_portfolio  |> select(ym, stk_max = port_ret,       stk_max_rf = rf_ret)
+      stk_drif <- stk_drif_portfolio |> select(ym, stk_drif = port_ret,      stk_drif_rf = rf_ret)
+      fac_max  <- fm_portfolio       |> select(ym, fac_max = portfolio_ret,  fac_max_rf = rf_ret)
+      fac_drif <- drif_portfolio     |> select(ym, fac_drif = portfolio_ret, fac_drif_rf = rf_ret)
 
       stk_max |>
         inner_join(stk_drif, by = "ym") |>
@@ -58,27 +73,32 @@ plan_bootstrap_ci <- function() {
     }),
 
     # Compute metrics for each draw
+    #
+    # #677 slice 2: sharpe now uses sharpe_ratio_rf() (R/utils_metrics.R)
+    # paired with each strategy's own risk-free draw column (added to
+    # boot_monthly_returns / boot_draws above), instead of bare cagr/vol.
     targets::tar_target(boot_metrics, {
       library(dplyr)
 
-      strat_names <- colnames(boot_monthly_returns |> select(-ym))
+      strat_names <- c("stk_max", "stk_drif", "fac_max", "fac_drif")
+      rf_names    <- paste0(strat_names, "_rf")
 
-      # Compute Sharpe, CAGR, max DD for a return vector
-      calc_boot_metrics <- function(ret) {
+      # Compute rf-adjusted Sharpe, CAGR, max DD for a return + rf pair
+      calc_boot_metrics <- function(ret, rf) {
         n <- length(ret)
         cagr <- prod(1 + ret)^(12 / n) - 1
         vol <- sd(ret) * sqrt(12)
-        sharpe <- if (vol > 0) cagr / vol else NA_real_
+        sr <- sharpe_ratio_rf(ret, rf, periods_per_year = 12L)
         cum <- cumprod(1 + ret)
         max_dd <- min(cum / cummax(cum) - 1)
-        c(sharpe = sharpe, cagr = cagr, max_dd = max_dd)
+        c(sharpe = sr$sharpe, cagr = cagr, max_dd = max_dd)
       }
 
       # For each draw, compute metrics per strategy
       results <- lapply(seq_along(boot_draws), function(i) {
         mat <- boot_draws[[i]]
         lapply(seq_along(strat_names), function(j) {
-          m <- calc_boot_metrics(mat[, j])
+          m <- calc_boot_metrics(mat[, strat_names[j]], mat[, rf_names[j]])
           tibble(
             draw = i,
             strategy = strat_names[j],

--- a/R/plan_ev_ebit.R
+++ b/R/plan_ev_ebit.R
@@ -109,16 +109,24 @@ plan_ev_ebit <- function() {
       oos      <- ev_params$oos_start
       test_end <- bt_partitions$factor$test_end
 
-      calc_metrics <- function(ret_vec, date_vec, strategy_name, period_name) {
+      # #677 slice 2: sharpe now uses the canonical risk-free-adjusted
+      # helper (R/utils_metrics.R::sharpe_ratio_rf()) instead of bare
+      # cagr/vol -- this file was one of the "no rf deducted" family
+      # (implied rf of exactly 0.00%, a formula signature -- see #677).
+      # ev_portfolios$RF is already carried on every row (ev_data pivots
+      # the RF column directly out of FF5), so no new join is needed here.
+      calc_metrics <- function(ret_vec, rf_vec, date_vec, strategy_name, period_name) {
         keep     <- !is.na(ret_vec)
         ret_vec  <- ret_vec[keep]
+        rf_vec   <- rf_vec[keep]
         date_vec <- date_vec[keep]
         if (length(ret_vec) < 12L) return(NULL)
         years    <- length(ret_vec) / 12
         cum_ret  <- prod(1 + ret_vec)
         cagr     <- (cum_ret^(1 / years) - 1) * 100
         vol      <- sd(ret_vec) * sqrt(12) * 100
-        sharpe   <- ifelse(vol > 0, (cagr / 100) / (vol / 100), NA_real_)
+        sr       <- sharpe_ratio_rf(ret_vec, rf_vec, periods_per_year = 12L)
+        sharpe   <- sr$sharpe
         cum_w    <- cumprod(1 + ret_vec)
         drawdown <- (cum_w - cummax(cum_w)) / cummax(cum_w)
         max_dd   <- min(drawdown) * 100
@@ -147,7 +155,8 @@ plan_ev_ebit <- function() {
         value_qual = "Value+Quality (50% HML + 50% RMW, QVAL proxy)",
         market     = "Benchmark (Cap-Weighted Market)"
       )
-      dates <- ev_portfolios$date
+      dates  <- ev_portfolios$date
+      rf_all <- ev_portfolios$RF
 
       is_pre_oos <- dates < oos
       is_oos     <- dates >= oos & dates <= test_end
@@ -155,9 +164,9 @@ plan_ev_ebit <- function() {
       rows <- list()
       for (nm in names(strategies)) {
         rows <- c(rows,
-          list(calc_metrics(strategies[[nm]],            dates,             labels[nm], "Full")),
-          list(calc_metrics(strategies[[nm]][is_pre_oos], dates[is_pre_oos], labels[nm], "Training")),
-          list(calc_metrics(strategies[[nm]][is_oos],     dates[is_oos],     labels[nm], "OOS"))
+          list(calc_metrics(strategies[[nm]],            rf_all,            dates,             labels[nm], "Full")),
+          list(calc_metrics(strategies[[nm]][is_pre_oos], rf_all[is_pre_oos], dates[is_pre_oos], labels[nm], "Training")),
+          list(calc_metrics(strategies[[nm]][is_oos],     rf_all[is_oos],     dates[is_oos],     labels[nm], "OOS"))
         )
       }
       dplyr::bind_rows(Filter(Negate(is.null), rows))
@@ -175,6 +184,7 @@ plan_ev_ebit <- function() {
       dates <- ev_portfolios$date
       rval  <- ev_portfolios$ret_value_qual
       rmkt  <- ev_portfolios$ret_market
+      rf    <- ev_portfolios$RF   # #677 slice 2: rf-adjusted sharpe below
 
       # Known value underperformance periods (from Swedroe documentation)
       p_pre66   <- dates < as.Date("1966-01-01")
@@ -183,34 +193,39 @@ plan_ev_ebit <- function() {
       p_under00 <- dates >= as.Date("2000-01-01") & dates <= as.Date("2012-12-31")
       p_recent  <- dates >= as.Date("2013-01-01")
 
-      calc_row <- function(ret_vec, period_label, strategy_name) {
-        ret_vec <- ret_vec[!is.na(ret_vec)]
+      # #677 slice 2: sharpe now uses sharpe_ratio_rf() (R/utils_metrics.R)
+      # instead of bare cagr/vol -- see calc_metrics() above for the same
+      # fix applied to ev_metrics.
+      calc_row <- function(ret_vec, rf_vec, period_label, strategy_name) {
+        keep    <- !is.na(ret_vec)
+        ret_vec <- ret_vec[keep]
+        rf_vec  <- rf_vec[keep]
         if (length(ret_vec) < 6L) return(NULL)
         years  <- length(ret_vec) / 12
         cagr   <- (prod(1 + ret_vec)^(1 / years) - 1) * 100
         vol    <- sd(ret_vec) * sqrt(12) * 100
-        sharpe <- ifelse(vol > 0, cagr / vol, NA_real_)
+        sr     <- sharpe_ratio_rf(ret_vec, rf_vec, periods_per_year = 12L)
         tibble::tibble(
           strategy = strategy_name,
           period   = period_label,
           n_months = length(ret_vec),
           cagr     = round(cagr, 2),
           vol      = round(vol, 2),
-          sharpe   = round(sharpe, 3)
+          sharpe   = round(sr$sharpe, 3)
         )
       }
 
       dplyr::bind_rows(
-        calc_row(rval[p_pre66],   "Pre-1966 (Value leadership)",         "Value+Quality"),
-        calc_row(rmkt[p_pre66],   "Pre-1966 (Value leadership)",         "Market"),
-        calc_row(rval[p_under66], "1966-1982 (Value underperformance)",  "Value+Quality"),
-        calc_row(rmkt[p_under66], "1966-1982 (Value underperformance)",  "Market"),
-        calc_row(rval[p_bull83],  "1983-1999 (Value recovery)",          "Value+Quality"),
-        calc_row(rmkt[p_bull83],  "1983-1999 (Value recovery)",          "Market"),
-        calc_row(rval[p_under00], "2000-2012 (Value underperformance)",  "Value+Quality"),
-        calc_row(rmkt[p_under00], "2000-2012 (Value underperformance)",  "Market"),
-        calc_row(rval[p_recent],  "2013+ (Recent period)",               "Value+Quality"),
-        calc_row(rmkt[p_recent],  "2013+ (Recent period)",               "Market")
+        calc_row(rval[p_pre66],   rf[p_pre66],   "Pre-1966 (Value leadership)",         "Value+Quality"),
+        calc_row(rmkt[p_pre66],   rf[p_pre66],   "Pre-1966 (Value leadership)",         "Market"),
+        calc_row(rval[p_under66], rf[p_under66], "1966-1982 (Value underperformance)",  "Value+Quality"),
+        calc_row(rmkt[p_under66], rf[p_under66], "1966-1982 (Value underperformance)",  "Market"),
+        calc_row(rval[p_bull83],  rf[p_bull83],  "1983-1999 (Value recovery)",          "Value+Quality"),
+        calc_row(rmkt[p_bull83],  rf[p_bull83],  "1983-1999 (Value recovery)",          "Market"),
+        calc_row(rval[p_under00], rf[p_under00], "2000-2012 (Value underperformance)",  "Value+Quality"),
+        calc_row(rmkt[p_under00], rf[p_under00], "2000-2012 (Value underperformance)",  "Market"),
+        calc_row(rval[p_recent],  rf[p_recent],  "2013+ (Recent period)",               "Value+Quality"),
+        calc_row(rmkt[p_recent],  rf[p_recent],  "2013+ (Recent period)",               "Market")
       )
     }),
 

--- a/R/plan_managed_futures.R
+++ b/R/plan_managed_futures.R
@@ -187,16 +187,24 @@ plan_managed_futures <- function() {
       oos      <- mf_params$oos_start
       test_end <- bt_partitions$macro$test_end
 
-      calc_metrics <- function(ret_vec, date_vec, strategy_name, period_name) {
+      # #677 slice 2: sharpe now uses the canonical risk-free-adjusted
+      # helper (R/utils_metrics.R::sharpe_ratio_rf()) instead of bare
+      # cagr/vol -- this file was one of the "no rf deducted" family
+      # (implied rf of exactly 0.00%, a formula signature -- see #677).
+      # mf_portfolios$RF is already joined onto every row (mf_data's
+      # inner_join with FF5's RF), so no new join is needed here.
+      calc_metrics <- function(ret_vec, rf_vec, date_vec, strategy_name, period_name) {
         keep     <- !is.na(ret_vec)
         ret_vec  <- ret_vec[keep]
+        rf_vec   <- rf_vec[keep]
         date_vec <- date_vec[keep]
         if (length(ret_vec) < 12L) return(NULL)
         years   <- length(ret_vec) / 12
         cum_ret <- prod(1 + ret_vec)
         cagr    <- (cum_ret^(1 / years) - 1) * 100
         vol     <- stats::sd(ret_vec) * sqrt(12) * 100
-        sharpe  <- ifelse(vol > 0, (cagr / 100) / (vol / 100), NA_real_)
+        sr      <- sharpe_ratio_rf(ret_vec, rf_vec, periods_per_year = 12L)
+        sharpe  <- sr$sharpe
         cum_w   <- cumprod(1 + ret_vec)
         dd      <- (cum_w - cummax(cum_w)) / cummax(cum_w)
         max_dd  <- min(dd) * 100
@@ -225,7 +233,8 @@ plan_managed_futures <- function() {
         ls = "Long-Short TS-Mom (MOP 2012, vol-targeted)",
         ew = "Equal-Weight Benchmark (SPY+TLT+GLD+DBC)"
       )
-      dates <- mf_portfolios$date
+      dates  <- mf_portfolios$date
+      rf_all <- mf_portfolios$RF
 
       is_pre_oos <- dates < oos
       is_oos     <- dates >= oos & dates <= test_end
@@ -233,9 +242,9 @@ plan_managed_futures <- function() {
       rows <- list()
       for (nm in names(strategies)) {
         rows <- c(rows,
-          list(calc_metrics(strategies[[nm]],            dates,             labels[nm], "Full")),
-          list(calc_metrics(strategies[[nm]][is_pre_oos], dates[is_pre_oos], labels[nm], "Training")),
-          list(calc_metrics(strategies[[nm]][is_oos],     dates[is_oos],     labels[nm], "OOS"))
+          list(calc_metrics(strategies[[nm]],            rf_all,            dates,             labels[nm], "Full")),
+          list(calc_metrics(strategies[[nm]][is_pre_oos], rf_all[is_pre_oos], dates[is_pre_oos], labels[nm], "Training")),
+          list(calc_metrics(strategies[[nm]][is_oos],     rf_all[is_oos],     dates[is_oos],     labels[nm], "OOS"))
         )
       }
       dplyr::bind_rows(Filter(Negate(is.null), rows))
@@ -255,6 +264,7 @@ plan_managed_futures <- function() {
       dates <- mf_portfolios$date
       rls   <- mf_portfolios$ret_ls   # canonical long-short MOP strategy
       rew   <- mf_portfolios$ret_ew   # benchmark
+      rf    <- mf_portfolios$RF       # #677 slice 2: rf-adjusted sharpe below
 
       # Trend-following era breakpoints (based on documented performance regimes)
       p_pre2010  <- dates < as.Date("2010-01-01")
@@ -262,32 +272,37 @@ plan_managed_futures <- function() {
       p_covid    <- dates >= as.Date("2020-01-01") & dates <= as.Date("2022-12-31")
       p_recent   <- dates >= as.Date("2023-01-01")
 
-      calc_row <- function(ret_vec, period_label, strategy_name) {
-        ret_vec <- ret_vec[!is.na(ret_vec)]
+      # #677 slice 2: sharpe now uses sharpe_ratio_rf() (R/utils_metrics.R)
+      # instead of bare cagr/vol -- see calc_metrics() above for the same fix
+      # applied to mf_metrics.
+      calc_row <- function(ret_vec, rf_vec, period_label, strategy_name) {
+        keep    <- !is.na(ret_vec)
+        ret_vec <- ret_vec[keep]
+        rf_vec  <- rf_vec[keep]
         if (length(ret_vec) < 6L) return(NULL)
         years  <- length(ret_vec) / 12
         cagr   <- (prod(1 + ret_vec)^(1 / years) - 1) * 100
         vol    <- stats::sd(ret_vec) * sqrt(12) * 100
-        sharpe <- ifelse(vol > 0, cagr / vol, NA_real_)
+        sr     <- sharpe_ratio_rf(ret_vec, rf_vec, periods_per_year = 12L)
         tibble::tibble(
           strategy = strategy_name,
           period   = period_label,
           n_months = length(ret_vec),
           cagr     = round(cagr, 2),
           vol      = round(vol, 2),
-          sharpe   = round(sharpe, 3)
+          sharpe   = round(sr$sharpe, 3)
         )
       }
 
       dplyr::bind_rows(
-        calc_row(rls[p_pre2010], "Pre-2010 (GFC, high dispersion)",       "TS-Mom L/S"),
-        calc_row(rew[p_pre2010], "Pre-2010 (GFC, high dispersion)",       "EW Benchmark"),
-        calc_row(rls[p_drought], "2010-2019 (trend-following drought)",    "TS-Mom L/S"),
-        calc_row(rew[p_drought], "2010-2019 (trend-following drought)",    "EW Benchmark"),
-        calc_row(rls[p_covid],   "2020-2022 (COVID + rates surge)",        "TS-Mom L/S"),
-        calc_row(rew[p_covid],   "2020-2022 (COVID + rates surge)",        "EW Benchmark"),
-        calc_row(rls[p_recent],  "2023+ (recent period)",                  "TS-Mom L/S"),
-        calc_row(rew[p_recent],  "2023+ (recent period)",                  "EW Benchmark")
+        calc_row(rls[p_pre2010], rf[p_pre2010], "Pre-2010 (GFC, high dispersion)",       "TS-Mom L/S"),
+        calc_row(rew[p_pre2010], rf[p_pre2010], "Pre-2010 (GFC, high dispersion)",       "EW Benchmark"),
+        calc_row(rls[p_drought], rf[p_drought], "2010-2019 (trend-following drought)",    "TS-Mom L/S"),
+        calc_row(rew[p_drought], rf[p_drought], "2010-2019 (trend-following drought)",    "EW Benchmark"),
+        calc_row(rls[p_covid],   rf[p_covid],   "2020-2022 (COVID + rates surge)",        "TS-Mom L/S"),
+        calc_row(rew[p_covid],   rf[p_covid],   "2020-2022 (COVID + rates surge)",        "EW Benchmark"),
+        calc_row(rls[p_recent],  rf[p_recent],  "2023+ (recent period)",                  "TS-Mom L/S"),
+        calc_row(rew[p_recent],  rf[p_recent],  "2023+ (recent period)",                  "EW Benchmark")
       )
     }),
 

--- a/R/plan_turn_of_month.R
+++ b/R/plan_turn_of_month.R
@@ -35,11 +35,28 @@ plan_turn_of_month <- function() {
       )
     }),
 
+    # ── Data: daily risk-free rate (#677 slice 2 — no-rf family) ──
+    # TOM previously computed sharpe = cagr/vol with NO risk-free deduction
+    # (implied rf of exactly 0.00% -- a formula signature, see #677). TOM is
+    # a DAILY strategy (sqrt(252) annualisation), so it needs its own daily
+    # rf series rather than the monthly stk_rf series used by the
+    # monthly strategies migrated alongside it in this slice.
+    targets::tar_target(tom_rf_daily, {
+      library(dplyr)
+
+      hd_factors(dataset = "FF3", frequency = "daily",
+                 from = as.character(tom_params$start_date)) |>
+        dplyr::filter(factor_name == "RF") |>
+        dplyr::mutate(date = as.Date(date), rf_ret = value / 100) |>
+        dplyr::select(date, rf_ret) |>
+        dplyr::arrange(date)
+    }),
+
     # ── Data: SPY daily returns ───────────────────────────────────
     targets::tar_target(tom_daily, {
       library(dplyr)
 
-      hd_ohlcv(tom_params$ticker,
+      spy <- hd_ohlcv(tom_params$ticker,
                from = as.character(tom_params$start_date)) |>
         dplyr::arrange(date) |>
         dplyr::mutate(
@@ -48,6 +65,8 @@ plan_turn_of_month <- function() {
         ) |>
         dplyr::filter(!is.na(ret)) |>
         dplyr::select(date, ret)
+
+      .tom_join_rf_daily(spy, tom_rf_daily)
     }),
 
     # ── TOM window indicator ─────────────────────────────────────
@@ -81,7 +100,7 @@ plan_turn_of_month <- function() {
           in_head = rank_start <= tom_params$n_head,
           in_tom  = in_tail | in_head
         ) |>
-        dplyr::select(date, ret, yr_mon, rank_start, rank_end, in_tail, in_head, in_tom)
+        dplyr::select(date, ret, rf_ret, yr_mon, rank_start, rank_end, in_tail, in_head, in_tom)
     }),
 
     # ── Strategy returns ─────────────────────────────────────────
@@ -92,8 +111,12 @@ plan_turn_of_month <- function() {
     targets::tar_target(tom_portfolio, {
       library(dplyr)
 
-      # Daily RF rate from annual assumption
-      rf_daily <- (1 + tom_params$rf_annual)^(1 / 252) - 1
+      # Daily cash rate from the annual assumption -- this is the CASH
+      # RETURN earned while resting outside the TOM window (a strategy-
+      # return assumption). Distinct from the tom_rf_daily-joined `rf_ret`
+      # column used below for the Sharpe risk-free deduction (#677 slice 2)
+      # -- do not conflate the two.
+      cash_rf_daily <- (1 + tom_params$rf_annual)^(1 / 252) - 1
 
       d <- tom_indicator |>
         dplyr::arrange(date) |>
@@ -103,7 +126,7 @@ plan_turn_of_month <- function() {
           is_switch    = in_tom != prev_in_tom,
 
           # Strategy gross return
-          ret_gross = dplyr::if_else(in_tom, ret, rf_daily),
+          ret_gross = dplyr::if_else(in_tom, ret, cash_rf_daily),
 
           # Apply one-way transaction cost on switch days
           # One switch out + one switch in per TOM window cycle
@@ -126,26 +149,37 @@ plan_turn_of_month <- function() {
     targets::tar_target(tom_metrics, {
       library(dplyr)
 
+      # #677 slice 2: sharpe_tom/sharpe_bh now use the canonical
+      # risk-free-adjusted helper (R/utils_metrics.R::sharpe_ratio_rf())
+      # instead of bare cagr/vol -- TOM was one of the "no rf deducted"
+      # family (implied rf of exactly 0.00%, a formula signature -- see
+      # #677). TOM is daily, so periods_per_year = 252L (not the 12L used
+      # by the monthly strategies migrated alongside it in this slice).
       calc <- function(d, label) {
         # Strategy
-        ret_s <- d$ret_net
-        ret_s <- ret_s[!is.na(ret_s)]
+        keep_s <- !is.na(d$ret_net)
+        ret_s  <- d$ret_net[keep_s]
+        rf_s   <- d$rf_ret[keep_s]
         n     <- length(ret_s)
         if (n < 20L) return(NULL)
         years     <- n / 252
         cum_s     <- prod(1 + ret_s)
         cagr_s    <- cum_s^(1 / years) - 1
         vol_s     <- sd(ret_s) * sqrt(252)
-        sharpe_s  <- if (vol_s > 0) cagr_s / vol_s else NA_real_
+        sr_s      <- sharpe_ratio_rf(ret_s, rf_s, periods_per_year = 252L)
+        sharpe_s  <- sr_s$sharpe
         eq_s      <- cumprod(1 + ret_s)
         max_dd_s  <- min(eq_s / cummax(eq_s) - 1)
 
         # Benchmark (buy & hold)
-        ret_b  <- d$ret[!is.na(d$ret)]
+        keep_b <- !is.na(d$ret)
+        ret_b  <- d$ret[keep_b]
+        rf_b   <- d$rf_ret[keep_b]
         cum_b  <- prod(1 + ret_b)
         cagr_b <- cum_b^(1 / years) - 1
         vol_b  <- sd(ret_b) * sqrt(252)
-        sharpe_b <- if (vol_b > 0) cagr_b / vol_b else NA_real_
+        sr_b     <- sharpe_ratio_rf(ret_b, rf_b, periods_per_year = 252L)
+        sharpe_b <- sr_b$sharpe
         eq_b   <- cumprod(1 + ret_b)
         max_dd_b <- min(eq_b / cummax(eq_b) - 1)
 
@@ -205,7 +239,7 @@ plan_turn_of_month <- function() {
         nt <- grid$n_tail[i]
         nh <- grid$n_head[i]
 
-        rf_daily <- (1 + tom_params$rf_annual)^(1 / 252) - 1
+        cash_rf_daily <- (1 + tom_params$rf_annual)^(1 / 252) - 1
 
         d <- d_base |>
           dplyr::group_by(yr_mon) |>
@@ -218,19 +252,26 @@ plan_turn_of_month <- function() {
             in_tom = (rank_end <= nt) | (rank_start <= nh),
             prev_in_tom  = dplyr::lag(in_tom, default = FALSE),
             is_switch    = in_tom != prev_in_tom,
-            ret_gross    = dplyr::if_else(in_tom, ret, rf_daily),
+            ret_gross    = dplyr::if_else(in_tom, ret, cash_rf_daily),
             cost_daily   = dplyr::if_else(is_switch, tom_params$cost_bps / 1e4, 0),
             ret_net      = ret_gross - cost_daily
           )
 
-        ret_vec <- d$ret_net[!is.na(d$ret_net)]
+        # #677 slice 2: same rf-adjusted sharpe fix as tom_metrics above,
+        # applied to the parameter-sweep table (same file, same formula
+        # signature) so the sweep ranks (n_tail, n_head) combinations on
+        # the same basis as the published TOM metrics.
+        keep    <- !is.na(d$ret_net)
+        ret_vec <- d$ret_net[keep]
+        rf_vec  <- d$rf_ret[keep]
         n       <- length(ret_vec)
         if (n < 20L) return(NULL)
         years   <- n / 252
         cum     <- prod(1 + ret_vec)
         cagr    <- cum^(1 / years) - 1
         vol     <- sd(ret_vec) * sqrt(252)
-        sharpe  <- if (vol > 0) cagr / vol else NA_real_
+        sr      <- sharpe_ratio_rf(ret_vec, rf_vec, periods_per_year = 252L)
+        sharpe  <- sr$sharpe
         eq_c    <- cumprod(1 + ret_vec)
         max_dd  <- min(eq_c / cummax(eq_c) - 1)
         pct_in  <- mean(d$in_tom, na.rm = TRUE)
@@ -331,6 +372,66 @@ plan_turn_of_month <- function() {
 # ── Internal helper ────────────────────────────────────────────────────────────
 # Prefixed .tom_* (private; not exported from the package).
 # Mirrors .drif_register_runs() from plan_drif.R.
+
+#' Join daily risk-free rate onto TOM's daily return series (#677 slice 2)
+#'
+#' Mirrors \code{.ltr_join_rf()} (\code{R/plan_ltr_momentum.R}) but keyed on
+#' \code{date} at DAILY granularity instead of \code{ym} at monthly
+#' granularity -- TOM is a daily strategy (\code{sqrt(252)} annualisation).
+#'
+#' Per \code{fail-loud-not-null.md}, a missing risk-free rate must never be
+#' silently coerced to \code{NA}/zero. As with \code{.ltr_join_rf()}, a
+#' **trailing** uncovered date range (beyond \code{max(rf$date)}) is a Fama-
+#' French publication lag, not a defect -- it is TRIMMED with a loud, counted
+#' \code{cli_warn} naming the dropped range and the effective end date. An
+#' **interior** uncovered date range is a real hole in the FF3 series and
+#' \code{cli_abort}s.
+#'
+#' @param port Tibble with a `date` column (TOM's daily return series).
+#' @param rf Tibble with columns `date`, `rf_ret` (the `tom_rf_daily` target).
+#' @return `port` with `rf_ret` joined, trailing uncovered dates removed.
+#' @noRd
+.tom_join_rf_daily <- function(port, rf) {
+  required <- c("date", "rf_ret")
+  missing_cols <- setdiff(required, names(rf))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = ".tom_join_rf_daily(): rf is missing {length(missing_cols)} required column{?s}: {.field {missing_cols}}.",
+      "i" = "Expected a tibble with date and rf_ret (the tom_rf_daily target)."
+    ))
+  }
+  if (!"date" %in% names(port)) {
+    cli::cli_abort(c("x" = ".tom_join_rf_daily(): port has no {.field date} column to join on."))
+  }
+
+  port_date_range <- range(port$date)
+  port <- dplyr::left_join(port, rf, by = "date")
+
+  missing_rf_date <- sort(port$date[is.na(port$rf_ret)])
+  if (length(missing_rf_date) == 0L) return(port)
+
+  rf_max   <- max(rf$date)
+  interior <- missing_rf_date[missing_rf_date <= rf_max]
+
+  if (length(interior) > 0L) {
+    cli::cli_abort(c(
+      "x" = "{length(interior)} date{?s} inside tom_rf_daily's own span have no risk-free rate.",
+      "i" = "Missing date{?s}: {.val {format(interior)}}.",
+      "i" = "tom_rf_daily spans {min(rf$date)}..{rf_max}, so this is a HOLE in the series, not a publication lag.",
+      "i" = "Investigate the FF3 source (R/plan_stock_backtest.R's stk_rf pattern) before trusting any TOM Sharpe figure."
+    ))
+  }
+
+  n_before <- nrow(port)
+  port <- dplyr::filter(port, !is.na(.data$rf_ret))
+  cli::cli_warn(c(
+    "!" = "Dropped {n_before - nrow(port)} trailing date{?s} from tom_daily with no risk-free rate yet.",
+    "i" = "Dropped date range: {format(min(missing_rf_date))}..{format(max(missing_rf_date))}.",
+    "i" = "tom_daily spans {port_date_range[1]}..{port_date_range[2]}; tom_rf_daily ends {rf_max} (Fama-French publication lag).",
+    "i" = "Every TOM metric is therefore computed through {rf_max}, not {port_date_range[2]}."
+  ))
+  port
+}
 
 #' Register Turn-of-the-Month backtest run in the strategy registry
 #'

--- a/tests/testthat/_snaps/plan-turn-of-month.md
+++ b/tests/testthat/_snaps/plan-turn-of-month.md
@@ -1,0 +1,21 @@
+# .tom_join_rf_daily abort messages are stable
+
+    Code
+      .tom_join_rf_daily(port, .mk_rf_daily(c("2026-01-05", "2026-01-07")))
+    Condition
+      Error in `.tom_join_rf_daily()`:
+      x 1 date inside tom_rf_daily's own span have no risk-free rate.
+      i Missing date: "2026-01-06".
+      i tom_rf_daily spans 2026-01-05..2026-01-07, so this is a HOLE in the series, not a publication lag.
+      i Investigate the FF3 source (R/plan_stock_backtest.R's stk_rf pattern) before trusting any TOM Sharpe figure.
+
+---
+
+    Code
+      .tom_join_rf_daily(.mk_port_daily("2026-01-05"), tibble::tibble(date = as.Date(
+        "2026-01-05")))
+    Condition
+      Error in `.tom_join_rf_daily()`:
+      x .tom_join_rf_daily(): rf is missing 1 required column: rf_ret.
+      i Expected a tibble with date and rf_ret (the tom_rf_daily target).
+

--- a/tests/testthat/test-plan-bootstrap-ci.R
+++ b/tests/testthat/test-plan-bootstrap-ci.R
@@ -96,3 +96,45 @@ test_that("boot_metrics: sharpe is rf-adjusted, positive rf lowers sharpe vs zer
     expect_lt(sharpe_pos, sharpe_zero)
   }
 })
+
+# ── strat_names is derived, not enumerated (#677 slice 2 review) ────────────
+#
+# The first form of this migration hardcoded
+#   strat_names <- c("stk_max", "stk_drif", "fac_max", "fac_drif")
+# which would silently drop a fifth strategy from the bootstrap. These tests
+# pin the derived behaviour so it cannot regress to an enumerated list.
+
+.boot_strat_names <- function(cols) {
+  all_cols <- setdiff(cols, "ym")
+  all_cols[!grepl("_rf$", all_cols)]
+}
+
+test_that("boot strategy list is derived from the data, not hardcoded", {
+  cols <- c("ym", "stk_max", "stk_max_rf", "fac_max", "fac_max_rf")
+  expect_equal(.boot_strat_names(cols), c("stk_max", "fac_max"))
+})
+
+test_that("a NEW strategy column is picked up automatically", {
+  cols <- c("ym", "stk_max", "stk_max_rf", "brand_new", "brand_new_rf")
+  expect_true("brand_new" %in% .boot_strat_names(cols))
+  expect_length(.boot_strat_names(cols), 2L)
+})
+
+test_that("rf columns are never mistaken for strategies", {
+  cols <- c("ym", "stk_max", "stk_max_rf")
+  expect_false(any(grepl("_rf$", .boot_strat_names(cols))))
+})
+
+test_that("boot_metrics aborts when a strategy has no paired rf column", {
+  cmd <- .target_command(plan_bootstrap_ci(), "boot_metrics")
+  set.seed(677)
+  bad <- cbind(
+    stk_max    = rnorm(12, 0.01, 0.02),
+    stk_max_rf = rep(0.001, 12),
+    orphan     = rnorm(12, 0.01, 0.02)   # no orphan_rf
+  )
+  expect_error(
+    .eval_command(cmd, boot_draws = list(bad), sharpe_ratio_rf = sharpe_ratio_rf),
+    regexp = "orphan_rf"
+  )
+})

--- a/tests/testthat/test-plan-bootstrap-ci.R
+++ b/tests/testthat/test-plan-bootstrap-ci.R
@@ -1,0 +1,98 @@
+testthat::local_edition(3)
+# Regression tests for #677 slice 2: bootstrap Sharpe CI (R/plan_bootstrap_ci.R)
+# now uses the canonical, risk-free-adjusted sharpe_ratio_rf() instead of
+# bare cagr/vol (implied rf of exactly 0.00%, the same formula signature as
+# the rest of the "no rf deducted" family). Decision recorded in the PR:
+# this IS migrated, not left as an internal-only diagnostic, because
+# boot_ci_summary's "does the Sharpe CI cross zero" flag is a statistical-
+# inference display compared implicitly against the rf-adjusted Sharpe
+# published elsewhere for the same strategies (stk_max, stk_drif, fac_max,
+# fac_drif) -- using a no-rf Sharpe here would make that comparison biased
+# toward "significant" more often than warranted.
+
+source(here::here("R/plan_bootstrap_ci.R"))
+source(here::here("R/utils_metrics.R"))
+
+.target_command <- function(target_list, name) {
+  hit <- vapply(target_list, function(t) identical(t$settings$name, name), logical(1))
+  if (sum(hit) != 1L) {
+    stop("target '", name, "' not found (or not unique) in this plan's target list")
+  }
+  target_list[[which(hit)]]$command$expr[[1]]
+}
+
+.eval_command <- function(expr, ...) {
+  env <- list2env(list(...), envir = new.env(parent = globalenv()))
+  eval(expr, envir = env)
+}
+
+# ── boot_monthly_returns: carries each strategy's own rf_ret ─────────────
+
+.toy_stk_portfolio <- function(n = 36L, seed, rf_val) {
+  set.seed(seed)
+  yms <- format(seq(as.Date("2010-01-01"), by = "month", length.out = n), "%Y-%m")
+  tibble::tibble(ym = yms, port_ret = stats::rnorm(n, 0.005, 0.02), rf_ret = rep(rf_val, n))
+}
+.toy_fac_portfolio <- function(n = 36L, seed, rf_val) {
+  set.seed(seed)
+  yms <- format(seq(as.Date("2010-01-01"), by = "month", length.out = n), "%Y-%m")
+  tibble::tibble(ym = yms, portfolio_ret = stats::rnorm(n, 0.004, 0.025), rf_ret = rep(rf_val, n))
+}
+
+test_that("boot_monthly_returns: carries each strategy's own return AND rf_ret column", {
+  cmd <- .target_command(plan_bootstrap_ci(), "boot_monthly_returns")
+
+  result <- .eval_command(
+    cmd,
+    stk_max_portfolio  = .toy_stk_portfolio(seed = 1, rf_val = 0.002),
+    stk_drif_portfolio = .toy_stk_portfolio(seed = 2, rf_val = 0.002),
+    fm_portfolio        = .toy_fac_portfolio(seed = 3, rf_val = 0.002),
+    drif_portfolio       = .toy_fac_portfolio(seed = 4, rf_val = 0.002)
+  )
+
+  expect_true(all(c(
+    "ym", "stk_max", "stk_max_rf", "stk_drif", "stk_drif_rf",
+    "fac_max", "fac_max_rf", "fac_drif", "fac_drif_rf"
+  ) %in% names(result)))
+  expect_false(anyNA(result$stk_max_rf))
+  expect_false(anyNA(result$fac_max_rf))
+})
+
+# ── boot_metrics: rf deduction actually lowers Sharpe ────────────────────
+
+.toy_boot_draws <- function(n = 60L, seed = 677L, rf_val = 0) {
+  set.seed(seed)
+  mat <- cbind(
+    stk_max     = stats::rnorm(n, 0.006, 0.02),
+    stk_drif    = stats::rnorm(n, 0.005, 0.022),
+    fac_max     = stats::rnorm(n, 0.004, 0.018),
+    fac_drif    = stats::rnorm(n, 0.0045, 0.019),
+    stk_max_rf  = rep(rf_val, n),
+    stk_drif_rf = rep(rf_val, n),
+    fac_max_rf  = rep(rf_val, n),
+    fac_drif_rf = rep(rf_val, n)
+  )
+  list(mat)  # single "draw" is enough to exercise calc_boot_metrics()
+}
+
+test_that("boot_metrics: sharpe is rf-adjusted, positive rf lowers sharpe vs zero-rf", {
+  cmd <- .target_command(plan_bootstrap_ci(), "boot_metrics")
+
+  res_zero <- .eval_command(
+    cmd, boot_draws = .toy_boot_draws(rf_val = 0), sharpe_ratio_rf = sharpe_ratio_rf
+  )
+  res_pos <- .eval_command(
+    cmd, boot_draws = .toy_boot_draws(rf_val = 0.003), sharpe_ratio_rf = sharpe_ratio_rf
+  )
+
+  expect_equal(nrow(res_zero), 4L)
+  expect_equal(nrow(res_pos), 4L)
+  expect_false(anyNA(res_zero$sharpe))
+  expect_false(anyNA(res_pos$sharpe))
+
+  for (strat in c("stk_max", "stk_drif", "fac_max", "fac_drif")) {
+    sharpe_zero <- res_zero$sharpe[res_zero$strategy == strat]
+    sharpe_pos  <- res_pos$sharpe[res_pos$strategy == strat]
+    expect_lt(sharpe_pos, sharpe_zero)
+  }
+})

--- a/tests/testthat/test-plan-ev-ebit.R
+++ b/tests/testthat/test-plan-ev-ebit.R
@@ -1,0 +1,126 @@
+testthat::local_edition(3)
+# Regression tests for #677 slice 2: canonical, risk-free-adjusted Sharpe
+# for EV/EBIT Value (R/plan_ev_ebit.R) -- one of the "no rf deducted"
+# family (implied rf of exactly 0.00%, a formula signature).
+#
+# Pattern mirrors tests/testthat/test-plan-ltr-momentum.R (#677 slice 1).
+
+source(here::here("R/plan_ev_ebit.R"))
+source(here::here("R/utils_metrics.R"))
+
+.target_command <- function(target_list, name) {
+  hit <- vapply(target_list, function(t) identical(t$settings$name, name), logical(1))
+  if (sum(hit) != 1L) {
+    stop("target '", name, "' not found (or not unique) in this plan's target list")
+  }
+  target_list[[which(hit)]]$command$expr[[1]]
+}
+
+.eval_command <- function(expr, ...) {
+  env <- list2env(list(...), envir = new.env(parent = globalenv()))
+  eval(expr, envir = env)
+}
+
+# NOTE: cannot use do.call(.eval_command, c(list(cmd), args_list)) here --
+# `cmd` is itself an unevaluated language object (a `{ ... }` block), and
+# do.call() re-evaluates language-object arguments in the CALLING frame
+# rather than passing them through as literal data, which resolves free
+# variables like `ev_params` against the wrong environment and errors.
+# Splicing via a plain list2env() call sidesteps the issue entirely.
+.eval_command_args <- function(expr, args_list) {
+  env <- list2env(args_list, envir = new.env(parent = globalenv()))
+  eval(expr, envir = env)
+}
+
+.toy_ev_portfolios <- function(n_months = 780L, seed = 677L, rf_val = 0.002) {
+  set.seed(seed)
+  dates <- seq(as.Date("1960-01-01"), by = "month", length.out = n_months)
+  tibble::tibble(
+    date           = dates,
+    ret_value_hml  = stats::rnorm(n_months, mean = 0.005, sd = 0.02),
+    ret_value_qual = stats::rnorm(n_months, mean = 0.006, sd = 0.025),
+    ret_market     = stats::rnorm(n_months, mean = 0.007, sd = 0.03),
+    RF             = rep(rf_val, n_months)
+  )
+}
+
+.ev_env_args <- function(port) {
+  list(
+    ev_params = list(
+      oos_start      = as.Date("2010-01-01"),
+      quality_weight = 0.5
+    ),
+    bt_partitions = list(factor = list(test_end = as.Date("2020-12-31"))),
+    ev_portfolios = port,
+    sharpe_ratio_rf = sharpe_ratio_rf
+  )
+}
+
+# ── ev_metrics: rf deduction actually lowers Sharpe ─────────────────────
+
+test_that("ev_metrics: Full-period sharpe is rf-adjusted, not bare cagr/vol", {
+  cmd <- .target_command(plan_ev_ebit(), "ev_metrics")
+
+  port_zero_rf <- .toy_ev_portfolios(rf_val = 0)
+  port_pos_rf  <- .toy_ev_portfolios(rf_val = 0.003)
+
+  res_zero <- .eval_command_args(cmd, .ev_env_args(port_zero_rf))
+  res_pos  <- .eval_command_args(cmd, .ev_env_args(port_pos_rf))
+
+  full_zero <- res_zero[res_zero$strategy == "Value+Quality (50% HML + 50% RMW, QVAL proxy)" &
+                           res_zero$period == "Full", ]
+  full_pos <- res_pos[res_pos$strategy == "Value+Quality (50% HML + 50% RMW, QVAL proxy)" &
+                         res_pos$period == "Full", ]
+
+  expect_equal(nrow(full_zero), 1L)
+  expect_equal(nrow(full_pos), 1L)
+  expect_false(is.na(full_zero$sharpe))
+  expect_false(is.na(full_pos$sharpe))
+  expect_lt(full_pos$sharpe, full_zero$sharpe)
+})
+
+test_that("ev_metrics: Training and OOS rows are still produced", {
+  cmd <- .target_command(plan_ev_ebit(), "ev_metrics")
+  port <- .toy_ev_portfolios()
+
+  result <- .eval_command_args(cmd, .ev_env_args(port))
+
+  expect_true(all(c("Full", "Training", "OOS") %in% result$period))
+  expect_false(anyNA(result$sharpe))
+})
+
+# ── ev_underperformance_periods: same rf-adjusted fix ────────────────────
+
+test_that("ev_underperformance_periods: rf deduction lowers sharpe vs zero-rf", {
+  cmd <- .target_command(plan_ev_ebit(), "ev_underperformance_periods")
+
+  port_zero_rf <- .toy_ev_portfolios(rf_val = 0)
+  port_pos_rf  <- .toy_ev_portfolios(rf_val = 0.003)
+
+  res_zero <- .eval_command_args(cmd, .ev_env_args(port_zero_rf))
+  res_pos  <- .eval_command_args(cmd, .ev_env_args(port_pos_rf))
+
+  row_zero <- res_zero[res_zero$strategy == "Value+Quality" &
+                          res_zero$period == "2000-2012 (Value underperformance)", ]
+  row_pos <- res_pos[res_pos$strategy == "Value+Quality" &
+                        res_pos$period == "2000-2012 (Value underperformance)", ]
+
+  expect_equal(nrow(row_zero), 1L)
+  expect_equal(nrow(row_pos), 1L)
+  expect_lt(row_pos$sharpe, row_zero$sharpe)
+})
+
+test_that("ev_underperformance_periods: all documented eras are present", {
+  cmd <- .target_command(plan_ev_ebit(), "ev_underperformance_periods")
+  port <- .toy_ev_portfolios()
+
+  result <- .eval_command_args(cmd, .ev_env_args(port))
+
+  expect_true(all(c(
+    "Pre-1966 (Value leadership)",
+    "1966-1982 (Value underperformance)",
+    "1983-1999 (Value recovery)",
+    "2000-2012 (Value underperformance)",
+    "2013+ (Recent period)"
+  ) %in% result$period))
+})

--- a/tests/testthat/test-plan-managed-futures.R
+++ b/tests/testthat/test-plan-managed-futures.R
@@ -1,0 +1,133 @@
+testthat::local_edition(3)
+# Regression tests for #677 slice 2: canonical, risk-free-adjusted Sharpe
+# for Managed Futures (R/plan_managed_futures.R) -- one of the "no rf
+# deducted" family (implied rf of exactly 0.00%, a formula signature).
+#
+# Pattern mirrors tests/testthat/test-plan-ltr-momentum.R (#677 slice 1):
+# the real shipped command expression is extracted from plan_managed_futures()
+# and eval()'d against synthetic mf_portfolios data, exercising the actual
+# shipped code rather than a re-implementation.
+
+source(here::here("R/plan_managed_futures.R"))
+source(here::here("R/utils_metrics.R"))
+
+.target_command <- function(target_list, name) {
+  hit <- vapply(target_list, function(t) identical(t$settings$name, name), logical(1))
+  if (sum(hit) != 1L) {
+    stop("target '", name, "' not found (or not unique) in this plan's target list")
+  }
+  target_list[[which(hit)]]$command$expr[[1]]
+}
+
+.eval_command <- function(expr, ...) {
+  env <- list2env(list(...), envir = new.env(parent = globalenv()))
+  eval(expr, envir = env)
+}
+
+# NOTE: cannot use do.call(.eval_command, c(list(cmd), args_list)) here --
+# `cmd` is itself an unevaluated language object (a `{ ... }` block), and
+# do.call() re-evaluates language-object arguments in the CALLING frame
+# rather than passing them through as literal data, which resolves free
+# variables like `mf_params` against the wrong environment and errors.
+# Splicing via a plain list2env() call sidesteps the issue entirely.
+.eval_command_args <- function(expr, args_list) {
+  env <- list2env(args_list, envir = new.env(parent = globalenv()))
+  eval(expr, envir = env)
+}
+
+.toy_mf_portfolios <- function(n_months = 260L, seed = 677L, rf_val = 0.002) {
+  set.seed(seed)
+  dates <- seq(as.Date("2005-01-01"), by = "month", length.out = n_months)
+  tibble::tibble(
+    date   = dates,
+    ret_lo = stats::rnorm(n_months, mean = 0.005, sd = 0.02),
+    ret_ls = stats::rnorm(n_months, mean = 0.006, sd = 0.03),
+    ret_ew = stats::rnorm(n_months, mean = 0.004, sd = 0.025),
+    RF     = rep(rf_val, n_months)
+  )
+}
+
+.mf_env_args <- function(port) {
+  list(
+    mf_params = list(
+      oos_start  = as.Date("2010-01-01"),
+      vol_target = 0.10,
+      proxy_note = "toy"
+    ),
+    bt_partitions = list(macro = list(test_end = as.Date("2020-12-31"))),
+    mf_portfolios = port,
+    sharpe_ratio_rf = sharpe_ratio_rf
+  )
+}
+
+# ── mf_metrics: rf deduction actually lowers Sharpe ─────────────────────
+
+test_that("mf_metrics: Full-period sharpe is rf-adjusted, not bare cagr/vol", {
+  cmd <- .target_command(plan_managed_futures(), "mf_metrics")
+
+  port_zero_rf <- .toy_mf_portfolios(rf_val = 0)
+  port_pos_rf  <- .toy_mf_portfolios(rf_val = 0.003)
+
+  res_zero <- .eval_command_args(cmd, .mf_env_args(port_zero_rf))
+  res_pos  <- .eval_command_args(cmd, .mf_env_args(port_pos_rf))
+
+  full_zero <- res_zero[res_zero$strategy == "Long-Short TS-Mom (MOP 2012, vol-targeted)" &
+                           res_zero$period == "Full", ]
+  full_pos <- res_pos[res_pos$strategy == "Long-Short TS-Mom (MOP 2012, vol-targeted)" &
+                         res_pos$period == "Full", ]
+
+  expect_equal(nrow(full_zero), 1L)
+  expect_equal(nrow(full_pos), 1L)
+  expect_false(is.na(full_zero$sharpe))
+  expect_false(is.na(full_pos$sharpe))
+
+  # A positive risk-free deduction must LOWER the reported Sharpe relative
+  # to the zero-rf case computed on the SAME return series (#677: the
+  # pre-fix formula was cagr/vol with implied rf == 0.00% always).
+  expect_lt(full_pos$sharpe, full_zero$sharpe)
+})
+
+test_that("mf_metrics: Training and OOS rows are still produced", {
+  cmd <- .target_command(plan_managed_futures(), "mf_metrics")
+  port <- .toy_mf_portfolios()
+
+  result <- .eval_command_args(cmd, .mf_env_args(port))
+
+  expect_true(all(c("Full", "Training", "OOS") %in% result$period))
+  expect_false(anyNA(result$sharpe))
+})
+
+# ── mf_underperformance_periods: same rf-adjusted fix ────────────────────
+
+test_that("mf_underperformance_periods: rf deduction lowers sharpe vs zero-rf", {
+  cmd <- .target_command(plan_managed_futures(), "mf_underperformance_periods")
+
+  port_zero_rf <- .toy_mf_portfolios(rf_val = 0)
+  port_pos_rf  <- .toy_mf_portfolios(rf_val = 0.003)
+
+  res_zero <- .eval_command_args(cmd, .mf_env_args(port_zero_rf))
+  res_pos  <- .eval_command_args(cmd, .mf_env_args(port_pos_rf))
+
+  row_zero <- res_zero[res_zero$strategy == "TS-Mom L/S" &
+                          res_zero$period == "2010-2019 (trend-following drought)", ]
+  row_pos <- res_pos[res_pos$strategy == "TS-Mom L/S" &
+                        res_pos$period == "2010-2019 (trend-following drought)", ]
+
+  expect_equal(nrow(row_zero), 1L)
+  expect_equal(nrow(row_pos), 1L)
+  expect_lt(row_pos$sharpe, row_zero$sharpe)
+})
+
+test_that("mf_underperformance_periods: all documented eras are present", {
+  cmd <- .target_command(plan_managed_futures(), "mf_underperformance_periods")
+  port <- .toy_mf_portfolios()
+
+  result <- .eval_command_args(cmd, .mf_env_args(port))
+
+  expect_true(all(c(
+    "Pre-2010 (GFC, high dispersion)",
+    "2010-2019 (trend-following drought)",
+    "2020-2022 (COVID + rates surge)",
+    "2023+ (recent period)"
+  ) %in% result$period))
+})

--- a/tests/testthat/test-plan-turn-of-month.R
+++ b/tests/testthat/test-plan-turn-of-month.R
@@ -1,0 +1,186 @@
+testthat::local_edition(3)
+# Regression tests for #677 slice 2: canonical, risk-free-adjusted Sharpe
+# for Turn-of-the-Month (R/plan_turn_of_month.R) -- one of the "no rf
+# deducted" family (implied rf of exactly 0.00%, a formula signature). TOM
+# is a DAILY strategy, so it gets its own daily rf join
+# (.tom_join_rf_daily(), mirroring .ltr_join_rf() from plan_ltr_momentum.R
+# but keyed on `date` instead of `ym`) and periods_per_year = 252L.
+
+source(here::here("R/plan_turn_of_month.R"))
+source(here::here("R/utils_metrics.R"))
+
+.target_command <- function(target_list, name) {
+  hit <- vapply(target_list, function(t) identical(t$settings$name, name), logical(1))
+  if (sum(hit) != 1L) {
+    stop("target '", name, "' not found (or not unique) in this plan's target list")
+  }
+  target_list[[which(hit)]]$command$expr[[1]]
+}
+
+.eval_command <- function(expr, ...) {
+  env <- list2env(list(...), envir = new.env(parent = globalenv()))
+  eval(expr, envir = env)
+}
+
+# NOTE: cannot use do.call(.eval_command, c(list(cmd), args_list)) here --
+# `cmd` is itself an unevaluated language object (a `{ ... }` block), and
+# do.call() re-evaluates language-object arguments in the CALLING frame
+# rather than passing them through as literal data, which resolves free
+# variables like `tom_params` against the wrong environment and errors.
+# Splicing via a plain list2env() call sidesteps the issue entirely.
+.eval_command_args <- function(expr, args_list) {
+  env <- list2env(args_list, envir = new.env(parent = globalenv()))
+  eval(expr, envir = env)
+}
+
+# ── .tom_join_rf_daily() coverage policy (mirrors .ltr_join_rf tests) ────
+
+.mk_port_daily <- function(dates) {
+  tibble::tibble(date = as.Date(dates), ret = seq_along(dates) / 10000)
+}
+.mk_rf_daily <- function(dates) {
+  tibble::tibble(date = as.Date(dates), rf_ret = rep(0.0001, length(dates)))
+}
+
+test_that(".tom_join_rf_daily attaches rf_ret with no NA when coverage is complete", {
+  out <- .tom_join_rf_daily(
+    .mk_port_daily(c("2026-01-05", "2026-01-06")),
+    .mk_rf_daily(c("2026-01-05", "2026-01-06"))
+  )
+  expect_equal(nrow(out), 2L)
+  expect_false(anyNA(out$rf_ret))
+})
+
+test_that(".tom_join_rf_daily trims a trailing uncovered date and warns", {
+  port <- .mk_port_daily(c("2026-01-05", "2026-01-06", "2026-01-07"))
+  rf   <- .mk_rf_daily(c("2026-01-05", "2026-01-06"))
+
+  expect_warning(out <- .tom_join_rf_daily(port, rf), regexp = "2026-01-07")
+  expect_equal(nrow(out), 2L)
+  expect_false(anyNA(out$rf_ret))
+  expect_false(as.Date("2026-01-07") %in% out$date)
+})
+
+test_that(".tom_join_rf_daily still aborts on an INTERIOR hole -- a real FF3 gap, not a lag", {
+  port <- .mk_port_daily(c("2026-01-05", "2026-01-06", "2026-01-07"))
+  rf   <- .mk_rf_daily(c("2026-01-05", "2026-01-07"))  # 2026-01-06 missing, inside span
+
+  expect_error(.tom_join_rf_daily(port, rf), regexp = "2026-01-06")
+  expect_error(.tom_join_rf_daily(port, rf), regexp = "HOLE")
+})
+
+test_that(".tom_join_rf_daily aborts when rf lacks required columns", {
+  expect_error(
+    .tom_join_rf_daily(.mk_port_daily("2026-01-05"), tibble::tibble(date = as.Date("2026-01-05"))),
+    regexp = "rf_ret"
+  )
+})
+
+test_that(".tom_join_rf_daily abort messages are stable", {
+  port <- .mk_port_daily(c("2026-01-05", "2026-01-06", "2026-01-07"))
+  expect_snapshot(error = TRUE, .tom_join_rf_daily(port, .mk_rf_daily(c("2026-01-05", "2026-01-07"))))
+  expect_snapshot(
+    error = TRUE,
+    .tom_join_rf_daily(.mk_port_daily("2026-01-05"), tibble::tibble(date = as.Date("2026-01-05")))
+  )
+})
+
+# ── tom_metrics: rf deduction actually lowers Sharpe ─────────────────────
+
+.toy_tom_portfolio <- function(n_days = 3000L, seed = 677L, rf_val = 0.0001) {
+  set.seed(seed)
+  dates <- seq(as.Date("2000-01-01"), by = "day", length.out = n_days)
+  tibble::tibble(
+    date    = dates,
+    ret     = stats::rnorm(n_days, mean = 0.0002, sd = 0.012),
+    ret_net = stats::rnorm(n_days, mean = 0.0003, sd = 0.006),
+    in_tom  = sample(c(TRUE, FALSE), n_days, replace = TRUE, prob = c(0.2, 0.8)),
+    rf_ret  = rep(rf_val, n_days)
+  )
+}
+
+.tom_env_args <- function(port) {
+  list(
+    tom_portfolio = port,
+    tom_params = list(
+      oos_start = as.Date("2004-01-01"),
+      oos_end   = as.Date("2006-12-31")
+    ),
+    sharpe_ratio_rf = sharpe_ratio_rf
+  )
+}
+
+test_that("tom_metrics: Full Period sharpe_tom/sharpe_bh are rf-adjusted, not bare cagr/vol", {
+  cmd <- .target_command(plan_turn_of_month(), "tom_metrics")
+
+  port_zero_rf <- .toy_tom_portfolio(rf_val = 0)
+  port_pos_rf  <- .toy_tom_portfolio(rf_val = 0.0002)
+
+  res_zero <- .eval_command_args(cmd, .tom_env_args(port_zero_rf))
+  res_pos  <- .eval_command_args(cmd, .tom_env_args(port_pos_rf))
+
+  full_zero <- res_zero[res_zero$period == "Full Period", ]
+  full_pos  <- res_pos[res_pos$period == "Full Period", ]
+
+  expect_equal(nrow(full_zero), 1L)
+  expect_equal(nrow(full_pos), 1L)
+  expect_false(is.na(full_zero$sharpe_tom))
+  expect_false(is.na(full_pos$sharpe_tom))
+  expect_false(is.na(full_zero$sharpe_bh))
+  expect_false(is.na(full_pos$sharpe_bh))
+
+  # A positive risk-free deduction must LOWER both the strategy and
+  # benchmark Sharpe relative to the zero-rf case (#677: the pre-fix
+  # formula was cagr/vol with implied rf == 0.00% always).
+  expect_lt(full_pos$sharpe_tom, full_zero$sharpe_tom)
+  expect_lt(full_pos$sharpe_bh, full_zero$sharpe_bh)
+})
+
+test_that("tom_metrics: Training and Testing rows are still produced", {
+  cmd <- .target_command(plan_turn_of_month(), "tom_metrics")
+  port <- .toy_tom_portfolio()
+
+  result <- .eval_command_args(cmd, .tom_env_args(port))
+
+  expect_true(all(c("Training", "Testing", "Full Period") %in% result$period))
+  expect_false(anyNA(result$sharpe_tom))
+  expect_false(anyNA(result$sharpe_bh))
+})
+
+# ── tom_param_sweep: same rf-adjusted fix ─────────────────────────────────
+
+.toy_tom_daily <- function(n_days = 3000L, seed = 677L, rf_val = 0.0001) {
+  set.seed(seed)
+  dates <- seq(as.Date("2000-01-01"), by = "day", length.out = n_days)
+  tibble::tibble(
+    date   = dates,
+    ret    = stats::rnorm(n_days, mean = 0.0003, sd = 0.012),
+    rf_ret = rep(rf_val, n_days)
+  )
+}
+
+test_that("tom_param_sweep: sharpe is rf-adjusted, positive rf lowers sharpe vs zero-rf", {
+  cmd <- .target_command(plan_turn_of_month(), "tom_param_sweep")
+
+  base_args <- function(daily) {
+    list(
+      tom_daily = daily,
+      tom_params = list(rf_annual = 0.00, cost_bps = 5L),
+      sharpe_ratio_rf = sharpe_ratio_rf
+    )
+  }
+
+  res_zero <- .eval_command_args(cmd, base_args(.toy_tom_daily(rf_val = 0)))
+  res_pos  <- .eval_command_args(cmd, base_args(.toy_tom_daily(rf_val = 0.0002)))
+
+  # Same (n_tail=1, n_head=3) row -- matches tom_params defaults -- compared
+  # across the two rf scenarios.
+  row_zero <- res_zero[res_zero$n_tail == 1L & res_zero$n_head == 3L, ]
+  row_pos  <- res_pos[res_pos$n_tail == 1L & res_pos$n_head == 3L, ]
+
+  expect_equal(nrow(row_zero), 1L)
+  expect_equal(nrow(row_pos), 1L)
+  expect_false(is.na(row_zero$sharpe))
+  expect_false(is.na(row_pos$sharpe))
+  expect_lt(row_pos$sharpe, row_zero$sharpe)
+})


### PR DESCRIPTION
## Summary

Slice 2 of #677's fix plan: migrate the "no rf deducted" family — Managed
Futures, Value (HML/EV-EBIT), and Turn-of-the-Month — onto the canonical
`sharpe_ratio_rf()` helper (`R/utils_metrics.R`, added in slice 1). These
three strategies computed `sharpe = cagr / vol` with **no risk-free
deduction at all** — an implied rf of exactly 0.00%, the formula signature
#677 used to identify this family.

Also migrates `R/plan_bootstrap_ci.R`'s `boot_metrics` — see the "Decision:
plan_bootstrap_ci.R" section below for why, per the task's caution against
migrating it reflexively just because it matched the grep.

## Per-strategy before/after

**I could not obtain real before/after numbers.** Per the dispatch
instructions I did not run `tar_make()` (targets-store conflict with
parallel agents), so there is no real build of `mf_metrics` / `ev_metrics`
/ `tom_metrics` against live data to diff against the published leaderboard
values quoted in the issue. What I verified instead:

- **Formula correctness**: new regression tests extract each target's real
  shipped command expression (not a re-implementation) and assert that a
  *positive* risk-free deduction **lowers** the reported Sharpe relative to
  a *zero*-rf case computed on the identical return series. All three
  strategies (plus `boot_metrics`) pass this on synthetic data.
- **Direction**: the issue's own table already establishes the rough
  magnitude for context — Family A's genuine rf deductions ranged from
  ~+1.4% to ~+4.4% (`plan_factormax.R`/`plan_drif.R`, same underlying FF3/FF5
  RF series this PR now also joins into Managed Futures/EV/TOM). Applying a
  similarly-sized deduction to the published figures gives a rough
  qualitative sense:

  | strategy | cagr (published) | vol (published) | sharpe now (published, no-rf) | plausible sharpe after (rough, rf~1.5-4%) |
  |---|---|---|---|---|
  | Managed Futures | 4.37 | 6.21 | 0.704 | roughly 0.5-0.5 lower band, could approach ~0.3-0.5 |
  | Value (HML) | 5.07 | 10.39 | 0.488 | smaller relative hit given larger vol, roughly ~0.35-0.45 |
  | TOM | 2.24 | 8.01 | 0.280 | smallest cushion — could approach or cross zero |

  **This table is illustrative, not computed** — I do not have the actual
  historical FF3/FF5 monthly/daily RF series values in this sandbox (no
  live data fetch was run). Treat it as "sharpe will fall, TOM has the
  least room" and nothing more precise.

**Action needed from the orchestrator**: rebuild the pipeline
(`tar_make()`) and diff `mf_metrics`/`ev_metrics`/`tom_metrics`/
`tom_param_sweep`/`boot_ci_summary` against the pre-#677 values quoted in
the issue table to get the real before/after. Per #680, `scripts/verify.sh`
passing does **not** prove the pipeline builds — also check
`tar_meta(fields = error)` after the rebuild.

## rf series used, per strategy

| strategy | rf source | frequency | how joined |
|---|---|---|---|
| Managed Futures | FF5 `RF` (already present as `mf_portfolios$RF`, joined via `mf_data`'s existing `inner_join` with FF5) | monthly | no new join needed — column was already there, just unused by the Sharpe formula |
| Value (HML/EV-EBIT) | FF5 `RF` (already present as `ev_portfolios$RF`, pivoted directly out of FF5 in `ev_data`) | monthly | no new join needed, same reason |
| TOM | FF3 daily `RF` — **new** `tom_rf_daily` target (mirrors `stk_rf`'s FF3 pattern but stays at daily granularity instead of compounding to monthly, since TOM annualises with `sqrt(252)`) | daily | new `.tom_join_rf_daily()` join, keyed on `date` |
| `plan_bootstrap_ci.R` (`boot_metrics`) | each strategy's own already-joined `rf_ret` column (`stk_max_portfolio$rf_ret`, `stk_drif_portfolio$rf_ret`, `fm_portfolio$rf_ret`, `drif_portfolio$rf_ret` — all four already carry it upstream) | monthly | added to `boot_monthly_returns`' `select()`; block-resampling in `boot_draws` preserves return/rf pairing automatically (same row indices applied across all 8 columns of one matrix) |

I did not touch `R/plan_stock_backtest.R`, `R/plan_factormax.R`, or
`R/plan_drif.R` — I only read already-existing `rf_ret`/`RF` columns they
produce.

## Decision: `plan_bootstrap_ci.R`

**Migrated it**, not skipped. Reasoning: `boot_ci_summary`'s
`ci_crosses_zero` flag exists specifically to answer "is this strategy's
Sharpe statistically distinguishable from zero" for `stk_max`, `stk_drif`,
`fac_max`, `fac_drif` — strategies whose *real* Sharpe is published
elsewhere on the leaderboard using the rf-adjusted definition (Factor
MAX/DRIF are Family A from slice 1; Stock MAX/DRIF were flagged "A-like" in
the issue with a nonzero implied rf already). Bootstrapping the no-rf
statistic here would give a **systematically inflated** Sharpe distribution
relative to what the leaderboard actually claims for the same strategy,
making the "does the CI cross zero" answer more optimistic than warranted —
the same class of defect the rest of #677 addresses, just on a diagnostic
display rather than a leaderboard row. This is a judgment call, not the
"reflexive migration" the task warned against: I treated it as in-scope
specifically *because* it is a statistical-inference display compared
implicitly against the rf-adjusted Sharpe, not because the formula merely
matched the grep.

## Coverage handling

- **Managed Futures / Value**: no new coverage-gap logic needed — both
  reuse an `RF` column that was already fully joined by an existing
  `inner_join` upstream (`mf_data`, `ev_data`). Any gap-handling behavior
  there is pre-existing and out of scope for this PR.
- **TOM**: new `.tom_join_rf_daily()` mirrors `.ltr_join_rf()`'s policy —
  a **trailing** uncovered date range (beyond `max(tom_rf_daily$date)`,
  i.e. FF3's publication lag) is trimmed with a loud, counted `cli_warn`
  naming the dropped range and the effective end date; an **interior**
  uncovered date range aborts with `cli_abort`, naming the hole and
  pointing at the FF3 source. Does **not** abort on any gap (the #678
  regression this PR must not repeat).
- **`plan_bootstrap_ci.R`**: no new join — reuses `rf_ret` columns already
  covered (or not) by their producing targets; out of scope to change that
  policy here.

## Tests

4 new files, 60 assertions total, all passing:

- `tests/testthat/test-plan-managed-futures.R` — `mf_metrics` and
  `mf_underperformance_periods`, extracting the real shipped command via
  the `.target_command()`/`.eval_command_args()` pattern from
  `test-plan-ltr-momentum.R` (slice 1).
- `tests/testthat/test-plan-ev-ebit.R` — same pattern for `ev_metrics` /
  `ev_underperformance_periods`.
- `tests/testthat/test-plan-turn-of-month.R` — `.tom_join_rf_daily()`
  coverage-policy tests (complete/trailing-trim/interior-abort/missing-
  column/snapshot, mirroring `.ltr_join_rf()`'s), plus `tom_metrics` and
  `tom_param_sweep` rf-adjustment tests.
- `tests/testthat/test-plan-bootstrap-ci.R` — `boot_monthly_returns` column
  carry-through and `boot_metrics` rf-adjustment tests.

All new `cli_abort()` messages have `expect_snapshot(error = TRUE, ...)`
coverage; `tests/testthat/_snaps/plan-turn-of-month.md` is committed
alongside.

Root test files start with `testthat::local_edition(3)`.

## Verify

`parse("_targets.R")` succeeded. `scripts/verify.sh` (foreground,
~10 min): **PASS**.

```
=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly (test-crypto-momentum.R,
test-qa-summary-deps.R, test-stock-backtest.R)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly (test-mom-prepeak-portfolio.R)

=== scripts/verify.sh: PASS ===
```

Root suite total went from baseline 474 to 492 (+18, expectations added by
the 4 new test files); package suite unchanged at total=694. No new
failures or skips beyond the documented baseline in either suite.

## Unverified / left out

- **Real before/after leaderboard numbers** — see above; needs a real
  `tar_make()` rebuild, which this dispatch was told not to run.
- Did not run `~/.claude/scripts/r_code_check.sh` (ast-grep unavailable in
  this sandbox — it requires the separate `llm` project's nix shell). This
  project's own canonical gate, `scripts/verify.sh`, was run and passed.
- Per #680: `scripts/verify.sh` passing does not prove the pipeline
  builds. Orchestrator should run `tar_make()` and check
  `tar_meta(fields = error)` post-merge.

## Out of scope (confirmed untouched)

Slice 3 (arithmetic family: `plan_backtest.R`, `plan_commodities_mean_reversion.R`,
`plan_avoid_worst.R`) and slice 4 (gate S17). Also did not touch
`R/plan_risk_state.R`, `.claude/CLAUDE.md`,
`packages/historicaldata/R/utils_mom_prepeak_metrics.R` (other agents'
scope), or `R/plan_stock_backtest.R`, `R/plan_factormax.R`, `R/plan_drif.R`
(read-only references to their already-existing `rf_ret`/`RF` columns).

Closes part of #677 (slice 2 of 4).
