### PR TITLE
fix(rf): restore pipeline — stop scoping the shared risk-free series to the stock backtest's window

### DIFF
--- a/R/plan_stock_backtest.R
+++ b/R/plan_stock_backtest.R
@@ -560,15 +560,50 @@ plan_stock_backtest <- function() {
     }),
 
     # ── Group 1: Risk-free rate (monthly) ─────────────────────────
+    # #677: stk_rf is no longer the stock backtest's private risk-free series.
+    # It is now the SHARED monthly rf consumed by ltr_portfolio
+    # (R/plan_ltr_momentum.R), cmr_metrics_* (R/plan_commodities_mean_reversion.R)
+    # and the three mom_prepeak siblings (R/plan_mom_prepeak.R) after those
+    # strategies migrated onto the canonical rf-adjusted Sharpe.
+    #
+    # It was fetched `from = stk_params$start_date` (2005-01) -- the stock
+    # backtest's own window. That truncation is invisible while only the stock
+    # backtest reads it, and fatal once anything with a longer history does:
+    # mom_prepeak's returns start 1973-02 and CMR's 1992-03, so on the first
+    # build after slice 3 those targets aborted with 383 and 1367 "months
+    # inside stk_rf's own span have no risk-free rate", taking `leaderboard`
+    # down with them.
+    #
+    # FF3 daily RF is available 1926-07-01..2026-02-27 (verified), so the data
+    # was always there -- only this filter was hiding it. Fetch the full
+    # series: a shared reference series must not be scoped to one consumer's
+    # window. Widening is safe for existing consumers, which all left_join by
+    # `ym` and simply ignore the extra earlier months.
     targets::tar_target(stk_rf, {
       library(dplyr)
 
-      hd_factors(dataset = "FF3", frequency = "daily",
-                 from = as.character(stk_params$start_date)) |>
+      # FF3's earliest available date, NOT any single strategy's start_date.
+      RF_SERIES_START <- "1926-07-01"
+
+      out <- hd_factors(dataset = "FF3", frequency = "daily",
+                        from = RF_SERIES_START) |>
         filter(factor_name == "RF") |>
         mutate(value = value / 100, ym = format(date, "%Y-%m")) |>
         group_by(ym) |>
         summarise(rf_ret = prod(1 + value) - 1, .groups = "drop")
+
+      if (nrow(out) == 0L || anyNA(out$rf_ret)) {
+        cli::cli_abort(c(
+          "x" = "stk_rf came back empty or with NA rf_ret.",
+          "i" = "Rows: {nrow(out)}; NA rf_ret: {sum(is.na(out$rf_ret))}.",
+          "i" = "Every strategy's Sharpe depends on this series -- check the FF3 source before proceeding."
+        ))
+      }
+
+      cli::cli_inform(c(
+        "v" = "stk_rf: {nrow(out)} months, {min(out$ym)}..{max(out$ym)} (shared rf series, #677)."
+      ))
+      out
     }),
 
     # ── Group 1: Monthly ADV per ticker (for ADV participation cap) ──


### PR DESCRIPTION
**`main` is broken.** The first `tar_make` after #677 slice 3 (PR #683) errored 9 targets, including `leaderboard`:

```
x cmr_metrics_1m/3m/6m -- 1377/1373/1367 months inside stk_rf's own span
  have no risk-free rate. Missing ym: '1992-03' .. '2004-12'.
x mom_prepeak/postpeak/combined/random_peak_metrics -- 383 months.
  Missing ym: '1973-02' .. '2004-12'.
x mom_prepeak_random_peak_test, leaderboard -- dependency failures.
```

## Root cause — not the coverage policy

`stk_rf` was fetched:

```r
from = as.character(stk_params$start_date)   # 2005-01
```

i.e. scoped to the **stock backtest's own window**. That is invisible while the stock backtest is its only reader, and fatal the moment anything with a longer history reads it. Slices 1–3 made `stk_rf` the shared risk-free series for LTR (2005+), CMR (1992-03+) and the three mom_prepeak siblings (1973-02+).

FF3 daily RF is available **1926-07-01 .. 2026-02-27**, verified against the live source. The data was always there — only this filter hid it.

A shared reference series must not be scoped to one consumer's window. `stk_rf` now fetches the full series from FF3's earliest date.

## Why widening is safe

Every consumer `left_join`s by `ym`, so extra earlier months add no rows. Verified the new series covers every consumer: **1196 months, 1926-07..2026-02, no NA**.

With it, all remaining gaps are **trailing** — mom_prepeak needs 2026-03, CMR needs 2026-03/04/05 — which PR #679's trim-and-warn policy already handles.

Also adds a fail-loud guard on `stk_rf` itself: an empty result or any `NA` `rf_ret` now aborts. Every strategy's Sharpe depends on this one series, and it had no assertion of its own.

## Follow-ups, not fixed here

- **The coverage policy has three cases, not two.** PR #679 split *trailing* (trim + warn) from *interior* (abort), but never considered **leading** months before the series starts — which is what these 9 targets actually hit. They were reported as "a HOLE in the series", sending a reader to look for a gap that does not exist. Moot for these consumers now the series starts in 1926, but the message is still wrong for that case.
- **The same policy is now duplicated across four helpers** — `.ltr_join_rf`, `.tom_join_rf_daily`, `.mom_prepeak_join_rf`, and CMR's own. That is the duplication this repo keeps paying for; it wants one shared helper.
- **FF3 RF ends 2026-02-27 while price data runs to 2026-05.** A ~6-month publication lag is plausible, but worth confirming it is a lag rather than a stalled refresh — cf. #673, where `equity_daily` turned out to have no scheduled refresh at all.

## Verification

Coverage was checked against the real consumer date ranges before committing, not just fixtures:

```
new stk_rf: 1196 months 1926-07 .. 2026-02 | any NA: FALSE
mom_prepeak ym: 1973-02 .. 2026-03
cmr ym:         1992-03 .. 2026-05
```

`scripts/verify.sh`: **PASS** — root `total=523 failed=3 skipped=0`, package `total=695 failed=1 skipped=15`, both baselines exact.

Per #680, `verify.sh` passing does not prove the pipeline builds — a full rebuild with an explicit `tar_meta(fields = error)` check follows immediately after merge.

Refs #677, #680.
