### PR TITLE
fix(sharpe): migrate OLMAR-1 + consolidate rf-join helpers (#677 slice 3b)

### DIFF
--- a/R/plan_commodities_mean_reversion.R
+++ b/R/plan_commodities_mean_reversion.R
@@ -179,11 +179,11 @@ plan_commodities_mean_reversion <- function() {
 #' Join a monthly risk-free series onto a CMR portfolio (#677)
 #'
 #' Mirrors \code{.ltr_join_rf()} in R/plan_ltr_momentum.R: joins on \code{ym}
-#' derived from \code{date}, aborts on an INTERIOR gap (a hole inside
-#' stk_rf's own span -- investigate, don't silently drop), and trims +
-#' \code{cli_warn}s on a TRAILING gap (Fama-French publication lag --
-#' expected, not a bug). A missing risk-free series must never be treated
-#' as zero -- see fail-loud-not-null.md.
+#' derived from \code{date}. As of #677 slice 3b the coverage policy itself
+#' lives in the shared \code{.join_rf_series()} (R/utils_metrics.R), which
+#' distinguishes THREE cases (leading / trailing / interior) -- see that
+#' function's roxygen for the full policy. A missing risk-free series must
+#' never be treated as zero -- see fail-loud-not-null.md.
 #'
 #' @param df Tibble with a `ym` column already derived, and `net_ret`.
 #' @param stk_rf Tibble with columns `ym`, `rf_ret` (R/plan_stock_backtest.R).
@@ -191,42 +191,14 @@ plan_commodities_mean_reversion <- function() {
 #' @return `df` with `rf_ret` joined, trailing uncovered months removed.
 #' @noRd
 .cmr_join_rf <- function(df, stk_rf, lookback) {
-  required <- c("ym", "rf_ret")
-  missing_cols <- setdiff(required, names(stk_rf))
-  if (length(missing_cols) > 0L) {
-    cli::cli_abort(c(
-      "x" = ".cmr_join_rf(): stk_rf is missing {length(missing_cols)} required column{?s}: {.field {missing_cols}}.",
-      "i" = "Expected a tibble with ym and rf_ret (R/plan_stock_backtest.R)."
-    ))
-  }
-
-  df_ym_range <- range(df$ym)
-  joined <- dplyr::left_join(df, stk_rf, by = "ym")
-
-  missing_rf_ym <- sort(joined$ym[is.na(joined$rf_ret)])
-  if (length(missing_rf_ym) == 0L) return(joined)
-
-  rf_max   <- max(stk_rf$ym)
-  interior <- missing_rf_ym[missing_rf_ym <= rf_max]
-
-  if (length(interior) > 0L) {
-    cli::cli_abort(c(
-      "x" = "{length(interior)} month{?s} inside stk_rf's own span have no risk-free rate (CMR {lookback} lookback).",
-      "i" = "Missing ym: {.val {interior}}.",
-      "i" = "stk_rf spans {min(stk_rf$ym)}..{rf_max}, so this is a HOLE in the series, not a publication lag.",
-      "i" = "Investigate the FF3 source (R/plan_stock_backtest.R) before trusting any CMR Sharpe figure."
-    ))
-  }
-
-  n_before <- nrow(joined)
-  joined <- dplyr::filter(joined, !is.na(.data$rf_ret))
-  cli::cli_warn(c(
-    "!" = "Dropped {n_before - nrow(joined)} trailing month{?s} from CMR {lookback} portfolio with no risk-free rate yet.",
-    "i" = "Dropped ym: {.val {missing_rf_ym}}.",
-    "i" = "Portfolio spans {df_ym_range[1]}..{df_ym_range[2]}; stk_rf ends {rf_max} (Fama-French publication lag).",
-    "i" = "Every CMR {lookback} Sharpe is therefore computed through {rf_max}, not {df_ym_range[2]}."
-  ))
-  joined
+  .join_rf_series(
+    df = df, rf = stk_rf, key = "ym",
+    label = ".cmr_join_rf", rf_label = "stk_rf",
+    rf_source = "R/plan_stock_backtest.R",
+    df_label = paste0("CMR ", lookback, " portfolio"),
+    strategy_label = paste0("CMR ", lookback),
+    period_noun = "month", check_key_col = FALSE
+  )
 }
 
 .compute_cmr_metrics <- function(portfolio_tbl, lookback, stk_rf, ann_factor = 12L) {

--- a/R/plan_ltr_momentum.R
+++ b/R/plan_ltr_momentum.R
@@ -464,59 +464,25 @@ plan_ltr_momentum <- function() {
 #' month routinely has no risk-free rate yet, and it recurs every month.
 #' Aborting turned an expected data-lag condition into a hard failure.
 #'
-#' Silently keeping `NA` rf is the defect this join exists to fix, so the
-#' policy distinguishes the two cases:
-#'   - **trailing** uncovered months (beyond `max(stk_rf$ym)`) — a
-#'     publication lag. TRIM them and `cli_warn`, naming the dropped months
-#'     and the effective end date, per `fail-loud-not-null.md`'s "Make the
-#'     drop observable". The drop is counted and reported, never silent.
-#'   - **interior** uncovered months (at or before `max(stk_rf$ym)`) — a real
-#'     hole in the FF3 series, not a lag. Still `cli_abort`.
+#' Silently keeping `NA` rf is the defect this join exists to fix. As of
+#' #677 slice 3b the coverage policy is shared with every other rf-joining
+#' strategy via \code{.join_rf_series()} (R/utils_metrics.R), which
+#' distinguishes THREE cases (leading / trailing / interior) rather than
+#' the two this function originally implemented directly -- see that
+#' function's roxygen for the full policy.
 #'
 #' @param port Tibble with a `ym` column (the LTR portfolio).
 #' @param stk_rf Tibble with columns `ym`, `rf_ret`.
 #' @return `port` with `rf_ret` joined, trailing uncovered months removed.
 #' @noRd
 .ltr_join_rf <- function(port, stk_rf) {
-  required <- c("ym", "rf_ret")
-  missing_cols <- setdiff(required, names(stk_rf))
-  if (length(missing_cols) > 0L) {
-    cli::cli_abort(c(
-      "x" = ".ltr_join_rf(): stk_rf is missing {length(missing_cols)} required column{?s}: {.field {missing_cols}}.",
-      "i" = "Expected a tibble with ym and rf_ret (R/plan_stock_backtest.R)."
-    ))
-  }
-  if (!"ym" %in% names(port)) {
-    cli::cli_abort(c("x" = ".ltr_join_rf(): port has no {.field ym} column to join on."))
-  }
-
-  port_ym_range <- range(port$ym)
-  port <- dplyr::left_join(port, stk_rf, by = "ym")
-
-  missing_rf_ym <- sort(port$ym[is.na(port$rf_ret)])
-  if (length(missing_rf_ym) == 0L) return(port)
-
-  rf_max   <- max(stk_rf$ym)
-  interior <- missing_rf_ym[missing_rf_ym <= rf_max]
-
-  if (length(interior) > 0L) {
-    cli::cli_abort(c(
-      "x" = "{length(interior)} month{?s} inside stk_rf's own span have no risk-free rate.",
-      "i" = "Missing ym: {.val {interior}}.",
-      "i" = "stk_rf spans {min(stk_rf$ym)}..{rf_max}, so this is a HOLE in the series, not a publication lag.",
-      "i" = "Investigate the FF3 source (R/plan_stock_backtest.R) before trusting any LTR Sharpe figure."
-    ))
-  }
-
-  n_before <- nrow(port)
-  port <- dplyr::filter(port, !is.na(.data$rf_ret))
-  cli::cli_warn(c(
-    "!" = "Dropped {n_before - nrow(port)} trailing month{?s} from ltr_portfolio with no risk-free rate yet.",
-    "i" = "Dropped ym: {.val {missing_rf_ym}}.",
-    "i" = "ltr_portfolio spans {port_ym_range[1]}..{port_ym_range[2]}; stk_rf ends {rf_max} (Fama-French publication lag).",
-    "i" = "Every LTR metric is therefore computed through {rf_max}, not {port_ym_range[2]}."
-  ))
-  port
+  .join_rf_series(
+    df = port, rf = stk_rf, key = "ym",
+    label = ".ltr_join_rf", rf_label = "stk_rf",
+    rf_source = "R/plan_stock_backtest.R",
+    df_label = "ltr_portfolio", strategy_label = "LTR",
+    period_noun = "month", df_arg_name = "port"
+  )
 }
 
 #' Register LTR backtest run in the strategy registry

--- a/R/plan_mom_prepeak.R
+++ b/R/plan_mom_prepeak.R
@@ -390,11 +390,12 @@ plan_mom_prepeak <- function() {
 #' Join a monthly risk-free series onto mom_prepeak returns (#677)
 #'
 #' Mirrors \code{.ltr_join_rf()} in R/plan_ltr_momentum.R: joins on
-#' \code{ym} derived from \code{exec_date}, aborts on an INTERIOR gap
-#' (a hole inside stk_rf's own span -- investigate, don't silently drop),
-#' and trims + \code{cli_warn}s on a TRAILING gap (Fama-French publication
-#' lag -- expected, not a bug). A missing risk-free series must never be
-#' treated as zero -- see fail-loud-not-null.md.
+#' \code{ym} derived from \code{exec_date}. As of #677 slice 3b the
+#' coverage policy itself lives in the shared \code{.join_rf_series()}
+#' (R/utils_metrics.R), which distinguishes THREE cases (leading /
+#' trailing / interior) -- see that function's roxygen for the full
+#' policy. A missing risk-free series must never be treated as zero --
+#' see fail-loud-not-null.md.
 #'
 #' @param returns_tbl Tibble with an `exec_date` column (mom_prepeak_returns
 #'   / mom_postpeak_returns / mom_combined_returns).
@@ -402,46 +403,19 @@ plan_mom_prepeak <- function() {
 #' @return `returns_tbl` with `rf_ret` joined, trailing uncovered months removed.
 #' @noRd
 .mom_prepeak_join_rf <- function(returns_tbl, stk_rf) {
-  required <- c("ym", "rf_ret")
-  missing_cols <- setdiff(required, names(stk_rf))
-  if (length(missing_cols) > 0L) {
-    cli::cli_abort(c(
-      "x" = ".mom_prepeak_join_rf(): stk_rf is missing {length(missing_cols)} required column{?s}: {.field {missing_cols}}.",
-      "i" = "Expected a tibble with ym and rf_ret (R/plan_stock_backtest.R)."
-    ))
-  }
   if (!"exec_date" %in% names(returns_tbl)) {
     cli::cli_abort(c("x" = ".mom_prepeak_join_rf(): returns_tbl has no {.field exec_date} column to join on."))
   }
 
   returns_tbl <- dplyr::mutate(returns_tbl, ym = format(as.Date(.data$exec_date), "%Y-%m"))
-  ret_ym_range <- range(returns_tbl$ym)
-  joined <- dplyr::left_join(returns_tbl, stk_rf, by = "ym")
 
-  missing_rf_ym <- sort(joined$ym[is.na(joined$rf_ret)])
-  if (length(missing_rf_ym) == 0L) return(joined)
-
-  rf_max   <- max(stk_rf$ym)
-  interior <- missing_rf_ym[missing_rf_ym <= rf_max]
-
-  if (length(interior) > 0L) {
-    cli::cli_abort(c(
-      "x" = "{length(interior)} month{?s} inside stk_rf's own span have no risk-free rate.",
-      "i" = "Missing ym: {.val {interior}}.",
-      "i" = "stk_rf spans {min(stk_rf$ym)}..{rf_max}, so this is a HOLE in the series, not a publication lag.",
-      "i" = "Investigate the FF3 source (R/plan_stock_backtest.R) before trusting any mom_prepeak Sharpe figure."
-    ))
-  }
-
-  n_before <- nrow(joined)
-  joined <- dplyr::filter(joined, !is.na(.data$rf_ret))
-  cli::cli_warn(c(
-    "!" = "Dropped {n_before - nrow(joined)} trailing month{?s} from mom_prepeak returns with no risk-free rate yet.",
-    "i" = "Dropped ym: {.val {missing_rf_ym}}.",
-    "i" = "returns_tbl spans {ret_ym_range[1]}..{ret_ym_range[2]}; stk_rf ends {rf_max} (Fama-French publication lag).",
-    "i" = "Every mom_prepeak Sharpe is therefore computed through {rf_max}, not {ret_ym_range[2]}."
-  ))
-  joined
+  .join_rf_series(
+    df = returns_tbl, rf = stk_rf, key = "ym",
+    label = ".mom_prepeak_join_rf", rf_label = "stk_rf",
+    rf_source = "R/plan_stock_backtest.R",
+    df_label = "mom_prepeak returns", strategy_label = "mom_prepeak",
+    period_noun = "month", check_key_col = FALSE
+  )
 }
 
 

--- a/R/plan_olmar.R
+++ b/R/plan_olmar.R
@@ -109,23 +109,31 @@ plan_olmar <- function() {
           date     = as.Date(date),
           cum_gross = cumprod(1 + gross_ret),
           cum_net   = cumprod(1 + net_ret)
-        )
+        ) |>
+        .olmar_join_rf(daily_rf)
     }),
 
     # ── Metrics ─────────────────────────────────────────────────
+    # #677 slice 3b: sharpe was previously mean(ret)*252/vol -- arithmetic
+    # numerator, NO risk-free deduction, while cagr two lines above was
+    # already geometric. The reported Sharpe was not the Sharpe of the
+    # reported CAGR. Now uses the canonical sharpe_ratio_rf()
+    # (R/utils_metrics.R): geometric numerator, rf-deducted, daily
+    # (periods_per_year = 252L) -- and cagr/vol are read straight off the
+    # same sharpe_ratio_rf() call so all three figures are guaranteed
+    # coherent with each other (the inconsistency this migration fixes).
     targets::tar_target(olmar_metrics, {
       library(dplyr)
 
       calc <- function(d, label) {
-        ret <- d$net_ret
-        ret <- ret[!is.na(ret)]
-        n   <- length(ret)
+        keep   <- !is.na(d$net_ret)
+        d      <- d[keep, , drop = FALSE]
+        ret    <- d$net_ret
+        rf_ret <- d$rf_ret
+        n      <- length(ret)
         if (n < 20L) return(NULL)
-        years    <- n / 252
-        cum      <- prod(1 + ret)
-        cagr     <- cum^(1 / years) - 1
-        vol      <- sd(ret) * sqrt(252)
-        sharpe   <- if (vol > 0) mean(ret) * 252 / vol else NA_real_
+
+        sr       <- sharpe_ratio_rf(ret, rf_ret, periods_per_year = 252L, na.rm = TRUE)
         eq_curve <- cumprod(1 + ret)
         dd       <- (eq_curve - cummax(eq_curve)) / cummax(eq_curve)
         max_dd   <- min(dd)
@@ -134,10 +142,10 @@ plan_olmar <- function() {
         tibble::tibble(
           period   = label,
           days     = n,
-          years    = round(years, 1),
-          cagr     = round(cagr * 100, 2),
-          vol      = round(vol * 100, 2),
-          sharpe   = round(sharpe, 3),
+          years    = round(n / 252, 1),
+          cagr     = round(sr$ann_ret * 100, 2),
+          vol      = round(sr$ann_vol * 100, 2),
+          sharpe   = round(sr$sharpe, 3),
           max_dd   = round(max_dd * 100, 2),
           avg_turnover_daily = round(avg_tv, 4)
         )
@@ -328,5 +336,33 @@ plan_olmar <- function() {
       })
     })
 
+  )
+}
+
+
+# ── Internal helper ────────────────────────────────────────────────────────────
+# Prefixed .olmar_* (private; not exported from the package).
+
+#' Join the shared daily risk-free series onto OLMAR's daily portfolio (#677)
+#'
+#' Mirrors \code{.tom_join_rf_daily()} in R/plan_turn_of_month.R -- OLMAR-1
+#' is the fifth strategy to consume the coverage policy in
+#' \code{.join_rf_series()} (R/utils_metrics.R), which distinguishes THREE
+#' cases (leading / trailing / interior) -- see that function's roxygen for
+#' the full policy. A missing risk-free series must never be treated as
+#' zero -- see fail-loud-not-null.md.
+#'
+#' @param port Tibble with a `date` column (the OLMAR-1 daily portfolio).
+#' @param rf Tibble with columns `date`, `rf_ret` (the `daily_rf` target,
+#'   R/plan_stock_backtest.R).
+#' @return `port` with `rf_ret` joined, trailing uncovered dates removed.
+#' @noRd
+.olmar_join_rf <- function(port, rf) {
+  .join_rf_series(
+    df = port, rf = rf, key = "date",
+    label = ".olmar_join_rf", rf_label = "daily_rf",
+    rf_source = "the daily_rf target, R/plan_stock_backtest.R",
+    df_label = "olmar_portfolio", strategy_label = "OLMAR-1",
+    period_noun = "date", df_arg_name = "port"
   )
 }

--- a/R/plan_stock_backtest.R
+++ b/R/plan_stock_backtest.R
@@ -606,6 +606,47 @@ plan_stock_backtest <- function() {
       out
     }),
 
+    # ── Group 1: Risk-free rate (daily) ────────────────────────────
+    # Shared DAILY rf series, consumed by TOM (R/plan_turn_of_month.R,
+    # sqrt(252) annualisation) and OLMAR-1 (R/plan_olmar.R, same). Mirrors
+    # stk_rf immediately above: fetched from FF3's earliest available date,
+    # NOT scoped to any one consumer's start_date.
+    #
+    # This target was previously `tom_rf_daily`, defined in
+    # R/plan_turn_of_month.R and fetched `from = tom_params$start_date`
+    # (1994-01-01) -- invisible while TOM was its only reader, and exactly
+    # the same scoping bug that broke stk_rf in #684 the moment a second
+    # consumer needed the series too. #677 slice 3b renamed and moved it
+    # here, alongside stk_rf, before OLMAR (start_date 2010-01-01) became
+    # that second consumer. Both TOM's and OLMAR's start dates are safely
+    # after 1926-07, so no leading-coverage gap exists for either today --
+    # but the series itself no longer depends on that being true.
+    targets::tar_target(daily_rf, {
+      library(dplyr)
+
+      RF_SERIES_START <- "1926-07-01"   # FF3's earliest available date
+
+      out <- hd_factors(dataset = "FF3", frequency = "daily",
+                        from = RF_SERIES_START) |>
+        filter(factor_name == "RF") |>
+        mutate(date = as.Date(date), rf_ret = value / 100) |>
+        select(date, rf_ret) |>
+        arrange(date)
+
+      if (nrow(out) == 0L || anyNA(out$rf_ret)) {
+        cli::cli_abort(c(
+          "x" = "daily_rf came back empty or with NA rf_ret.",
+          "i" = "Rows: {nrow(out)}; NA rf_ret: {sum(is.na(out$rf_ret))}.",
+          "i" = "Every daily-frequency strategy's Sharpe depends on this series -- check the FF3 source before proceeding."
+        ))
+      }
+
+      cli::cli_inform(c(
+        "v" = "daily_rf: {nrow(out)} days, {min(out$date)}..{max(out$date)} (shared daily rf series, #677)."
+      ))
+      out
+    }),
+
     # ── Group 1: Monthly ADV per ticker (for ADV participation cap) ──
     targets::tar_target(stk_monthly_adv, {
       library(dplyr)

--- a/R/plan_turn_of_month.R
+++ b/R/plan_turn_of_month.R
@@ -35,23 +35,6 @@ plan_turn_of_month <- function() {
       )
     }),
 
-    # ── Data: daily risk-free rate (#677 slice 2 — no-rf family) ──
-    # TOM previously computed sharpe = cagr/vol with NO risk-free deduction
-    # (implied rf of exactly 0.00% -- a formula signature, see #677). TOM is
-    # a DAILY strategy (sqrt(252) annualisation), so it needs its own daily
-    # rf series rather than the monthly stk_rf series used by the
-    # monthly strategies migrated alongside it in this slice.
-    targets::tar_target(tom_rf_daily, {
-      library(dplyr)
-
-      hd_factors(dataset = "FF3", frequency = "daily",
-                 from = as.character(tom_params$start_date)) |>
-        dplyr::filter(factor_name == "RF") |>
-        dplyr::mutate(date = as.Date(date), rf_ret = value / 100) |>
-        dplyr::select(date, rf_ret) |>
-        dplyr::arrange(date)
-    }),
-
     # ── Data: SPY daily returns ───────────────────────────────────
     targets::tar_target(tom_daily, {
       library(dplyr)
@@ -66,7 +49,7 @@ plan_turn_of_month <- function() {
         dplyr::filter(!is.na(ret)) |>
         dplyr::select(date, ret)
 
-      .tom_join_rf_daily(spy, tom_rf_daily)
+      .tom_join_rf_daily(spy, daily_rf)
     }),
 
     # ── TOM window indicator ─────────────────────────────────────
@@ -113,7 +96,7 @@ plan_turn_of_month <- function() {
 
       # Daily cash rate from the annual assumption -- this is the CASH
       # RETURN earned while resting outside the TOM window (a strategy-
-      # return assumption). Distinct from the tom_rf_daily-joined `rf_ret`
+      # return assumption). Distinct from the daily_rf-joined `rf_ret`
       # column used below for the Sharpe risk-free deduction (#677 slice 2)
       # -- do not conflate the two.
       cash_rf_daily <- (1 + tom_params$rf_annual)^(1 / 252) - 1
@@ -379,58 +362,24 @@ plan_turn_of_month <- function() {
 #' \code{date} at DAILY granularity instead of \code{ym} at monthly
 #' granularity -- TOM is a daily strategy (\code{sqrt(252)} annualisation).
 #'
-#' Per \code{fail-loud-not-null.md}, a missing risk-free rate must never be
-#' silently coerced to \code{NA}/zero. As with \code{.ltr_join_rf()}, a
-#' **trailing** uncovered date range (beyond \code{max(rf$date)}) is a Fama-
-#' French publication lag, not a defect -- it is TRIMMED with a loud, counted
-#' \code{cli_warn} naming the dropped range and the effective end date. An
-#' **interior** uncovered date range is a real hole in the FF3 series and
-#' \code{cli_abort}s.
+#' As of #677 slice 3b the coverage policy itself lives in the shared
+#' \code{.join_rf_series()} (R/utils_metrics.R), which distinguishes THREE
+#' cases (leading / trailing / interior) -- see that function's roxygen for
+#' the full policy.
 #'
 #' @param port Tibble with a `date` column (TOM's daily return series).
-#' @param rf Tibble with columns `date`, `rf_ret` (the `tom_rf_daily` target).
+#' @param rf Tibble with columns `date`, `rf_ret` (the `daily_rf` target,
+#'   R/plan_stock_backtest.R).
 #' @return `port` with `rf_ret` joined, trailing uncovered dates removed.
 #' @noRd
 .tom_join_rf_daily <- function(port, rf) {
-  required <- c("date", "rf_ret")
-  missing_cols <- setdiff(required, names(rf))
-  if (length(missing_cols) > 0L) {
-    cli::cli_abort(c(
-      "x" = ".tom_join_rf_daily(): rf is missing {length(missing_cols)} required column{?s}: {.field {missing_cols}}.",
-      "i" = "Expected a tibble with date and rf_ret (the tom_rf_daily target)."
-    ))
-  }
-  if (!"date" %in% names(port)) {
-    cli::cli_abort(c("x" = ".tom_join_rf_daily(): port has no {.field date} column to join on."))
-  }
-
-  port_date_range <- range(port$date)
-  port <- dplyr::left_join(port, rf, by = "date")
-
-  missing_rf_date <- sort(port$date[is.na(port$rf_ret)])
-  if (length(missing_rf_date) == 0L) return(port)
-
-  rf_max   <- max(rf$date)
-  interior <- missing_rf_date[missing_rf_date <= rf_max]
-
-  if (length(interior) > 0L) {
-    cli::cli_abort(c(
-      "x" = "{length(interior)} date{?s} inside tom_rf_daily's own span have no risk-free rate.",
-      "i" = "Missing date{?s}: {.val {format(interior)}}.",
-      "i" = "tom_rf_daily spans {min(rf$date)}..{rf_max}, so this is a HOLE in the series, not a publication lag.",
-      "i" = "Investigate the FF3 source (R/plan_stock_backtest.R's stk_rf pattern) before trusting any TOM Sharpe figure."
-    ))
-  }
-
-  n_before <- nrow(port)
-  port <- dplyr::filter(port, !is.na(.data$rf_ret))
-  cli::cli_warn(c(
-    "!" = "Dropped {n_before - nrow(port)} trailing date{?s} from tom_daily with no risk-free rate yet.",
-    "i" = "Dropped date range: {format(min(missing_rf_date))}..{format(max(missing_rf_date))}.",
-    "i" = "tom_daily spans {port_date_range[1]}..{port_date_range[2]}; tom_rf_daily ends {rf_max} (Fama-French publication lag).",
-    "i" = "Every TOM metric is therefore computed through {rf_max}, not {port_date_range[2]}."
-  ))
-  port
+  .join_rf_series(
+    df = port, rf = rf, key = "date",
+    label = ".tom_join_rf_daily", rf_label = "daily_rf",
+    rf_source = "the daily_rf target, R/plan_stock_backtest.R",
+    df_label = "tom_daily", strategy_label = "TOM",
+    period_noun = "date", df_arg_name = "port"
+  )
 }
 
 #' Register Turn-of-the-Month backtest run in the strategy registry

--- a/R/utils_metrics.R
+++ b/R/utils_metrics.R
@@ -198,3 +198,138 @@ sharpe_ratio_rf <- function(ret, rf, periods_per_year = 12L, na.rm = TRUE) {
     n       = n
   )
 }
+
+#' Join a risk-free series onto a return series by a shared key (#677 slice 3b)
+#'
+#' Canonical THREE-CASE risk-free coverage policy, shared by every strategy
+#' that left-joins a Fama-French risk-free series onto its own return
+#' series. Before this helper existed, the same ~40-line policy was
+#' duplicated near-verbatim across four call sites -- \code{.ltr_join_rf()}
+#' (\code{R/plan_ltr_momentum.R}), \code{.tom_join_rf_daily()}
+#' (\code{R/plan_turn_of_month.R}), \code{.mom_prepeak_join_rf()}
+#' (\code{R/plan_mom_prepeak.R}), and CMR's own
+#' (\code{R/plan_commodities_mean_reversion.R}) -- see issue #677.
+#'
+#' Consolidating also fixes the gap PR #684 found: none of the four
+#' distinguished a LEADING gap (the return series starts before the
+#' risk-free series does) from an INTERIOR one (a real hole inside the
+#' risk-free series' own span). A leading gap was reported as "a HOLE in
+#' the series", sending a reader hunting for a gap that does not exist.
+#'
+#' Per \code{fail-loud-not-null.md}, a missing risk-free rate must NEVER be
+#' silently coerced to \code{NA}/zero/a dropped row without comment. The
+#' three cases:
+#'   \describe{
+#'     \item{LEADING}{\code{key < min(rf[[key]])}. The risk-free series
+#'       simply does not go back this far -- by construction, not because
+#'       of a gap in its own coverage. \strong{Aborts}, naming it
+#'       "leading", never "hole".}
+#'     \item{TRAILING}{\code{key > max(rf[[key]])}. A Fama-French
+#'       publication lag -- expected, not a bug. TRIMMED with a loud,
+#'       counted \code{cli_warn} naming the dropped periods and the
+#'       effective end date (per fail-loud-not-null.md's "Make the drop
+#'       observable").}
+#'     \item{INTERIOR}{\code{min(rf[[key]]) <= key <= max(rf[[key]])} but
+#'       missing. A real hole inside the risk-free series' own span.
+#'       \strong{Aborts.}}
+#'   }
+#' If a return series has both leading and interior gaps, leading is
+#' reported first -- it is the more fundamental "no risk-free rate exists
+#' for this period at all" case.
+#'
+#' This is a pure function (no target/database access), so it is
+#' unit-testable directly -- see \code{tests/testthat/test-join-rf-series.R}.
+#' PR #678's guard shipped untested because it lived inside a target
+#' reading a gitignored parquet, which is exactly how it broke `main` twice.
+#'
+#' @param df Tibble to join `rf` onto. Must already have the `key` column
+#'   (or pass \code{check_key_col = FALSE} when the caller derives it
+#'   itself immediately before calling).
+#' @param rf Tibble with columns `key`, `rf_ret`.
+#' @param key Character. Name of the shared join column: \code{"ym"}
+#'   (monthly, character \code{"YYYY-MM"}) or \code{"date"} (daily, a
+#'   `Date` column).
+#' @param label Character. Function identity used in error/warning message
+#'   prefixes, e.g. \code{".ltr_join_rf"}.
+#' @param rf_label Character. How the risk-free series is named in prose,
+#'   e.g. \code{"stk_rf"} or \code{"daily_rf"}.
+#' @param rf_source Character. Where `rf` comes from, cited in the
+#'   missing-columns message and the interior-gap investigate line, e.g.
+#'   \code{"R/plan_stock_backtest.R"}.
+#' @param df_label Character. Name of `df` for warning/abort text, e.g.
+#'   \code{"ltr_portfolio"} or \code{"CMR 1m portfolio"}.
+#' @param strategy_label Character. Strategy name for the
+#'   trust-this-Sharpe line, e.g. \code{"LTR"} or \code{"CMR 1m"}.
+#' @param period_noun Character. \code{"month"} or \code{"date"} -- used
+#'   for cli's pluralisation (\code{{period_noun}{?s}}).
+#' @param check_key_col Logical. If \code{TRUE} (default), abort when `df`
+#'   has no `key` column. Callers that derive `key` themselves just before
+#'   calling (e.g. mom_prepeak deriving `ym` from `exec_date`), or that
+#'   already guarantee it by construction (e.g. CMR), pass `FALSE`.
+#' @param df_arg_name Character. Word used for `df` in the
+#'   missing-key-column message, e.g. \code{"port"}.
+#'
+#' @return `df` with `rf_ret` joined; trailing uncovered periods removed.
+#' @noRd
+.join_rf_series <- function(df, rf, key,
+                             label, rf_label, rf_source, df_label,
+                             strategy_label, period_noun = "month",
+                             check_key_col = TRUE, df_arg_name = "df") {
+  required <- c(key, "rf_ret")
+  missing_cols <- setdiff(required, names(rf))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "{label}(): {rf_label} is missing {length(missing_cols)} required column{?s}: {.field {missing_cols}}.",
+      "i" = "Expected a tibble with {key} and rf_ret ({rf_source})."
+    ))
+  }
+  if (isTRUE(check_key_col) && !key %in% names(df)) {
+    cli::cli_abort(c(
+      "x" = "{label}(): {df_arg_name} has no {.field {key}} column to join on."
+    ))
+  }
+
+  fmt <- function(x) if (inherits(x, "Date")) format(x) else x
+
+  df_key_range <- range(df[[key]])
+  joined <- dplyr::left_join(df, rf, by = key)
+
+  missing_key <- sort(joined[[key]][is.na(joined$rf_ret)])
+  if (length(missing_key) == 0L) return(joined)
+
+  rf_min <- min(rf[[key]])
+  rf_max <- max(rf[[key]])
+
+  leading  <- missing_key[missing_key < rf_min]
+  interior <- missing_key[missing_key >= rf_min & missing_key <= rf_max]
+
+  if (length(leading) > 0L) {
+    cli::cli_abort(c(
+      "x" = "{length(leading)} {period_noun}{?s} come before {rf_label} even starts ({strategy_label}).",
+      "i" = "Missing {period_noun}{?s}: {.val {fmt(leading)}}.",
+      "i" = "{rf_label} starts {fmt(rf_min)}; {df_label} starts {fmt(df_key_range[1])}.",
+      "i" = "This is LEADING coverage: the risk-free series simply does not reach this far back yet -- a different situation from a gap inside its own span.",
+      "i" = "Trim {df_label} to start no earlier than {fmt(rf_min)}, or source an earlier {rf_label}."
+    ))
+  }
+
+  if (length(interior) > 0L) {
+    cli::cli_abort(c(
+      "x" = "{length(interior)} {period_noun}{?s} inside {rf_label}'s own span have no risk-free rate ({strategy_label}).",
+      "i" = "Missing {period_noun}{?s}: {.val {fmt(interior)}}.",
+      "i" = "{rf_label} spans {fmt(rf_min)}..{fmt(rf_max)}, so this is a HOLE in the series, not a publication lag.",
+      "i" = "Investigate the FF3 source ({rf_source}) before trusting any {strategy_label} Sharpe figure."
+    ))
+  }
+
+  # trailing -- Fama-French publication lag; trim + loud, counted warn
+  n_before <- nrow(joined)
+  joined <- dplyr::filter(joined, !is.na(.data$rf_ret))
+  cli::cli_warn(c(
+    "!" = "Dropped {n_before - nrow(joined)} trailing {period_noun}{?s} from {df_label} with no risk-free rate yet.",
+    "i" = "Dropped {period_noun}{?s}: {.val {fmt(missing_key)}}.",
+    "i" = "{df_label} spans {fmt(df_key_range[1])}..{fmt(df_key_range[2])}; {rf_label} ends {fmt(rf_max)} (Fama-French publication lag).",
+    "i" = "Every {strategy_label} metric is therefore computed through {fmt(rf_max)}, not {fmt(df_key_range[2])}."
+  ))
+  joined
+}

--- a/tests/testthat/_snaps/cmr-units.md
+++ b/tests/testthat/_snaps/cmr-units.md
@@ -3,18 +3,18 @@
     Code
       .cmr_join_rf(df, gapped_rf, lookback = "test")
     Condition
-      Error in `.cmr_join_rf()`:
-      x 1 month inside stk_rf's own span have no risk-free rate (CMR test lookback).
-      i Missing ym: "2020-10".
+      Error in `.join_rf_series()`:
+      x 1 month inside stk_rf's own span have no risk-free rate (CMR test).
+      i Missing month: "2020-10".
       i stk_rf spans 2020-01..2021-12, so this is a HOLE in the series, not a publication lag.
-      i Investigate the FF3 source (R/plan_stock_backtest.R) before trusting any CMR Sharpe figure.
+      i Investigate the FF3 source (R/plan_stock_backtest.R) before trusting any CMR test Sharpe figure.
 
 # .cmr_join_rf aborts when stk_rf lacks required columns
 
     Code
       .cmr_join_rf(df, bad_rf, lookback = "test")
     Condition
-      Error in `.cmr_join_rf()`:
+      Error in `.join_rf_series()`:
       x .cmr_join_rf(): stk_rf is missing 1 required column: rf_ret.
       i Expected a tibble with ym and rf_ret (R/plan_stock_backtest.R).
 

--- a/tests/testthat/_snaps/join-rf-series.md
+++ b/tests/testthat/_snaps/join-rf-series.md
@@ -1,0 +1,46 @@
+# .join_rf_series abort messages are stable (monthly)
+
+    Code
+      .call_join(.mk_df_ym(c("2026-01", "2026-02", "2026-03")), .mk_rf_ym(c("2026-01",
+        "2026-03")), .args_ym)
+    Condition
+      Error:
+      x 1 month inside test_rf's own span have no risk-free rate (TEST).
+      i Missing month: "2026-02".
+      i test_rf spans 2026-01..2026-03, so this is a HOLE in the series, not a publication lag.
+      i Investigate the FF3 source (test source) before trusting any TEST Sharpe figure.
+
+---
+
+    Code
+      .call_join(.mk_df_ym(c("2025-11", "2025-12", "2026-01")), .mk_rf_ym(c("2025-12",
+        "2026-01")), .args_ym)
+    Condition
+      Error:
+      x 1 month come before test_rf even starts (TEST).
+      i Missing month: "2025-11".
+      i test_rf starts 2025-12; test_df starts 2025-11.
+      i This is LEADING coverage: the risk-free series simply does not reach this far back yet -- a different situation from a gap inside its own span.
+      i Trim test_df to start no earlier than 2025-12, or source an earlier test_rf.
+
+---
+
+    Code
+      .call_join(.mk_df_ym("2026-01"), tibble::tibble(ym = "2026-01"), .args_ym)
+    Condition
+      Error:
+      x .test_join(): test_rf is missing 1 required column: rf_ret.
+      i Expected a tibble with ym and rf_ret (test source).
+
+# .join_rf_series abort messages are stable (daily)
+
+    Code
+      .call_join(.mk_df_date(c("2026-01-05", "2026-01-06", "2026-01-07")),
+      .mk_rf_date(c("2026-01-05", "2026-01-07")), .args_date)
+    Condition
+      Error:
+      x 1 date inside test_daily_rf's own span have no risk-free rate (TEST-DAILY).
+      i Missing date: "2026-01-06".
+      i test_daily_rf spans 2026-01-05..2026-01-07, so this is a HOLE in the series, not a publication lag.
+      i Investigate the FF3 source (test daily source) before trusting any TEST-DAILY Sharpe figure.
+

--- a/tests/testthat/_snaps/mom-prepeak-sharpe.md
+++ b/tests/testthat/_snaps/mom-prepeak-sharpe.md
@@ -3,9 +3,9 @@
     Code
       .mom_prepeak_join_rf(rets, rf)
     Condition
-      Error in `.mom_prepeak_join_rf()`:
-      x 1 month inside stk_rf's own span have no risk-free rate.
-      i Missing ym: "2020-10".
+      Error in `.join_rf_series()`:
+      x 1 month inside stk_rf's own span have no risk-free rate (mom_prepeak).
+      i Missing month: "2020-10".
       i stk_rf spans 2020-01..2021-12, so this is a HOLE in the series, not a publication lag.
       i Investigate the FF3 source (R/plan_stock_backtest.R) before trusting any mom_prepeak Sharpe figure.
 
@@ -14,7 +14,7 @@
     Code
       .mom_prepeak_join_rf(rets, bad_rf)
     Condition
-      Error in `.mom_prepeak_join_rf()`:
+      Error in `.join_rf_series()`:
       x .mom_prepeak_join_rf(): stk_rf is missing 1 required column: rf_ret.
       i Expected a tibble with ym and rf_ret (R/plan_stock_backtest.R).
 

--- a/tests/testthat/_snaps/plan-ltr-momentum.md
+++ b/tests/testthat/_snaps/plan-ltr-momentum.md
@@ -3,9 +3,9 @@
     Code
       .ltr_join_rf(port, .mk_rf(c("2026-01", "2026-03")))
     Condition
-      Error in `.ltr_join_rf()`:
-      x 1 month inside stk_rf's own span have no risk-free rate.
-      i Missing ym: "2026-02".
+      Error in `.join_rf_series()`:
+      x 1 month inside stk_rf's own span have no risk-free rate (LTR).
+      i Missing month: "2026-02".
       i stk_rf spans 2026-01..2026-03, so this is a HOLE in the series, not a publication lag.
       i Investigate the FF3 source (R/plan_stock_backtest.R) before trusting any LTR Sharpe figure.
 
@@ -14,7 +14,7 @@
     Code
       .ltr_join_rf(.mk_port("2026-01"), tibble::tibble(ym = "2026-01"))
     Condition
-      Error in `.ltr_join_rf()`:
+      Error in `.join_rf_series()`:
       x .ltr_join_rf(): stk_rf is missing 1 required column: rf_ret.
       i Expected a tibble with ym and rf_ret (R/plan_stock_backtest.R).
 

--- a/tests/testthat/_snaps/plan-olmar.md
+++ b/tests/testthat/_snaps/plan-olmar.md
@@ -1,0 +1,11 @@
+# .olmar_join_rf abort messages are stable
+
+    Code
+      .olmar_join_rf(port, .mk_rf_daily(c("2026-01-05", "2026-01-07")))
+    Condition
+      Error in `.join_rf_series()`:
+      x 1 date inside daily_rf's own span have no risk-free rate (OLMAR-1).
+      i Missing date: "2026-01-06".
+      i daily_rf spans 2026-01-05..2026-01-07, so this is a HOLE in the series, not a publication lag.
+      i Investigate the FF3 source (the daily_rf target, R/plan_stock_backtest.R) before trusting any OLMAR-1 Sharpe figure.
+

--- a/tests/testthat/_snaps/plan-turn-of-month.md
+++ b/tests/testthat/_snaps/plan-turn-of-month.md
@@ -3,11 +3,11 @@
     Code
       .tom_join_rf_daily(port, .mk_rf_daily(c("2026-01-05", "2026-01-07")))
     Condition
-      Error in `.tom_join_rf_daily()`:
-      x 1 date inside tom_rf_daily's own span have no risk-free rate.
+      Error in `.join_rf_series()`:
+      x 1 date inside daily_rf's own span have no risk-free rate (TOM).
       i Missing date: "2026-01-06".
-      i tom_rf_daily spans 2026-01-05..2026-01-07, so this is a HOLE in the series, not a publication lag.
-      i Investigate the FF3 source (R/plan_stock_backtest.R's stk_rf pattern) before trusting any TOM Sharpe figure.
+      i daily_rf spans 2026-01-05..2026-01-07, so this is a HOLE in the series, not a publication lag.
+      i Investigate the FF3 source (the daily_rf target, R/plan_stock_backtest.R) before trusting any TOM Sharpe figure.
 
 ---
 
@@ -15,7 +15,7 @@
       .tom_join_rf_daily(.mk_port_daily("2026-01-05"), tibble::tibble(date = as.Date(
         "2026-01-05")))
     Condition
-      Error in `.tom_join_rf_daily()`:
-      x .tom_join_rf_daily(): rf is missing 1 required column: rf_ret.
-      i Expected a tibble with date and rf_ret (the tom_rf_daily target).
+      Error in `.join_rf_series()`:
+      x .tom_join_rf_daily(): daily_rf is missing 1 required column: rf_ret.
+      i Expected a tibble with date and rf_ret (the daily_rf target, R/plan_stock_backtest.R).
 

--- a/tests/testthat/test-join-rf-series.R
+++ b/tests/testthat/test-join-rf-series.R
@@ -1,0 +1,197 @@
+testthat::local_edition(3)
+# Unit tests for .join_rf_series() (#677 slice 3b) -- the canonical
+# THREE-CASE risk-free coverage policy shared by .ltr_join_rf()
+# (R/plan_ltr_momentum.R), .tom_join_rf_daily() (R/plan_turn_of_month.R),
+# .mom_prepeak_join_rf() (R/plan_mom_prepeak.R), .cmr_join_rf()
+# (R/plan_commodities_mean_reversion.R), and .olmar_join_rf()
+# (R/plan_olmar.R).
+#
+# Pure and unit-testable per this function's own roxygen: PR #678's guard
+# shipped untested because it lived inside a target reading a gitignored
+# parquet, and that is exactly how main broke twice (#678, then again via
+# the LEADING gap #684 found and left as a follow-up). These tests cover
+# the gap #684 flagged: LEADING coverage must abort saying "leading",
+# never "hole" -- unlike an INTERIOR hole, which still says "HOLE".
+
+source(here::here("R/utils_metrics.R"))
+
+# ── Fixtures: monthly (ym, character "YYYY-MM") ──────────────────────────
+
+.mk_df_ym <- function(yms) tibble::tibble(ym = yms, ret = seq_along(yms) / 1000)
+.mk_rf_ym <- function(yms) tibble::tibble(ym = yms, rf_ret = rep(0.001, length(yms)))
+
+.args_ym <- list(
+  key = "ym", label = ".test_join", rf_label = "test_rf",
+  rf_source = "test source", df_label = "test_df",
+  strategy_label = "TEST", period_noun = "month"
+)
+
+# ── Fixtures: daily (date, Date) ──────────────────────────────────────────
+
+.mk_df_date <- function(dates) tibble::tibble(date = as.Date(dates), ret = seq_along(dates) / 1000)
+.mk_rf_date <- function(dates) tibble::tibble(date = as.Date(dates), rf_ret = rep(0.0001, length(dates)))
+
+.args_date <- list(
+  key = "date", label = ".test_join_daily", rf_label = "test_daily_rf",
+  rf_source = "test daily source", df_label = "test_daily_df",
+  strategy_label = "TEST-DAILY", period_noun = "date"
+)
+
+.call_join <- function(df, rf, args, ...) {
+  do.call(.join_rf_series, c(list(df = df, rf = rf), args, list(...)))
+}
+
+# ── Complete coverage: no gaps, either key type ───────────────────────────
+
+test_that("complete coverage returns all rows with no NA rf_ret (monthly)", {
+  out <- .call_join(.mk_df_ym(c("2026-01", "2026-02")), .mk_rf_ym(c("2026-01", "2026-02")), .args_ym)
+  expect_equal(nrow(out), 2L)
+  expect_false(anyNA(out$rf_ret))
+})
+
+test_that("complete coverage returns all rows with no NA rf_ret (daily)", {
+  out <- .call_join(
+    .mk_df_date(c("2026-01-05", "2026-01-06")),
+    .mk_rf_date(c("2026-01-05", "2026-01-06")),
+    .args_date
+  )
+  expect_equal(nrow(out), 2L)
+  expect_false(anyNA(out$rf_ret))
+})
+
+# ── TRAILING: trim + warn (Fama-French publication lag) ──────────────────
+
+test_that("trailing gap (monthly) is trimmed and warns, naming the dropped period", {
+  df <- .mk_df_ym(c("2026-01", "2026-02", "2026-03"))
+  rf <- .mk_rf_ym(c("2026-01", "2026-02"))
+  expect_warning(out <- .call_join(df, rf, .args_ym), regexp = "2026-03")
+  expect_equal(nrow(out), 2L)
+  expect_false(anyNA(out$rf_ret))
+  expect_false("2026-03" %in% out$ym)
+})
+
+test_that("trailing gap (daily) is trimmed and warns, naming the dropped period", {
+  df <- .mk_df_date(c("2026-01-05", "2026-01-06", "2026-01-07"))
+  rf <- .mk_rf_date(c("2026-01-05", "2026-01-06"))
+  expect_warning(out <- .call_join(df, rf, .args_date), regexp = "2026-01-07")
+  expect_equal(nrow(out), 2L)
+  expect_false(anyNA(out$rf_ret))
+  expect_false(as.Date("2026-01-07") %in% out$date)
+})
+
+# ── INTERIOR: abort, correctly described as a HOLE ────────────────────────
+
+test_that("interior gap (monthly) aborts, naming the missing month and 'HOLE'", {
+  df <- .mk_df_ym(c("2026-01", "2026-02", "2026-03"))
+  rf <- .mk_rf_ym(c("2026-01", "2026-03"))  # 2026-02 missing, inside rf's own span
+  expect_error(.call_join(df, rf, .args_ym), regexp = "2026-02")
+  expect_error(.call_join(df, rf, .args_ym), regexp = "HOLE")
+})
+
+test_that("interior gap (daily) aborts, naming the missing date and 'HOLE'", {
+  df <- .mk_df_date(c("2026-01-05", "2026-01-06", "2026-01-07"))
+  rf <- .mk_rf_date(c("2026-01-05", "2026-01-07"))  # 2026-01-06 missing, inside rf's own span
+  expect_error(.call_join(df, rf, .args_date), regexp = "2026-01-06")
+  expect_error(.call_join(df, rf, .args_date), regexp = "HOLE")
+})
+
+# ── LEADING: abort, says "leading", NEVER "hole" -- the wording bug #684 ──
+# flagged (PR #679/#683/#684 reported this case as "a HOLE in the series",
+# sending a reader hunting for a gap that does not exist).
+
+test_that("leading gap (monthly) aborts, says LEADING and never 'hole'", {
+  df <- .mk_df_ym(c("2025-11", "2025-12", "2026-01"))
+  rf <- .mk_rf_ym(c("2025-12", "2026-01"))  # rf starts after df -- 2025-11 is LEADING
+  err <- tryCatch(.call_join(df, rf, .args_ym), error = function(e) e)
+  expect_s3_class(err, "rlang_error")
+  msg <- conditionMessage(err)
+  expect_match(msg, "2025-11", fixed = TRUE)
+  expect_match(msg, "LEADING", fixed = TRUE)
+  expect_false(grepl("hole", msg, ignore.case = TRUE))
+})
+
+test_that("leading gap (daily) aborts, says LEADING and never 'hole'", {
+  df <- .mk_df_date(c("2026-01-03", "2026-01-04", "2026-01-05"))
+  rf <- .mk_rf_date(c("2026-01-04", "2026-01-05"))  # 2026-01-03 is LEADING
+  err <- tryCatch(.call_join(df, rf, .args_date), error = function(e) e)
+  msg <- conditionMessage(err)
+  expect_match(msg, "2026-01-03", fixed = TRUE)
+  expect_match(msg, "LEADING", fixed = TRUE)
+  expect_false(grepl("hole", msg, ignore.case = TRUE))
+})
+
+test_that("leading takes priority when a leading AND an interior gap both exist", {
+  # 2025-11 is LEADING (before rf starts); 2026-01 is INTERIOR (inside rf's span).
+  df <- .mk_df_ym(c("2025-11", "2025-12", "2026-01", "2026-02"))
+  rf <- .mk_rf_ym(c("2025-12", "2026-02"))
+  err <- tryCatch(.call_join(df, rf, .args_ym), error = function(e) e)
+  msg <- conditionMessage(err)
+  expect_match(msg, "LEADING", fixed = TRUE)
+  expect_match(msg, "2025-11", fixed = TRUE)
+})
+
+# ── Missing columns / missing key column ──────────────────────────────────
+
+test_that("aborts when rf lacks required columns", {
+  expect_error(
+    .call_join(.mk_df_ym("2026-01"), tibble::tibble(ym = "2026-01"), .args_ym),
+    regexp = "rf_ret"
+  )
+})
+
+test_that("aborts when df has no key column and check_key_col is TRUE (default)", {
+  bad_df <- tibble::tibble(not_ym = "2026-01", ret = 1)
+  expect_error(
+    .call_join(bad_df, .mk_rf_ym("2026-01"), .args_ym),
+    regexp = "ym"
+  )
+})
+
+test_that("check_key_col = FALSE skips the key-column presence check", {
+  # df already has ym present -- FALSE just skips the defensive check, so
+  # behaviour is identical to the default when the column IS present (this
+  # is how CMR / mom_prepeak use it: they guarantee `ym` by construction
+  # before calling, mirroring their pre-#677-slice-3b behaviour of never
+  # checking for it at all).
+  out <- .call_join(
+    .mk_df_ym(c("2026-01", "2026-02")), .mk_rf_ym(c("2026-01", "2026-02")),
+    .args_ym, check_key_col = FALSE
+  )
+  expect_equal(nrow(out), 2L)
+})
+
+# ── Snapshot coverage for the abort messages themselves ───────────────────
+
+test_that(".join_rf_series abort messages are stable (monthly)", {
+  expect_snapshot(
+    error = TRUE,
+    .call_join(
+      .mk_df_ym(c("2026-01", "2026-02", "2026-03")),
+      .mk_rf_ym(c("2026-01", "2026-03")),
+      .args_ym
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    .call_join(
+      .mk_df_ym(c("2025-11", "2025-12", "2026-01")),
+      .mk_rf_ym(c("2025-12", "2026-01")),
+      .args_ym
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    .call_join(.mk_df_ym("2026-01"), tibble::tibble(ym = "2026-01"), .args_ym)
+  )
+})
+
+test_that(".join_rf_series abort messages are stable (daily)", {
+  expect_snapshot(
+    error = TRUE,
+    .call_join(
+      .mk_df_date(c("2026-01-05", "2026-01-06", "2026-01-07")),
+      .mk_rf_date(c("2026-01-05", "2026-01-07")),
+      .args_date
+    )
+  )
+})

--- a/tests/testthat/test-plan-olmar.R
+++ b/tests/testthat/test-plan-olmar.R
@@ -1,0 +1,161 @@
+testthat::local_edition(3)
+# Regression tests for #677 slice 3b: OLMAR-1's Sharpe migrated from an
+# arithmetic-numerator, NO-risk-free-deduction formula
+# (`mean(ret) * 252 / vol`) onto the canonical sharpe_ratio_rf()
+# (geometric numerator, rf-deducted, periods_per_year = 252L). OLMAR-1 was
+# the last unmigrated strategy in issue #677 and sat at the top of the
+# leaderboard (0.883) while every strategy it was ranked against had
+# already been corrected downward by slices 1-3. It also fixes an
+# inconsistency WITHIN olmar_metrics itself: cagr was already geometric,
+# so the pre-fix sharpe was not the Sharpe of the reported CAGR.
+#
+# These tests cover two things: (1) .olmar_join_rf() -- the fifth caller of
+# the shared .join_rf_series() coverage policy (R/utils_metrics.R), mirroring
+# .tom_join_rf_daily() (R/plan_turn_of_month.R); and (2) olmar_metrics'
+# sharpe/cagr/vol values, evaluated by extracting the target's command
+# expression and running it against toy fixtures (mirrors
+# tests/testthat/test-plan-turn-of-month.R's approach for tom_metrics).
+
+source(here::here("R/utils_metrics.R"))
+source(here::here("R/plan_olmar.R"))
+
+.target_command <- function(target_list, name) {
+  hit <- vapply(target_list, function(t) identical(t$settings$name, name), logical(1))
+  if (sum(hit) != 1L) {
+    stop("target '", name, "' not found (or not unique) in this plan's target list")
+  }
+  target_list[[which(hit)]]$command$expr[[1]]
+}
+
+.eval_command_args <- function(expr, args_list) {
+  env <- list2env(args_list, envir = new.env(parent = globalenv()))
+  eval(expr, envir = env)
+}
+
+# ── .olmar_join_rf(): coverage policy (mirrors .tom_join_rf_daily tests) ──
+
+.mk_port_daily <- function(dates) {
+  tibble::tibble(
+    date      = as.Date(dates),
+    gross_ret = seq_along(dates) / 10000,
+    net_ret   = seq_along(dates) / 10000,
+    turnover  = 0.1
+  )
+}
+.mk_rf_daily <- function(dates) {
+  tibble::tibble(date = as.Date(dates), rf_ret = rep(0.0001, length(dates)))
+}
+
+test_that(".olmar_join_rf attaches rf_ret with no NA when coverage is complete", {
+  out <- .olmar_join_rf(
+    .mk_port_daily(c("2026-01-05", "2026-01-06")),
+    .mk_rf_daily(c("2026-01-05", "2026-01-06"))
+  )
+  expect_equal(nrow(out), 2L)
+  expect_false(anyNA(out$rf_ret))
+})
+
+test_that(".olmar_join_rf trims a trailing uncovered date and warns", {
+  port <- .mk_port_daily(c("2026-01-05", "2026-01-06", "2026-01-07"))
+  rf   <- .mk_rf_daily(c("2026-01-05", "2026-01-06"))
+
+  expect_warning(out <- .olmar_join_rf(port, rf), regexp = "2026-01-07")
+  expect_equal(nrow(out), 2L)
+  expect_false(anyNA(out$rf_ret))
+})
+
+test_that(".olmar_join_rf still aborts on an INTERIOR hole -- a real FF3 gap, not a lag", {
+  port <- .mk_port_daily(c("2026-01-05", "2026-01-06", "2026-01-07"))
+  rf   <- .mk_rf_daily(c("2026-01-05", "2026-01-07"))  # 2026-01-06 missing, inside span
+
+  expect_error(.olmar_join_rf(port, rf), regexp = "2026-01-06")
+  expect_error(.olmar_join_rf(port, rf), regexp = "HOLE")
+})
+
+test_that(".olmar_join_rf aborts when rf lacks required columns", {
+  expect_error(
+    .olmar_join_rf(.mk_port_daily("2026-01-05"), tibble::tibble(date = as.Date("2026-01-05"))),
+    regexp = "rf_ret"
+  )
+})
+
+test_that(".olmar_join_rf abort messages are stable", {
+  port <- .mk_port_daily(c("2026-01-05", "2026-01-06", "2026-01-07"))
+  expect_snapshot(error = TRUE, .olmar_join_rf(port, .mk_rf_daily(c("2026-01-05", "2026-01-07"))))
+})
+
+# ── olmar_metrics: rf-adjusted, geometric Sharpe ──────────────────────────
+
+.toy_olmar_portfolio <- function(n_days = 800L, seed = 677L, rf_val = 0.0002, ret_sd = 0.03) {
+  set.seed(seed)
+  dates <- seq(as.Date("2010-01-04"), by = "day", length.out = n_days)
+  ret   <- stats::rnorm(n_days, mean = 0.0006, sd = ret_sd)  # deliberately volatile fixture
+  tibble::tibble(
+    date      = dates,
+    gross_ret = ret,
+    net_ret   = ret,
+    turnover  = 0.15,
+    rf_ret    = rep(rf_val, n_days)
+  )
+}
+
+.olmar_env_args <- function(port, test_start = "2011-01-01", test_end = "2011-06-30") {
+  list(
+    olmar_portfolio = port,
+    olmar_params    = list(test_start = as.Date(test_start), test_end = as.Date(test_end)),
+    sharpe_ratio_rf = sharpe_ratio_rf
+  )
+}
+
+test_that("olmar_metrics Full Period sharpe/cagr/vol match sharpe_ratio_rf() exactly", {
+  cmd  <- .target_command(plan_olmar(), "olmar_metrics")
+  port <- .toy_olmar_portfolio()
+
+  result <- .eval_command_args(cmd, .olmar_env_args(port))
+  full   <- result[result$period == "Full Period", ]
+
+  expected <- sharpe_ratio_rf(port$net_ret, port$rf_ret, periods_per_year = 252L)
+
+  expect_equal(nrow(full), 1L)
+  expect_equal(full$sharpe, round(expected$sharpe, 3))
+  expect_equal(full$cagr, round(expected$ann_ret * 100, 2))
+  expect_equal(full$vol, round(expected$ann_vol * 100, 2))
+})
+
+test_that("olmar_metrics sharpe differs from the old arithmetic no-rf formula on a volatile fixture", {
+  cmd  <- .target_command(plan_olmar(), "olmar_metrics")
+  port <- .toy_olmar_portfolio(ret_sd = 0.04)  # high vol -> arithmetic/geometric gap is large
+
+  result <- .eval_command_args(cmd, .olmar_env_args(port))
+  full   <- result[result$period == "Full Period", ]
+
+  # Old (pre-#677) formula: arithmetic mean numerator, NO risk-free deduction.
+  old_vol    <- sd(port$net_ret) * sqrt(252)
+  old_sharpe <- if (old_vol > 0) mean(port$net_ret) * 252 / old_vol else NA_real_
+
+  expect_false(isTRUE(all.equal(full$sharpe, round(old_sharpe, 3))))
+})
+
+test_that("a positive risk-free rate lowers olmar_metrics sharpe relative to zero-rf", {
+  cmd <- .target_command(plan_olmar(), "olmar_metrics")
+
+  port_zero_rf <- .toy_olmar_portfolio(rf_val = 0)
+  port_pos_rf  <- .toy_olmar_portfolio(rf_val = 0.0003)
+
+  res_zero <- .eval_command_args(cmd, .olmar_env_args(port_zero_rf))
+  res_pos  <- .eval_command_args(cmd, .olmar_env_args(port_pos_rf))
+
+  full_zero <- res_zero[res_zero$period == "Full Period", ]
+  full_pos  <- res_pos[res_pos$period == "Full Period", ]
+
+  expect_lt(full_pos$sharpe, full_zero$sharpe)
+})
+
+test_that("olmar_metrics still produces Training/Testing/Full Period rows", {
+  cmd    <- .target_command(plan_olmar(), "olmar_metrics")
+  port   <- .toy_olmar_portfolio()
+  result <- .eval_command_args(cmd, .olmar_env_args(port))
+
+  expect_true(all(c("Training", "Testing", "Full Period") %in% result$period))
+  expect_false(anyNA(result$sharpe))
+})


### PR DESCRIPTION
## Summary

Second half of #677: migrates the last unmigrated strategy (OLMAR-1) onto the canonical rf-adjusted Sharpe, and consolidates the four duplicated rf-join helpers into one shared, unit-tested function.

## Part 1 — OLMAR-1

`R/plan_olmar.R:128` computed `sharpe = mean(ret) * 252 / vol` — arithmetic numerator, **no risk-free deduction**, daily. `cagr` two lines above was already geometric, so the reported Sharpe was not the Sharpe of the reported CAGR — an inconsistency **within the same function**.

OLMAR-1 sat at **#1 on the leaderboard at 0.883** while every strategy it was ranked against had already been corrected downward by slices 1–3 (#679, #681, #682, #683, #684).

Now uses the canonical `sharpe_ratio_rf()` (geometric numerator, rf-deducted, `periods_per_year = 252L`). `cagr`/`vol` in the output tibble are now read straight off the same `sharpe_ratio_rf()` call, so all three figures are guaranteed coherent with each other.

### Before/after (standalone verification, not the targets store)

I can't run `tar_make()` (store conflict, per instructions), so I reproduced the OLMAR-1 backtest + `daily_rf` join directly against live data outside the pipeline:

```
Portfolio: 4093 days, 2010-01-04 .. 2026-04-13 (20 of 30 tickers passed the history filter)
daily_rf:  26190 days, 1926-07-01 .. 2026-02-27
Rows trimmed (trailing, no rf yet): 30 (2026-03-02..2026-04-13)

OLD (arithmetic, no rf):  cagr=15.96%  vol=18.67%  sharpe=0.887
NEW (geometric, rf-adj):  cagr=15.96%  vol=18.67%  sharpe=0.780  (ann_rf=1.40%)
Delta sharpe: 0.887 -> 0.780 (-0.107)
```

cagr/vol are unchanged (same formula, just now sourced from `sharpe_ratio_rf()` instead of duplicated inline). Sharpe fell by ~0.11 (~12% relative) once the real ~1.40%/yr risk-free rate since 2010 is deducted — matching the issue's estimate of `(15.89 − rf)/18.67`. **The migration moved the number; it did not silently do nothing.**

This is a standalone reproduction (20/30 tickers passed vs whatever the production run gets, slightly different price snapshot), not the pipeline's own build — the orchestrator should confirm the real production Sharpe/rank move after a rebuild.

## Part 2 — consolidate the rf-join helpers

There were four near-identical implementations of the same rf coverage policy (`.ltr_join_rf`, `.tom_join_rf_daily`, `.mom_prepeak_join_rf`, CMR's own). OLMAR needed a fifth. All five now call one shared, pure, unit-tested `.join_rf_series()` in `R/utils_metrics.R`.

### Three-case policy (closes the gap PR #684 found)

PR #679 split trailing (trim+warn) from interior (abort) but never considered **leading** — a return series starting *before* the risk-free series does. PR #684 hit exactly this (9 targets) and it was reported as "a HOLE in the series", sending a reader hunting for a gap that does not exist. The shared helper now distinguishes all three:

| case | condition | action |
|---|---|---|
| **leading** | before `min(rf[[key]])` | **abort**, says "LEADING", never "hole" |
| **trailing** | after `max(rf[[key]])` | trim + `cli_warn`, naming dropped periods + effective end |
| **interior** | within `[min, max]` | abort, correctly described as a HOLE |

Works for both monthly (`ym`, character) and daily (`date`, `Date`) keys via a `key`/`period_noun` parameter rather than two near-duplicate helpers. If a series has both a leading and an interior gap simultaneously, leading is reported first (documented in the roxygen).

### Signature

```r
.join_rf_series(df, rf, key, label, rf_label, rf_source, df_label,
                 strategy_label, period_noun = "month",
                 check_key_col = TRUE, df_arg_name = "df")
```

Lives in `R/utils_metrics.R` (the precedent PR #678 set for `sharpe_ratio_rf()`) — pure, no target/database access, unit-testable directly (`tests/testthat/test-join-rf-series.R`). PR #678's original guard shipped untested because it lived inside a target reading a gitignored parquet, which is exactly how `main` broke twice.

### The five migrated call sites — behaviour unchanged

`.ltr_join_rf`, `.tom_join_rf_daily`, `.mom_prepeak_join_rf`, `.cmr_join_rf` are now thin wrappers around `.join_rf_series()`. `.olmar_join_rf` is new (fifth caller).

**All four snapshot diffs are pure wording normalisation** — reviewed each individually, not mass-accepted:
- `Error in \`.ltr_join_rf()\`:` → `Error in \`.join_rf_series()\`:` (delegation frame)
- Strategy label folded into the first bullet, e.g. `(LTR)`, `(CMR test)`, `(TOM)`
- `"Missing ym: ..."` → `"Missing month: ..."` (and `"Missing date: ..."` unchanged in spirit for TOM)
- `tom_rf_daily` → `daily_rf` (see below)

**The actual dropped/missing period values and abort/trim boundaries are byte-identical to before** — every diff was `diff old.md new.md`'d and confirmed to change only prose, never which months/dates get trimmed or aborted on.

### Did I unify the daily rf target? Yes — moved + renamed

`tom_rf_daily` (`R/plan_turn_of_month.R`) fetched `from = tom_params$start_date` (1994-01-01) — **the exact same consumer-scoping bug that broke `stk_rf` in #684** the moment a second consumer needed the series (mom_prepeak/CMR needed history back to 1973/1992, and `stk_rf` was scoped to the stock backtest's 2005 start). This wasn't "TOM-specific filtering" in any meaningful sense — it was just an unscoped fetch that happened to use a TOM param, so I moved it rather than leaving it and bolting an OLMAR-specific fetch alongside.

`daily_rf` (`R/plan_stock_backtest.R`, right after `stk_rf`) now fetches FF3's full daily series from `1926-07-01` unscoped, with the same empty/NA fail-loud guard `stk_rf` carries. TOM (starts 1994) and OLMAR-1 (starts 2010) are both safely inside that range today — no leading gap fires in production — but the series itself no longer depends on that being true.

## Tests

- `tests/testthat/test-join-rf-series.R` — 14 `test_that` blocks covering complete coverage / trailing / interior / leading × {monthly, daily}, leading-takes-priority when both leading and interior gaps exist, missing rf columns, missing df key column, `check_key_col = FALSE`, and snapshot coverage of every abort message including one that specifically asserts the leading-case message contains `"LEADING"` and **never** contains `"hole"` (case-insensitive).
- `tests/testthat/test-plan-olmar.R` — 9 `test_that` blocks: `.olmar_join_rf` coverage (mirrors `.tom_join_rf_daily`'s tests), `olmar_metrics` sharpe/cagr/vol matching `sharpe_ratio_rf()` exactly, differing from the old arithmetic formula on a volatile fixture, and a positive rf lowering Sharpe relative to zero-rf.
- All new root test files start with `testthat::local_edition(3)`.
- `_snaps/join-rf-series.md` and `_snaps/plan-olmar.md` committed alongside.

## Verification

`parse("_targets.R")`: PASS.

`scripts/verify.sh`: **PASS**.
- Root: `total=546 failed=3 skipped=0` — the 3 failures match the known baseline exactly (unchanged). +23 tests vs the `c827bd7` baseline (523), all new tests passing.
- Package: `total=695 failed=1 skipped=15` — exact baseline match, unchanged.

Per #680, `verify.sh` passing does **not** prove the pipeline builds — this PR touches five call sites in a series that has already broken `main` twice this way (#678, #684). **The orchestrator must rebuild (`docs/` `tar_make()`) and check `tar_meta(fields = error)` before merging**, and confirm OLMAR-1's real production Sharpe/rank move roughly as shown in the standalone verification above.

**Not verified:** `r_code_check.sh` (ast-grep/jarl code-quality gate) — `ast-grep` is not on `PATH` in this worktree's environment; the script exited with a tooling error unrelated to the code changes, so this gate was not run.

## Out of scope

Slice 4 (gate S17 — asserting `sharpe` is coherent with `cagr`/`vol`/`rf` published beside it across the whole leaderboard).

Refs #677, #678, #679, #680, #682, #683, #684
