### PR TITLE
feat(cost-convention): record lending decision + publish borrow sensitivity sweep (#665)

### DIFF
--- a/R/plan_cost_convention.R
+++ b/R/plan_cost_convention.R
@@ -185,6 +185,105 @@ derive_borrow_status <- function(strategy, directionality, has_borrow_rate,
 }
 
 # ─────────────────────────────────────────────────────────────────────────
+# #665 (Part 1 of 2): record the securities-lending decision as data.
+#
+# Securities-lending income was previously modelled NOWHERE -- an absence
+# nobody had decided on, not a decision (fail-loud-not-null.md: the null-ish
+# state and the deliberate-zero state are indistinguishable unless the
+# decision is itself recorded). `lending_status` below is that decision,
+# made explicit and machine-readable, alongside `borrow_status` above.
+#
+# THE DECISION (recorded here, not re-derived -- see the PR body for the
+# reasoning that produced it): securities-lending income is deliberately
+# modelled as ZERO for every strategy. Not because it is zero, but because
+# it is judged IMMATERIAL at this book's composition -- the long book is
+# S&P-500-constituent/liquid-ETF names (`ltr_universe`, R/plan_mom_prepeak.R,
+# 529 tickers), which lend as general collateral at single-digit bps,
+# against a 50bp borrow assumption whose own uncertainty is roughly +-25bp.
+# A ~1-5bp revenue line sits below the resolution of everything around it.
+# This is a MATERIALITY JUDGEMENT, not a measurement -- `# MANUAL: no
+# source` below, the same convention as the unsourced `0.03`/`0.005`
+# borrow_rate_annual constants above -- and it stops holding the moment the
+# book holds hard-to-borrow names.
+#
+# LENDING_STATUS_ALLOWED is the single source of truth for the vocabulary,
+# deliberately reusing BORROW_STATUS_ALLOWED's non-numeric categories --
+# lending shares the same three "no independently-financeable position"
+# exceptions borrow already documents (Value (HML), PSO Optimal, Avoid
+# Worst -- LENDING_STATUS_OVERRIDES below), because whether a position can
+# be lent is symmetric with whether it can be borrowed against: both require
+# a position that exists, separately, in this codebase's model.
+#   - "zero_assumed_immaterial" -- the default; a real, separately-held long
+#                                  position exists, lending income on it is
+#                                  assumed zero per the documented judgement
+#                                  above.
+#   - "embedded_in_source"       -- long exposure is inside a pre-computed
+#                                  factor return series, not a
+#                                  separately-lendable position.
+#   - "inherited"                 -- a meta-portfolio blending already-net
+#                                  constituent returns; lending (if any) is a
+#                                  property of the constituents, not this row.
+#   - "not_tradeable"             -- registry states this is not a tradeable
+#                                  strategy at all (no cost model of any
+#                                  kind, so no modelled position to lend).
+LENDING_STATUS_ALLOWED <- c(
+  "zero_assumed_immaterial", "embedded_in_source", "inherited", "not_tradeable"
+)
+
+# Three rows have no independently-financeable position at all (regardless
+# of side), for the identical reason their borrow_status is overridden away
+# from a directionality-derived default -- see BORROW_STATUS_OVERRIDES above
+# for the source verification each of these three cites. Managed Futures and
+# CMR are NOT in this list: their borrow_status override is about their
+# SHORT leg (futures financing embedded in the curve), which says nothing
+# about whether their ETF-proxy LONG leg is a real, lendable position -- it
+# is, so they take the "zero_assumed_immaterial" default like every other
+# row with a real long book.
+LENDING_STATUS_OVERRIDES <- tibble::tibble(
+  strategy = c("Value (HML)", "PSO Optimal", "Avoid Worst"),
+  lending_status_override = c("embedded_in_source", "inherited", "not_tradeable")
+)
+
+#' Derive each strategy's lending_status (#665)
+#'
+#' Every strategy defaults to `"zero_assumed_immaterial"` -- the single,
+#' portfolio-level decision documented in the comment block above. Three
+#' rows have no independently-financeable position at all, mirroring the
+#' identical three borrow_status overrides for the identical reason
+#' (`LENDING_STATUS_OVERRIDES`). Fails loud (fail-loud-not-null.md) on an
+#' override outside `LENDING_STATUS_ALLOWED` rather than silently accepting
+#' it.
+#'
+#' @param strategy Character vector. Strategy display names, used only in
+#'   error messages.
+#' @param override Character vector (same length as `strategy`), or NA where
+#'   the default applies. Values from `LENDING_STATUS_OVERRIDES`.
+#' @return Character vector of lending_status values, each a member of
+#'   `LENDING_STATUS_ALLOWED`.
+#' @noRd
+derive_lending_status <- function(strategy, override = NA_character_) {
+  n <- length(strategy)
+  if (length(override) == 1L) override <- rep(override, n)
+  if (length(override) != n) {
+    cli::cli_abort(c("x" = "derive_lending_status(): override must have length 1 or {n}."))
+  }
+
+  vapply(seq_len(n), function(i) {
+    ov <- override[i]
+    if (!is.na(ov)) {
+      if (!ov %in% LENDING_STATUS_ALLOWED) {
+        cli::cli_abort(c(
+          "x" = "{.val {strategy[i]}}: override lending_status {.val {ov}} is not in the allowed set.",
+          "i" = "Allowed values: {paste(LENDING_STATUS_ALLOWED, collapse = ', ')}."
+        ))
+      }
+      return(ov)
+    }
+    "zero_assumed_immaterial"
+  }, character(1L))
+}
+
+# ─────────────────────────────────────────────────────────────────────────
 # #665 (quantification only): borrow-rate sensitivity sweep.
 #
 # REPORTING ONLY. Nothing here feeds `leaderboard` / `all_metrics` / any
@@ -391,9 +490,60 @@ plan_cost_convention <- function() {
         ) |>
         dplyr::select(-directionality, -borrow_status_override)
 
+      # ── #665 Part 1: attach the securities-lending decision ────────────
+      # See the LENDING_STATUS_ALLOWED comment block above for the decision
+      # itself. lending_source_ref follows the SAME "file:line, verified at
+      # authoring commit" convention as cost_source_ref, except the claim
+      # being verified is a materiality JUDGEMENT, not a code fact -- hence
+      # the `# MANUAL: no source` marker on every row (reproducible-ingestion
+      # discipline, CLAUDE.md: a hand-entered figure/decision with no parser
+      # is technical debt, flagged on sight, not silently treated as settled).
+      with_lending <- with_status |>
+        dplyr::left_join(LENDING_STATUS_OVERRIDES, by = "strategy") |>
+        dplyr::mutate(
+          lending_status = derive_lending_status(
+            strategy = strategy,
+            override = lending_status_override
+          ),
+          lending_source_ref = dplyr::case_when(
+            strategy == "Value (HML)" ~ paste0(
+              "# MANUAL: no source -- #665 zero-lending decision; ",
+              "embedded_in_source for the same reason as its borrow_status ",
+              "override (R/plan_ev_ebit.R:33,79): the pre-computed FF ",
+              "factor series holds no separately-tradeable long position ",
+              "to lend."
+            ),
+            strategy == "PSO Optimal" ~ paste0(
+              "# MANUAL: no source -- #665 zero-lending decision; ",
+              "inherited for the same reason as its borrow_status override ",
+              "(R/plan_portfolio_opt.R): a meta-portfolio blending ",
+              "already-net constituent returns, so lending income (if any) ",
+              "is a property of the constituents, not this row."
+            ),
+            strategy == "Avoid Worst" ~ paste0(
+              "# MANUAL: no source -- #665 zero-lending decision; ",
+              "not_tradeable for the same reason as its borrow_status ",
+              "override (R/plan_avoid_worst.R:5): no cost model of any ",
+              "kind exists in code, so there is no modelled position to ",
+              "lend."
+            ),
+            TRUE ~ paste0(
+              "# MANUAL: no source -- #665 zero-lending decision; deliberate ",
+              "zero, judged immaterial for this book's composition, not a ",
+              "measurement. Long book here is general collateral ",
+              "(ltr_universe: 529 S&P-500-constituent/liquid-ETF tickers, ",
+              "R/plan_mom_prepeak.R), lending revenue on GC is single-digit ",
+              "bps against a 50bp borrow assumption whose own uncertainty ",
+              "is ~25bp -- below the resolution of everything around it. ",
+              "Reassess if the book ever holds hard-to-borrow names."
+            )
+          )
+        ) |>
+        dplyr::select(-lending_status_override)
+
       # Visible at every tar_make() (fail-loud-not-null.md: an unrecognised /
       # unmodelled state must be visible, never silently absorbed).
-      unmodelled <- with_status$strategy[with_status$borrow_status == "unmodelled"]
+      unmodelled <- with_lending$strategy[with_lending$borrow_status == "unmodelled"]
       if (length(unmodelled) > 0L) {
         cli::cli_warn(c(
           "!" = paste0(
@@ -409,7 +559,7 @@ plan_cost_convention <- function() {
         ))
       }
 
-      with_status
+      with_lending
     }),
 
     # ── #665 (quantification only): borrow-rate sensitivity sweep ───────

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -1062,6 +1062,78 @@ check_borrow_status_registry <- function(strategy_cost_convention) {
 }
 
 
+#' Assert every strategy's `lending_status` is derivable and in the allowed
+#' vocabulary (S18)
+#'
+#' Sibling to `check_borrow_status_registry()` (S16), not an extension of it
+#' -- deliberately a separate gate rather than folded into S16, for three
+#' reasons: (1) S16's docstring, tests, and error messages are scoped
+#' specifically to `borrow_status` vs `borrow_rate_annual` consistency, and
+#' widening it to also reason about lending would make one function assert
+#' two independent claims about two independently-derived columns; (2)
+#' `lending_status` has no numeric counterpart to cross-check for
+#' contradiction the way S16 checks `borrow_status` against
+#' `borrow_rate_annual` -- the #665 decision is qualitative-only (a
+#' materiality judgement, not a rate), so a "contradiction" assertion would
+#' have nothing to compare against; (3) keeping the gates separate keeps the
+#' failure message unambiguous -- a `borrow_status` regression and a
+#' `lending_status` regression are different defects with different fixes,
+#' and a shared gate would force a reader to work out which one actually
+#' broke from a single generic message.
+#'
+#' Guards against the #665 defect class: securities-lending income was
+#' previously modelled NOWHERE, with no decision recorded either way
+#' (fail-loud-not-null.md: an absence nobody decided on is indistinguishable
+#' from a deliberate zero unless the decision itself is machine-readable).
+#' `lending_status` (derived by `derive_lending_status()`,
+#' R/plan_cost_convention.R) makes that decision explicit; this gate is the
+#' belt-and-braces check that the derivation actually held for every row --
+#' no NA status and no status outside `LENDING_STATUS_ALLOWED`.
+#'
+#' @param strategy_cost_convention Tibble with at least `strategy`,
+#'   `lending_status` columns (the output of the `strategy_cost_convention`
+#'   target, R/plan_cost_convention.R).
+#' @return `TRUE` invisibly on success.
+#' @noRd
+check_lending_status_registry <- function(strategy_cost_convention) {
+  required_cols <- c("strategy", "lending_status")
+  missing_cols <- setdiff(required_cols, names(strategy_cost_convention))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "strategy_cost_convention is missing {length(missing_cols)} required column(s): {missing_cols}.",
+      "i" = "check_lending_status_registry() (S18) requires strategy, lending_status."
+    ))
+  }
+
+  # ── Assertion 1: no NA lending_status ────────────────────────────────────
+  na_status <- strategy_cost_convention$strategy[is.na(strategy_cost_convention$lending_status)]
+  if (length(na_status) > 0L) {
+    cli::cli_abort(c(
+      "x" = paste0(
+        "strategy_cost_convention has ", length(na_status),
+        " strategy/strategies with NA lending_status (#665):"
+      ),
+      setNames(sprintf("  %s", na_status), rep("i", length(na_status))),
+      "i" = "Every strategy must resolve to a status in LENDING_STATUS_ALLOWED (R/plan_cost_convention.R) -- never NA."
+    ))
+  }
+
+  # ── Assertion 2: no out-of-vocabulary lending_status ─────────────────────
+  bad_vocab <- unique(setdiff(strategy_cost_convention$lending_status, LENDING_STATUS_ALLOWED))
+  if (length(bad_vocab) > 0L) {
+    cli::cli_abort(c(
+      "x" = paste0(
+        "strategy_cost_convention has lending_status value(s) outside the allowed vocabulary: ",
+        paste(bad_vocab, collapse = ", ")
+      ),
+      "i" = paste0("Allowed values: ", paste(LENDING_STATUS_ALLOWED, collapse = ", "), ".")
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+
 #' Assert leaderboard `sharpe` is coherent with `cagr`, `vol`, and `ann_rf`
 #' published beside it (S17)
 #'
@@ -1553,6 +1625,21 @@ plan_qa_gates <- function() {
       command = {
         check_borrow_status_registry(strategy_cost_convention)
         cli::cli_inform(c("v" = "qa_borrow_status_registry: S16 passed (all borrow_status values derivable, in vocabulary, and consistent with borrow_rate_annual)"))
+        TRUE
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: strategy_cost_convention's lending_status is derivable and in
+    # the allowed vocabulary (S18) -- sibling to S16, not an extension of it
+    # (see check_lending_status_registry() roxygen for why). Guards against
+    # the #665 defect class where securities-lending income was modelled
+    # nowhere, with no decision recorded either way.
+    targets::tar_target(
+      qa_lending_status_registry,
+      command = {
+        check_lending_status_registry(strategy_cost_convention)
+        cli::cli_inform(c("v" = "qa_lending_status_registry: S18 passed (all lending_status values derivable and in vocabulary)"))
         TRUE
       },
       cue = targets::tar_cue(mode = "always")

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -418,6 +418,139 @@ if (!is.null(lb)) {
 }
 ```
 
+#### Financing Sensitivity
+
+The leaderboard above charges each strategy a single, unsourced borrow rate — and, as of [#665](https://github.com/JohnGavin/historical/issues/665), assumes zero securities-lending income everywhere (a documented materiality judgement, not a measurement — see `lending_status` in `strategy_cost_convention`, R/plan_cost_convention.R). This tab does not correct that number; it measures how much of each strategy's edge survives if the single borrow-rate assumption is wrong. Two things to read correctly here: the 0% column is a no-financing counterfactual, not a claim that financing is free — do not treat it as "the" answer; and this sweep's Sharpe omits the risk-free rate (it reports *relative* deltas across borrow rates, where rf cancels), so its levels are **not** directly comparable to the leaderboard's own rf-adjusted Sharpe above — only the delta column is.
+
+```{r}
+#| label: financing-sensitivity
+bss <- safe_tar_read("borrow_sensitivity_sweep")
+scc <- safe_tar_read("strategy_cost_convention")
+if (!is.null(bss)) {
+  gh_url <- tryCatch({
+    remote <- system("git remote get-url origin 2>/dev/null", intern = TRUE)
+    sub("\\.git$", "", sub("^git@github\\.com:", "https://github.com/", remote))
+  }, error = function(e) NULL)
+  git_sha <- tryCatch(
+    system("git rev-parse HEAD 2>/dev/null", intern = TRUE),
+    error = function(e) "main"
+  )
+  git_sha <- if (length(git_sha) == 0 || !nzchar(git_sha)) "main" else git_sha
+  gh_base <- if (!is.null(gh_url) && length(gh_url) > 0) gh_url else
+    "https://github.com/JohnGavin/historical"
+  sweep_link <- sprintf(
+    "[`borrow_sensitivity_sweep`](%s/blob/%s/R/plan_cost_convention.R#L601)",
+    gh_base, git_sha
+  )
+  fn_link <- sprintf(
+    "[`compute_borrow_sensitivity()`](%s/blob/%s/R/plan_cost_convention.R#L322)",
+    gh_base, git_sha
+  )
+
+  rates_sorted <- sort(unique(bss$borrow_rate_annual))
+  max_rate <- max(rates_sorted)
+  n_swept <- dplyr::n_distinct(bss$strategy)
+
+  status_lookup <- if (!is.null(scc)) {
+    dplyr::select(scc, strategy, borrow_status)
+  } else {
+    tibble(strategy = character(0), borrow_status = character(0))
+  }
+
+  # Wide pivot: one row per strategy, one Sharpe column per swept borrow
+  # rate. rate_label's rounding formula is reused verbatim below to build
+  # `rate_cols` so the two never drift apart.
+  sharpe_wide <- bss |>
+    mutate(rate_label = paste0("Sharpe @", round(borrow_rate_annual * 100), "%")) |>
+    select(strategy, rate_label, sharpe) |>
+    tidyr::pivot_wider(names_from = rate_label, values_from = sharpe)
+
+  rate_cols <- paste0("Sharpe @", round(rates_sorted * 100), "%")
+  delta_col <- paste0("Delta Sharpe (0%->", round(max_rate * 100), "%)")
+
+  # sharpe_delta at the HIGHEST swept rate -- the largest, not smallest,
+  # degradation is what a reader needs to see first (#665: "the single most
+  # informative number in the issue" for the previously-unmodelled trio).
+  delta_tbl <- bss |>
+    filter(borrow_rate_annual == max_rate) |>
+    select(strategy, sharpe_delta)
+  names(delta_tbl)[names(delta_tbl) == "sharpe_delta"] <- delta_col
+
+  sens_table <- sharpe_wide |>
+    left_join(delta_tbl, by = "strategy") |>
+    left_join(status_lookup, by = "strategy") |>
+    select(strategy, dplyr::all_of(rate_cols), dplyr::all_of(delta_col), borrow_status) |>
+    arrange(.data[[delta_col]]) |>
+    mutate(dplyr::across(dplyr::where(is.numeric), ~round(., 2))) |>
+    rename(Strategy = strategy, `Borrow Status` = borrow_status)
+
+  most_affected <- head(sens_table$Strategy, 3)
+
+  cmr_note <- if ("CMR" %in% sens_table$Strategy) {
+    cmr_status <- sens_table$`Borrow Status`[sens_table$Strategy == "CMR"]
+    if (!is.na(cmr_status) && cmr_status == "not_applicable") {
+      paste0(
+        " CMR is included for illustration only: its borrow_status is \"not_applicable\" -- ",
+        "its universe is commodity futures/ETFs/price indices, where financing sits in the ",
+        "futures curve, not an equity-style short-borrow rate, so this row is a sensitivity ",
+        "illustration, not a cost CMR would actually pay."
+      )
+    } else ""
+  } else ""
+
+  sens_caption <- paste0(
+    "Sharpe at borrow rate ", paste0(round(rates_sorted * 100), "%", collapse = " / "),
+    " (annualised), holding trade cost, signal, and weights fixed, for the ", n_swept,
+    " strategies with a real short leg, computed by ", fn_link, " and assembled in ", sweep_link,
+    " (reporting only -- feeds no published return, #665). Ordered by ", delta_col,
+    " (most sensitive first): ", paste(most_affected, collapse = ", "),
+    " lose the most Sharpe as the borrow assumption rises, so read this table from the top, ",
+    "not from the leaderboard's own ranking. The 0% column is a no-financing counterfactual, ",
+    "not a claim that financing is free. This sweep's Sharpe omits the risk-free rate (it ",
+    "reports RELATIVE deltas across borrow rates, where rf cancels), so its levels are NOT ",
+    "comparable to the leaderboard's own rf-adjusted Sharpe above -- ", delta_col,
+    " is the column that means something here.",
+    cmr_note
+  )
+
+  numeric_cols <- which(sapply(sens_table, function(x) is.numeric(x) ||
+                                  grepl("^[0-9.%$,-]+$", as.character(x[1]))))
+
+  DT::datatable(
+    sens_table,
+    caption = htmltools::tags$caption(
+      style = "caption-side: top; text-align: left; font-weight: bold;",
+      class = "dt-caption",
+      sens_caption
+    ),
+    rownames = FALSE,
+    filter = "top",
+    options = list(
+      pageLength = 15,
+      scrollX = TRUE,
+      autoWidth = FALSE,
+      dom = "frtip",
+      order = list(),
+      search = list(regex = TRUE, caseInsensitive = TRUE),
+      columnDefs = list(
+        list(className = 'dt-right', targets = numeric_cols - 1)
+      ),
+      initComplete = DT::JS(
+        "function(settings, json) {",
+        "  var isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark'",
+        "    || document.body.classList.contains('dark-mode');",
+        "  if (isDark) {",
+        "    $(this.api().table().container()).css({'color': '#ddd', 'background-color': '#1a1a1a'});",
+        "    $(this.api().table().header()).css({'color': '#ddd', 'background-color': '#222'});",
+        "    $('input', this.api().table().container()).css({'color': '#ddd', 'background-color': '#333', 'border-color': '#555'});",
+        "  }",
+        "}"
+      )
+    )
+  )
+}
+```
+
 #### Strategy Details
 
 Each strategy links to its full definition, implementation, and backtest:

--- a/tests/testthat/_snaps/lending-status-registry.md
+++ b/tests/testthat/_snaps/lending-status-registry.md
@@ -1,0 +1,28 @@
+# check_lending_status_registry throws on NA lending_status
+
+    Code
+      check_lending_status_registry(bad)
+    Condition
+      Error in `check_lending_status_registry()`:
+      x strategy_cost_convention has 1 strategy/strategies with NA lending_status (#665):
+      i  CMR
+      i Every strategy must resolve to a status in LENDING_STATUS_ALLOWED (R/plan_cost_convention.R) -- never NA.
+
+# check_lending_status_registry throws on an out-of-vocabulary status
+
+    Code
+      check_lending_status_registry(bad)
+    Condition
+      Error in `check_lending_status_registry()`:
+      x strategy_cost_convention has lending_status value(s) outside the allowed vocabulary: bogus_status
+      i Allowed values: zero_assumed_immaterial, embedded_in_source, inherited, not_tradeable.
+
+# check_lending_status_registry throws when required columns are missing
+
+    Code
+      check_lending_status_registry(bad)
+    Condition
+      Error in `check_lending_status_registry()`:
+      x strategy_cost_convention is missing 1 required column(s): lending_status.
+      i check_lending_status_registry() (S18) requires strategy, lending_status.
+

--- a/tests/testthat/_snaps/lending-status.md
+++ b/tests/testthat/_snaps/lending-status.md
@@ -1,0 +1,9 @@
+# an override outside LENDING_STATUS_ALLOWED aborts
+
+    Code
+      derive_lending_status("Bogus", override = "not_a_real_status")
+    Condition
+      Error in `FUN()`:
+      x "Bogus": override lending_status "not_a_real_status" is not in the allowed set.
+      i Allowed values: zero_assumed_immaterial, embedded_in_source, inherited, not_tradeable.
+

--- a/tests/testthat/test-lending-status-registry.R
+++ b/tests/testthat/test-lending-status-registry.R
@@ -1,0 +1,51 @@
+testthat::local_edition(3)
+# Tests for check_lending_status_registry() — QA gate S18 (#665 Part 1)
+#
+# The function is defined in R/plan_qa_gates.R and depends on
+# LENDING_STATUS_ALLOWED, defined in R/plan_cost_convention.R (single source
+# of truth for the lending_status vocabulary). Tests exercise the gate
+# directly without running tar_make(). Sibling to test-borrow-status-registry.R
+# (S16) -- see check_lending_status_registry()'s roxygen for why this is a
+# separate gate rather than an extension of S16.
+
+source(here::here("R/plan_cost_convention.R"))
+source(here::here("R/plan_qa_gates.R"))
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+good <- tibble::tibble(
+  strategy       = c("Stock MAX", "CMR", "Value (HML)"),
+  lending_status = c("zero_assumed_immaterial", "zero_assumed_immaterial", "embedded_in_source")
+)
+
+# ── Pass case ────────────────────────────────────────────────────────────
+
+test_that("check_lending_status_registry passes on a consistent registry", {
+  expect_true(check_lending_status_registry(good))
+})
+
+# ── Assertion 1: no NA lending_status ────────────────────────────────────
+
+test_that("check_lending_status_registry throws on NA lending_status", {
+  bad <- good
+  bad$lending_status[bad$strategy == "CMR"] <- NA_character_
+  expect_error(check_lending_status_registry(bad), regexp = "CMR")
+  expect_snapshot(error = TRUE, check_lending_status_registry(bad))
+})
+
+# ── Assertion 2: out-of-vocabulary status ───────────────────────────────
+
+test_that("check_lending_status_registry throws on an out-of-vocabulary status", {
+  bad <- good
+  bad$lending_status[bad$strategy == "Stock MAX"] <- "bogus_status"
+  expect_error(check_lending_status_registry(bad), regexp = "bogus_status")
+  expect_snapshot(error = TRUE, check_lending_status_registry(bad))
+})
+
+# ── Required columns ─────────────────────────────────────────────────────
+
+test_that("check_lending_status_registry throws when required columns are missing", {
+  bad <- dplyr::select(good, -lending_status)
+  expect_error(check_lending_status_registry(bad), regexp = "lending_status")
+  expect_snapshot(error = TRUE, check_lending_status_registry(bad))
+})

--- a/tests/testthat/test-lending-status.R
+++ b/tests/testthat/test-lending-status.R
@@ -1,0 +1,120 @@
+testthat::local_edition(3)
+# Tests for derive_lending_status() (#665 Part 1)
+#
+# The function and its supporting constants (LENDING_STATUS_ALLOWED,
+# LENDING_STATUS_OVERRIDES) are defined in R/plan_cost_convention.R. Tests
+# exercise the pure function directly without running tar_make().
+#
+# Background (#665): securities-lending income was previously modelled
+# nowhere in this codebase, with no decision recorded either way --
+# indistinguishable, per fail-loud-not-null.md, from a bug. lending_status
+# makes the decision (deliberately zero, judged immaterial for this book's
+# composition -- see R/plan_cost_convention.R for the full reasoning)
+# machine-readable, mirroring how borrow_status (#664) made the borrow-side
+# ambiguity machine-readable.
+
+source(here::here("R/plan_cost_convention.R"))
+
+# ── Default: every strategy resolves to zero_assumed_immaterial ────────────
+
+test_that("a strategy with no override resolves to zero_assumed_immaterial", {
+  expect_equal(
+    derive_lending_status("Stock MAX"),
+    "zero_assumed_immaterial"
+  )
+  expect_equal(
+    derive_lending_status(c("Stock MAX", "CMR", "Mom Pre-Peak")),
+    rep("zero_assumed_immaterial", 3L)
+  )
+})
+
+# ── Overrides take priority over the default ────────────────────────────────
+
+test_that("a valid override wins over the zero_assumed_immaterial default", {
+  expect_equal(
+    derive_lending_status("Value (HML)", override = "embedded_in_source"),
+    "embedded_in_source"
+  )
+  expect_equal(
+    derive_lending_status("PSO Optimal", override = "inherited"),
+    "inherited"
+  )
+  expect_equal(
+    derive_lending_status("Avoid Worst", override = "not_tradeable"),
+    "not_tradeable"
+  )
+})
+
+test_that("an override outside LENDING_STATUS_ALLOWED aborts", {
+  expect_error(
+    derive_lending_status("Bogus", override = "not_a_real_status"),
+    regexp = "Bogus"
+  )
+  expect_snapshot(
+    error = TRUE,
+    derive_lending_status("Bogus", override = "not_a_real_status")
+  )
+})
+
+test_that("mismatched override vector length aborts", {
+  expect_error(
+    derive_lending_status(c("A", "B"), override = c("embedded_in_source", "inherited", "not_tradeable")),
+    regexp = "length"
+  )
+})
+
+# ── Full 17-strategy registry resolves exactly as documented (#665) ────────
+#
+# override values below are read from LENDING_STATUS_OVERRIDES (the real
+# source), not re-typed, so a change to the override table is caught by
+# this test.
+
+test_that("all 17 strategies resolve to the expected lending_status (#665)", {
+  strategy <- c(
+    "Factor MAX", "Factor DRIF", "Stock MAX", "Stock DRIF", "XGB DRIF",
+    "LTR", "OLMAR-1", "TOM", "CMR", "Risk State", "Avoid Worst",
+    "Mom Pre-Peak", "Mom Post-Peak", "Mom 12-2",
+    "Value (HML)", "Managed Futures", "PSO Optimal"
+  )
+  override <- LENDING_STATUS_OVERRIDES$lending_status_override[
+    match(strategy, LENDING_STATUS_OVERRIDES$strategy)
+  ]
+
+  status <- derive_lending_status(strategy, override)
+
+  expected <- c(
+    "zero_assumed_immaterial", "zero_assumed_immaterial",  # Factor MAX, Factor DRIF
+    "zero_assumed_immaterial", "zero_assumed_immaterial",  # Stock MAX, Stock DRIF
+    "zero_assumed_immaterial",                              # XGB DRIF
+    "zero_assumed_immaterial",                              # LTR
+    "zero_assumed_immaterial",                              # OLMAR-1
+    "zero_assumed_immaterial",                              # TOM
+    "zero_assumed_immaterial",                              # CMR (long ETF/futures leg is real)
+    "zero_assumed_immaterial",                              # Risk State
+    "not_tradeable",                                        # Avoid Worst
+    "zero_assumed_immaterial", "zero_assumed_immaterial", "zero_assumed_immaterial", # Mom trio
+    "embedded_in_source",                                   # Value (HML)
+    "zero_assumed_immaterial",                              # Managed Futures (ETF-proxy long leg is real)
+    "inherited"                                             # PSO Optimal
+  )
+  expect_equal(status, expected)
+
+  # No strategy is left in a null-ish / undecided state -- every value is a
+  # member of the documented vocabulary, never NA (fail-loud-not-null.md).
+  expect_false(anyNA(status))
+  expect_true(all(status %in% LENDING_STATUS_ALLOWED))
+})
+
+test_that("LENDING_STATUS_ALLOWED contains exactly the 4 documented statuses", {
+  expect_setequal(
+    LENDING_STATUS_ALLOWED,
+    c("zero_assumed_immaterial", "embedded_in_source", "inherited", "not_tradeable")
+  )
+})
+
+test_that("LENDING_STATUS_OVERRIDES covers exactly the 3 no-independent-position rows", {
+  expect_setequal(
+    LENDING_STATUS_OVERRIDES$strategy,
+    c("Value (HML)", "PSO Optimal", "Avoid Worst")
+  )
+})


### PR DESCRIPTION
Continues #665 after #676 landed the borrow-charge half. #665 is currently shown CLOSED on GitHub, but its 2026-08-17 comment lists two items still open: the lending decision was never recorded, and `borrow_sensitivity_sweep` was computed but never rendered. This PR closes both. It changes no strategy's returns — `strategy_cost_convention` and `borrow_sensitivity_sweep` are both reporting-only targets that feed no published return.

## Part 1 — lending decision recorded as data

Added `lending_status` + `lending_source_ref` to `strategy_cost_convention` (`R/plan_cost_convention.R`), mirroring `borrow_status`'s established pattern.

**The decision recorded** (not re-derived — this is the call, transcribed from the task):

> Securities-lending income is deliberately modelled as zero for every strategy. Not because it is zero, but because it is immaterial at this book's composition. The long book is S&P 500 constituents and liquid ETFs (`ltr_universe` is 529 such tickers) — general collateral, which lends for single-digit basis points. Against a 50bp borrow assumption whose own uncertainty is roughly ±25bp, a ~1–5bp revenue line sits below the resolution of everything around it. This is a judgement about materiality, not a measurement, and it stops holding the moment the book holds hard-to-borrow names.

Every row carries a `# MANUAL: no source` marker in `lending_source_ref` (reproducible-ingestion discipline — this is a hand-made judgement, not a parsed figure).

**Values** — `LENDING_STATUS_ALLOWED = c("zero_assumed_immaterial", "embedded_in_source", "inherited", "not_tradeable")`. 14 of 17 strategies default to `zero_assumed_immaterial`. Three rows are overridden to the *same* non-numeric category their `borrow_status` already uses, for the identical reason (no independently-financeable position exists in the model at all, regardless of side):

| strategy | lending_status | why |
|---|---|---|
| Value (HML) | `embedded_in_source` | pre-computed FF series, no separate long position to lend |
| PSO Optimal | `inherited` | meta-portfolio; lending (if any) belongs to constituents |
| Avoid Worst | `not_tradeable` | no cost model of any kind in code, so nothing to lend |

Managed Futures and CMR are **not** in this override list, unlike their `borrow_status` overrides. Their `borrow_status→not_applicable` override is about the *short* leg (futures financing embedded in the curve); their *long* leg is a real ETF-proxy/commodity-ETF position, so they take the `zero_assumed_immaterial` default like every other strategy with a genuine long book.

**QA gate: new S18, not an extension of S16.** `check_lending_status_registry()` (`R/plan_qa_gates.R`) is a sibling to `check_borrow_status_registry()` (S16), argued in its roxygen for three reasons: (1) S16's tests/messages are scoped specifically to `borrow_status` vs `borrow_rate_annual` consistency — widening it would make one function assert two independent claims about two independently-derived columns; (2) `lending_status` has no numeric counterpart to cross-check for contradiction the way S16 checks `borrow_status` against `borrow_rate_annual` — the #665 decision is qualitative-only, so a "contradiction" assertion has nothing to compare against; (3) separate gates keep failure messages unambiguous — a regression in one column shouldn't require a reader to work out which of two independent claims actually broke. S18 asserts the two claims S16-style logic *can* still make: no NA `lending_status`, no out-of-vocabulary value.

**Tests:** `tests/testthat/test-lending-status.R` (derivation function, 7 `test_that` blocks) and `test-lending-status-registry.R` (gate S18, 4 `test_that` blocks) — 11 new blocks total, mirroring the existing `test-borrow-status(.R|-registry.R)` structure. Includes the explicit check requested: all 17 strategies resolve to the expected `lending_status`, none is `NA` (`expect_false(anyNA(status))`), and an unrecognised override value `cli_abort()`s (snapshot-covered). `_snaps/lending-status.md` and `_snaps/lending-status-registry.md` committed alongside.

## Part 2 — `borrow_sensitivity_sweep` published

`R/plan_cost_convention.R:601`'s `borrow_sensitivity_sweep` target existed and computed correctly but was referenced only inside `R/`, never rendered — #665 calls it "the single most informative number in the issue." Added a **"Financing Sensitivity"** tab to `docs/leaderboard.qmd`'s Rankings page tabset (`# Rankings` → `### {.tabset}`), immediately after the existing "By Partition" tab and before "Strategy Details" — same tabset as the rankings table itself, per "next to the rankings."

Follows the file's established conventions: `safe_tar_read()`, bespoke `DT::datatable()` call (not `hd_dt()`, because the caption needs dynamic GitHub source links the way the "Full Period" tab's `cost_note`/`gross_note` do), dark-mode `initComplete` JS, `filter = "top"`, dynamically-computed caption text (nothing hardcoded — strategy count, rate list, and the "most affected" list are all pulled from the target at render time).

**Design:** one row per strategy, one Sharpe column per swept rate (0%/3%/10%/25%), plus a `Delta Sharpe (0%→25%)` column, sorted by that delta ascending — worst-affected strategies (largest Sharpe loss) lead the table, not the leaderboard's own ranking. `Borrow Status` is joined in from `strategy_cost_convention` so a reader can immediately see CMR's row is `not_applicable`.

**The two reader caveats**, stated in both the prose above the chunk and the DT caption itself (redundant on purpose — captions are easy to miss):

1. The sweep's Sharpe omits the risk-free rate (relative deltas across borrow rates, where rf cancels), so its *levels* are not comparable to the leaderboard's own rf-adjusted Sharpe — only the delta column is.
2. CMR is included for illustration only. Its `borrow_status` is `not_applicable` (commodity futures/ETFs — financing sits in the curve), so its row is a sensitivity illustration, not a cost it would actually pay.

The 0% column is explicitly called out as a no-financing counterfactual, not "the" answer.

**Verification of the qmd logic**: since `tar_make()` and rendering are out of scope for this dispatch (store conflict / needs the built store — see below), I extracted the chunk's R code from the `.qmd`, ran `parse()` on it (OK), and executed it against synthetic mock data shaped like the real `borrow_sensitivity_sweep`/`strategy_cost_convention` targets (8 strategies × 4 rates, one `not_applicable` row for CMR) to exercise the pivot/join/sort/caption-assembly logic end to end — it ran without error and produced the expected sorted 8×7 table, correct caption text, and a correctly-triggered CMR caveat. This is not equivalent to a real render.

**`#L` anchors**: my edits to `R/plan_cost_convention.R` shifted the `compute_borrow_sensitivity()` and `borrow_sensitivity_sweep` target line numbers to L322 and L601 respectively (the file grew from 490 to 639 lines). Updated the two new caption links accordingly and confirmed both are within the file's new line count (639) so gate S6 (`check_anchor_in_range`, which scans *all* `#L<n>` GitHub blob links in rendered HTML, not just Mermaid diagram links) will pass once rendered.

## Verification

`parse("_targets.R")`: PASS.

`scripts/verify.sh` (foreground, full run):

```
PASS: _targets.R parses
PASS: testthat edition 3 active
root suite: total=574 failed=3 skipped=0 — failures match the known baseline exactly (3, issue #569)
package suite: total=695 failed=1 skipped=15 — failures match the known baseline exactly (1, issue #569)
scripts/verify.sh: PASS
```

Root total rose from the 563 baseline (commit `2dcfea2`) to 574 — the +11 is exactly the 11 new `test_that` blocks added in Part 1; no baseline failure signature changed. Package suite is byte-identical to baseline (I did not touch `packages/historicaldata/`).

## What I did NOT do / left for the orchestrator

- **Did not run `tar_make()`** (store conflict, per instructions) — `qa_lending_status_registry` (S18) and the new `strategy_cost_convention` columns have never executed inside a real pipeline run. `check_lending_status_registry()` and `derive_lending_status()` are tested directly (unit-level), same convention as S16/`derive_borrow_status()`, but the *target* itself (the `dplyr::left_join`/`case_when` wiring inside `plan_cost_convention()`) is unexercised until a real `tar_make()` runs.
- **Did not render `docs/leaderboard.qmd`.** Per #680 (cited in the task), the orchestrator must rebuild, run `tar_meta(fields = error)`, **and render `docs/leaderboard.qmd`** to confirm: (a) `borrow_sensitivity_sweep` and `strategy_cost_convention` both resolve without error under the real store, (b) the new "Financing Sensitivity" tab actually renders a populated table (a qmd chunk referencing a target that doesn't resolve fails only at render time — my mock-data exercise proves the *logic* is sound but cannot prove the *real target* resolves cleanly against production data), and (c) the two new `#L` anchors survive real-HTML rendering under gate S6.
- **Did not touch `plan_mom_prepeak_gauntlet.R`** — the walk-forward gauntlet still evaluates on the pre-#676 zero-borrow basis, per the prior comment on #665 ("deliberately left for its own decision"). Untouched here too; still open.
- **Did not obtain a sourced lending-rate series.** `lending_status = "zero_assumed_immaterial"` is, like the pre-existing `0.03`/`0.005` borrow rates, a `# MANUAL: no source` judgement. No follow-up issue filed for this — flagging here in case one is wanted (the prior #665 comment notes the analogous borrow-rate follow-up is "still unfiled" too).
- **Did not close #665** — it is already showing CLOSED on GitHub (closed 2026-08-16, `stateReason: COMPLETED`) despite the 2026-08-17 comment listing this remaining work; I have not attempted to reopen/re-close it since that's outside this dispatch's scope.
