### PR TITLE
feat(qa): S17 leaderboard sharpe-coherence gate (#677 slice 4)

### DIFF
--- a/R/plan_avoid_worst.R
+++ b/R/plan_avoid_worst.R
@@ -31,9 +31,10 @@
 #' @param rets Numeric vector of daily returns.
 #' @param aw_daily_rf Tibble with columns `date`, `rf_ret` (daily Fama-French RF).
 #' @param ann_factor Integer. Annualisation factor (252 for daily).
-#' @return Numeric scalar Sharpe (may be NA_real_).
+#' @return A list with `sharpe` and `ann_rf` (either may be NA_real_ -- see
+#'   `.aw_sharpe_rf()`'s roxygen for when).
 #' @noRd
-.aw_sharpe_rf <- function(dates, rets, aw_daily_rf, ann_factor = 252L) {
+.aw_sharpe_rf_full <- function(dates, rets, aw_daily_rf, ann_factor = 252L) {
   required <- c("date", "rf_ret")
   missing_cols <- setdiff(required, names(aw_daily_rf))
   if (length(missing_cols) > 0L) {
@@ -47,7 +48,7 @@
     dplyr::filter(!is.na(.data$ret)) |>
     dplyr::left_join(aw_daily_rf, by = "date")
 
-  if (nrow(df) < 2L) return(NA_real_)
+  if (nrow(df) < 2L) return(list(sharpe = NA_real_, ann_rf = NA_real_))
 
   missing_rf_dates <- sort(df$date[is.na(df$rf_ret)])
   if (length(missing_rf_dates) > 0L) {
@@ -69,7 +70,14 @@
     ))
   }
 
-  sharpe_ratio_rf(df$ret, df$rf_ret, periods_per_year = ann_factor)$sharpe
+  sharpe_ratio_rf(df$ret, df$rf_ret, periods_per_year = ann_factor)
+}
+
+#' Thin wrapper over .aw_sharpe_rf_full() returning just the Sharpe ratio
+#' @return Numeric scalar Sharpe (may be NA_real_).
+#' @noRd
+.aw_sharpe_rf <- function(dates, rets, aw_daily_rf, ann_factor = 252L) {
+  .aw_sharpe_rf_full(dates, rets, aw_daily_rf, ann_factor)$sharpe
 }
 
 plan_avoid_worst <- function() {
@@ -516,6 +524,11 @@ plan_avoid_worst <- function() {
         best_10 <- ord[seq(max(1, n - 9), n)]
 
         metrics_for <- function(r, scenario, r_dts) {
+          # #677 slice 4: capture the full sharpe_ratio_rf() result so
+          # ann_rf can be published alongside sharpe -- QA gate S17
+          # (check_leaderboard_sharpe_coherence(), R/plan_qa_gates.R)
+          # asserts sharpe == (cagr - ann_rf) / vol for every leaderboard row.
+          sr <- .aw_sharpe_rf_full(r_dts, r, aw_daily_rf, ann_factor = 252L)
           tibble::tibble(
             strategy = "SPY",
             period = label,
@@ -529,7 +542,9 @@ plan_avoid_worst <- function() {
                                  cummax(cumprod(1 + r))) * 100, 1),
             # #677: canonical rf-adjusted geometric Sharpe (R/utils_metrics.R),
             # replacing the arithmetic-mean, no-rf formula.
-            sharpe = round(.aw_sharpe_rf(r_dts, r, aw_daily_rf, ann_factor = 252L), 2),
+            sharpe = round(sr$sharpe, 2),
+            # ann_rf published in the same PERCENT convention as cagr/vol above.
+            ann_rf = round(sr$ann_rf * 100, 2),
             window_start = min(dts),
             window_end   = max(dts)
           )

--- a/R/plan_commodities_mean_reversion.R
+++ b/R/plan_commodities_mean_reversion.R
@@ -213,7 +213,7 @@ plan_commodities_mean_reversion <- function() {
   if (n < 12L) {
     return(tibble::tibble(
       lookback = lookback, n_months = n,
-      sharpe = NA_real_, cagr = NA_real_, vol = NA_real_,
+      sharpe = NA_real_, cagr = NA_real_, vol = NA_real_, ann_rf = NA_real_,
       max_dd = NA_real_, avg_dd_duration = NA_real_, max_dd_duration = NA_real_
     ))
   }
@@ -254,6 +254,11 @@ plan_commodities_mean_reversion <- function() {
     sharpe          = round(sharpe, 3),
     cagr            = round(cagr, 4),
     vol             = round(vol, 4),
+    # ann_rf published alongside sharpe (#677 slice 4), same FRACTION
+    # convention as cagr/vol above -- QA gate S17
+    # (check_leaderboard_sharpe_coherence(), R/plan_qa_gates.R) asserts
+    # sharpe == (cagr - ann_rf) / vol for every leaderboard row.
+    ann_rf          = round(sr$ann_rf, 4),
     max_dd          = round(max_dd, 4),
     avg_dd_duration = dd_stats$avg_dd_duration,
     max_dd_duration = dd_stats$max_dd_duration

--- a/R/plan_drif.R
+++ b/R/plan_drif.R
@@ -290,7 +290,12 @@ plan_drif <- function() {
         if (n < 12) return(NULL)
         ann_ret <- prod(1 + df$portfolio_ret)^(12/n) - 1
         ann_vol <- sd(df$portfolio_ret) * sqrt(12)
-        sharpe <- (ann_ret - mean(df$rf_ret, na.rm = TRUE) * 12) / ann_vol
+        # ann_rf captured as its own variable (#677 slice 4) so it can be
+        # published alongside sharpe -- QA gate S17
+        # (check_leaderboard_sharpe_coherence(), R/plan_qa_gates.R) asserts
+        # sharpe == (cagr - ann_rf) / vol for every leaderboard row.
+        ann_rf <- mean(df$rf_ret, na.rm = TRUE) * 12
+        sharpe <- (ann_ret - ann_rf) / ann_vol
         cum <- cumprod(1 + df$portfolio_ret)
         max_dd <- min(cum / cummax(cum) - 1)
         hit <- mean(df$portfolio_ret > df$benchmark_ret, na.rm = TRUE)
@@ -301,7 +306,7 @@ plan_drif <- function() {
 
         tibble(
           period = label, months = n,
-          cagr = ann_ret, vol = ann_vol, sharpe = sharpe,
+          cagr = ann_ret, vol = ann_vol, sharpe = sharpe, ann_rf = ann_rf,
           max_dd = max_dd, hit_rate = hit,
           bench_cagr = bench_ann, bench_vol = bench_vol,
           bench_sharpe = bench_sharpe

--- a/R/plan_ev_ebit.R
+++ b/R/plan_ev_ebit.R
@@ -138,6 +138,11 @@ plan_ev_ebit <- function() {
           cagr         = round(cagr, 2),
           vol          = round(vol, 2),
           sharpe       = round(sharpe, 3),
+          # ann_rf published alongside sharpe (#677 slice 4), same PERCENT
+          # convention as cagr/vol above -- QA gate S17
+          # (check_leaderboard_sharpe_coherence(), R/plan_qa_gates.R) asserts
+          # sharpe == (cagr - ann_rf) / vol for every leaderboard row.
+          ann_rf       = round(sr$ann_rf * 100, 2),
           max_dd       = round(max_dd, 2),
           calmar       = round(calmar, 3),
           window_start = min(date_vec),

--- a/R/plan_factormax.R
+++ b/R/plan_factormax.R
@@ -184,7 +184,12 @@ plan_factormax <- function() {
         if (n < 12) return(NULL)
         ann_ret <- prod(1 + df$portfolio_ret)^(12/n) - 1
         ann_vol <- sd(df$portfolio_ret) * sqrt(12)
-        sharpe <- (ann_ret - mean(df$rf_ret) * 12) / ann_vol
+        # ann_rf captured as its own variable (#677 slice 4) so it can be
+        # published alongside sharpe -- QA gate S17
+        # (check_leaderboard_sharpe_coherence(), R/plan_qa_gates.R) asserts
+        # sharpe == (cagr - ann_rf) / vol for every leaderboard row.
+        ann_rf <- mean(df$rf_ret) * 12
+        sharpe <- (ann_ret - ann_rf) / ann_vol
         cum <- cumprod(1 + df$portfolio_ret)
         dd <- cum / cummax(cum) - 1
         max_dd <- min(dd)
@@ -197,7 +202,7 @@ plan_factormax <- function() {
         tibble(
           period = label,
           months = n,
-          cagr = ann_ret, vol = ann_vol, sharpe = sharpe,
+          cagr = ann_ret, vol = ann_vol, sharpe = sharpe, ann_rf = ann_rf,
           max_dd = max_dd, hit_rate = hit,
           bench_cagr = bench_ann, bench_vol = bench_vol,
           bench_sharpe = bench_sharpe

--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -33,6 +33,17 @@
 # See also: R/plan_qa_gates.R `qa_leaderboard_metric_ranges` -- the range gate
 # that asserts every row here is within a plausible fractional range.
 #
+# ── ann_rf (#677 slice 4) ───────────────────────────────────────────────────
+# `ann_rf` is the annualised risk-free rate each source metrics target
+# actually deducted when computing `sharpe`. It follows the EXACT SAME
+# fraction/percent convention as `cagr` in its own source target -- every
+# `.norm_*` helper below divides `ann_rf` by 100 in lockstep with `cagr`, and
+# the direct add_meta() targets (fm_metrics, drif_metrics, stk_max_metrics,
+# stk_drif_metrics, xgb_drif_metrics, port_metrics) already
+# carry it as a fraction, same as their `cagr`. It is REQUIRED (never NA) --
+# see R/plan_qa_gates.R `check_leaderboard_sharpe_coherence()` (S17), which
+# asserts `sharpe == (cagr - ann_rf) / vol` for every leaderboard row.
+#
 # ── Period vocabulary (#643) ────────────────────────────────────────────────
 # The `period` column MUST only contain values from `PERIOD_LABELS_ALLOWED`
 # (R/plan_partitions.R). Two source targets (mf_metrics, ev_metrics) used
@@ -74,7 +85,8 @@ plan_leaderboard <- function() {
       .norm_ltr <- function(m) {
         if (is.null(m) || nrow(m) == 0) return(NULL)
         m |>
-          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100)
+          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100,
+                 ann_rf = ann_rf / 100)
       }
 
       # olmar_metrics has `days` instead of `months`; daily ann_factor.
@@ -84,7 +96,8 @@ plan_leaderboard <- function() {
         if (is.null(m) || nrow(m) == 0) return(NULL)
         m |>
           rename(months = days) |>
-          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100)
+          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100,
+                 ann_rf = ann_rf / 100)
       }
 
       # tom_metrics uses cagr_tom, vol_tom, sharpe_tom, max_dd_tom.
@@ -101,6 +114,7 @@ plan_leaderboard <- function() {
           cagr   = cagr_tom / 100,
           vol    = vol_tom / 100,
           sharpe = sharpe_tom,
+          ann_rf = ann_rf_tom / 100,
           max_dd = max_dd_tom / 100
         )
       }
@@ -121,6 +135,7 @@ plan_leaderboard <- function() {
           cagr   = cagr,
           vol    = vol,
           sharpe = sharpe,
+          ann_rf = ann_rf,
           max_dd = max_dd,
           cmr_lookback = lookback  # preserve for inspection
         )
@@ -140,7 +155,8 @@ plan_leaderboard <- function() {
         m |>
           filter(strategy == "SPY_overlay") |>
           select(-strategy) |>
-          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100)
+          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100,
+                 ann_rf = ann_rf / 100)
       }
 
       # mom_prepeak_metrics / siblings have no period column (one row per
@@ -159,6 +175,7 @@ plan_leaderboard <- function() {
             cagr   = cagr / 100,
             vol    = vol / 100,
             sharpe = sharpe,
+            ann_rf = ann_rf / 100,
             max_dd = max_dd / 100
           )
       }
@@ -173,7 +190,8 @@ plan_leaderboard <- function() {
           filter(scenario == "Remove 10 Worst") |>
           select(-scenario) |>
           rename(months = n_days) |>
-          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100)
+          mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100,
+                 ann_rf = ann_rf / 100)
       }
 
       # mf_metrics has multiple internal strategies (Long-Only, Long-Short, EW benchmark)
@@ -200,7 +218,8 @@ plan_leaderboard <- function() {
           rename(months = n_months) |>
           mutate(
             period = ifelse(period == "Full", "Full Period", period),
-            cagr   = cagr / 100, vol = vol / 100, max_dd = max_dd / 100
+            cagr   = cagr / 100, vol = vol / 100, max_dd = max_dd / 100,
+            ann_rf = ann_rf / 100
           )
       }
 
@@ -222,7 +241,8 @@ plan_leaderboard <- function() {
           rename(months = n_months) |>
           mutate(
             period = ifelse(period == "Full", "Full Period", period),
-            cagr   = cagr / 100, vol = vol / 100, max_dd = max_dd / 100
+            cagr   = cagr / 100, vol = vol / 100, max_dd = max_dd / 100,
+            ann_rf = ann_rf / 100
           )
       }
 
@@ -278,7 +298,8 @@ plan_leaderboard <- function() {
         port_row <- port_metrics |>
           transmute(
             period = period, months = months,
-            cagr = opt_cagr, vol = opt_vol, sharpe = opt_sharpe, max_dd = opt_maxdd,
+            cagr = opt_cagr, vol = opt_vol, sharpe = opt_sharpe, ann_rf = ann_rf,
+            max_dd = opt_maxdd,
             strategy = "PSO Optimal", level = "Combined",
             signal = "Weighted portfolio",
             definition = "stock-backtest.html#comparison"

--- a/R/plan_ltr_momentum.R
+++ b/R/plan_ltr_momentum.R
@@ -202,6 +202,11 @@ plan_ltr_momentum <- function() {
           vol        = round(ann_vol * 100, 1),
           max_dd     = round(max_dd * 100, 1),
           sharpe     = round(sr$sharpe, 2),
+          # ann_rf published alongside sharpe (#677 slice 4), same PERCENT
+          # convention as cagr/vol above -- QA gate S17
+          # (check_leaderboard_sharpe_coherence(), R/plan_qa_gates.R) asserts
+          # sharpe == (cagr - ann_rf) / vol for every leaderboard row.
+          ann_rf     = round(sr$ann_rf * 100, 1),
           hac_sharpe = round(hac$naive_sharpe, 2),
           hac_tstat  = round(hac$hac_tstat, 2),
           avg_long   = if ("n_long" %in% names(df)) round(mean(df$n_long, na.rm = TRUE)) else NA_integer_,

--- a/R/plan_managed_futures.R
+++ b/R/plan_managed_futures.R
@@ -216,6 +216,11 @@ plan_managed_futures <- function() {
           cagr         = round(cagr, 2),
           vol          = round(vol, 2),
           sharpe       = round(sharpe, 3),
+          # ann_rf published alongside sharpe (#677 slice 4), same PERCENT
+          # convention as cagr/vol above -- QA gate S17
+          # (check_leaderboard_sharpe_coherence(), R/plan_qa_gates.R) asserts
+          # sharpe == (cagr - ann_rf) / vol for every leaderboard row.
+          ann_rf       = round(sr$ann_rf * 100, 2),
           max_dd       = round(max_dd, 2),
           calmar       = round(calmar, 3),
           window_start = min(date_vec),

--- a/R/plan_mom_prepeak.R
+++ b/R/plan_mom_prepeak.R
@@ -150,6 +150,11 @@ plan_mom_prepeak <- function() {
       rets <- .mom_prepeak_join_rf(mom_prepeak_returns, stk_rf)
       m <- .mom_prepeak_compute_metrics(rets, strategy = "mom_prepeak")
       m$sharpe <- round(.mom_prepeak_sharpe(rets, m), 3)
+      # ann_rf published alongside sharpe (#677 slice 4), same PERCENT
+      # convention as cagr/vol (.mom_prepeak_compute_metrics(), packages/
+      # historicaldata/R/utils_mom_prepeak_metrics.R stores them as
+      # round(x * 100, 1)).
+      m$ann_rf <- round(.mom_prepeak_ann_rf(rets, m) * 100, 2)
       m
     }),
 
@@ -157,6 +162,7 @@ plan_mom_prepeak <- function() {
       rets <- .mom_prepeak_join_rf(mom_postpeak_returns, stk_rf)
       m <- .mom_prepeak_compute_metrics(rets, strategy = "mom_postpeak")
       m$sharpe <- round(.mom_prepeak_sharpe(rets, m), 3)
+      m$ann_rf <- round(.mom_prepeak_ann_rf(rets, m) * 100, 2)
       m
     }),
 
@@ -164,6 +170,7 @@ plan_mom_prepeak <- function() {
       rets <- .mom_prepeak_join_rf(mom_combined_returns, stk_rf)
       m <- .mom_prepeak_compute_metrics(rets, strategy = "mom_combined")
       m$sharpe <- round(.mom_prepeak_sharpe(rets, m), 3)
+      m$ann_rf <- round(.mom_prepeak_ann_rf(rets, m) * 100, 2)
       m
     }),
 
@@ -441,9 +448,9 @@ plan_mom_prepeak <- function() {
 #' @param metrics_row One-row tibble from \code{.mom_prepeak_compute_metrics()}
 #'   (needs `blown_up`, `bankrupt_month`).
 #' @param ann_factor Integer. Annualisation factor (12 for monthly).
-#' @return Numeric scalar Sharpe (may be NA_real_).
+#' @return A list with `sharpe` and `ann_rf` (either may be NA_real_).
 #' @noRd
-.mom_prepeak_sharpe <- function(returns_tbl, metrics_row, ann_factor = 12L) {
+.mom_prepeak_sr <- function(returns_tbl, metrics_row, ann_factor = 12L) {
   if (!"rf_ret" %in% names(returns_tbl)) {
     cli::cli_abort(c(
       "x" = ".mom_prepeak_sharpe(): {.arg returns_tbl} has no {.field rf_ret} column.",
@@ -455,18 +462,40 @@ plan_mom_prepeak <- function() {
   r    <- returns_tbl$ret_ls[keep]
   rf   <- returns_tbl$rf_ret[keep]
   n    <- length(r)
-  if (n < 12L) return(NA_real_)
+  if (n < 12L) return(list(sharpe = NA_real_, ann_rf = NA_real_))
 
   blown_up       <- isTRUE(metrics_row$blown_up[[1L]])
   bankrupt_month <- metrics_row$bankrupt_month[[1L]]
 
   if (blown_up) {
-    if (is.na(bankrupt_month) || bankrupt_month <= 1L) return(NA_real_)
+    if (is.na(bankrupt_month) || bankrupt_month <= 1L) return(list(sharpe = NA_real_, ann_rf = NA_real_))
     r  <- r[seq_len(bankrupt_month - 1L)]
     rf <- rf[seq_len(bankrupt_month - 1L)]
   }
 
-  sharpe_ratio_rf(r, rf, periods_per_year = ann_factor)$sharpe
+  sr <- sharpe_ratio_rf(r, rf, periods_per_year = ann_factor)
+  list(sharpe = sr$sharpe, ann_rf = sr$ann_rf)
+}
+
+#' Thin wrapper over .mom_prepeak_sr() returning just the Sharpe ratio
+#' @return Numeric scalar Sharpe (may be NA_real_).
+#' @noRd
+.mom_prepeak_sharpe <- function(returns_tbl, metrics_row, ann_factor = 12L) {
+  .mom_prepeak_sr(returns_tbl, metrics_row, ann_factor)$sharpe
+}
+
+#' Companion accessor to \code{.mom_prepeak_sharpe()}: the annualised
+#' risk-free rate used in the same Sharpe computation (#677 slice 4)
+#'
+#' Published alongside `sharpe` in `mom_prepeak_metrics` /
+#' `mom_postpeak_metrics` / `mom_combined_metrics` so QA gate S17
+#' (\code{check_leaderboard_sharpe_coherence()}, R/plan_qa_gates.R) can
+#' assert \code{sharpe == (cagr - ann_rf) / vol} for every leaderboard row.
+#'
+#' @return Numeric scalar annualised risk-free rate (may be NA_real_).
+#' @noRd
+.mom_prepeak_ann_rf <- function(returns_tbl, metrics_row, ann_factor = 12L) {
+  .mom_prepeak_sr(returns_tbl, metrics_row, ann_factor)$ann_rf
 }
 
 

--- a/R/plan_olmar.R
+++ b/R/plan_olmar.R
@@ -146,6 +146,11 @@ plan_olmar <- function() {
           cagr     = round(sr$ann_ret * 100, 2),
           vol      = round(sr$ann_vol * 100, 2),
           sharpe   = round(sr$sharpe, 3),
+          # ann_rf published alongside sharpe (#677 slice 4), same PERCENT
+          # convention as cagr/vol above -- QA gate S17
+          # (check_leaderboard_sharpe_coherence(), R/plan_qa_gates.R) asserts
+          # sharpe == (cagr - ann_rf) / vol for every leaderboard row.
+          ann_rf   = round(sr$ann_rf * 100, 2),
           max_dd   = round(max_dd * 100, 2),
           avg_turnover_daily = round(avg_tv, 4)
         )

--- a/R/plan_portfolio_opt.R
+++ b/R/plan_portfolio_opt.R
@@ -299,7 +299,19 @@ plan_portfolio_opt <- function() {
           hrp_maxdd  = maxdd_of(df$hrp_ret),
           eq_cagr    = cagr_of(df$equalwt_ret),
           eq_sharpe  = sharpe_of(df$equalwt_ret, rf_ann),
-          eq_maxdd   = maxdd_of(df$equalwt_ret)
+          eq_maxdd   = maxdd_of(df$equalwt_ret),
+          # ann_rf published alongside opt_sharpe (#677 slice 4). All three
+          # sharpe_of() calls above share this SAME rf_ann (one risk-free
+          # rate per period, not per weighting scheme), so a single ann_rf
+          # column is correct here -- it is specifically the rate behind
+          # opt_sharpe, which is the only one of the three that reaches the
+          # leaderboard as "PSO Optimal" (R/plan_leaderboard.R port_row).
+          # FRACTION convention (port_metrics is never *100 -- see
+          # R/plan_leaderboard.R port_row, which uses opt_cagr/opt_vol/
+          # opt_sharpe/opt_maxdd unconverted) -- QA gate S17
+          # (check_leaderboard_sharpe_coherence(), R/plan_qa_gates.R) asserts
+          # sharpe == (cagr - ann_rf) / vol for every leaderboard row.
+          ann_rf     = rf_ann
         )
       }
 

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -1062,6 +1062,163 @@ check_borrow_status_registry <- function(strategy_cost_convention) {
 }
 
 
+#' Assert leaderboard `sharpe` is coherent with `cagr`, `vol`, and `ann_rf`
+#' published beside it (S17)
+#'
+#' Guards against the #677 defect class: `sharpe` on the `leaderboard`
+#' target was computed by at least FOUR distinct mathematical bases across
+#' ~13 source metrics targets (geometric vs arithmetic numerator; risk-free
+#' deducted or not), so strategies were ranked against each other on a
+#' statistic that was not actually comparable -- LTR's implied risk-free
+#' rate of -32.89% (a \code{hac_sharpe} value renamed into \code{sharpe},
+#' pre-#677 \code{R/plan_leaderboard.R}) was the sharpest symptom, but three
+#' further strategies (TOM, Value (HML), Managed Futures) deducted NO
+#' risk-free rate at all -- an implied rf of exactly 0.00%, a formula
+#' signature, not a coincidence.
+#'
+#' #677 slices 1-3b migrated every leaderboard-feeding source metrics target
+#' onto the canonical, risk-free-adjusted \code{sharpe_ratio_rf()}
+#' (R/utils_metrics.R) and required every one of them to ALSO publish the
+#' \code{ann_rf} it used (see the module-level "ann_rf (#677 slice 4)"
+#' comment in R/plan_leaderboard.R). This gate is the belt-and-braces check
+#' that the migration held EXACTLY, not approximately: rather than a
+#' "plausible band" on the implied risk-free rate -- which cannot distinguish
+#' a strategy whose sample genuinely spans a near-zero-rate era from one that
+#' silently deducted no risk-free rate at all, see
+#' \code{.claude/rules/fail-loud-not-null.md} -- it recomputes
+#' \code{(cagr - ann_rf) / vol} from the published columns and asserts it
+#' equals the published \code{sharpe} to within a rounding tolerance.
+#'
+#' Three assertions, per \code{fail-loud-not-null.md}'s "a row that cannot be
+#' checked must fail, not pass silently" -- an uncheckable row is NEVER
+#' skipped, only ever aborted:
+#'   \enumerate{
+#'     \item \code{ann_rf} must be present (non-NA) on EVERY row. A missing
+#'       \code{ann_rf} is exactly #677 defect B's failure mode one level up
+#'       the stack: a source metrics target computing \code{sharpe} without
+#'       ever publishing the risk-free rate it used to compute it.
+#'     \item \code{vol} must be a positive, non-NA number on every row -- the
+#'       coherence formula divides by it, and a zero/NA \code{vol} makes the
+#'       published \code{sharpe} itself unverifiable.
+#'     \item \code{abs(sharpe - (cagr - ann_rf) / vol) < tol} for every row.
+#'       A \code{sharpe} that is \code{NA} while \code{cagr}/\code{vol}/
+#'       \code{ann_rf} are all present and checkable is treated as an
+#'       INFINITE discrepancy (a genuine incoherence), never silently
+#'       excluded from the check.
+#'   }
+#'
+#' @section Tolerance:
+#' \code{tol} defaults to 0.02 (2 Sharpe-ratio "points"). This is not a slack
+#' number picked to make the check pass -- it is sized to the single
+#' coarsest ACTUAL rounding combination among the ~13 source metrics targets
+#' that feed this gate: \code{aw_metrics} (R/plan_avoid_worst.R) and
+#' \code{ltr_metrics} (R/plan_ltr_momentum.R) both round
+#' \code{cagr}/\code{vol}/\code{ann_rf} to ONE decimal place of PERCENT (a
+#' rounding half-width of 0.05 percentage points = 0.0005 as a fraction,
+#' applied independently to \code{cagr}, \code{vol}, AND \code{ann_rf}) and
+#' round \code{sharpe} itself to only TWO decimal places (a rounding
+#' half-width of 0.005). Propagating those three independent 0.0005-fraction
+#' errors through \code{(cagr - ann_rf) / vol} at their smallest observed
+#' \code{vol} (Avoid Worst's ~0.18, LTR's ~0.17) bounds the coherence gap at
+#' ~0.012 in the worst case; \code{tol = 0.02} keeps a margin above that
+#' bound. Every other source target
+#' (fm_metrics/drif_metrics/stk_max_metrics/stk_drif_metrics/xgb_drif_metrics:
+#' unrounded floats; cmr_summary: 4-decimal fractions;
+#' tom_metrics/rsc_metrics/mf_metrics/ev_metrics/mom_prepeak siblings:
+#' 2-decimal-percent + 3-decimal sharpe; port_metrics: unrounded floats) is
+#' comfortably tighter than this bound, so \code{tol} is NOT tuned
+#' per-strategy -- one shared tolerance, sized to the worst case, keeps the
+#' gate from ever needing a strategy-specific carve-out (the exact
+#' anti-pattern \code{fail-loud-not-null.md} warns against: "Widening tol to
+#' accommodate a real incoherence would defeat the entire purpose of this
+#' slice").
+#'
+#' @param leaderboard Tibble with at least \code{strategy}, \code{period},
+#'   \code{cagr}, \code{vol}, \code{sharpe}, \code{ann_rf} columns (the
+#'   output of the \code{leaderboard} targets pipeline target).
+#' @param tol Numeric. Coherence tolerance on \code{sharpe}. See the
+#'   Tolerance section.
+#' @return \code{TRUE} invisibly on success.
+#' @noRd
+check_leaderboard_sharpe_coherence <- function(leaderboard, tol = 0.02) {
+  required_cols <- c("strategy", "period", "cagr", "vol", "sharpe", "ann_rf")
+  missing_cols <- setdiff(required_cols, names(leaderboard))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "Leaderboard is missing {length(missing_cols)} required column(s): {missing_cols}.",
+      "i" = "check_leaderboard_sharpe_coherence() (S17) requires strategy, period, cagr, vol, sharpe, ann_rf."
+    ))
+  }
+
+  # ── Assertion 1: ann_rf must never be NA -- fail-loud-not-null.md ────────
+  # A row whose Sharpe coherence cannot be verified must ABORT, never pass
+  # silently (#677 defect B: a missing risk-free rate was previously
+  # indistinguishable from "legitimately zero").
+  na_rf <- is.na(leaderboard$ann_rf)
+  if (any(na_rf)) {
+    offenders <- unique(paste(leaderboard$strategy[na_rf], leaderboard$period[na_rf], sep = " / "))
+    cli::cli_abort(c(
+      "x" = paste0(
+        "Leaderboard has ", length(offenders),
+        " row(s) with NA ann_rf -- Sharpe coherence cannot be verified (#677):"
+      ),
+      setNames(sprintf("  %s", offenders), rep("i", length(offenders))),
+      "i" = paste0(
+        "Every source metrics target that computes sharpe MUST also publish ",
+        "the ann_rf it used -- see R/utils_metrics.R::sharpe_ratio_rf() and ",
+        "the module-level 'ann_rf (#677 slice 4)' comment in R/plan_leaderboard.R."
+      )
+    ))
+  }
+
+  # ── Assertion 2: vol must be a checkable (positive, non-NA) denominator ──
+  bad_vol <- is.na(leaderboard$vol) | leaderboard$vol <= 0
+  if (any(bad_vol)) {
+    offenders <- unique(paste(leaderboard$strategy[bad_vol], leaderboard$period[bad_vol], sep = " / "))
+    cli::cli_abort(c(
+      "x" = paste0(
+        "Leaderboard has ", length(offenders),
+        " row(s) with a non-positive or NA vol -- Sharpe coherence cannot be verified:"
+      ),
+      setNames(sprintf("  %s", offenders), rep("i", length(offenders))),
+      "i" = "(cagr - ann_rf) / vol is undefined when vol is 0 or NA."
+    ))
+  }
+
+  # ── Assertion 3: sharpe == (cagr - ann_rf) / vol, within rounding tol ────
+  computed <- (leaderboard$cagr - leaderboard$ann_rf) / leaderboard$vol
+  diff <- abs(leaderboard$sharpe - computed)
+  # An NA sharpe alongside checkable cagr/vol/ann_rf is itself an
+  # incoherence -- Inf so it is caught below, never silently excluded.
+  diff[is.na(leaderboard$sharpe)] <- Inf
+
+  bad <- diff > tol
+  if (any(bad)) {
+    msgs <- sprintf(
+      "  %s / %s -- sharpe = %s, (cagr - ann_rf) / vol = %s, diff = %s",
+      leaderboard$strategy[bad], leaderboard$period[bad],
+      format(leaderboard$sharpe[bad], digits = 4),
+      format(computed[bad], digits = 4),
+      format(diff[bad], digits = 3)
+    )
+    cli::cli_abort(c(
+      "x" = paste0(
+        "Leaderboard sharpe is incoherent with cagr/vol/ann_rf in ",
+        sum(bad), " place(s) (tol = ", tol, "), #677:"
+      ),
+      setNames(msgs, rep("i", length(msgs))),
+      "i" = paste0(
+        "sharpe must equal (cagr - ann_rf) / vol -- check the offending ",
+        "strategy's source metrics target and its .norm_* helper in ",
+        "R/plan_leaderboard.R for a formula or unit-conversion bug."
+      )
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+
 # ---- QA gate plan ----
 
 plan_qa_gates <- function() {
@@ -1396,6 +1553,29 @@ plan_qa_gates <- function() {
       command = {
         check_borrow_status_registry(strategy_cost_convention)
         cli::cli_inform(c("v" = "qa_borrow_status_registry: S16 passed (all borrow_status values derivable, in vocabulary, and consistent with borrow_rate_annual)"))
+        TRUE
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: leaderboard sharpe is coherent with cagr/vol/ann_rf (S17) --
+    # guards against the #677 defect class where sharpe was computed by at
+    # least FOUR distinct mathematical bases across ~13 source metrics
+    # targets (geometric vs arithmetic numerator; risk-free deducted or
+    # not), so strategies were ranked against each other on a statistic
+    # that was not actually comparable. #677 slices 1-3b migrated every
+    # leaderboard-feeding source metrics target onto the canonical
+    # sharpe_ratio_rf() (R/utils_metrics.R) and required each to publish
+    # the ann_rf it used; this gate asserts
+    # sharpe == (cagr - ann_rf) / vol exactly (within a documented
+    # rounding tolerance), never a "plausible band" -- see
+    # check_leaderboard_sharpe_coherence() roxygen for the full rationale
+    # and tolerance derivation.
+    targets::tar_target(
+      qa_leaderboard_sharpe_coherence,
+      command = {
+        check_leaderboard_sharpe_coherence(leaderboard)
+        cli::cli_inform(c("v" = "qa_leaderboard_sharpe_coherence: S17 passed (sharpe coherent with cagr/vol/ann_rf for every row)"))
         TRUE
       },
       cue = targets::tar_cue(mode = "always")

--- a/R/plan_risk_state.R
+++ b/R/plan_risk_state.R
@@ -326,17 +326,23 @@ plan_risk_state <- function() {
         hac <- hd_hac_sharpe(ret_vec, ann_factor = periods_per_year)
         # Canonical, risk-free-adjusted Sharpe (#677) -- see
         # R/utils_metrics.R::sharpe_ratio_rf(). Distinct from hac_sharpe.
-        sharpe_val <- if (!is.null(rf_vec)) {
-          sharpe_ratio_rf(ret_vec, rf_vec, periods_per_year = periods_per_year)$sharpe
+        sr_result <- if (!is.null(rf_vec)) {
+          sharpe_ratio_rf(ret_vec, rf_vec, periods_per_year = periods_per_year)
         } else {
-          NA_real_
+          list(sharpe = NA_real_, ann_rf = NA_real_)
         }
+        sharpe_val <- sr_result$sharpe
         tibble::tibble(
           strategy  = strategy_name,
           period    = label,
           cagr      = round((cum^(1 / years) - 1) * 100, 2),
           vol       = round(sd(ret_vec) * sqrt(periods_per_year) * 100, 2),
           sharpe    = round(sharpe_val, 3),
+          # ann_rf published alongside sharpe (#677 slice 4), same PERCENT
+          # convention as cagr/vol above -- QA gate S17
+          # (check_leaderboard_sharpe_coherence(), R/plan_qa_gates.R) asserts
+          # sharpe == (cagr - ann_rf) / vol for every leaderboard row.
+          ann_rf    = round(sr_result$ann_rf * 100, 2),
           max_dd    = round(min((cum_dd - cummax(cum_dd)) /
                                   cummax(cum_dd)) * 100, 2),
           hac_tstat = round(hac$hac_tstat, 3),

--- a/R/plan_stock_backtest.R
+++ b/R/plan_stock_backtest.R
@@ -440,7 +440,10 @@ calc_backtest_metrics <- function(df, label, rf_col = "rf_ret") {
 
   dplyr::tibble(
     period = label, months = n,
-    cagr = ann_ret, vol = ann_vol, sharpe = sharpe, max_dd = max_dd,
+    # ann_rf published alongside sharpe (#677 slice 4) so QA gate S17
+    # (check_leaderboard_sharpe_coherence(), R/plan_qa_gates.R) can assert
+    # sharpe == (cagr - ann_rf) / vol for every leaderboard row.
+    cagr = ann_ret, vol = ann_vol, sharpe = sharpe, ann_rf = rf_ann, max_dd = max_dd,
     avg_long = mean(df$n_long), avg_short = mean(df$n_short, na.rm = TRUE)
   )
 }

--- a/R/plan_turn_of_month.R
+++ b/R/plan_turn_of_month.R
@@ -179,6 +179,11 @@ plan_turn_of_month <- function() {
           cagr_tom     = round(cagr_s * 100, 2),
           vol_tom      = round(vol_s  * 100, 2),
           sharpe_tom   = round(sharpe_s,   3),
+          # ann_rf_tom published alongside sharpe_tom (#677 slice 4), same
+          # PERCENT convention as cagr_tom/vol_tom above -- QA gate S17
+          # (check_leaderboard_sharpe_coherence(), R/plan_qa_gates.R) asserts
+          # sharpe == (cagr - ann_rf) / vol for every leaderboard row.
+          ann_rf_tom   = round(sr_s$ann_rf * 100, 2),
           max_dd_tom   = round(max_dd_s * 100, 2),
 
           # Buy & hold

--- a/tests/testthat/_snaps/aw-sharpe-rf.md
+++ b/tests/testthat/_snaps/aw-sharpe-rf.md
@@ -3,7 +3,7 @@
     Code
       .aw_sharpe_rf(dts, r, rf, ann_factor = 252L)
     Condition
-      Error in `.aw_sharpe_rf()`:
+      Error in `.aw_sharpe_rf_full()`:
       x 1 day inside the daily risk-free series' own span have no rate.
       i Missing dates: "2020-02-20".
       i Fama-French daily RF spans 2020-01-02..2020-04-10, so this is a HOLE, not a publication lag.
@@ -14,7 +14,7 @@
     Code
       .aw_sharpe_rf(dts, r, bad_rf, ann_factor = 252L)
     Condition
-      Error in `.aw_sharpe_rf()`:
+      Error in `.aw_sharpe_rf_full()`:
       x .aw_sharpe_rf(): aw_daily_rf is missing 1 required column: rf_ret.
       i Expected a tibble with date and rf_ret (this file's aw_daily_rf target).
 

--- a/tests/testthat/_snaps/leaderboard-sharpe-coherence.md
+++ b/tests/testthat/_snaps/leaderboard-sharpe-coherence.md
@@ -1,0 +1,59 @@
+# check_leaderboard_sharpe_coherence throws when required columns are missing
+
+    Code
+      check_leaderboard_sharpe_coherence(bad)
+    Condition
+      Error in `check_leaderboard_sharpe_coherence()`:
+      x Leaderboard is missing 1 required column(s): ann_rf.
+      i check_leaderboard_sharpe_coherence() (S17) requires strategy, period, cagr, vol, sharpe, ann_rf.
+
+# check_leaderboard_sharpe_coherence throws when ann_rf is NA (#677 defect B, one level up)
+
+    Code
+      check_leaderboard_sharpe_coherence(bad)
+    Condition
+      Error in `check_leaderboard_sharpe_coherence()`:
+      x Leaderboard has 1 row(s) with NA ann_rf -- Sharpe coherence cannot be verified (#677):
+      i  LTR / Full Period
+      i Every source metrics target that computes sharpe MUST also publish the ann_rf it used -- see R/utils_metrics.R::sharpe_ratio_rf() and the module-level 'ann_rf (#677 slice 4)' comment in R/plan_leaderboard.R.
+
+# check_leaderboard_sharpe_coherence throws when vol is zero
+
+    Code
+      check_leaderboard_sharpe_coherence(bad)
+    Condition
+      Error in `check_leaderboard_sharpe_coherence()`:
+      x Leaderboard has 1 row(s) with a non-positive or NA vol -- Sharpe coherence cannot be verified:
+      i  LTR / Full Period
+      i (cagr - ann_rf) / vol is undefined when vol is 0 or NA.
+
+# check_leaderboard_sharpe_coherence throws when sharpe does not match (cagr - ann_rf) / vol
+
+    Code
+      check_leaderboard_sharpe_coherence(bad)
+    Condition
+      Error in `check_leaderboard_sharpe_coherence()`:
+      x Leaderboard sharpe is incoherent with cagr/vol/ann_rf in 1 place(s) (tol = 0.02), #677:
+      i  LTR / Full Period -- sharpe = 1.5, (cagr - ann_rf) / vol = 0.3453, diff = 1.15
+      i sharpe must equal (cagr - ann_rf) / vol -- check the offending strategy's source metrics target and its .norm_* helper in R/plan_leaderboard.R for a formula or unit-conversion bug.
+
+# check_leaderboard_sharpe_coherence catches LTR's pre-fix state (a naive HAC Sharpe renamed into sharpe)
+
+    Code
+      check_leaderboard_sharpe_coherence(ltr_prefix)
+    Condition
+      Error in `check_leaderboard_sharpe_coherence()`:
+      x Leaderboard sharpe is incoherent with cagr/vol/ann_rf in 1 place(s) (tol = 0.02), #677:
+      i  LTR / Full Period -- sharpe = 2.36, (cagr - ann_rf) / vol = 0.3453, diff = 2.01
+      i sharpe must equal (cagr - ann_rf) / vol -- check the offending strategy's source metrics target and its .norm_* helper in R/plan_leaderboard.R for a formula or unit-conversion bug.
+
+# check_leaderboard_sharpe_coherence catches the no-rf family's signature (sharpe == cagr / vol exactly, despite a non-zero ann_rf)
+
+    Code
+      check_leaderboard_sharpe_coherence(value_no_rf)
+    Condition
+      Error in `check_leaderboard_sharpe_coherence()`:
+      x Leaderboard sharpe is incoherent with cagr/vol/ann_rf in 1 place(s) (tol = 0.02), #677:
+      i  Value (HML) / Full Period -- sharpe = 0.488, (cagr - ann_rf) / vol = 0.06833, diff = 0.42
+      i sharpe must equal (cagr - ann_rf) / vol -- check the offending strategy's source metrics target and its .norm_* helper in R/plan_leaderboard.R for a formula or unit-conversion bug.
+

--- a/tests/testthat/_snaps/mom-prepeak-sharpe.md
+++ b/tests/testthat/_snaps/mom-prepeak-sharpe.md
@@ -31,7 +31,7 @@
     Code
       .mom_prepeak_sharpe(rets, metrics_row)
     Condition
-      Error in `.mom_prepeak_sharpe()`:
+      Error in `.mom_prepeak_sr()`:
       x .mom_prepeak_sharpe(): `returns_tbl` has no rf_ret column.
       i Join a risk-free series onto returns_tbl first -- see `.mom_prepeak_join_rf()`.
 

--- a/tests/testthat/test-leaderboard-sharpe-coherence.R
+++ b/tests/testthat/test-leaderboard-sharpe-coherence.R
@@ -1,0 +1,243 @@
+testthat::local_edition(3)
+# Tests for check_leaderboard_sharpe_coherence() — QA gate S17 (#677)
+#
+# #677 found that leaderboard `sharpe` was computed by at least FOUR
+# distinct mathematical bases across ~13 source metrics targets (geometric
+# vs arithmetic numerator; risk-free deducted or not). Slices 1-3b migrated
+# every leaderboard-feeding source metrics target onto the canonical
+# sharpe_ratio_rf() (R/utils_metrics.R) and required each to publish the
+# ann_rf it used. This gate is the belt-and-braces check that
+# sharpe == (cagr - ann_rf) / vol holds EXACTLY (within a documented
+# rounding tolerance) for every leaderboard row -- not a "plausible band"
+# on the implied risk-free rate, which cannot distinguish a genuinely
+# low-rf era from a formula that silently deducted no risk-free rate at
+# all (fail-loud-not-null.md).
+#
+# The function is defined in R/plan_qa_gates.R. Tests exercise the gate
+# directly without running tar_make().
+
+source(here::here("R/plan_qa_gates.R"))
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+good_leaderboard <- tibble::tibble(
+  strategy = c("Factor MAX", "Factor MAX", "LTR"),
+  period   = c("Training", "Full Period", "Full Period"),
+  cagr     = c(0.02, 0.0349, 0.0770),
+  vol      = c(0.09, 0.0892, 0.1720),
+  ann_rf   = c(0.02, 0.0436, 0.0176),
+  sharpe   = c((0.02 - 0.02) / 0.09, (0.0349 - 0.0436) / 0.0892, (0.0770 - 0.0176) / 0.1720)
+)
+
+# The full "current production leaderboard" (Full Period rows), reconstructed
+# from the sanity-check table in issue #677's slice 4 task -- verified
+# offline (max diff = 0.00124, comfortably under tol = 0.02) before writing
+# these tests. Kept as a standing regression: if any of the ~13
+# leaderboard-feeding source targets ever reverts to a different Sharpe
+# basis, this fixture (not just the synthetic ones below) should catch it.
+production_leaderboard <- tibble::tibble(
+  strategy = c(
+    "OLMAR-1", "Avoid Worst", "Managed Futures", "LTR", "Risk State",
+    "Mom Pre-Peak", "Factor DRIF", "Value (HML)", "TOM", "PSO Optimal",
+    "Factor MAX", "Mom 12-2", "CMR", "Mom Post-Peak", "Stock MAX",
+    "XGB DRIF", "Stock DRIF"
+  ),
+  period = "Full Period",
+  cagr   = c(15.96, 13.50, 4.37, 7.40, 6.15, 8.80, 5.15, 5.07, 2.13, 0.85,
+             3.49, 0.90, -0.78, -10.90, -14.00, -20.10, -18.21) / 100,
+  vol    = c(18.67, 18.00, 6.21, 17.10, 14.73, 19.80, 10.31, 10.39, 8.00, 6.57,
+             8.92, 22.50, 4.99, 22.10, 17.51, 17.05, 14.73) / 100,
+  sharpe = c(0.780, 0.620, 0.477, 0.330, 0.252, 0.226, 0.076, 0.068, -0.039,
+             -0.084, -0.098, -0.151, -0.544, -0.685, -0.899, -1.261, -1.332),
+  ann_rf = c(1.40, 2.34, 1.41, 1.76, 2.44, 4.33, 4.36, 4.36, 2.44, 1.41,
+             4.36, 4.30, 1.93, 4.24, 1.74, 1.41, 1.41) / 100
+)
+
+# ── Assertion 3 (happy path): sharpe coherent with cagr/vol/ann_rf ──────────
+
+test_that("check_leaderboard_sharpe_coherence passes when sharpe is exactly (cagr - ann_rf) / vol", {
+  expect_true(check_leaderboard_sharpe_coherence(good_leaderboard))
+})
+
+test_that("check_leaderboard_sharpe_coherence passes on the real production leaderboard (#677 slice 4 sanity check)", {
+  expect_true(check_leaderboard_sharpe_coherence(production_leaderboard))
+})
+
+# ── Required columns ─────────────────────────────────────────────────────────
+
+test_that("check_leaderboard_sharpe_coherence throws when required columns are missing", {
+  bad <- dplyr::select(good_leaderboard, -ann_rf)
+  expect_error(
+    check_leaderboard_sharpe_coherence(bad),
+    regexp = "ann_rf"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_sharpe_coherence(bad)
+  )
+})
+
+# ── Assertion 1: ann_rf must never be NA ────────────────────────────────────
+
+test_that("check_leaderboard_sharpe_coherence throws when ann_rf is NA (#677 defect B, one level up)", {
+  bad <- good_leaderboard
+  bad$ann_rf[bad$strategy == "LTR"] <- NA_real_
+  expect_error(
+    check_leaderboard_sharpe_coherence(bad),
+    regexp = "LTR"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_sharpe_coherence(bad)
+  )
+})
+
+test_that("check_leaderboard_sharpe_coherence names every offending strategy/period when multiple rows have NA ann_rf", {
+  bad <- good_leaderboard
+  bad$ann_rf <- NA_real_
+  expect_error(
+    check_leaderboard_sharpe_coherence(bad),
+    regexp = "3 row"
+  )
+})
+
+# ── Assertion 2: vol must be positive and non-NA ────────────────────────────
+
+test_that("check_leaderboard_sharpe_coherence throws when vol is zero", {
+  bad <- good_leaderboard
+  bad$vol[bad$strategy == "LTR"] <- 0
+  expect_error(
+    check_leaderboard_sharpe_coherence(bad),
+    regexp = "LTR"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_sharpe_coherence(bad)
+  )
+})
+
+test_that("check_leaderboard_sharpe_coherence throws when vol is NA", {
+  bad <- good_leaderboard
+  bad$vol[bad$strategy == "LTR"] <- NA_real_
+  expect_error(
+    check_leaderboard_sharpe_coherence(bad),
+    regexp = "LTR"
+  )
+})
+
+# ── Assertion 3: incoherent sharpe (generic) ────────────────────────────────
+
+test_that("check_leaderboard_sharpe_coherence throws when sharpe does not match (cagr - ann_rf) / vol", {
+  bad <- good_leaderboard
+  bad$sharpe[bad$strategy == "LTR"] <- 1.5  # arbitrary, unrelated to cagr/vol/ann_rf
+  expect_error(
+    check_leaderboard_sharpe_coherence(bad),
+    regexp = "LTR"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_sharpe_coherence(bad)
+  )
+})
+
+test_that("check_leaderboard_sharpe_coherence treats NA sharpe (with checkable cagr/vol/ann_rf) as incoherent, not skipped", {
+  bad <- good_leaderboard
+  bad$sharpe[bad$strategy == "LTR"] <- NA_real_
+  expect_error(
+    check_leaderboard_sharpe_coherence(bad),
+    regexp = "LTR"
+  )
+})
+
+test_that("check_leaderboard_sharpe_coherence passes when the discrepancy is within the rounding tolerance", {
+  ok <- good_leaderboard
+  # LTR's stored sharpe nudged by less than tol (0.02) -- still coherent.
+  ok$sharpe[ok$strategy == "LTR"] <- ok$sharpe[ok$strategy == "LTR"] + 0.01
+  expect_true(check_leaderboard_sharpe_coherence(ok))
+})
+
+test_that("check_leaderboard_sharpe_coherence fails just outside the rounding tolerance", {
+  bad <- good_leaderboard
+  bad$sharpe[bad$strategy == "LTR"] <- bad$sharpe[bad$strategy == "LTR"] + 0.03
+  expect_error(check_leaderboard_sharpe_coherence(bad), regexp = "LTR")
+})
+
+# ── Historical-defect reconstructions (#677) ────────────────────────────────
+#
+# These pin the exact two failure modes issue #677 was opened to fix. A gate
+# that passes today but would not have caught the bug it was built for is
+# worth very little -- these tests are the point.
+
+test_that("check_leaderboard_sharpe_coherence catches LTR's pre-fix state (a naive HAC Sharpe renamed into sharpe)", {
+  # Pre-#677, R/plan_leaderboard.R's .norm_ltr() did `rename(sharpe = hac_sharpe)`.
+  # LTR's real cagr/vol (7.70%/17.20%) implied a risk-free rate of -32.89% --
+  # not a rate, a different statistic (cagr/vol for LTR was 0.448; the
+  # published figure was 2.360, a 5.3x gap). ann_rf here is LTR's real,
+  # correctly-computed annualised risk-free rate (1.76%, from the production
+  # fixture above) -- exactly what #677 slice 1 wired in. sharpe = 2.360 is
+  # the pre-fix hac_sharpe value that should never have been called sharpe.
+  ltr_prefix <- tibble::tibble(
+    strategy = "LTR",
+    period   = "Full Period",
+    cagr     = 0.0770,
+    vol      = 0.1720,
+    ann_rf   = 0.0176,
+    sharpe   = 2.360
+  )
+  expect_error(
+    check_leaderboard_sharpe_coherence(ltr_prefix),
+    regexp = "LTR"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_sharpe_coherence(ltr_prefix)
+  )
+})
+
+test_that("check_leaderboard_sharpe_coherence catches the no-rf family's signature (sharpe == cagr / vol exactly, despite a non-zero ann_rf)", {
+  # Pre-#677, TOM / Value (HML) / Managed Futures computed sharpe = cagr/vol
+  # with NO risk-free deduction at all -- an implied rf of exactly 0.00%, a
+  # formula signature, not a coincidence (#677). Value (HML)'s real ann_rf
+  # (4.36%, from the production fixture above) makes that omission visible:
+  # sharpe stored as the un-adjusted cagr/vol ratio is incoherent with a
+  # published, non-zero ann_rf sitting right next to it.
+  cagr   <- 0.0507
+  vol    <- 0.1039
+  ann_rf <- 0.0436
+  value_no_rf <- tibble::tibble(
+    strategy = "Value (HML)",
+    period   = "Full Period",
+    cagr     = cagr,
+    vol      = vol,
+    ann_rf   = ann_rf,
+    sharpe   = cagr / vol  # the pre-#677 no-rf formula
+  )
+  expect_error(
+    check_leaderboard_sharpe_coherence(value_no_rf),
+    regexp = "Value \\(HML\\)"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_sharpe_coherence(value_no_rf)
+  )
+})
+
+test_that("check_leaderboard_sharpe_coherence catches a missing/NA ann_rf row reconstructed as #677 defect B", {
+  # Pre-fix ltr_subperiod$sharpe was silently NA for every subperiod because
+  # compute_sp_metrics() read a non-existent rf_ret column
+  # (mean(NULL, na.rm = TRUE) == NA, no error -- fail-loud-not-null.md).
+  # Reconstructed here one level up: a row that reached the leaderboard
+  # without ever publishing the ann_rf its sharpe depended on.
+  defect_b <- tibble::tibble(
+    strategy = "LTR",
+    period   = "Q1 2020",
+    cagr     = 0.05,
+    vol      = 0.12,
+    ann_rf   = NA_real_,
+    sharpe   = NA_real_
+  )
+  expect_error(
+    check_leaderboard_sharpe_coherence(defect_b),
+    regexp = "ann_rf"
+  )
+})


### PR DESCRIPTION
## Summary

Slice 4 of #677 — the last piece. Every leaderboard-feeding metrics target
now publishes the `ann_rf` it used to compute `sharpe`, and QA gate **S17**
(`check_leaderboard_sharpe_coherence()`, `R/plan_qa_gates.R`) asserts
`abs(sharpe - (cagr - ann_rf) / vol) < tol` for every row on every
`tar_make()`.

This is the exact gate, not a heuristic band on the implied risk-free rate —
a band cannot distinguish a strategy genuinely sampled from a near-zero-rate
era from one that deducted no risk-free rate at all, which is exactly the
lesson #677 exists to teach.

## S17's assertion and chosen `tol`

Three assertions, in order, none of which silently skip an uncheckable row
(`fail-loud-not-null.md`):

1. `ann_rf` must be non-NA on every row — a missing `ann_rf` is #677 defect B
   one level up the stack.
2. `vol` must be a positive, non-NA number (the formula divides by it).
3. `abs(sharpe - (cagr - ann_rf) / vol) < tol`. An `NA` `sharpe` alongside
   otherwise-checkable `cagr`/`vol`/`ann_rf` is treated as an **infinite**
   discrepancy — caught, never excluded.

`tol = 0.02`. This was derived, not guessed: `aw_metrics`
(`R/plan_avoid_worst.R`) and `ltr_metrics` (`R/plan_ltr_momentum.R`) are the
codebase's coarsest rounding combination — `cagr`/`vol`/`ann_rf` rounded to
**1 decimal place of percent** (half-width 0.0005 as a fraction, on three
independent terms) and `sharpe` itself rounded to only **2 decimal places**
(half-width 0.005). Propagating those errors through `(cagr - ann_rf) / vol`
at their smallest observed `vol` (~0.17–0.18) bounds the worst-case
coherence gap at ~0.012; `tol = 0.02` keeps margin above that without
widening enough to hide a real incoherence. Every other source target is
comfortably tighter (unrounded floats for fm/drif/stk_max/stk_drif/xgb_drif/
port_metrics; 4-decimal fractions for cmr_summary; 2-decimal-percent +
3-decimal sharpe for tom/rsc/mf/ev/mom_prepeak siblings) — verified offline
against the real production Full-Period row for all 17 strategies
(reconstructed from the current leaderboard) before writing the gate: **max
diff = 0.00124**, well inside `tol`. No strategy needed a carve-out.

## Which `.norm_*` helpers needed `/100` and which didn't

`ann_rf` follows the **exact same convention as `cagr`** in its own source
target — divided by 100 wherever `cagr` is:

| Helper | `/100`? | Why |
|---|---|---|
| `.norm_ltr` | Yes | `ltr_metrics` stores cagr/vol/ann_rf as percent |
| `.norm_olmar` | Yes | `olmar_metrics` percent |
| `.norm_tom` | Yes | `tom_metrics` percent (`ann_rf_tom`) |
| `.norm_rsc` | Yes | `rsc_metrics` percent |
| `.norm_aw` | Yes | `aw_metrics` percent |
| `.norm_mom_sibling` | Yes | mom_prepeak/postpeak/combined percent |
| `.norm_mf` | Yes | `mf_metrics` percent |
| `.norm_value` (ev) | Yes | `ev_metrics` percent |
| `.norm_cmr` | No | `cmr_summary` already fraction (#336 convention) |
| fm/drif/stk_max/stk_drif/xgb_drif (no wrapper, direct `add_meta()`) | No | already fraction natively |
| `port_row` (PSO Optimal) | No | `port_metrics` already fraction |

## Source-target changes (add `ann_rf`)

- `R/plan_factormax.R`, `R/plan_drif.R` — inline `calc_metrics()`, not
  `sharpe_ratio_rf()`, but same formula; captured `ann_rf` as its own
  variable.
- `R/plan_stock_backtest.R` `calc_backtest_metrics()` — feeds Stock MAX,
  Stock DRIF, XGB DRIF.
- `R/plan_olmar.R`, `R/plan_turn_of_month.R`, `R/plan_commodities_mean_reversion.R`
  (`.compute_cmr_metrics()`, including its `n < 12` NA branch),
  `R/plan_risk_state.R`, `R/plan_ev_ebit.R`, `R/plan_managed_futures.R`,
  `R/plan_ltr_momentum.R`, `R/plan_portfolio_opt.R` (`calc_port_metrics()`)
  — all already called `sharpe_ratio_rf()`, just weren't keeping `$ann_rf`.
- `R/plan_avoid_worst.R` — `.aw_sharpe_rf()` split into `.aw_sharpe_rf_full()`
  (returns the full `sharpe_ratio_rf()` list) + a thin `.aw_sharpe_rf()`
  wrapper returning just `$sharpe`, so the other 3 non-leaderboard call
  sites and their existing tests stay byte-identical. Only `aw_metrics`
  calls the `_full()` variant.
- `R/plan_mom_prepeak.R` — same pattern: `.mom_prepeak_sr()` (full list) +
  thin `.mom_prepeak_sharpe()` (unchanged signature/behaviour, existing
  tests untouched) + new `.mom_prepeak_ann_rf()` accessor, used by the 3
  leaderboard-feeding targets.

## Historical-defect tests (the point of this slice)

`tests/testthat/test-leaderboard-sharpe-coherence.R` reconstructs and pins
both failure modes #677 was opened to fix, plus defect B:

- **LTR pre-fix**: `cagr=7.70%, vol=17.20%, ann_rf=1.76%, sharpe=2.360`
  (the naive `hac_sharpe` renamed into `sharpe`) → S17 aborts, names LTR.
- **No-rf family signature**: `sharpe == cagr/vol` exactly despite a real,
  non-zero `ann_rf` sitting beside it (reconstructed on Value (HML)'s real
  numbers) → S17 aborts.
- **Missing/NA `ann_rf`** row (defect B, one level up) → S17 aborts naming
  `ann_rf`.
- Plus: required-columns, non-positive/NA `vol`, generic incoherent
  `sharpe`, NA `sharpe` with otherwise-valid inputs, tolerance-boundary
  (just inside / just outside `tol`), and a **standing regression fixture**
  — all 17 strategies' real current Full-Period numbers — asserting the
  live leaderboard passes today.

All new `cli_abort()` messages have `expect_snapshot(error = TRUE, ...)`
coverage; snapshots committed
(`tests/testthat/_snaps/leaderboard-sharpe-coherence.md`).

Two **pre-existing** snapshots needed updating as a direct, cosmetic
consequence of the `.aw_sharpe_rf`/`.mom_prepeak_sharpe` refactor above:
`cli_abort()`'s default "Error in `fn()`:" line now names the new inner
`_full()`/`_sr()` helper instead of the outer thin wrapper (the message
text itself is unchanged). Updated `tests/testthat/_snaps/aw-sharpe-rf.md`
and `tests/testthat/_snaps/mom-prepeak-sharpe.md` accordingly — reviewed
diff-by-diff, only that one line changed in each.

## `scripts/verify.sh` — PASS

```
=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

=== scripts/verify.sh: PASS ===
```

Root suite total went from 546 (baseline) to 560 (14 new S17 tests), all new
tests pass. Package suite unchanged (total=695, failed=1 baseline,
skipped=15 baseline).

## Not verified / left for the orchestrator

Per instructions, **`tar_make()` was NOT run** (targets store conflict risk
with the orchestrator's own store; and per #680, `verify.sh` does not prove
the DAG builds). This PR touches nearly every metrics target that feeds the
leaderboard — the orchestrator must rebuild
(`tar_make()`) and check `tar_meta(fields = error)` before merging. In
particular, confirm no target errors on the new `ann_rf` column (e.g. a
`bind_rows()` schema mismatch) and that the live `leaderboard` target
actually passes the new `qa_leaderboard_sharpe_coherence` gate end to end —
the arithmetic sanity check in this PR reconstructs the current published
numbers by hand from the issue's own sanity-check table, it does not read
`tar_read(leaderboard)` directly.

Closes #677.
