### PR TITLE
fix(registry): add ann_rf to 11 unit maps; fix mom_prepeak percent bug (#691)

### DIFF
--- a/R/plan_avoid_worst.R
+++ b/R/plan_avoid_worst.R
@@ -1270,6 +1270,8 @@ plan_avoid_worst <- function() {
   # Units (#640): aw_metrics stores cagr/vol/max_dd as PERCENT (x*100 in
   # metrics_for() above — the source #637 flagged as percent-native), sharpe
   # is a scale-free ratio, n_days is a count, and years is a year-duration.
+  # ann_rf (#677 slice 4, #691) is PERCENT, same convention as cagr
+  # (round(sr$ann_rf * 100, 2) above).
   full_row <- aw_metrics[
     aw_metrics$period == "Full Period" & aw_metrics$scenario == "All Days",
     , drop = FALSE
@@ -1278,7 +1280,8 @@ plan_avoid_worst <- function() {
     metric_cols <- setdiff(names(full_row), c("period", "scenario"))
     aw_units <- c(
       years = "years", n_days = "count", cagr = "percent",
-      vol = "percent", max_dd = "percent", sharpe = "ratio"
+      vol = "percent", max_dd = "percent", sharpe = "ratio",
+      ann_rf = "percent"
     )
     historicaldata::hd_metric_record(
       con, uu, full_row[, metric_cols, drop = FALSE], units = aw_units

--- a/R/plan_commodities_mean_reversion.R
+++ b/R/plan_commodities_mean_reversion.R
@@ -323,6 +323,8 @@ plan_commodities_mean_reversion <- function() {
     # n_months is a count. avg_dd_duration/max_dd_duration are drawdown
     # lengths measured in the return series' own periodicity (months, for
     # CMR's monthly returns) — classified as "count" (periods), not "days".
+    # ann_rf (#677 slice 4, #691) is a decimal fraction, same convention as
+    # cagr (round(sr$ann_rf, 4) above, never *100).
     row <- cmr_summary[cmr_summary$lookback == p, , drop = FALSE]
     if (nrow(row) == 1L) {
       metric_cols <- setdiff(names(row), "lookback")
@@ -330,7 +332,8 @@ plan_commodities_mean_reversion <- function() {
       cmr_units <- c(
         n_months = "count", sharpe = "ratio", cagr = "fraction",
         vol = "fraction", max_dd = "fraction",
-        avg_dd_duration = "count", max_dd_duration = "count"
+        avg_dd_duration = "count", max_dd_duration = "count",
+        ann_rf = "fraction"
       )
       historicaldata::hd_metric_record(con, uu, wide, units = cmr_units)
     }

--- a/R/plan_drif.R
+++ b/R/plan_drif.R
@@ -612,14 +612,17 @@ plan_drif <- function() {
   # Record full-period metrics row
   # Units (#640): drif_metrics stores cagr/vol/max_dd/hit_rate/bench_* as
   # decimal fractions (see calc_metrics() above), sharpe/bench_sharpe are
-  # scale-free ratios, and months is a period count.
+  # scale-free ratios, and months is a period count. ann_rf (#677 slice 4,
+  # #691) is a decimal fraction, same convention as cagr
+  # (ann_rf <- mean(df$rf_ret, na.rm = TRUE) * 12 above, never *100).
   full_row <- drif_metrics[drif_metrics$period == "Full Period", , drop = FALSE]
   if (nrow(full_row) == 1L) {
     metric_cols <- setdiff(names(full_row), "period")
     drif_units <- c(
       months = "count", cagr = "fraction", vol = "fraction",
       sharpe = "ratio", max_dd = "fraction", hit_rate = "fraction",
-      bench_cagr = "fraction", bench_vol = "fraction", bench_sharpe = "ratio"
+      bench_cagr = "fraction", bench_vol = "fraction", bench_sharpe = "ratio",
+      ann_rf = "fraction"
     )
     historicaldata::hd_metric_record(
       con, uu, full_row[, metric_cols, drop = FALSE], units = drif_units

--- a/R/plan_factormax.R
+++ b/R/plan_factormax.R
@@ -508,14 +508,17 @@ plan_factormax <- function() {
   # Record full-period metrics row
   # Units (#640): fm_metrics stores cagr/vol/max_dd/hit_rate/bench_* as
   # decimal fractions (see .fm_metrics calc_metrics()), sharpe/bench_sharpe
-  # are scale-free ratios, and months is a period count.
+  # are scale-free ratios, and months is a period count. ann_rf (#677
+  # slice 4, #691) is a decimal fraction, same convention as cagr
+  # (ann_rf <- mean(df$rf_ret) * 12 above, never *100).
   full_row <- fm_metrics[fm_metrics$period == "Full Period", , drop = FALSE]
   if (nrow(full_row) == 1L) {
     metric_cols <- setdiff(names(full_row), "period")
     fm_units <- c(
       months = "count", cagr = "fraction", vol = "fraction",
       sharpe = "ratio", max_dd = "fraction", hit_rate = "fraction",
-      bench_cagr = "fraction", bench_vol = "fraction", bench_sharpe = "ratio"
+      bench_cagr = "fraction", bench_vol = "fraction", bench_sharpe = "ratio",
+      ann_rf = "fraction"
     )
     historicaldata::hd_metric_record(
       con, uu, full_row[, metric_cols, drop = FALSE], units = fm_units

--- a/R/plan_ltr_momentum.R
+++ b/R/plan_ltr_momentum.R
@@ -546,14 +546,15 @@ plan_ltr_momentum <- function() {
   # hac_tstat are scale-free ratios (#677: `sharpe` is the new canonical,
   # risk-free-adjusted column added alongside the pre-existing `hac_sharpe`
   # -- both need a unit or hd_metric_record() aborts loud per #640), and
-  # months/avg_long/avg_short are counts.
+  # months/avg_long/avg_short are counts. ann_rf (#677 slice 4, #691) is
+  # PERCENT, same convention as cagr (round(sr$ann_rf * 100, 1) above).
   full_row <- ltr_metrics[ltr_metrics$period == "Full Period", , drop = FALSE]
   if (nrow(full_row) == 1L) {
     metric_cols <- setdiff(names(full_row), "period")
     ltr_units <- c(
       months = "count", cagr = "percent", vol = "percent", max_dd = "percent",
       sharpe = "ratio", hac_sharpe = "ratio", hac_tstat = "ratio",
-      avg_long = "count", avg_short = "count"
+      avg_long = "count", avg_short = "count", ann_rf = "percent"
     )
     historicaldata::hd_metric_record(
       con, uu, full_row[, metric_cols, drop = FALSE], units = ltr_units

--- a/R/plan_mom_prepeak.R
+++ b/R/plan_mom_prepeak.R
@@ -579,15 +579,21 @@ plan_mom_prepeak <- function() {
       wide <- metrics_row[, metric_cols, drop = FALSE]
       # Units (#640): see .mom_prepeak_compute_metrics() in
       # packages/historicaldata/R/utils_mom_prepeak_metrics.R — cagr/vol/
-      # max_dd are decimal fractions, sharpe is a scale-free ratio,
-      # n_months/max_cons_losses/bankrupt_month are counts, avg_dd_days/
+      # max_dd are PERCENT (round(x * 100, 1) at lines 128-130 there; also
+      # confirmed by R/plan_leaderboard.R's .norm_mom_sibling(), which
+      # divides cagr/vol/max_dd/ann_rf by 100 -- corrected from the
+      # previously-declared "fraction" under #691), sharpe is a scale-free
+      # ratio, n_months/max_cons_losses/bankrupt_month are counts, avg_dd_days/
       # max_dd_days are day-durations. blown_up/loss_clustered are logical
       # and are auto-skipped by .normalise_metric_long (no unit needed).
+      # ann_rf (#677 slice 4, #691) is PERCENT, same convention as cagr
+      # (round(.mom_prepeak_ann_rf(...) * 100, 2) above).
       mom_prepeak_units <- c(
-        n_months = "count", sharpe = "ratio", cagr = "fraction",
-        vol = "fraction", max_dd = "fraction",
+        n_months = "count", sharpe = "ratio", cagr = "percent",
+        vol = "percent", max_dd = "percent",
         bankrupt_month = "count", avg_dd_days = "days",
-        max_dd_days = "days", max_cons_losses = "count"
+        max_dd_days = "days", max_cons_losses = "count",
+        ann_rf = "percent"
       )
       historicaldata::hd_metric_record(con, uu, wide, units = mom_prepeak_units)
     }

--- a/R/plan_portfolio_opt.R
+++ b/R/plan_portfolio_opt.R
@@ -539,6 +539,15 @@ plan_portfolio_opt <- function() {
   # if they are ever registered.
   # Units (#640): opt_cagr/opt_vol/opt_maxdd are decimal fractions (per the
   # comment above), opt_sharpe is a scale-free ratio, months is a count.
+  # ann_rf (#677 slice 4) was added to port_metrics as a decimal fraction
+  # (calc_port_metrics() above, never *100) but is NOT currently selected by
+  # `pso_cols` below -- unlike the other ten registry writers in this repo,
+  # this one uses an explicit intersect() allow-list rather than a
+  # setdiff()-based exclusion, so new columns on port_metrics do not
+  # automatically flow into hd_metric_record() here. `ann_rf` is declared in
+  # `pso_units` for forward-compatibility/consistency with the leaderboard's
+  # unit convention, but this target does not currently attempt to write
+  # ann_rf and was therefore not among the writers erroring under #691.
   full_row <- port_metrics[port_metrics$period == "Full Period", , drop = FALSE]
   if (nrow(full_row) == 1L) {
     pso_cols <- intersect(
@@ -547,7 +556,7 @@ plan_portfolio_opt <- function() {
     )
     pso_units <- c(
       months = "count", opt_cagr = "fraction", opt_vol = "fraction",
-      opt_sharpe = "ratio", opt_maxdd = "fraction"
+      opt_sharpe = "ratio", opt_maxdd = "fraction", ann_rf = "fraction"
     )
     if (length(pso_cols) > 0L) {
       historicaldata::hd_metric_record(

--- a/R/plan_risk_state.R
+++ b/R/plan_risk_state.R
@@ -846,7 +846,9 @@ plan_risk_state <- function() {
   # (round(x*100, ...) in calc_metrics() above); sharpe/hac_tstat/hac_sharpe
   # are scale-free ratios (#677: `sharpe` is the new canonical,
   # risk-free-adjusted column added alongside the pre-existing `hac_sharpe`
-  # -- both need a unit or hd_metric_record() aborts loud per #640).
+  # -- both need a unit or hd_metric_record() aborts loud per #640). ann_rf
+  # (#677 slice 4, #691) is PERCENT, same convention as cagr
+  # (round(sr_result$ann_rf * 100, 2) above).
   full_row <- rsc_metrics[
     rsc_metrics$strategy == "SPY_overlay" & rsc_metrics$period == "Full Period",
     , drop = FALSE
@@ -855,7 +857,8 @@ plan_risk_state <- function() {
     metric_cols <- setdiff(names(full_row), c("strategy", "period"))
     rsc_units <- c(
       cagr = "percent", vol = "percent", max_dd = "percent",
-      sharpe = "ratio", hac_tstat = "ratio", hac_sharpe = "ratio"
+      sharpe = "ratio", hac_tstat = "ratio", hac_sharpe = "ratio",
+      ann_rf = "percent"
     )
     historicaldata::hd_metric_record(
       con, uu, full_row[, metric_cols, drop = FALSE], units = rsc_units

--- a/R/plan_stock_backtest.R
+++ b/R/plan_stock_backtest.R
@@ -1412,14 +1412,16 @@ plan_stock_backtest <- function() {
   # Units (#640): calc_backtest_metrics() stores cagr/vol/max_dd as decimal
   # fractions (ann_ret/ann_vol/max_dd are computed as raw fractions, never
   # multiplied by 100 — see calc_backtest_metrics() above), sharpe is a
-  # scale-free ratio, and months/avg_long/avg_short are counts.
+  # scale-free ratio, and months/avg_long/avg_short are counts. ann_rf
+  # (#677 slice 4, #691) is a decimal fraction, same convention as cagr
+  # (rf_ann in calc_backtest_metrics() above, never *100).
   full_row <- metrics[metrics$period == "Full Period", , drop = FALSE]
   if (nrow(full_row) == 1L) {
     metric_cols <- setdiff(names(full_row), "period")
     stk_units <- c(
       months = "count", cagr = "fraction", vol = "fraction",
       sharpe = "ratio", max_dd = "fraction",
-      avg_long = "count", avg_short = "count"
+      avg_long = "count", avg_short = "count", ann_rf = "fraction"
     )
     historicaldata::hd_metric_record(
       con, uu, full_row[, metric_cols, drop = FALSE], units = stk_units

--- a/R/plan_turn_of_month.R
+++ b/R/plan_turn_of_month.R
@@ -442,6 +442,8 @@ plan_turn_of_month <- function() {
   # Record Full Period metrics row (#640: cagr_*/vol_*/max_dd_*/pct_in_tom
   # are PERCENT — round(x*100, ...) in calc() above; sharpe_* are scale-free
   # ratios; n_days/n_tom_days are counts; years is a year-duration).
+  # ann_rf_tom (#677 slice 4, #691) is PERCENT, same convention as cagr_tom
+  # (round(sr_s$ann_rf * 100, 2) above).
   full_row <- tom_metrics[tom_metrics$period == "Full Period", , drop = FALSE]
   if (nrow(full_row) == 1L) {
     metric_cols <- setdiff(names(full_row), "period")
@@ -451,7 +453,8 @@ plan_turn_of_month <- function() {
       max_dd_tom = "percent",
       cagr_bh = "percent", vol_bh = "percent", sharpe_bh = "ratio",
       max_dd_bh = "percent",
-      n_tom_days = "count", pct_in_tom = "percent"
+      n_tom_days = "count", pct_in_tom = "percent",
+      ann_rf_tom = "percent"
     )
     historicaldata::hd_metric_record(
       con, uu, full_row[, metric_cols, drop = FALSE], units = tom_units

--- a/R/plan_xgb_signal.R
+++ b/R/plan_xgb_signal.R
@@ -319,14 +319,16 @@ plan_xgb_signal <- function() {
   # logical is silently skipped by .normalise_metric_long).
   # Units (#640): xgb_drif_metrics comes from calc_backtest_metrics(), which
   # stores cagr/vol/max_dd as decimal fractions, sharpe as a scale-free
-  # ratio, and months/avg_long/avg_short as counts.
+  # ratio, and months/avg_long/avg_short as counts. ann_rf (#677 slice 4,
+  # #691) is a decimal fraction, same convention as cagr (rf_ann in
+  # calc_backtest_metrics(), R/plan_stock_backtest.R, never *100).
   full_row <- xgb_drif_metrics[xgb_drif_metrics$period == "Full Period", , drop = FALSE]
   if (nrow(full_row) == 1L) {
     metric_cols <- setdiff(names(full_row), "period")
     xgb_units <- c(
       months = "count", cagr = "fraction", vol = "fraction",
       sharpe = "ratio", max_dd = "fraction",
-      avg_long = "count", avg_short = "count"
+      avg_long = "count", avg_short = "count", ann_rf = "fraction"
     )
     historicaldata::hd_metric_record(
       con, uu, full_row[, metric_cols, drop = FALSE], units = xgb_units

--- a/tests/testthat/_snaps/registry-unit-map-coverage.md
+++ b/tests/testthat/_snaps/registry-unit-map-coverage.md
@@ -1,0 +1,9 @@
+# .extract_units_map aborts informatively when the variable is not found
+
+    Code
+      .extract_units_map(file, "nonexistent_units")
+    Condition
+      Error in `.extract_units_map()`:
+      x Could not find `nonexistent_units <- c(...)` in 'plan_ltr_momentum.R'.
+      i The unit map may have been renamed or restructured.
+

--- a/tests/testthat/test-registry-unit-map-coverage.R
+++ b/tests/testthat/test-registry-unit-map-coverage.R
@@ -1,0 +1,206 @@
+testthat::local_edition(3)
+
+# Regression test for #691: `ann_rf` was added to 11 metrics targets
+# (#677 slice 4, #686) without being added to the corresponding
+# hand-maintained `<prefix>_units` maps the registry writers pass to
+# historicaldata::hd_metric_record(). Because hd_metric_record() aborts on
+# any column with no declared unit (#640), every one of those writers began
+# erroring -- hidden by `error = "continue"` in docs/_targets.R (see #691).
+#
+# The units maps are locals inside each writer's helper function, so they
+# cannot be imported and inspected directly. This test statically parses
+# each plan file's AST (parse(), no evaluation of target bodies, no store
+# build -- a worktree must not build the store, see .claude/CLAUDE.md
+# "Verifying a change") to extract the literal `<prefix>_units <- c(...)`
+# assignment, and compares its names against the metrics-computing
+# function's own tibble() column list (also read from source and hardcoded
+# below, with a citation to the exact lines verified for #691's PR).
+#
+# `hd_metric_record()`'s wide-form path
+# (.normalise_metric_long(), packages/historicaldata/R/registry_metrics.R:
+# 408-431) only requires a unit for NUMERIC, non-NA columns of the selected
+# metric_cols -- character columns (e.g. `strategy`) and Date columns (e.g.
+# `window_start`) are auto-skipped regardless of whether the map covers
+# them. The "required" sets below are therefore the numeric subset of each
+# target's own columns, not literally every column name.
+
+# ── AST-based extractor for a local `<varname> <- c(...)` assignment ──────
+# Walks the parsed (unevaluated) expression tree of `file` looking for an
+# assignment whose LHS is the symbol `varname` and whose RHS is a call
+# (almost always `c(...)`). Returns the evaluated RHS -- safe here because
+# every `<prefix>_units` map in this repo is a literal named character
+# vector with no external references (verified by inspection for all 11
+# call sites this test covers).
+.extract_units_map <- function(file, varname) {
+  exprs <- parse(file, keep.source = FALSE)
+  found <- NULL
+  # Calls like `full_row[, metric_cols, drop = FALSE]` leave an empty
+  # (missing) argument slot in their parse tree; as.list() surfaces it as
+  # R's internal missing-arg sentinel, and merely referencing that binding
+  # (even to test its class) raises "argument is missing, with no default".
+  # tryCatch() around every touch of a list element guards against it.
+  is_call_safe <- function(x) tryCatch(is.call(x), error = function(err) FALSE)
+  walk <- function(e) {
+    if (!is.null(found) || !is_call_safe(e)) {
+      return(invisible())
+    }
+    if (identical(e[[1]], as.symbol("<-")) &&
+      is.symbol(e[[2]]) && identical(as.character(e[[2]]), varname)) {
+      found <<- eval(e[[3]])
+      return(invisible())
+    }
+    for (part in as.list(e)) {
+      if (!is.null(found)) break
+      if (is_call_safe(part)) walk(part)
+    }
+  }
+  for (e in exprs) {
+    if (!is.null(found)) break
+    walk(e)
+  }
+  if (is.null(found)) {
+    # basename(), not the full path -- keeps the abort message (and its
+    # snapshot) portable across checkouts/CI per portable-build-artifacts.
+    cli::cli_abort(c(
+      "x" = "Could not find {.code {varname} <- c(...)} in {.file {basename(file)}}.",
+      "i" = "The unit map may have been renamed or restructured."
+    ))
+  }
+  found
+}
+
+plan_dir <- here::here("R")
+
+# One entry per registry writer's unit map. `required` is the verified
+# numeric-column set of the metrics target that feeds this writer -- see
+# the cited source lines for each.
+unit_map_cases <- list(
+  list(
+    plan_file = "plan_ltr_momentum.R", varname = "ltr_units",
+    # compute_ltr_metrics(), R/plan_ltr_momentum.R:198-214
+    required = c(
+      "months", "cagr", "vol", "max_dd", "sharpe", "ann_rf",
+      "hac_sharpe", "hac_tstat", "avg_long", "avg_short"
+    )
+  ),
+  list(
+    plan_file = "plan_avoid_worst.R", varname = "aw_units",
+    # metrics_for(), R/plan_avoid_worst.R:551-569 -- strategy (character)
+    # and window_start/window_end (Date) are auto-skipped by
+    # hd_metric_record()'s numeric-only wide-form path; period/scenario are
+    # excluded from metric_cols by setdiff() before this point.
+    required = c("years", "n_days", "cagr", "vol", "max_dd", "sharpe", "ann_rf")
+  ),
+  list(
+    plan_file = "plan_turn_of_month.R", varname = "tom_units",
+    # calc(), R/plan_turn_of_month.R:173-198
+    required = c(
+      "n_days", "years", "cagr_tom", "vol_tom", "sharpe_tom",
+      "ann_rf_tom", "max_dd_tom", "cagr_bh", "vol_bh", "sharpe_bh",
+      "max_dd_bh", "n_tom_days", "pct_in_tom"
+    )
+  ),
+  list(
+    plan_file = "plan_risk_state.R", varname = "rsc_units",
+    # calc_metrics(), R/plan_risk_state.R:335-352 -- strategy (character)
+    # and window_start/window_end (Date) are auto-skipped.
+    required = c("cagr", "vol", "sharpe", "ann_rf", "max_dd", "hac_tstat", "hac_sharpe")
+  ),
+  list(
+    plan_file = "plan_mom_prepeak.R", varname = "mom_prepeak_units",
+    # .mom_prepeak_compute_metrics(), packages/historicaldata/R/
+    # utils_mom_prepeak_metrics.R:124-138, plus `m$ann_rf <- ...` at
+    # R/plan_mom_prepeak.R:157/165/173 -- blown_up/loss_clustered (logical)
+    # are auto-skipped.
+    required = c(
+      "n_months", "sharpe", "cagr", "vol", "max_dd",
+      "bankrupt_month", "avg_dd_days", "max_dd_days",
+      "max_cons_losses", "ann_rf"
+    )
+  ),
+  list(
+    plan_file = "plan_commodities_mean_reversion.R", varname = "cmr_units",
+    # .compute_cmr_metrics(), R/plan_commodities_mean_reversion.R:251-265
+    required = c(
+      "n_months", "sharpe", "cagr", "vol", "ann_rf", "max_dd",
+      "avg_dd_duration", "max_dd_duration"
+    )
+  ),
+  list(
+    plan_file = "plan_factormax.R", varname = "fm_units",
+    # calc_metrics(), R/plan_factormax.R:202-209
+    required = c(
+      "months", "cagr", "vol", "sharpe", "ann_rf", "max_dd",
+      "hit_rate", "bench_cagr", "bench_vol", "bench_sharpe"
+    )
+  ),
+  list(
+    plan_file = "plan_drif.R", varname = "drif_units",
+    # calc_metrics(), R/plan_drif.R:307-313
+    required = c(
+      "months", "cagr", "vol", "sharpe", "ann_rf", "max_dd",
+      "hit_rate", "bench_cagr", "bench_vol", "bench_sharpe"
+    )
+  ),
+  list(
+    plan_file = "plan_stock_backtest.R", varname = "stk_units",
+    # calc_backtest_metrics(), R/plan_stock_backtest.R:431-449 (shared by
+    # stk_max and stk_drif via .stk_register_runs())
+    required = c("months", "cagr", "vol", "sharpe", "ann_rf", "max_dd", "avg_long", "avg_short")
+  ),
+  list(
+    plan_file = "plan_xgb_signal.R", varname = "xgb_units",
+    # calc_backtest_metrics(), R/plan_stock_backtest.R:431-449 (shared)
+    required = c("months", "cagr", "vol", "sharpe", "ann_rf", "max_dd", "avg_long", "avg_short")
+  ),
+  list(
+    plan_file = "plan_portfolio_opt.R", varname = "pso_units",
+    # calc_port_metrics(), R/plan_portfolio_opt.R:287-316 -- `ann_rf` exists
+    # on port_metrics but `pso_cols` (an explicit intersect() allow-list,
+    # unlike the setdiff()-based exclusion every other writer here uses)
+    # never selects it, so this writer does not currently attempt to write
+    # ann_rf. Required set reflects only what pso_cols actually selects.
+    required = c("months", "opt_cagr", "opt_vol", "opt_sharpe", "opt_maxdd")
+  )
+)
+
+for (case in unit_map_cases) {
+  local({
+    this_case <- case
+    test_that(
+      sprintf("%s covers its metrics target's numeric columns (#691)", this_case$varname),
+      {
+        file <- file.path(plan_dir, this_case$plan_file)
+        units_map <- .extract_units_map(file, this_case$varname)
+        missing <- setdiff(this_case$required, names(units_map))
+        expect_equal(
+          missing, character(0),
+          info = sprintf(
+            "%s (%s) is missing unit declarations for: %s",
+            this_case$varname, this_case$plan_file, paste(missing, collapse = ", ")
+          )
+        )
+      }
+    )
+  })
+}
+
+test_that("mom_prepeak_units declares cagr/vol/max_dd as percent, not fraction (#691)", {
+  # .mom_prepeak_compute_metrics() (packages/historicaldata/R/
+  # utils_mom_prepeak_metrics.R:128-130) returns round(cagr * 100, 1) etc --
+  # PERCENT -- and R/plan_leaderboard.R's .norm_mom_sibling() independently
+  # confirms this by dividing cagr/vol/max_dd/ann_rf by 100. The unit map
+  # previously declared these three as "fraction", writing values 100x too
+  # large into bt.metric under a unit that claimed otherwise (#691's second
+  # defect).
+  file <- file.path(plan_dir, "plan_mom_prepeak.R")
+  units_map <- .extract_units_map(file, "mom_prepeak_units")
+  expect_equal(unname(units_map["cagr"]), "percent")
+  expect_equal(unname(units_map["vol"]), "percent")
+  expect_equal(unname(units_map["max_dd"]), "percent")
+})
+
+test_that(".extract_units_map aborts informatively when the variable is not found", {
+  file <- file.path(plan_dir, "plan_ltr_momentum.R")
+  expect_snapshot(error = TRUE, .extract_units_map(file, "nonexistent_units"))
+})


### PR DESCRIPTION
## Summary

`ann_rf` was added to 11 metrics targets by #677 slice 4 (#686) but never
added to the hand-maintained `<prefix>_units` maps the registry writers pass
to `historicaldata::hd_metric_record()`. That function correctly aborts on
any column with no declared unit (#640), so every writer whose metrics
target gained `ann_rf` began erroring — hidden by `error = "continue"` in
`docs/_targets.R`.

## Part 1 — unit assigned per map, and the evidence

Each unit was independently verified against the metrics-computing
function's own source, not copied from the issue's table. All 11 checked
out against the issue except `pso_units` (see the discrepancy noted below).

| Map (file) | Unit added | Evidence |
|---|---|---|
| `ltr_units` (`R/plan_ltr_momentum.R`) | `ann_rf = "percent"` | `compute_ltr_metrics()` returns `round(sr$ann_rf * 100, 1)` |
| `aw_units` (`R/plan_avoid_worst.R`) | `ann_rf = "percent"` | `metrics_for()` returns `round(sr$ann_rf * 100, 2)` |
| `tom_units` (`R/plan_turn_of_month.R`) | `ann_rf_tom = "percent"` | `calc()` returns `round(sr_s$ann_rf * 100, 2)`; column is named `ann_rf_tom`, not `ann_rf` |
| `rsc_units` (`R/plan_risk_state.R`) | `ann_rf = "percent"` | `calc_metrics()` returns `round(sr_result$ann_rf * 100, 2)` |
| `mom_prepeak_units` (`R/plan_mom_prepeak.R`) | `ann_rf = "percent"` | `m$ann_rf <- round(.mom_prepeak_ann_rf(...) * 100, 2)` (×3 call sites) |
| `cmr_units` (`R/plan_commodities_mean_reversion.R`) | `ann_rf = "fraction"` | `.compute_cmr_metrics()` returns `round(sr$ann_rf, 4)` — never ×100 |
| `fm_units` (`R/plan_factormax.R`) | `ann_rf = "fraction"` | `calc_metrics()`: `ann_rf <- mean(df$rf_ret) * 12` — never ×100 |
| `drif_units` (`R/plan_drif.R`) | `ann_rf = "fraction"` | `calc_metrics()`: `ann_rf <- mean(df$rf_ret, na.rm=TRUE) * 12` — never ×100 |
| `stk_units` (`R/plan_stock_backtest.R`) | `ann_rf = "fraction"` | shared `calc_backtest_metrics()`: `rf_ann <- mean(df[[rf_col]]) * 12` — never ×100 |
| `xgb_units` (`R/plan_xgb_signal.R`) | `ann_rf = "fraction"` | same shared `calc_backtest_metrics()` as `stk` |
| `pso_units` (`R/plan_portfolio_opt.R`) | `ann_rf = "fraction"` | `calc_port_metrics()`: `ann_rf = rf_ann` (`mean(df$rf_ret) * 12`) — never ×100 |

**Discrepancy found in Part 1:** the issue lists `pso_optimal_register_runs`
among the six writers "expected to error on their next rebuild." That's not
correct. `.pso_optimal_register_runs()` selects its metric columns via an
explicit `intersect(c("months","opt_cagr","opt_vol","opt_sharpe",
"opt_maxdd"), names(full_row))` allow-list — unlike the other ten writers,
which all use a `setdiff(names(full_row), <excluded>)` exclusion pattern that
automatically pulls in any new column. `port_metrics` does carry `ann_rf`,
but `pso_cols` never selects it, so this specific target does not currently
attempt to write `ann_rf` and was not erroring. I added `ann_rf = "fraction"`
to `pso_units` anyway (matches the issue's literal instruction and is
forward-compatible/consistent with the other ten maps), but left `pso_cols`
unchanged — expanding what this writer publishes to the registry is a
separate, larger decision than fixing a unit-declaration bug. Documented
inline at `R/plan_portfolio_opt.R:537-549`.

Confirmed `mom_prepeak_gauntlet_register`/`gauntlet_units` is unaffected, per
the issue — it writes a disjoint metric set (`hac_sharpe`, `ff5_alpha`,
`pbo`, …) that never gained `ann_rf`.

## Part 2 — mom_prepeak percent/fraction correction

`mom_prepeak_units` declared `cagr`/`vol`/`max_dd` as `"fraction"`. Verified
wrong: `.mom_prepeak_compute_metrics()`
(`packages/historicaldata/R/utils_mom_prepeak_metrics.R:128-130`) returns
`round(cagr * 100, 1)` / `round(vol * 100, 1)` / `round(max_dd * 100, 1)` —
percent. `R/plan_leaderboard.R`'s `.norm_mom_sibling()` independently
confirms this by dividing `cagr`/`vol`/`max_dd`/`ann_rf` by 100 before
adding the row to the leaderboard. Changed all three (plus the new `ann_rf`)
to `"percent"`.

## Part 3 — a test that fails against pre-fix code

Added `tests/testthat/test-registry-unit-map-coverage.R`. Since the 11 unit
maps are locals inside each writer's helper function (not importable
directly), the test statically parses each plan file's AST (`parse()`, no
target-body evaluation, no store build — a worktree must not build the
store) to extract the literal `<prefix>_units <- c(...)` assignment, and
asserts its names cover the metrics target's verified numeric column set
(hardcoded per-map, cited against the exact source lines read for this PR).
A separate test asserts `mom_prepeak_units$cagr/vol/max_dd == "percent"`.

**Demonstrated genuine failure against pre-fix code:** temporarily restored
`R/plan_ltr_momentum.R` to its pre-fix (`HEAD`) content and re-ran the test
file:

```
FAILURE: 'test-registry-unit-map-coverage.R:174:9' ----------
Expected `missing` to equal `character(0)`.
Differences:
`actual`:   "ann_rf"
`expected`:

ltr_units (plan_ltr_momentum.R) is missing unit declarations for: ann_rf

[ FAIL 1 | WARN 0 | SKIP 0 | PASS 14 ]
```

Restored the fix and re-ran — all 15 pass:

```
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 15 ]
```

Per `snapshot-test-policy`, the new `cli_abort()` inside the test's
AST-extraction helper has `expect_snapshot(error = TRUE, ...)` coverage
(`tests/testthat/_snaps/registry-unit-map-coverage.md`). The snapshot
message uses `basename(file)`, not the full path, so it stays portable
across checkouts/CI (`portable-build-artifacts`).

## Part 4 — scripts/verify.sh

Run in the foreground (backgrounded automatically past the 10-minute Bash
timeout on the cold-shell entry; waited for completion, then re-ran once
more after a snapshot-portability fix to get final fresh evidence):

```
PASS: _targets.R parses
PASS: docs/_targets.R parses
PASS: docs/_targets.R is structurally valid (tar_validate, 7.65s)
PASS: testthat edition 3 active

=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

=== scripts/verify.sh: PASS ===
```

Root suite: `total=587 failed=3 skipped=0` (matches baseline exactly — the
15 new tests all pass and are counted in the 587 total). Package suite:
`total=695 failed=1 skipped=15` (matches baseline exactly). No regressions.

`tar_make()` was **not** run — a worktree must not build the targets store
(would race the main checkout's store, per `.claude/CLAUDE.md`). The six
previously-errored registry targets (`ltr_register_runs`,
`avoid_worst_register_runs`, `fm_register_runs`, `tom_register_runs`,
`cmr_registry_run`, `drif_register_runs`) plus the five statically-identical
ones (`xgb_drif_register_runs`, `stk_max_register_runs`,
`stk_drif_register_runs`, `mom_prepeak_register_runs`, `rsc_register_runs`)
need a real rebuild to confirm green — that's for the maintainer to run
against the main checkout.

## Follow-up (out of scope for this PR)

- Backfill or invalidate the `bt.metric` rows already written under
  `mom_prepeak`'s previously-wrong `"fraction"` unit for `cagr`/`vol`/
  `max_dd` — those rows are stored as raw percent values (e.g. `-21.0`) but
  were labelled `"fraction"`, so any reader that trusted the label got a
  value 100× too large. This PR does not touch existing `bt.metric` rows.
- The issue's "structural half" (lifting all 12 maps to named top-level
  constants + a `tar_make()`-time QA gate) is explicitly out of scope here —
  this PR's test (Part 3) is a static-analysis substitute that catches the
  same class of drift without a store build, per the issue's own fallback
  option (b).

## Not closing the issue

This PR does not use a closing keyword. The issue's "structural half" fix
(lifting the maps to constants + a QA gate, so the *next* new column can't
reproduce this silently) is explicitly left as follow-up, and the
`bt.metric` backfill for the mom_prepeak percent-bug rows is also
unaddressed. Both are named directly in the issue as required or
recommended; leaving the issue open until a maintainer decides how (or
whether) to pursue them, per #665.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
