### PR TITLE
test(registry-unit-map-coverage): guard against vacuous-pass on empty derived required set (#691, #693 follow-up)

### DIFF
--- a/tests/testthat/_snaps/registry-unit-map-coverage.md
+++ b/tests/testthat/_snaps/registry-unit-map-coverage.md
@@ -7,3 +7,33 @@
       x Could not find `nonexistent_units <- c(...)` in 'plan_ltr_momentum.R'.
       i The unit map may have been renamed or restructured.
 
+# .derive_required_from_tibble aborts informatively when no tibble() columns remain (#693 follow-up)
+
+    Code
+      .derive_required_from_tibble(file, "toy_fn", exclude = c("strategy", "period"))
+    Condition
+      Error in `.derive_required_from_tibble()`:
+      x `toy_fn()` in 'toy_plan.R' has no tibble() columns left after excluding "strategy" and "period".
+      i `toy_fn()` was probably refactored away from a `tibble(...)`/`tibble::tibble(...)` constructor (e.g. to `data.frame()`, `as_tibble()`, or a `dplyr::transmute()` pipeline) -- `.extract_tibble_column_names()` only recognises the former.
+      i Update this test's extractor (or its `fn_name`/`exclude`) to match the new constructor; an empty required set would make this test's coverage check pass vacuously.
+
+# .extract_intersect_allowlist aborts informatively when the allow-list is empty (#693 follow-up)
+
+    Code
+      .extract_intersect_allowlist(file, "toy_cols")
+    Condition
+      Error in `.extract_intersect_allowlist()`:
+      x `toy_cols`'s `intersect(...)` allow-list in 'toy_plan.R' is empty.
+      i The allow-list's first argument was probably emptied, or replaced with something that no longer lists columns explicitly.
+      i An empty allow-list would make this test's coverage check pass vacuously; fix the allow-list or re-classify this case.
+
+# .check_declared_required aborts informatively when the declared list is empty (#693 follow-up)
+
+    Code
+      .check_declared_required(character(0), "toy_units")
+    Condition
+      Error in `.check_declared_required()`:
+      x `toy_units`'s hand-declared required-columns list is empty.
+      i Check the `unit_map_cases` entry for `toy_units` in 'test-registry-unit-map-coverage.R'.
+      i An empty required set would make this test's coverage check pass vacuously, per .claude/rules/fail-loud-not-null.md.
+

--- a/tests/testthat/test-registry-unit-map-coverage.R
+++ b/tests/testthat/test-registry-unit-map-coverage.R
@@ -221,10 +221,26 @@ testthat::local_edition(3)
 
 # Combines the two extractors above: the numeric-column set a metrics-
 # computing function emits, minus its known non-numeric/excluded columns.
+#
+# Guards against the vacuous-pass hole this test was written to close: if
+# `fn_name` no longer contains a recognisable tibble()/tibble::tibble() call
+# (e.g. refactored to data.frame(), as_tibble(), or a dplyr::transmute()
+# pipeline), .extract_tibble_column_names() silently returns character(0),
+# and absent this check `required` below would become character(0) too --
+# making the caller's expect_equal(missing, character(0)) pass without
+# checking anything (#693 follow-up; see .claude/rules/fail-loud-not-null.md).
 .derive_required_from_tibble <- function(file, fn_name, exclude = character(0)) {
   body <- .extract_function_body(file, fn_name)
   all_cols <- .extract_tibble_column_names(body)
-  setdiff(all_cols, exclude)
+  required <- setdiff(all_cols, exclude)
+  if (length(required) == 0) {
+    cli::cli_abort(c(
+      "x" = "{.fn {fn_name}} in {.file {basename(file)}} has no tibble() columns left after excluding {.val {exclude}}.",
+      "i" = "{.fn {fn_name}} was probably refactored away from a {.code tibble(...)}/{.code tibble::tibble(...)} constructor (e.g. to {.code data.frame()}, {.code as_tibble()}, or a {.code dplyr::transmute()} pipeline) -- {.fn .extract_tibble_column_names} only recognises the former.",
+      "i" = "Update this test's extractor (or its {.arg fn_name}/{.arg exclude}) to match the new constructor; an empty required set would make this test's coverage check pass vacuously."
+    ))
+  }
+  required
 }
 
 # For the one writer (pso_optimal) that uses an explicit intersect()
@@ -241,7 +257,35 @@ testthat::local_edition(3)
       "i" = "This extractor only handles the explicit allow-list pattern; the case may need re-classifying."
     ))
   }
-  eval(rhs[[2]])
+  allowlist <- eval(rhs[[2]])
+  # Same guard as .derive_required_from_tibble() above, for the same reason:
+  # an empty allow-list would make required <- character(0) and the caller's
+  # expect_equal(missing, character(0)) would pass without checking anything
+  # (#693 follow-up; .claude/rules/fail-loud-not-null.md).
+  if (length(allowlist) == 0) {
+    cli::cli_abort(c(
+      "x" = "{.code {varname}}'s {.code intersect(...)} allow-list in {.file {basename(file)}} is empty.",
+      "i" = "The allow-list's first argument was probably emptied, or replaced with something that no longer lists columns explicitly.",
+      "i" = "An empty allow-list would make this test's coverage check pass vacuously; fix the allow-list or re-classify this case."
+    ))
+  }
+  allowlist
+}
+
+# Guard for `mode = "declared"` cases: `required` there is hand-written in
+# this file's `unit_map_cases` list below, not derived from source, so it
+# cannot go empty via a refactor the way the two extractors above can. It is
+# guarded anyway for uniformity with them -- the cost is one length() check,
+# and the failure mode (a vacuously-passing coverage check) is identical.
+.check_declared_required <- function(required, varname) {
+  if (length(required) > 0) {
+    return(required)
+  }
+  cli::cli_abort(c(
+    "x" = "{.code {varname}}'s hand-declared required-columns list is empty.",
+    "i" = "Check the {.code unit_map_cases} entry for {.code {varname}} in {.file test-registry-unit-map-coverage.R}.",
+    "i" = "An empty required set would make this test's coverage check pass vacuously, per .claude/rules/fail-loud-not-null.md."
+  ))
 }
 
 plan_dir <- here::here("R")
@@ -364,7 +408,7 @@ for (case in unit_map_cases) {
             .derive_required_from_tibble(fn_file, this_case$fn_name, this_case$exclude)
           },
           intersect = .extract_intersect_allowlist(file, this_case$allowlist_varname),
-          declared = this_case$required,
+          declared = .check_declared_required(this_case$required, this_case$varname),
           cli::cli_abort("Unknown unit_map_cases mode: {this_case$mode}")
         )
 
@@ -399,4 +443,47 @@ test_that("mom_prepeak_units declares cagr/vol/max_dd as percent, not fraction (
 test_that(".extract_units_map aborts informatively when the variable is not found", {
   file <- file.path(plan_dir, "plan_ltr_momentum.R")
   expect_snapshot(error = TRUE, .extract_units_map(file, "nonexistent_units"))
+})
+
+# ── Vacuous-pass guard coverage (#693 follow-up) ───────────────────────────
+# The three tests below exercise the empty-`required` guards added to
+# .derive_required_from_tibble(), .extract_intersect_allowlist(), and
+# .check_declared_required(). Each constructs the minimal input that makes
+# its extractor return character(0), and asserts the guard aborts instead of
+# silently letting `required` become empty (which, upstream in the test
+# loop, would make expect_equal(missing, character(0)) pass vacuously).
+#
+# The fixture files use a fixed basename ("toy_plan.R") inside a temp
+# directory: basename(file) is the only part of the path that reaches the
+# abort message, so the snapshot stays stable even though the directory
+# itself is different on every run (portable-build-artifacts).
+test_that(".derive_required_from_tibble aborts informatively when no tibble() columns remain (#693 follow-up)", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_plan.R")
+  writeLines(
+    c(
+      "toy_fn <- function() {",
+      "  tibble::tibble(strategy = 'x', period = 'Full')",
+      "}"
+    ),
+    file
+  )
+  expect_snapshot(
+    error = TRUE,
+    .derive_required_from_tibble(file, "toy_fn", exclude = c("strategy", "period"))
+  )
+})
+
+test_that(".extract_intersect_allowlist aborts informatively when the allow-list is empty (#693 follow-up)", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_plan.R")
+  writeLines("toy_cols <- intersect(character(0), names(full_row))", file)
+  expect_snapshot(
+    error = TRUE,
+    .extract_intersect_allowlist(file, "toy_cols")
+  )
+})
+
+test_that(".check_declared_required aborts informatively when the declared list is empty (#693 follow-up)", {
+  expect_snapshot(error = TRUE, .check_declared_required(character(0), "toy_units"))
 })


### PR DESCRIPTION
## The hole

In `tests/testthat/test-registry-unit-map-coverage.R`, the test added under
#693 (as a follow-up to #691) derives each writer's `required` set of
numeric columns from source at test time, rather than hand-maintaining it.
Two of the three derivation paths could each silently produce
`character(0)` instead of failing:

- `.derive_required_from_tibble()` (`mode = "tibble"`, 9 of the 11 cases):
  `.extract_tibble_column_names()` returns `character(0)` when the walked
  function body contains no recognisable `tibble()`/`tibble::tibble()` call.
  If any of the nine metrics-computing functions were refactored from
  `tibble(...)` to `data.frame(...)`, `as_tibble(...)`, or a
  `dplyr::transmute()` pipeline, this extractor would find nothing.
- `.extract_intersect_allowlist()` (`mode = "intersect"`, the `pso_optimal`
  case): if the `intersect(...)` allow-list's first argument were ever
  emptied, `eval()` would return `character(0)`.

In both cases, `setdiff(character(0), names(units_map))` is `character(0)`,
so `expect_equal(missing, character(0))` in the test loop **passes** — the
case goes green while checking nothing. `hd_metric_record()` would then
abort at build time exactly like #691, on top of a fully green test suite.
This is precisely the pattern `.claude/rules/fail-loud-not-null.md`
prohibits — silently coercing an unrecognised/absent state to something
that looks like "nothing to check" instead of aborting — occurring *inside*
a test written specifically to enforce that rule. Flagged in review on #692
(https://github.com/JohnGavin/historical/pull/692#issuecomment) and
referenced again in #693.

## The fix

- `.derive_required_from_tibble()` now aborts when its derived `required`
  set is empty, naming the function and file it walked and explaining the
  likely cause (constructor refactored away from `tibble()`).
- `.extract_intersect_allowlist()` now aborts the same way when the
  allow-list is empty, naming the allow-list variable and file.
- Added `.check_declared_required()` and wired it into the `mode =
  "declared"` branch too. The one declared case (`mom_prepeak_units`) is
  hand-written in this file and cannot go empty via a source refactor the
  way the two extractors above can — but guarding it costs one `length()`
  check and keeps all three modes uniform, so I added it rather than
  leaving `declared` as the odd one out.

All three abort messages use `basename(file)`, matching the existing style
in `.extract_units_map()`'s abort (kept portable across checkouts per
`portable-build-artifacts`).

Per `.claude/rules/snapshot-test-policy.md`, all three new `cli_abort()`
paths have `expect_snapshot(error = TRUE, ...)` coverage. The two
extractor tests use a fixed-basename (`toy_plan.R`) fixture inside a
`withr::local_tempdir()` so the snapshot text — which embeds
`basename(file)` — stays stable even though the containing directory is
randomised per run.

## Demonstration 1 — it fires

Temporarily changed `compute_ltr_metrics()` in `R/plan_ltr_momentum.R` from
`tibble::tibble(...)` to `as.data.frame(list(...))` (one of the nine
tibble-derived cases) and re-ran the coverage test file:

```
ERROR: 'test-registry-unit-map-coverage.R:408:13' ----------
Error in `.derive_required_from_tibble(fn_file, this_case$fn_name, this_case$exclude)`: x `compute_ltr_metrics()` in 'plan_ltr_momentum.R' has no tibble() columns left after excluding "period".
i `compute_ltr_metrics()` was probably refactored away from a `tibble(...)`/`tibble::tibble(...)` constructor (e.g. to `data.frame()`, `as_tibble()`, or a `dplyr::transmute()` pipeline) -- `.extract_tibble_column_names()` only recognises the former.
i Update this test's extractor (or its `fn_name`/`exclude`) to match the new constructor; an empty required set would make this test's coverage check pass vacuously.
Backtrace:
    ▆
 1. └─.derive_required_from_tibble(fn_file, this_case$fn_name, this_case$exclude) at test-registry-unit-map-coverage.R:408:13
 2.   └─cli::cli_abort(...) at test-registry-unit-map-coverage.R:237:5
 3.     └─rlang::abort(...)

[ FAIL 1 | WARN 0 | SKIP 0 | PASS 17 ]
```

Then reverted with `git checkout -- R/plan_ltr_momentum.R`. `git diff --stat`
afterward touches only the two files in this PR — the demonstration edit
left no trace.

## Demonstration 2 — it does not false-positive

Re-ran the coverage test file unmodified (i.e. with the revert applied):
`[ FAIL 0 | WARN 0 | SKIP 0 | PASS 18 ]` — 18/18 pass, including the three
new guard-coverage tests, with no snapshot warnings on the second run
(snapshots stable).

The full suite via `scripts/verify.sh` (below) confirms nothing else
regressed.

## Would this have caught #691?

**No.** #691's actual defect was `ann_rf` being added to a metrics target
(a real `tibble()` column) with no matching addition to the unit map — the
AST walk *did* see that column; the unit map just didn't cover it. This PR
closes a different, adjacent hole: the derivation itself silently returning
nothing when the source no longer matches the extractor's expected shape.
That hole was opened by the #693 fix for #691, not by #691 itself, and is
exactly what review comment on #692 called out this test as not yet
guarding against.

## Verification

`scripts/verify.sh` (foreground, full run):

```
PASS: _targets.R parses
PASS: docs/_targets.R parses
PASS: docs/_targets.R is structurally valid (tar_validate, 7.39s)
PASS: testthat edition 3 active

=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

=== scripts/verify.sh: PASS ===
```

`::VERIFY:ROOT_SUMMARY:: total=590 failed=3 skipped=0` — baseline is
`total=587 failed=3 skipped=0`; the +3 is exactly the three new
`expect_snapshot(error = TRUE, ...)` tests added here, and all three
failure signatures match the documented baseline exactly.

`::VERIFY:PKG_SUMMARY:: total=695 failed=1 skipped=15` — unchanged from
baseline (this PR touches no package code).

Refs #691, #693. No closing keyword — both remain open for other reasons.
