### PR TITLE
feat(scripts): detect dead tar_read() refs and dashboard staleness (#695)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,6 +20,14 @@
 # the demonstration: six registry writers errored on every build for four
 # commits, surfaced only on the first occasion anyone ran the check by hand.
 #
+# STEP 3 (#695): after the store exists, this script also runs
+# scripts/check_dashboard_freshness.R --data-staleness, which needs a real
+# store to compare each docs/*.qmd page own referenced targets build times
+# against that page rendered .html -- the ONE surface of #695's three that
+# verify.sh cannot cover (verify.sh runs Check 1 + Check 2 of the same
+# script, which need no store -- see that script header comment for the
+# full three-check design).
+#
 # MAIN CHECKOUT ONLY. A worktree has no targets store of its own and must
 # not build one that could race the main checkout's docs/_targets store (see
 # .claude/CLAUDE.md "Verifying a change" and the worktree-location rule).
@@ -30,19 +38,23 @@
 #   scripts/build.sh
 #
 # Exit codes:
-#   0  tar_make() ran and scripts/check_pipeline_errors.R found no errored
-#      targets.
+#   0  tar_make() ran, scripts/check_pipeline_errors.R found no errored
+#      targets, and scripts/check_dashboard_freshness.R --data-staleness
+#      found no dead target references (and no staleness escalated to a
+#      failure -- see that script header for HD_FAIL_ON_STALE_DASHBOARDS).
 #   1  the build RAN but reported a problem: one or more targets errored
-#      (per check_pipeline_errors.R), and/or tar_make() itself exited
-#      non-zero (a crashed build still leaves a store worth inspecting, so
-#      check_pipeline_errors.R always runs -- see Step 2 below -- but a
+#      (per check_pipeline_errors.R), a dead target reference or escalated
+#      staleness (per check_dashboard_freshness.R), and/or tar_make() itself
+#      exited non-zero (a crashed build still leaves a store worth
+#      inspecting, so Steps 2 and 3 always run -- see below -- but a
 #      non-zero tar_make() exit is never silently treated as a pass even
 #      when the store it left behind happens to read clean).
 #   2  the build did NOT run at all: wrong location (not the main checkout,
 #      or run from a linked worktree), the nix shell itself could not be
-#      entered (pre-flight check below), or check_pipeline_errors.R could
-#      not read a store at all (no store / tar_meta() failed). This is NOT
-#      a pass -- never treat it as one.
+#      entered (pre-flight check below), check_pipeline_errors.R could not
+#      read a store at all (no store / tar_meta() failed), or
+#      check_dashboard_freshness.R --data-staleness could not run its checks
+#      at all. This is NOT a pass -- never treat it as one.
 
 set -euo pipefail
 
@@ -137,14 +149,37 @@ echo "--- check_pipeline_errors.R exited $CHECK_STATUS ---"
 echo ""
 
 # ---------------------------------------------------------------------------
+# Step 3: scripts/check_dashboard_freshness.R --data-staleness (#695). Runs
+# UNCONDITIONALLY, same reasoning as Step 2: a crashed or partially-errored
+# tar_make() (docs/_targets.R sets error = "continue" project-wide) still
+# leaves a store with real build times for whatever DID succeed, worth
+# checking. This re-runs Check 1 (dead target references) and Check 2
+# (source-vs-render staleness) as well as Check 3 (data staleness) -- see
+# that script header comment for the full three-check design and why Check
+# 3 specifically needs a real store (hence living here, not in
+# scripts/verify.sh). Staleness (Check 2/Check 3) is informational-only by
+# default (HD_FAIL_ON_STALE_DASHBOARDS=1 escalates it) -- dead references
+# (Check 1) are always a hard failure. See that script header for the full
+# exit-code contract; the same 0/1/2 meaning is reused here.
+# ---------------------------------------------------------------------------
+echo "--- Step 3: scripts/check_dashboard_freshness.R --data-staleness (#695) ---"
+set +e
+nix develop "$REPO_ROOT" --command Rscript scripts/check_dashboard_freshness.R --data-staleness
+DASHBOARD_STATUS=$?
+set -e
+echo "--- check_dashboard_freshness.R --data-staleness exited $DASHBOARD_STATUS ---"
+echo ""
+
+# ---------------------------------------------------------------------------
 # Final verdict -- printed LAST and kept short, so it is the final thing on
 # screen rather than buried 900+ lines up in the tar_make() build log
-# (#693). The errored-target list itself was already printed by Step 2,
-# directly above this block.
+# (#693). The errored-target/dead-reference/staleness lists were already
+# printed by Step 2 and Step 3, directly above this block.
 # ---------------------------------------------------------------------------
 echo "=== scripts/build.sh: summary ==="
-echo "tar_make() exit code:               $TAR_MAKE_STATUS"
-echo "check_pipeline_errors.R exit code:  $CHECK_STATUS"
+echo "tar_make() exit code:                              $TAR_MAKE_STATUS"
+echo "check_pipeline_errors.R exit code:                 $CHECK_STATUS"
+echo "check_dashboard_freshness.R --data-staleness exit: $DASHBOARD_STATUS"
 echo ""
 
 if [[ "$CHECK_STATUS" -eq 2 ]]; then
@@ -154,10 +189,23 @@ if [[ "$CHECK_STATUS" -eq 2 ]]; then
   exit 2
 fi
 
-if [[ "$TAR_MAKE_STATUS" -ne 0 ]] || [[ "$CHECK_STATUS" -ne 0 ]]; then
+if [[ "$DASHBOARD_STATUS" -eq 2 ]]; then
+  echo "!!! check_dashboard_freshness.R --data-staleness could not run the check at all"
+  echo "!!! (no store, tar_manifest()/tar_meta() failed, or a broken extractor) -- see"
+  echo "!!! its output above."
+  echo "!!! BUILD DID NOT RUN. This is NOT a pass.                                   !!!"
+  exit 2
+fi
+
+if [[ "$TAR_MAKE_STATUS" -ne 0 ]] || [[ "$CHECK_STATUS" -ne 0 ]] || [[ "$DASHBOARD_STATUS" -ne 0 ]]; then
   echo "=== scripts/build.sh: FAIL ==="
   if [[ "$CHECK_STATUS" -ne 0 ]]; then
     echo "One or more targets errored -- see the [ERROR] list above."
+  fi
+  if [[ "$DASHBOARD_STATUS" -ne 0 ]]; then
+    echo "Dashboard freshness found a problem -- see the [DEAD-REF]/[STALE]/[DATA-STALE]"
+    echo "lines above (staleness only fails when HD_FAIL_ON_STALE_DASHBOARDS is set --"
+    echo "see scripts/check_dashboard_freshness.R header comment)."
   fi
   if [[ "$TAR_MAKE_STATUS" -ne 0 ]]; then
     echo "tar_make() itself also exited non-zero ($TAR_MAKE_STATUS) -- see the build"
@@ -168,5 +216,5 @@ if [[ "$TAR_MAKE_STATUS" -ne 0 ]] || [[ "$CHECK_STATUS" -ne 0 ]]; then
   exit 1
 fi
 
-echo "=== scripts/build.sh: PASS (tar_make() clean, no errored targets) ==="
+echo "=== scripts/build.sh: PASS (tar_make() clean, no errored targets, dashboard freshness clean) ==="
 exit 0

--- a/scripts/check_dashboard_freshness.R
+++ b/scripts/check_dashboard_freshness.R
@@ -1,0 +1,678 @@
+#!/usr/bin/env Rscript
+# scripts/check_dashboard_freshness.R — detects the render-time surface named
+# in #695 as the one nothing catches (Option A: detection only; the actual
+# re-render is deliberately out of scope of this script, see #695's PR).
+#
+# scripts/verify.sh's tar_validate() proves the pipeline STRUCTURE is sound;
+# scripts/check_pipeline_errors.R (via scripts/build.sh) proves no target
+# BODY errored. Neither catches: (a) a docs/*.qmd chunk calling tar_read()
+# for a target name that no longer exists in the pipeline -- fails only at
+# an actual quarto render, or (b) a page whose committed .html predates its
+# own .qmd source, or a page's target data being older than what the
+# pipeline currently holds -- both invisible because nothing re-renders
+# automatically (GitHub Pages serves the committed .html directly; see
+# #695's issue body for the confirmed `gh api repos/.../pages` evidence).
+# This script closes (a) and (b) without needing a render.
+#
+# THREE CHECKS, TWO COST TIERS:
+#   Check 1 (dead target references) -- for each docs/*.qmd, extract every
+#     tar_read()/tar_read_raw()/safe_tar_read() target-name argument (see
+#     "Why safe_tar_read()" below) and compare against
+#     targets::tar_manifest(script = "docs/_targets.R")$name. A reference to
+#     a target absent from the manifest is a real defect: it WILL fail at
+#     render time. Needs no store, but tar_manifest() must fully evaluate
+#     docs/_targets.R to build the real target list -- measured 2026-08-20 at
+#     ~7.5s warm, the same order of cost as scripts/verify.sh's own
+#     tar_validate() call (~7s, per that script's header). There is no
+#     cheaper way to get the CURRENT target-name set; tar_validate() itself
+#     returns NULL invisibly (confirmed by inspection), so its cost cannot be
+#     reused. Given that cost, this check is NOT added to verify.sh --quick
+#     mode (documented there as "parse + tar_validate only"); it runs in full
+#     mode only, embedded in the SAME Rscript process (via source(), not a
+#     second `nix develop --command` call) to avoid paying a second ~13s
+#     nix-develop entry on top of the ~7.5s tar_manifest() cost.
+#   Check 2 (source-vs-render staleness) -- for each docs/*.qmd, compare its
+#     last git commit date against its .html sibling's. Needs no store, no
+#     manifest, no target extraction -- just `git log -1 --format=%ct`, ~30
+#     calls, measured well under a second. Runs in verify.sh full mode
+#     alongside Check 1 (kept together as one "dashboard freshness" report
+#     rather than splitting across --quick/full).
+#   Check 3 (data staleness) -- for each docs/*.qmd, compare its page-render
+#     time (parsed from the committed .html's build_info() "Built" footer,
+#     falling back to the .html's own git commit date when no footer is
+#     present -- see #695 follow-up filed for the 7 dashboards missing one)
+#     against the newest targets::tar_meta() build time among the SPECIFIC
+#     targets that page reads (not the store's global newest time -- that
+#     would mark every page stale the instant anything rebuilds, defeating
+#     the point of per-page restriction). Needs a REAL targets store, so it
+#     is NOT part of verify.sh; it runs only under --data-staleness, called
+#     from scripts/build.sh after scripts/check_pipeline_errors.R, in the
+#     MAIN CHECKOUT ONLY (a worktree has no store and must not build one that
+#     could race the main checkout's -- see .claude/CLAUDE.md).
+#
+# EXTRACTION APPROACH -- knitr::purl(), not regex on the .qmd text. This repo
+# spent a whole session (#691->#696) on the cost of fragile ad-hoc
+# extraction; the brief for this script explicitly avoided repeating that.
+# knitr::purl(documentation = 0, quiet = TRUE) tangles each .qmd's R chunks
+# to a temp .R file, which is then parse()'d (no evaluation) into an
+# expression list, walked for calls headed by a recognised read-function
+# name (bare or `pkg::fn` form), taking the FIRST argument. Verified
+# empirically against every docs/*.qmd (2026-08-20, warm nix shell):
+#   - All 15 files purl() cleanly (no errors). 8 emit a cosmetic
+#     "Duplicated chunk option(s) 'label'" warning (setup/scorecard/heatmap/
+#     build-info chunks that set `label` in both the chunk header and a pipe
+#     comment) -- suppressWarnings() around the purl() call, confirmed to be
+#     the ONLY warning class these files produce.
+#   - 4 files (drif.qmd, factor-max.qmd, jst-dashboard.qmd,
+#     negative-results.qmd) purl() to ZERO expressions. Verified these are
+#     genuinely redirect stub pages (0 ```{r fences in the raw source, `>
+#     This page has moved.` prose + a <meta http-equiv="refresh">) -- NOT a
+#     broken extractor. .cdf_extract_qmd_targets() distinguishes this
+#     legitimate case from a real extraction failure via
+#     .cdf_has_r_chunk_fence(): it aborts ONLY when purl() finds zero
+#     expressions AND the raw .qmd has at least one ```{r fence (meaning
+#     purl() silently dropped real chunks -- e.g. a non-R engine masquerading
+#     as r, or a chunk-header form purl() cannot parse). This narrow,
+#     single-purpose fence count is NOT how target names are extracted (that
+#     stays purl()+parse()-only per the brief) -- it exists solely as a
+#     sanity invariant. index.qmd purl()s to 27 expressions but references
+#     ZERO targets -- confirmed legitimate (a landing page with no
+#     tar_read-family calls at all), and is NOT flagged, because the
+#     fence-vs-zero-expression check (not a zero-target-reference check) is
+#     what distinguishes "broken" from "genuinely nothing here".
+#   - Every tar_read()/tar_read_raw() call's first argument across all 15
+#     files is a character literal or a bare symbol (0 calls with the target
+#     name in a variable/expression) -- confirmed via
+#     `grep -rnE "tar_read(_raw)?\(([^\"'a-zA-Z_.]|[a-zA-Z_.]+\()"` returning
+#     no matches. .cdf_extract_read_targets() aborts loudly on anything else
+#     (per .claude/rules/fail-loud-not-null.md) rather than silently skipping
+#     an unresolvable reference -- untested code path today, but the guard
+#     stays because the 0-variable-calls state is a fact about today's
+#     source, not a structural guarantee.
+#
+# WHY safe_tar_read() IS ALSO TREATED AS A READ (scope addition beyond the
+# original task brief, discovered during development): docs/vignette_utils.R
+# defines `safe_tar_read(name, strict = ...)`, a wrapper around
+# targets::tar_read_raw(name) that falls back to a bundled RDS fixture (or
+# NULL) on error -- used by 8 of the 15 dashboard pages. The brief specified
+# extracting only tar_read()/tar_read_raw(); treating those alone as "the"
+# read functions would make Check 1 and Check 3 silently blind on every page
+# that uses the wrapper. Verified 2026-08-20: for stock-backtest.qmd and
+# falsification.qmd (the two files with the heaviest safe_tar_read() use),
+# the SET of distinct target names referenced only via safe_tar_read() is
+# non-empty for falsification.qmd specifically ("cg_dag", "cg_caption" --
+# see the inline-expression limitation below), so the wrapper cannot be
+# ignored without a real coverage gap.
+#
+# KNOWN LIMITATION -- inline R expressions (single-backtick `` `r { ... } ``
+# `` syntax, as opposed to fenced ```{r} chunks) are NOT tangled by
+# knitr::purl() (confirmed: purl() only extracts fenced chunks, by design --
+# there is no supported knitr API to extract inline expressions without
+# evaluating them). Measured 2026-08-20: docs/falsification.qmd has 8 inline
+# tar_read-family calls invisible to this script, 2 of which reference
+# target names ("cg_dag" at line 806, "cg_caption" at line 986) that are
+# NEVER referenced in any fenced chunk in that file -- these two names are
+# therefore completely outside this script's coverage: Check 1 cannot catch
+# a dead reference to either, and Check 3 will not include either target
+# when computing falsification.qmd's own-targets staleness bound.
+# docs/stock-backtest.qmd has 19 inline calls, but (verified by diffing the
+# full-source unique target-name set against the purl()-extracted set) every
+# name referenced inline there is ALSO referenced at least once in a fenced
+# chunk in the same file -- so stock-backtest.qmd has no actual coverage gap
+# despite the high inline call count. This script deliberately does NOT
+# regex the .qmd text to close this gap (the brief was explicit: no regex
+# extraction of tar_read, and inline-expression parsing has no clean
+# non-regex alternative within knitr's public API) -- it is documented here,
+# at the one call site the gap affects, instead.
+#
+# EXIT CODES:
+#   0  ran clean: no dead target references (Check 1 -- ALWAYS a hard
+#      failure when found, see below), and no staleness escalated to a
+#      failure (see HD_FAIL_ON_STALE_DASHBOARDS below).
+#   1  a real problem was found and treated as a failure:
+#        - Check 1 always fails the run when it finds a dead reference --
+#          confirmed today: zero instances, so this does not turn a green
+#          run red. This is a genuine defect class (#695's issue body shows
+#          the live leaderboard is missing two merged features precisely
+#          because nothing else in the repo detects it), not a style
+#          preference, so it is not gated behind an opt-in flag.
+#        - Check 2/Check 3 staleness is REPORTED but does NOT fail the run
+#          by default -- ~8 of 15 dashboards are stale RIGHT NOW (#695's own
+#          evidence), so defaulting staleness to a hard failure would turn
+#          verify.sh/build.sh red on main until #695's separate re-render PR
+#          lands. Set HD_FAIL_ON_STALE_DASHBOARDS=1 (any of "1"/"true"/"yes",
+#          case-insensitive -- see .cdf_env_flag_true(), which exists
+#          specifically because `isTRUE(as.logical(Sys.getenv(...)))` is a
+#          known footgun: as.logical("1") is NA, not TRUE, per
+#          .claude/rules/fail-loud-not-null.md) to escalate staleness to a
+#          hard failure once the re-render half of #695 is done. This is the
+#          explicit, documented escalation path -- not an unwritten
+#          intention.
+#   2  could not run the check(s) at all: knitr::purl()/parse() failed or
+#      found a broken extraction, targets::tar_manifest()/tar_meta() failed,
+#      or (--data-staleness only) no store was found. NOT a pass.
+#
+# Usage:
+#   nix develop --command Rscript scripts/check_dashboard_freshness.R
+#     Runs Check 1 + Check 2 (no store needed). This is also what
+#     scripts/verify.sh's full mode calls, but embedded via source() into
+#     its existing Rscript process rather than spawned as a second process
+#     (see the cost note above) -- run this file directly only for a
+#     standalone/manual check.
+#   nix develop --command Rscript scripts/check_dashboard_freshness.R --data-staleness
+#     Additionally runs Check 3. MAIN CHECKOUT ONLY in practice (needs a
+#     real docs/_targets store) -- this is what scripts/build.sh calls,
+#     after scripts/check_pipeline_errors.R.
+#
+# This file is also source()'d directly by
+# tests/testthat/test-dashboard-freshness.R to unit-test the extractor
+# functions against synthetic fixtures -- sourcing it does NOT run the
+# checks (see the `sys.nframe() == 0` guard at the bottom: 0 only when this
+# file is the Rscript entry point, non-zero when source()'d, confirmed
+# empirically 2026-08-20).
+
+suppressPackageStartupMessages({
+  library(here)
+})
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+# Read-function names this checker recognises -- see "Why safe_tar_read()"
+# in the header comment above.
+.CDF_READ_FN_NAMES <- c("tar_read", "tar_read_raw", "safe_tar_read")
+
+# Returns the function name for a bare call (`tar_read(...)`) or a
+# `pkg::fn(...)` call (`targets::tar_read(...)`); NULL for anything else
+# (e.g. a call stored behind an indirection this checker cannot resolve).
+.cdf_call_head_name <- function(e) {
+  if (!is.call(e)) {
+    return(NULL)
+  }
+  head <- e[[1]]
+  if (is.symbol(head)) {
+    return(as.character(head))
+  }
+  if (is.call(head) && length(head) == 3 && identical(head[[1]], as.symbol("::"))) {
+    return(as.character(head[[3]]))
+  }
+  NULL
+}
+
+# Walks a parsed (unevaluated) expression list looking for calls to
+# .CDF_READ_FN_NAMES, returning the unique set of target names referenced.
+# Aborts -- does not skip or return NA -- the moment a matched call's first
+# argument is neither a string literal nor a bare symbol, per
+# .claude/rules/fail-loud-not-null.md: an unresolvable reference must stop
+# the check, never be silently treated as "no reference here".
+.cdf_extract_read_targets <- function(exprs, qmd_basename) {
+  names_out <- character(0)
+  is_call_safe <- function(x) tryCatch(is.call(x), error = function(err) FALSE)
+  walk <- function(e) {
+    if (!is_call_safe(e)) {
+      return(invisible())
+    }
+    fn_name <- .cdf_call_head_name(e)
+    if (!is.null(fn_name) && fn_name %in% .CDF_READ_FN_NAMES) {
+      args <- as.list(e)[-1]
+      if (length(args) == 0) {
+        cli::cli_abort(c(
+          "x" = "{.fn {fn_name}} call with no arguments in {.file {qmd_basename}}.",
+          "i" = "Expected a target name as the first argument."
+        ))
+      }
+      arg1 <- args[[1]]
+      target_name <- if (is.character(arg1) && length(arg1) == 1) {
+        arg1
+      } else if (is.symbol(arg1)) {
+        as.character(arg1)
+      } else {
+        cli::cli_abort(c(
+          "x" = "{.fn {fn_name}} called with a non-literal, non-symbol first argument in {.file {qmd_basename}}.",
+          "i" = "Argument was: {.code {deparse(arg1)}}",
+          "i" = "This checker can only statically resolve a string literal or a bare symbol target name."
+        ))
+      }
+      names_out <<- c(names_out, target_name)
+    }
+    for (part in as.list(e)) {
+      if (is_call_safe(part)) walk(part)
+    }
+  }
+  for (e in exprs) walk(e)
+  unique(names_out)
+}
+
+# TRUE if the raw .qmd text contains at least one fenced R chunk
+# (```` ```{r ```` at the start of a line). NOT used for target-name
+# extraction -- see the header comment's "EXTRACTION APPROACH" section for
+# why this is a narrow structural sanity check, not a second extraction
+# path.
+.cdf_has_r_chunk_fence <- function(qmd_path) {
+  lines <- readLines(qmd_path, warn = FALSE)
+  any(grepl("^```\\{r", lines))
+}
+
+# Purls `qmd_path`'s R chunks to a temp file, parses it (no evaluation), and
+# returns the unique set of target names referenced via .CDF_READ_FN_NAMES.
+# Aborts if purl()/parse() itself fails, or if purl() extracts zero
+# expressions from a file that plainly has R chunks (see header comment).
+.cdf_extract_qmd_targets <- function(qmd_path) {
+  qmd_basename <- basename(qmd_path)
+  tmp_dir <- tempfile("dashboard_freshness_")
+  dir.create(tmp_dir)
+  on.exit(unlink(tmp_dir, recursive = TRUE), add = TRUE)
+  tmp_r <- file.path(tmp_dir, "purled.R")
+
+  # suppressWarnings(): verified 2026-08-20 the only warnings knitr::purl()
+  # emits across every docs/*.qmd are cosmetic "Duplicated chunk option(s)
+  # 'label'" notices (chunks that set `label` in both the header and a pipe
+  # comment) -- see header comment.
+  tryCatch(
+    suppressWarnings(knitr::purl(qmd_path, output = tmp_r, documentation = 0, quiet = TRUE)),
+    error = function(e) {
+      cli::cli_abort(c(
+        "x" = "knitr::purl() failed on {.file {qmd_basename}}.",
+        "i" = conditionMessage(e)
+      ))
+    }
+  )
+
+  exprs <- tryCatch(
+    parse(tmp_r, keep.source = FALSE),
+    error = function(e) {
+      cli::cli_abort(c(
+        "x" = "Failed to parse() knitr::purl() output for {.file {qmd_basename}}.",
+        "i" = conditionMessage(e)
+      ))
+    }
+  )
+
+  if (length(exprs) == 0 && .cdf_has_r_chunk_fence(qmd_path)) {
+    cli::cli_abort(c(
+      "x" = "knitr::purl() extracted zero R expressions from {.file {qmd_basename}}, but the file contains R chunk fence(s).",
+      "i" = "This is more likely a broken extractor (e.g. a non-r engine, an unusual chunk header) than a page with no code.",
+      "i" = "Investigate before trusting this check; do not add an exception without confirming the file genuinely has no executable R."
+    ))
+  }
+
+  .cdf_extract_read_targets(exprs, qmd_basename)
+}
+
+# Sorted docs/*.qmd paths under `docs_dir`.
+.cdf_qmd_files <- function(docs_dir) {
+  sort(list.files(docs_dir, pattern = "\\.qmd$", full.names = TRUE))
+}
+
+# Named list: basename(qmd) -> unique character vector of referenced target
+# names (possibly empty, e.g. index.qmd or a redirect stub).
+.cdf_collect_page_targets <- function(qmd_files) {
+  stats::setNames(
+    lapply(qmd_files, .cdf_extract_qmd_targets),
+    basename(qmd_files)
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+# Parses an env var as a boolean flag against a fixed, explicit vocabulary --
+# NEVER `isTRUE(as.logical(Sys.getenv(...)))`: as.logical("1") is NA, not
+# TRUE, which would silently default the flag OFF. See
+# .claude/rules/fail-loud-not-null.md and
+# .claude/memory/feedback_as-logical-numeric-strings.md.
+.cdf_env_flag_true <- function(var_name) {
+  val <- Sys.getenv(var_name, unset = "")
+  tolower(val) %in% c("1", "true", "yes")
+}
+
+# Last commit time (POSIXct, seconds resolution) of `abs_path` under
+# `repo_root`, via `git log -1 --format=%ct` (committer date, unix epoch --
+# avoids ISO-8601 timezone-offset parsing entirely). Returns NA (POSIXct) if
+# the path has no commit history (untracked, or newly added and unstaged).
+.cdf_git_last_commit_time <- function(abs_path, repo_root) {
+  rel_path <- sub(paste0("^", repo_root, "/"), "", abs_path, fixed = TRUE)
+  out <- suppressWarnings(system2(
+    "git", c("-C", repo_root, "log", "-1", "--format=%ct", "--", rel_path),
+    stdout = TRUE, stderr = FALSE
+  ))
+  status <- attr(out, "status")
+  if (!is.null(status) && status != 0) {
+    return(as.POSIXct(NA))
+  }
+  if (length(out) == 0 || !nzchar(out[1])) {
+    return(as.POSIXct(NA))
+  }
+  as.POSIXct(as.numeric(out[1]), origin = "1970-01-01", tz = Sys.timezone())
+}
+
+# Parses the "Built" timestamp out of a committed .html's build_info()
+# footer (docs/vignette_utils.R:205, format "Built</strong> YYYY-MM-DD
+# HH:MM:SS", confirmed against docs/leaderboard.html 2026-08-20). Falls back
+# to the .html's own git commit time when no footer is found -- this is a
+# DOCUMENTED, CLEARLY-LABELLED fallback (the `source` field in the returned
+# list), not a silent substitution: 7 of 15 dashboards currently have no
+# build_info() footer at all (see the follow-up issue filed alongside this
+# script) and would otherwise report no render time whatsoever.
+.cdf_page_render_time <- function(html_path, repo_root) {
+  if (file.exists(html_path)) {
+    html_text <- tryCatch(
+      paste(readLines(html_path, warn = FALSE), collapse = "\n"),
+      error = function(e) NA_character_
+    )
+    if (!is.na(html_text)) {
+      m <- regmatches(
+        html_text,
+        regexpr("Built</strong>\\s*[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}", html_text)
+      )
+      if (length(m) == 1 && nzchar(m)) {
+        ts_str <- sub("^Built</strong>\\s*", "", m)
+        ts <- as.POSIXct(ts_str, format = "%Y-%m-%d %H:%M:%S", tz = Sys.timezone())
+        if (!is.na(ts)) {
+          return(list(time = ts, source = "build_info() footer"))
+        }
+      }
+    }
+  }
+  git_time <- .cdf_git_last_commit_time(html_path, repo_root)
+  if (!is.na(git_time)) {
+    return(list(time = git_time, source = "git commit date (fallback -- no build_info() footer found)"))
+  }
+  list(time = as.POSIXct(NA), source = "unavailable (no footer, no git history)")
+}
+
+# ---------------------------------------------------------------------------
+# Check 1 -- dead target references
+# ---------------------------------------------------------------------------
+
+# Returns a named list: page basename -> character vector of target names it
+# references that are absent from `manifest_names`. Empty list means clean.
+.cdf_check_dead_references <- function(page_targets, manifest_names) {
+  problems <- list()
+  for (page in names(page_targets)) {
+    missing <- setdiff(page_targets[[page]], manifest_names)
+    if (length(missing) > 0) {
+      problems[[page]] <- missing
+    }
+  }
+  problems
+}
+
+# ---------------------------------------------------------------------------
+# Check 2 -- source-vs-render staleness
+# ---------------------------------------------------------------------------
+
+# Returns a named list: page basename -> gap in days (.qmd commit time minus
+# .html commit time) for every page whose .qmd is newer than its .html.
+# Pages with no git history for the .qmd, or no .html counterpart at all,
+# are reported separately by the caller (not silently dropped).
+.cdf_check_source_staleness <- function(qmd_files, repo_root) {
+  stale <- list()
+  no_html <- character(0)
+  untracked <- character(0)
+  for (f in qmd_files) {
+    base <- basename(f)
+    html_path <- sub("\\.qmd$", ".html", f)
+    qmd_time <- .cdf_git_last_commit_time(f, repo_root)
+    if (is.na(qmd_time)) {
+      untracked <- c(untracked, base)
+      next
+    }
+    if (!file.exists(html_path)) {
+      no_html <- c(no_html, base)
+      next
+    }
+    html_time <- .cdf_git_last_commit_time(html_path, repo_root)
+    if (is.na(html_time)) {
+      no_html <- c(no_html, base)
+      next
+    }
+    if (qmd_time > html_time) {
+      stale[[base]] <- as.numeric(difftime(qmd_time, html_time, units = "days"))
+    }
+  }
+  list(stale = stale, no_html = no_html, untracked = untracked)
+}
+
+# ---------------------------------------------------------------------------
+# Check 3 -- data staleness (needs a real store)
+# ---------------------------------------------------------------------------
+
+# Returns a named list: page basename -> list(gap_hrs=, source=) for every
+# page whose own referenced targets' newest tar_meta() build time is after
+# the page's render time. `meta_time` is a named numeric-time vector
+# (name -> POSIXct), typically from targets::tar_meta(fields = time).
+.cdf_check_data_staleness <- function(qmd_files, page_targets, meta_time, repo_root, note_fn = NULL) {
+  stale <- list()
+  for (f in qmd_files) {
+    base <- basename(f)
+    refs <- page_targets[[base]]
+    if (length(refs) == 0) next
+    known_refs <- intersect(refs, names(meta_time))
+    unknown_refs <- setdiff(refs, names(meta_time))
+    if (length(unknown_refs) > 0 && !is.null(note_fn)) {
+      note_fn(base, unknown_refs)
+    }
+    if (length(known_refs) == 0) next
+    max_target_time <- max(meta_time[known_refs], na.rm = TRUE)
+
+    html_path <- sub("\\.qmd$", ".html", f)
+    render <- .cdf_page_render_time(html_path, repo_root)
+    if (is.na(render$time)) next
+
+    if (max_target_time > render$time) {
+      stale[[base]] <- list(
+        gap_hrs = as.numeric(difftime(max_target_time, render$time, units = "hours")),
+        source = render$source
+      )
+    }
+  }
+  stale
+}
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+# Runs Check 1 + Check 2 (and Check 3 when `data_staleness = TRUE`, which
+# requires an existing store at `store_path`). Prints a human-readable
+# report and a machine-parseable `::VERIFY:DASHBOARD_FRESHNESS_STATUS:: <n>`
+# marker line, and RETURNS (does not quit()) an overall status: 0 (clean),
+# 1 (a real problem was found -- see EXIT CODES in the header comment for
+# what counts), or 2 (could not run at all -- extraction/manifest/store
+# failure).
+#
+# Deliberately does NOT call quit() itself, even on a status-2 condition:
+# this function is source()'d and invoked from INSIDE scripts/verify.sh's
+# existing Rscript process (see header comment on why -- avoiding a second
+# nix-develop entry), which also still has test suites left to run after
+# this check. A quit() here would silently truncate that process before the
+# test suites ran, and verify.sh's OWN established convention (see its
+# header comment: "does NOT quit() on failure ... a failure here is
+# reported via OVERALL_STATUS") is that only the initial hard parse gate
+# quits early -- everything else continues to completion and reports via
+# markers. The standalone entry point at the bottom of this file (used by
+# `Rscript scripts/check_dashboard_freshness.R` directly, and by
+# scripts/build.sh's separate `--data-staleness` invocation) DOES quit()
+# with whatever status this function returns, since those are each their
+# own standalone process with nothing left to run afterward.
+.cdf_main <- function(data_staleness = FALSE, repo_root = here::here()) {
+  docs_dir <- file.path(repo_root, "docs")
+
+  cat("=== scripts/check_dashboard_freshness.R ===\n")
+  cat(sprintf("Repo root: %s\n", repo_root))
+  cat(sprintf(
+    "Mode: %s\n",
+    if (data_staleness) "Check 1 + Check 2 + Check 3 (data staleness needs a real store)" else "Check 1 + Check 2 (no store needed)"
+  ))
+  cat("\n")
+
+  overall_status <- 0
+  qmd_files <- .cdf_qmd_files(docs_dir)
+
+  t_extract_start <- Sys.time()
+  page_targets <- tryCatch(
+    .cdf_collect_page_targets(qmd_files),
+    error = function(e) {
+      cat("!!! EXTRACTION FAILED -- see error below. This is NOT a pass. !!!\n")
+      cat(rlang::cnd_message(e), "\n")
+      NULL
+    }
+  )
+  if (is.null(page_targets)) {
+    cat("::VERIFY:DASHBOARD_FRESHNESS_STATUS:: 2\n")
+    return(invisible(2L))
+  }
+  t_extract_elapsed <- as.numeric(Sys.time() - t_extract_start, units = "secs")
+  cat(sprintf(
+    "--- extracted target references from %d docs/*.qmd file(s) (%.2fs) ---\n",
+    length(qmd_files), t_extract_elapsed
+  ))
+
+  t_manifest_start <- Sys.time()
+  manifest <- tryCatch(
+    targets::tar_manifest(script = file.path(docs_dir, "_targets.R"), fields = "name"),
+    error = function(e) {
+      cat("!!! targets::tar_manifest() failed -- cannot run Check 1. This is NOT a pass. !!!\n")
+      cat(rlang::cnd_message(e), "\n")
+      NULL
+    }
+  )
+  if (is.null(manifest)) {
+    cat("::VERIFY:DASHBOARD_FRESHNESS_STATUS:: 2\n")
+    return(invisible(2L))
+  }
+  t_manifest_elapsed <- as.numeric(Sys.time() - t_manifest_start, units = "secs")
+  manifest_names <- manifest$name
+  cat(sprintf(
+    "--- targets::tar_manifest(docs/_targets.R): %d targets (%.2fs) ---\n",
+    length(manifest_names), t_manifest_elapsed
+  ))
+
+  cat("\n=== Check 1: dead target references ===\n")
+  dead <- .cdf_check_dead_references(page_targets, manifest_names)
+  n_refs_total <- length(unique(unlist(page_targets, use.names = FALSE)))
+  if (length(dead) == 0) {
+    cat(sprintf(
+      "PASS: no dead target references across %d page(s), %d distinct target reference(s)\n",
+      length(page_targets), n_refs_total
+    ))
+  } else {
+    overall_status <- 1
+    cat("FAIL: dead target references found (these WILL fail at render/tar_read time):\n")
+    for (page in names(dead)) {
+      cat(sprintf(
+        "  [DEAD-REF] %s -- references non-existent target(s): %s\n",
+        page, paste(dead[[page]], collapse = ", ")
+      ))
+    }
+  }
+
+  cat("\n=== Check 2: source-vs-render staleness (git commit date, .qmd vs .html) ===\n")
+  src_stale <- .cdf_check_source_staleness(qmd_files, repo_root)
+  for (base in src_stale$untracked) {
+    cat(sprintf("  [SKIP] %s -- not tracked by git; cannot assess staleness\n", base))
+  }
+  for (base in src_stale$no_html) {
+    cat(sprintf("  [NO-HTML] %s -- no committed .html counterpart found\n", base))
+  }
+  if (length(src_stale$stale) == 0) {
+    cat("PASS: no page's .qmd source is newer than its committed .html\n")
+  } else {
+    ordered <- names(src_stale$stale)[order(-unlist(src_stale$stale))]
+    cat(sprintf(
+      "STALE: %d of %d page(s) have .qmd source newer than their committed .html:\n",
+      length(src_stale$stale), length(qmd_files)
+    ))
+    for (page in ordered) {
+      cat(sprintf(
+        "  [STALE] %s -- source is %.1f day(s) newer than its rendered .html\n",
+        page, src_stale$stale[[page]]
+      ))
+    }
+    if (.cdf_env_flag_true("HD_FAIL_ON_STALE_DASHBOARDS")) {
+      cat("HD_FAIL_ON_STALE_DASHBOARDS is set -- treating source staleness as a hard failure.\n")
+      overall_status <- 1
+    } else {
+      cat("NOTE: staleness is reported but does NOT fail this run by default (see script header for rationale).\n")
+      cat("      Set HD_FAIL_ON_STALE_DASHBOARDS=1 to escalate this to a hard failure.\n")
+    }
+  }
+
+  if (data_staleness) {
+    store_path <- file.path(docs_dir, "_targets")
+    cat("\n=== Check 3: data staleness (page render time vs newest tar_meta() time of its own targets) ===\n")
+    if (!dir.exists(store_path)) {
+      cat(sprintf("!!! No targets store found at '%s' !!!\n", store_path))
+      cat("!!! Check 3 needs a real store (tar_make() must run first) -- see scripts/build.sh Step 1. !!!\n")
+      cat("!!! CHECK 3 DID NOT RUN. This is NOT a pass. !!!\n")
+      cat("::VERIFY:DASHBOARD_FRESHNESS_STATUS:: 2\n")
+      return(invisible(2L))
+    }
+    meta <- tryCatch(
+      targets::tar_meta(store = store_path, fields = time, targets_only = TRUE),
+      error = function(e) {
+        cat("!!! targets::tar_meta() failed -- cannot run Check 3. This is NOT a pass. !!!\n")
+        cat(rlang::cnd_message(e), "\n")
+        NULL
+      }
+    )
+    if (is.null(meta)) {
+      cat("::VERIFY:DASHBOARD_FRESHNESS_STATUS:: 2\n")
+      return(invisible(2L))
+    }
+    meta_time <- stats::setNames(meta$time, meta$name)
+
+    data_stale <- .cdf_check_data_staleness(
+      qmd_files, page_targets, meta_time, repo_root,
+      note_fn = function(base, unknown_refs) {
+        cat(sprintf(
+          "  [NOTE] %s -- %d referenced target(s) have no tar_meta() build record (never built, or a dead reference already reported by Check 1): %s\n",
+          base, length(unknown_refs), paste(unknown_refs, collapse = ", ")
+        ))
+      }
+    )
+    if (length(data_stale) == 0) {
+      cat("PASS: no page's own referenced targets are newer than the page's render time\n")
+    } else {
+      cat(sprintf("STALE: %d page(s) have target data newer than their rendered output:\n", length(data_stale)))
+      for (page in names(data_stale)) {
+        d <- data_stale[[page]]
+        cat(sprintf(
+          "  [DATA-STALE] %s -- referenced target(s) rebuilt %.1f hour(s) after render (render time source: %s)\n",
+          page, d$gap_hrs, d$source
+        ))
+      }
+      if (.cdf_env_flag_true("HD_FAIL_ON_STALE_DASHBOARDS")) {
+        cat("HD_FAIL_ON_STALE_DASHBOARDS is set -- treating data staleness as a hard failure.\n")
+        overall_status <- 1
+      } else {
+        cat("NOTE: data staleness is reported but does NOT fail this run by default (see script header for rationale).\n")
+        cat("      Set HD_FAIL_ON_STALE_DASHBOARDS=1 to escalate this to a hard failure.\n")
+      }
+    }
+  }
+
+  cat("\n")
+  if (overall_status == 0) {
+    cat("=== scripts/check_dashboard_freshness.R: PASS ===\n")
+  } else {
+    cat("=== scripts/check_dashboard_freshness.R: FAIL ===\n")
+  }
+  cat(sprintf("::VERIFY:DASHBOARD_FRESHNESS_STATUS:: %d\n", overall_status))
+  invisible(overall_status)
+}
+
+# Only run when this file is the Rscript entry point (sys.nframe() == 0),
+# never when source()'d for its functions -- confirmed empirically
+# 2026-08-20: `Rscript file.R` gives sys.nframe() == 0 at top level;
+# `source("file.R")` gives sys.nframe() > 0 (source() itself adds a frame).
+# tests/testthat/test-dashboard-freshness.R and scripts/verify.sh both
+# source() this file and must NOT trigger a live run.
+if (sys.nframe() == 0) {
+  args <- commandArgs(trailingOnly = TRUE)
+  status <- .cdf_main(data_staleness = "--data-staleness" %in% args)
+  quit(status = status, save = "no")
+}

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -9,8 +9,9 @@
 #   1. parse("_targets.R")                                    (always)
 #   2. parse("docs/_targets.R")                                (always, #680)
 #   3. tar_validate(script="docs/_targets.R")                  (always, #680)
-#   4. root testthat suite  (tests/testthat/)                  (full mode only)
-#   5. package testthat suite (packages/historicaldata/)        (full mode only)
+#   4. dashboard freshness Check 1 + Check 2 (#695)            (full mode only)
+#   5. root testthat suite  (tests/testthat/)                  (full mode only)
+#   6. package testthat suite (packages/historicaldata/)        (full mode only)
 #
 # TWO PIPELINES — always pass script= explicitly (#680). `_targets.R` at repo
 # root is a small "rn node" sandbox pipeline (~4 plan_ references). The real
@@ -39,11 +40,22 @@
 # tar_make() itself EXITS 0 even when targets errored — a green tar_make()
 # run is not proof either. That is exactly why check_pipeline_errors.R reads
 # tar_meta() directly instead of trusting the exit code.
-# A THIRD, still-uncovered surface: docs/*.qmd chunks call tar_read() for a
-# specific target name. A chunk referencing a target that no longer exists
-# (typo, rename, removal) fails only at RENDER time — not at parse, not at
-# tar_validate(), not at tar_make(). Nothing in this script, and nothing else
-# in the repo yet, catches that; it requires an actual quarto render pass.
+# A THIRD surface — docs/*.qmd chunks calling tar_read()/tar_read_raw()/
+# safe_tar_read() for a specific target name — used to be entirely
+# uncovered: a chunk referencing a target that no longer exists (typo,
+# rename, removal) fails only at RENDER time, not at parse, not at
+# tar_validate(), not at tar_make(). scripts/check_dashboard_freshness.R
+# (#695) now closes the DEAD-REFERENCE half of that gap (its Check 1, run
+# below in full mode only — see the fragment's own comment for why it is
+# not in --quick) plus a related but distinct gap, source-vs-render
+# staleness (its Check 2: a committed .html older than its own .qmd source —
+# GitHub Pages serves the committed .html directly, so nothing else notices
+# this). What remains uncovered by THIS script: DATA staleness — a
+# correctly-rendered page still showing month-old target values because
+# nothing re-renders it after the pipeline rebuilds. That needs a real
+# targets store, so it is Check 3 of the same script, wired into
+# scripts/build.sh instead (main-checkout only) — see that script and
+# check_dashboard_freshness.R own header comment.
 #
 # Both testthat suites carry a small number of known pre-existing failures
 # (see the BASELINE_* arrays below, issue #569) that predate this script and
@@ -65,9 +77,15 @@
 #
 # Exit codes:
 #   0  verified: both pipelines parse, docs/_targets.R validates structurally
-#      OK, and both testthat suites' failures == their baseline exactly
+#      OK, dashboard freshness Check 1 found no dead target references (full
+#      mode only — see #695), and both testthat suites' failures == their
+#      baseline exactly
 #   1  verification RAN and found a problem (new/missing test failure, a
-#      parse error in docs/_targets.R, or a tar_validate() structural error)
+#      parse error in docs/_targets.R, a tar_validate() structural error, a
+#      dead target reference in a docs/*.qmd chunk (#695 Check 1 — always a
+#      hard failure), or — only when HD_FAIL_ON_STALE_DASHBOARDS is set — a
+#      stale dashboard (#695 Check 2, informational-only by default; see
+#      scripts/check_dashboard_freshness.R header comment for why)
 #   2  verification did NOT run at all (nix develop / Rscript unavailable or
 #      crashed, or the ROOT _targets.R failed to parse) — this is NOT a pass,
 #      never treat it as one
@@ -217,6 +235,30 @@ DOCS_VALIDATE_FRAGMENT='
     cat(sprintf("::VERIFY:TAR_VALIDATE_ELAPSED:: %.2f\n", validate_elapsed))
 '
 
+# scripts/check_dashboard_freshness.R Check 1 (dead target references) and
+# Check 2 (source-vs-render staleness) -- #695, the third render-time
+# surface named by #680 that nothing else in this script catches: a
+# docs/*.qmd chunk calling tar_read() for a target name that no longer
+# exists fails only at an actual quarto render (Check 1); a committed .html
+# older than its own .qmd source silently keeps serving stale content, since
+# GitHub Pages serves the committed .html directly with nothing re-rendering
+# it (Check 2). FULL MODE ONLY, not --quick: Check 1 needs
+# targets::tar_manifest(docs/_targets.R), which must fully evaluate the real
+# pipeline script -- the same order of cost (~7-8s warm, measured
+# 2026-08-20) as this script own tar_validate() call above, and --quick is
+# documented as parse plus structural validate only. Embedded via source()
+# into THIS Rscript process rather than a second nix develop --command call,
+# to avoid paying a second ~13s nix-develop entry on top of that ~7-8s
+# manifest cost. Does NOT quit() on failure, matching
+# DOCS_VALIDATE_FRAGMENT above and check_dashboard_freshness.R own internal
+# contract (see that script header comment) -- a problem is reported via
+# OVERALL_STATUS below via the printed ::VERIFY:DASHBOARD_FRESHNESS_STATUS::
+# marker, never treated as verification did not run.
+DASHBOARD_FRESHNESS_FRAGMENT='
+    source(file.path("scripts", "check_dashboard_freshness.R"))
+    invisible(.cdf_main(data_staleness = FALSE))
+'
+
 if [[ "$QUICK" -eq 1 ]]; then
   R_SCRIPT='
     cat("::VERIFY:CWD::", getwd(), "\n")
@@ -247,6 +289,7 @@ else
     if (!isTRUE(parse_ok)) quit(status = 1, save = "no")
     cat("::VERIFY:PARSE_OK::\n")
 '"$DOCS_VALIDATE_FRAGMENT"'
+'"$DASHBOARD_FRESHNESS_FRAGMENT"'
 
     # NOT_CRAN=true — WITHOUT this, testthat silently SKIPS every
     # skip_on_cran()-gated test, and that gate is what this project uses to
@@ -488,6 +531,38 @@ OVERALL_STATUS=0
 if [[ "$DOCS_STATUS" -ne 0 ]] || [[ "$VALIDATE_STATUS" -ne 0 ]]; then
   OVERALL_STATUS=1
 fi
+
+# scripts/check_dashboard_freshness.R Check 1 + Check 2 (#695). The full
+# human-readable report already streamed to the terminal above (tee), since
+# this check runs embedded inside the same nix develop -- command Rscript
+# call as everything else in this section -- only the final status marker is
+# parsed here. A status of 2 (the check itself could not run, e.g.
+# tar_manifest() failed to evaluate docs/_targets.R) is folded into
+# OVERALL_STATUS=1 rather than exiting this script with 2: by this point the
+# root and package test suites have ALREADY run and their results are known
+# (this R process never quit() early -- see check_dashboard_freshness.R
+# header comment on why), so discarding that information to report "did not
+# run at all" would be wrong. A tar_manifest() failure of the real pipeline
+# is also very likely to have already surfaced above as a tar_validate()
+# FAILURE (VALIDATE_STATUS), since both evaluate the same docs/_targets.R.
+DASHBOARD_FRESHNESS_STATUS_RAW="$(grep '::VERIFY:DASHBOARD_FRESHNESS_STATUS::' "$R_OUT" | tail -1 | sed 's/.*:: *//' | tr -d '[:space:]')"
+case "$DASHBOARD_FRESHNESS_STATUS_RAW" in
+  0)
+    echo "PASS: dashboard freshness (scripts/check_dashboard_freshness.R Check 1 + Check 2 — see full report above)"
+    ;;
+  1)
+    echo "FAIL: dashboard freshness found a problem — see [DEAD-REF]/[STALE] lines in the report above"
+    OVERALL_STATUS=1
+    ;;
+  2)
+    echo "!!! dashboard freshness check could not run (status 2) — see the report above for the underlying error !!!"
+    OVERALL_STATUS=1
+    ;;
+  *)
+    echo "!!! dashboard freshness check produced no ::VERIFY:DASHBOARD_FRESHNESS_STATUS:: marker at all — see report above !!!"
+    OVERALL_STATUS=1
+    ;;
+esac
 
 CURRENT_ROOT_SIGNATURES="$(awk '/::VERIFY:ROOT_SIGNATURES_START::/{flag=1; next} /::VERIFY:ROOT_SIGNATURES_END::/{flag=0} flag' "$R_OUT")"
 CURRENT_ROOT_SNAPSHOT="$(awk '/::VERIFY:ROOT_SNAPSHOT_FAILS_START::/{flag=1; next} /::VERIFY:ROOT_SNAPSHOT_FAILS_END::/{flag=0} flag' "$R_OUT")"

--- a/tests/testthat/_snaps/dashboard-freshness.md
+++ b/tests/testthat/_snaps/dashboard-freshness.md
@@ -1,0 +1,102 @@
+# .cdf_extract_read_targets aborts informatively on a non-literal, non-symbol first argument (#695)
+
+    Code
+      .cdf_extract_read_targets(exprs, "toy_dashboard.qmd")
+    Condition
+      Error in `walk()`:
+      x `tar_read()` called with a non-literal, non-symbol first argument in 'toy_dashboard.qmd'.
+      i Argument was: `paste0("prefix_", "suffix")`
+      i This checker can only statically resolve a string literal or a bare symbol target name.
+
+# .cdf_extract_read_targets aborts informatively on a zero-argument read call (#695)
+
+    Code
+      .cdf_extract_read_targets(exprs, "toy_dashboard.qmd")
+    Condition
+      Error in `walk()`:
+      x `tar_read()` call with no arguments in 'toy_dashboard.qmd'.
+      i Expected a target name as the first argument.
+
+# .cdf_extract_qmd_targets aborts when a chunk fence is present but purl() extracts zero expressions (#695)
+
+    Code
+      .cdf_extract_qmd_targets(file)
+    Condition
+      Error in `.cdf_extract_qmd_targets()`:
+      x knitr::purl() extracted zero R expressions from 'toy_dashboard.qmd', but the file contains R chunk fence(s).
+      i This is more likely a broken extractor (e.g. a non-r engine, an unusual chunk header) than a page with no code.
+      i Investigate before trusting this check; do not add an exception without confirming the file genuinely has no executable R.
+
+# .cdf_extract_qmd_targets aborts informatively when knitr::purl() itself fails (#695)
+
+    Code
+      .cdf_extract_qmd_targets(missing_file)
+    Condition
+      Error in `value[[3L]]()`:
+      x knitr::purl() failed on 'toy_dashboard.qmd'.
+      i cannot open the connection
+
+# key .cdf_* function signatures are stable
+
+    Code
+      args(.cdf_extract_qmd_targets)
+    Output
+      function (qmd_path) 
+      NULL
+
+---
+
+    Code
+      args(.cdf_extract_read_targets)
+    Output
+      function (exprs, qmd_basename) 
+      NULL
+
+---
+
+    Code
+      args(.cdf_check_dead_references)
+    Output
+      function (page_targets, manifest_names) 
+      NULL
+
+---
+
+    Code
+      args(.cdf_check_source_staleness)
+    Output
+      function (qmd_files, repo_root) 
+      NULL
+
+---
+
+    Code
+      args(.cdf_check_data_staleness)
+    Output
+      function (qmd_files, page_targets, meta_time, repo_root, note_fn = NULL) 
+      NULL
+
+---
+
+    Code
+      args(.cdf_page_render_time)
+    Output
+      function (html_path, repo_root) 
+      NULL
+
+---
+
+    Code
+      args(.cdf_git_last_commit_time)
+    Output
+      function (abs_path, repo_root) 
+      NULL
+
+---
+
+    Code
+      args(.cdf_main)
+    Output
+      function (data_staleness = FALSE, repo_root = here::here()) 
+      NULL
+

--- a/tests/testthat/test-dashboard-freshness.R
+++ b/tests/testthat/test-dashboard-freshness.R
@@ -1,0 +1,377 @@
+testthat::local_edition(3)
+source(here::here("scripts", "check_dashboard_freshness.R"))
+
+# Regression / unit tests for scripts/check_dashboard_freshness.R (#695,
+# Option A: detection only -- no re-rendering is exercised or expected here).
+#
+# scripts/check_dashboard_freshness.R defines all its logic as `.cdf_*`
+# functions and only RUNS them when it is the Rscript entry point
+# (`sys.nframe() == 0` at its own top level -- see that file's final block).
+# source()'ing it here (sys.nframe() > 0) loads the functions without
+# triggering a live check1/2/3 run against the real repo, which is what lets
+# these tests exercise the extractor against small synthetic fixtures
+# instead of the real docs/*.qmd tree.
+#
+# Fixture files inside withr::local_tempdir() use FIXED basenames
+# ("toy_dashboard.qmd" etc.) -- basename(path) is the only part of the path
+# this checker's cli_abort() messages ever include, so snapshots stay
+# portable across checkouts/CI (portable-build-artifacts), matching the
+# pattern in test-registry-unit-map-coverage.R.
+
+# ── .cdf_call_head_name() ──────────────────────────────────────────────────
+
+test_that(".cdf_call_head_name resolves a bare-symbol call head", {
+  e <- quote(tar_read("x"))
+  expect_equal(.cdf_call_head_name(e), "tar_read")
+})
+
+test_that(".cdf_call_head_name resolves a pkg::fn call head", {
+  e <- quote(targets::tar_read_raw("x"))
+  expect_equal(.cdf_call_head_name(e), "tar_read_raw")
+})
+
+test_that(".cdf_call_head_name returns NULL for a non-call", {
+  expect_null(.cdf_call_head_name(quote(x)))
+  expect_null(.cdf_call_head_name("just a string"))
+})
+
+# ── .cdf_extract_read_targets() ────────────────────────────────────────────
+
+test_that(".cdf_extract_read_targets resolves the string-literal form", {
+  exprs <- parse(text = 'x <- tar_read("target_a")')
+  expect_equal(.cdf_extract_read_targets(exprs, "toy.qmd"), "target_a")
+})
+
+test_that(".cdf_extract_read_targets resolves the bare-symbol form", {
+  exprs <- parse(text = "y <- tar_read(target_b)")
+  expect_equal(.cdf_extract_read_targets(exprs, "toy.qmd"), "target_b")
+})
+
+test_that(".cdf_extract_read_targets resolves the targets::-qualified form (tar_read and tar_read_raw)", {
+  exprs <- parse(text = paste(
+    'a <- targets::tar_read("target_c")',
+    "b <- targets::tar_read_raw(target_d)",
+    sep = "\n"
+  ))
+  expect_equal(sort(.cdf_extract_read_targets(exprs, "toy.qmd")), c("target_c", "target_d"))
+})
+
+test_that(".cdf_extract_read_targets recognises safe_tar_read() as a read function", {
+  exprs <- parse(text = 'z <- safe_tar_read("target_e")')
+  expect_equal(.cdf_extract_read_targets(exprs, "toy.qmd"), "target_e")
+})
+
+test_that(".cdf_extract_read_targets de-duplicates repeated references to the same target", {
+  exprs <- parse(text = paste(
+    'a <- tar_read("target_f")',
+    'b <- tar_read("target_f")',
+    sep = "\n"
+  ))
+  expect_equal(.cdf_extract_read_targets(exprs, "toy.qmd"), "target_f")
+})
+
+test_that(".cdf_extract_read_targets ignores calls to unrelated functions with the same argument shape", {
+  exprs <- parse(text = 'x <- some_other_fn("not_a_target")')
+  expect_equal(.cdf_extract_read_targets(exprs, "toy.qmd"), character(0))
+})
+
+test_that(".cdf_extract_read_targets aborts informatively on a non-literal, non-symbol first argument (#695)", {
+  exprs <- parse(text = 'x <- tar_read(paste0("prefix_", "suffix"))')
+  expect_snapshot(error = TRUE, .cdf_extract_read_targets(exprs, "toy_dashboard.qmd"))
+})
+
+test_that(".cdf_extract_read_targets aborts informatively on a zero-argument read call (#695)", {
+  exprs <- parse(text = "x <- tar_read()")
+  expect_snapshot(error = TRUE, .cdf_extract_read_targets(exprs, "toy_dashboard.qmd"))
+})
+
+# ── .cdf_has_r_chunk_fence() ───────────────────────────────────────────────
+
+test_that(".cdf_has_r_chunk_fence detects a fenced R chunk", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_dashboard.qmd")
+  writeLines(c("---", "title: Toy", "---", "", "```{r}", "1 + 1", "```"), file)
+  expect_true(.cdf_has_r_chunk_fence(file))
+})
+
+test_that(".cdf_has_r_chunk_fence is FALSE for a pure-prose page", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_dashboard.qmd")
+  writeLines(c("---", "title: Toy", "---", "", "Just prose, no chunks."), file)
+  expect_false(.cdf_has_r_chunk_fence(file))
+})
+
+# ── .cdf_extract_qmd_targets() ─────────────────────────────────────────────
+# End-to-end: knitr::purl() + parse() + .cdf_extract_read_targets(), against
+# small synthetic .qmd fixtures under a fixed basename.
+
+test_that(".cdf_extract_qmd_targets returns an empty set for a redirect stub with zero R chunks (drif.qmd-style, #695)", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_dashboard.qmd")
+  writeLines(c(
+    "---", "title: Redirect stub", "---", "",
+    "> **This page has moved.**", "",
+    '<meta http-equiv="refresh" content="0; url=elsewhere.html">'
+  ), file)
+  expect_equal(.cdf_extract_qmd_targets(file), character(0))
+})
+
+test_that(".cdf_extract_qmd_targets returns an empty set for a page with chunks but no tar_read calls (index.qmd-style, #695)", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_dashboard.qmd")
+  writeLines(c(
+    "---", "title: Landing page", "---", "",
+    "```{r}", "#| label: setup", "x <- 1 + 1", "```"
+  ), file)
+  expect_equal(.cdf_extract_qmd_targets(file), character(0))
+})
+
+test_that(".cdf_extract_qmd_targets extracts a mix of string-literal, symbol, and safe_tar_read forms from real chunks", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_dashboard.qmd")
+  writeLines(c(
+    "---", "title: Mixed dashboard", "---", "",
+    "```{r}", "#| label: load-a",
+    'a <- tar_read("mix_target_a")',
+    "```",
+    "",
+    "```{r}", "#| label: load-b",
+    "b <- tar_read(mix_target_b)",
+    'c <- safe_tar_read("mix_target_c")',
+    "```"
+  ), file)
+  expect_equal(
+    sort(.cdf_extract_qmd_targets(file)),
+    c("mix_target_a", "mix_target_b", "mix_target_c")
+  )
+})
+
+test_that(".cdf_extract_qmd_targets aborts when a chunk fence is present but purl() extracts zero expressions (#695)", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_dashboard.qmd")
+  writeLines(c(
+    "---", "title: Comment-only chunk", "---", "",
+    "```{r}", "# just a comment, no executable code", "```"
+  ), file)
+  expect_snapshot(error = TRUE, .cdf_extract_qmd_targets(file))
+})
+
+test_that(".cdf_extract_qmd_targets aborts informatively when knitr::purl() itself fails (#695)", {
+  dir <- withr::local_tempdir()
+  missing_file <- file.path(dir, "toy_dashboard.qmd")
+  # Never created -- purl() must fail to open it.
+  expect_snapshot(error = TRUE, .cdf_extract_qmd_targets(missing_file))
+})
+
+# ── .cdf_env_flag_true() ───────────────────────────────────────────────────
+# Exists specifically because isTRUE(as.logical(Sys.getenv(...))) is a known
+# footgun -- as.logical("1") is NA, not TRUE (.claude/rules/fail-loud-not-null.md).
+
+test_that(".cdf_env_flag_true recognises the documented truthy vocabulary, case-insensitively", {
+  withr::local_envvar(c(HD_TEST_FLAG = "1"))
+  expect_true(.cdf_env_flag_true("HD_TEST_FLAG"))
+  withr::local_envvar(c(HD_TEST_FLAG = "true"))
+  expect_true(.cdf_env_flag_true("HD_TEST_FLAG"))
+  withr::local_envvar(c(HD_TEST_FLAG = "TRUE"))
+  expect_true(.cdf_env_flag_true("HD_TEST_FLAG"))
+  withr::local_envvar(c(HD_TEST_FLAG = "YES"))
+  expect_true(.cdf_env_flag_true("HD_TEST_FLAG"))
+})
+
+test_that(".cdf_env_flag_true is FALSE for unset, empty, or non-truthy values -- crucially including \"1\" is NOT what breaks it", {
+  withr::local_envvar(c(HD_TEST_FLAG = NA)) # unset
+  expect_false(.cdf_env_flag_true("HD_TEST_FLAG"))
+  withr::local_envvar(c(HD_TEST_FLAG = ""))
+  expect_false(.cdf_env_flag_true("HD_TEST_FLAG"))
+  withr::local_envvar(c(HD_TEST_FLAG = "0"))
+  expect_false(.cdf_env_flag_true("HD_TEST_FLAG"))
+  withr::local_envvar(c(HD_TEST_FLAG = "no"))
+  expect_false(.cdf_env_flag_true("HD_TEST_FLAG"))
+})
+
+# ── .cdf_check_dead_references() ───────────────────────────────────────────
+# Pure logic, no filesystem/store needed.
+
+test_that(".cdf_check_dead_references flags a page referencing a target absent from the manifest", {
+  page_targets <- list("a.qmd" = c("real_target"), "b.qmd" = c("real_target", "ghost_target"))
+  manifest_names <- c("real_target", "other_target")
+  problems <- .cdf_check_dead_references(page_targets, manifest_names)
+  expect_equal(names(problems), "b.qmd")
+  expect_equal(problems[["b.qmd"]], "ghost_target")
+})
+
+test_that(".cdf_check_dead_references returns an empty list when every reference resolves", {
+  page_targets <- list("a.qmd" = c("real_target"))
+  manifest_names <- c("real_target", "other_target")
+  expect_equal(.cdf_check_dead_references(page_targets, manifest_names), list())
+})
+
+# ── .cdf_git_last_commit_time() / .cdf_check_source_staleness() ────────────
+# Uses a scratch git repo with explicit GIT_AUTHOR_DATE/GIT_COMMITTER_DATE so
+# commit times are reproducible rather than "whenever the test happened to run".
+
+.make_scratch_git_repo <- function(env = parent.frame()) {
+  # .local_envir = env (the CALLER's frame, i.e. the test_that() block) is
+  # required here: withr::local_tempdir()'s default .local_envir =
+  # parent.frame() would otherwise tie cleanup to THIS helper function's own
+  # (already-returned) execution frame, deleting the tempdir before the test
+  # body ever uses it -- confirmed empirically (every test using this helper
+  # failed with "cannot open the connection" until this fix was added).
+  dir <- withr::local_tempdir(.local_envir = env)
+  system2("git", c("-C", dir, "init", "-q"))
+  system2("git", c("-C", dir, "config", "user.email", "test@example.com"))
+  system2("git", c("-C", dir, "config", "user.name", "Test"))
+  dir
+}
+
+.commit_file_at <- function(repo_dir, rel_path, content, iso_date) {
+  full_path <- file.path(repo_dir, rel_path)
+  writeLines(content, full_path)
+  withr::with_envvar(
+    c(GIT_AUTHOR_DATE = iso_date, GIT_COMMITTER_DATE = iso_date),
+    {
+      system2("git", c("-C", repo_dir, "add", rel_path))
+      system2("git", c(
+        "-C", repo_dir, "commit", "-q", "-m", shQuote(paste("add", rel_path))
+      ))
+    }
+  )
+  invisible(full_path)
+}
+
+test_that(".cdf_git_last_commit_time reads a committed file's commit time", {
+  repo <- .make_scratch_git_repo()
+  .commit_file_at(repo, "toy_dashboard.qmd", "content", "2026-01-01T00:00:00")
+  t <- .cdf_git_last_commit_time(file.path(repo, "toy_dashboard.qmd"), repo)
+  expect_false(is.na(t))
+  expect_equal(as.Date(t), as.Date("2026-01-01"))
+})
+
+test_that(".cdf_git_last_commit_time returns NA for an untracked path", {
+  repo <- .make_scratch_git_repo()
+  t <- .cdf_git_last_commit_time(file.path(repo, "never_committed.qmd"), repo)
+  expect_true(is.na(t))
+})
+
+test_that(".cdf_check_source_staleness flags a page whose .qmd source postdates its .html", {
+  repo <- .make_scratch_git_repo()
+  .commit_file_at(repo, "toy_dashboard.html", "old render", "2026-01-01T00:00:00")
+  .commit_file_at(repo, "toy_dashboard.qmd", "new source", "2026-01-15T00:00:00")
+  result <- .cdf_check_source_staleness(file.path(repo, "toy_dashboard.qmd"), repo)
+  expect_equal(names(result$stale), "toy_dashboard.qmd")
+  expect_equal(result$stale[["toy_dashboard.qmd"]], 14, tolerance = 0.1)
+  expect_equal(result$no_html, character(0))
+  expect_equal(result$untracked, character(0))
+})
+
+test_that(".cdf_check_source_staleness does not flag a page whose .html postdates its .qmd", {
+  repo <- .make_scratch_git_repo()
+  .commit_file_at(repo, "toy_dashboard.qmd", "source", "2026-01-01T00:00:00")
+  .commit_file_at(repo, "toy_dashboard.html", "fresh render", "2026-01-15T00:00:00")
+  result <- .cdf_check_source_staleness(file.path(repo, "toy_dashboard.qmd"), repo)
+  expect_equal(result$stale, list())
+})
+
+test_that(".cdf_check_source_staleness reports a tracked .qmd with no committed .html separately from staleness", {
+  repo <- .make_scratch_git_repo()
+  .commit_file_at(repo, "toy_dashboard.qmd", "source", "2026-01-01T00:00:00")
+  result <- .cdf_check_source_staleness(file.path(repo, "toy_dashboard.qmd"), repo)
+  expect_equal(result$stale, list())
+  expect_equal(result$no_html, "toy_dashboard.qmd")
+})
+
+test_that(".cdf_check_source_staleness reports an untracked .qmd separately from staleness", {
+  repo <- .make_scratch_git_repo()
+  # Never committed -- git has no history for it.
+  writeLines("uncommitted", file.path(repo, "toy_dashboard.qmd"))
+  result <- .cdf_check_source_staleness(file.path(repo, "toy_dashboard.qmd"), repo)
+  expect_equal(result$stale, list())
+  expect_equal(result$untracked, "toy_dashboard.qmd")
+})
+
+# ── .cdf_page_render_time() ─────────────────────────────────────────────────
+
+test_that(".cdf_page_render_time reads the build_info() footer timestamp when present", {
+  repo <- .make_scratch_git_repo()
+  html <- paste0(
+    "<html><body>Some content ",
+    "<strong>Built</strong> 2026-03-04 12:34:56 more text</body></html>"
+  )
+  .commit_file_at(repo, "toy_dashboard.html", html, "2026-01-01T00:00:00")
+  result <- .cdf_page_render_time(file.path(repo, "toy_dashboard.html"), repo)
+  expect_equal(result$source, "build_info() footer")
+  expect_equal(format(result$time, "%Y-%m-%d %H:%M:%S", tz = Sys.timezone()), "2026-03-04 12:34:56")
+})
+
+test_that(".cdf_page_render_time falls back to the .html's git commit date when no footer is present (#695 follow-up)", {
+  repo <- .make_scratch_git_repo()
+  .commit_file_at(repo, "toy_dashboard.html", "<html><body>no footer here</body></html>", "2026-02-02T00:00:00")
+  result <- .cdf_page_render_time(file.path(repo, "toy_dashboard.html"), repo)
+  expect_match(result$source, "fallback")
+  expect_equal(as.Date(result$time), as.Date("2026-02-02"))
+})
+
+test_that(".cdf_page_render_time reports unavailable when there is no footer and no git history", {
+  repo <- .make_scratch_git_repo()
+  result <- .cdf_page_render_time(file.path(repo, "never_existed.html"), repo)
+  expect_true(is.na(result$time))
+  expect_match(result$source, "unavailable")
+})
+
+# ── .cdf_check_data_staleness() ─────────────────────────────────────────────
+# Pure logic against a synthetic meta_time vector -- no store needed.
+
+test_that(".cdf_check_data_staleness flags a page whose own target was rebuilt after its render time", {
+  repo <- .make_scratch_git_repo()
+  html <- paste0("<html><body><strong>Built</strong> 2026-01-01 00:00:00</body></html>")
+  qmd_path <- .commit_file_at(repo, "toy_dashboard.qmd", "source", "2026-01-01T00:00:00")
+  .commit_file_at(repo, "toy_dashboard.html", html, "2026-01-01T00:00:00")
+  page_targets <- list("toy_dashboard.qmd" = "some_target")
+  meta_time <- stats::setNames(
+    as.POSIXct("2026-01-05 00:00:00", tz = Sys.timezone()),
+    "some_target"
+  )
+  result <- .cdf_check_data_staleness(qmd_path, page_targets, meta_time, repo)
+  expect_equal(names(result), "toy_dashboard.qmd")
+  expect_equal(result[["toy_dashboard.qmd"]]$gap_hrs, 96, tolerance = 0.1)
+})
+
+test_that(".cdf_check_data_staleness skips pages with no referenced targets", {
+  repo <- .make_scratch_git_repo()
+  qmd_path <- .commit_file_at(repo, "toy_dashboard.qmd", "source", "2026-01-01T00:00:00")
+  page_targets <- list("toy_dashboard.qmd" = character(0))
+  meta_time <- stats::setNames(numeric(0), character(0))
+  result <- .cdf_check_data_staleness(qmd_path, page_targets, meta_time, repo)
+  expect_equal(result, list())
+})
+
+test_that(".cdf_check_data_staleness surfaces unknown (never-built) references via note_fn without failing", {
+  repo <- .make_scratch_git_repo()
+  html <- paste0("<html><body><strong>Built</strong> 2026-01-01 00:00:00</body></html>")
+  qmd_path <- .commit_file_at(repo, "toy_dashboard.qmd", "source", "2026-01-01T00:00:00")
+  .commit_file_at(repo, "toy_dashboard.html", html, "2026-01-01T00:00:00")
+  page_targets <- list("toy_dashboard.qmd" = c("never_built_target"))
+  meta_time <- stats::setNames(numeric(0), character(0))
+  noted <- list()
+  result <- .cdf_check_data_staleness(
+    qmd_path, page_targets, meta_time, repo,
+    note_fn = function(base, unknown_refs) {
+      noted[[base]] <<- unknown_refs
+    }
+  )
+  expect_equal(result, list())
+  expect_equal(noted[["toy_dashboard.qmd"]], "never_built_target")
+})
+
+# ── Function signature stability (catches API drift, snapshot-test-policy.md) ──
+
+test_that("key .cdf_* function signatures are stable", {
+  expect_snapshot(args(.cdf_extract_qmd_targets))
+  expect_snapshot(args(.cdf_extract_read_targets))
+  expect_snapshot(args(.cdf_check_dead_references))
+  expect_snapshot(args(.cdf_check_source_staleness))
+  expect_snapshot(args(.cdf_check_data_staleness))
+  expect_snapshot(args(.cdf_page_render_time))
+  expect_snapshot(args(.cdf_git_last_commit_time))
+  expect_snapshot(args(.cdf_main))
+})


### PR DESCRIPTION
## Summary

Implements #695's "Option A" (detection only): `scripts/check_dashboard_freshness.R`, wired into `scripts/verify.sh` (Check 1 + Check 2) and `scripts/build.sh` (adds Check 3). Closes the third render-time surface #680 named and #695's issue body documented as the only one still uncovered — a `docs/*.qmd` chunk calling `tar_read()` for a target that no longer exists fails only at an actual `quarto render`, and a committed `.html` older than its own `.qmd` (or older than the data it reads) silently keeps serving stale content since GitHub Pages serves the committed `.html` directly.

**Re-rendering the 8 currently-stale dashboards is explicitly out of scope** — that is #695's other half, tracked by the issue itself, not this PR.

## Provenance — this builds on a prior session's uncommitted work

A previous agent dispatched against this same task got most of the way (the script, the wiring into both scripts, the test file, and the snapshot) and was killed mid-task before committing. I recovered its files from a salvage location and treated them as a **starting point, not a finished product** — I own everything in this diff and re-verified all of it myself rather than trusting the prior report. Concretely, what I did on top of the recovered files:

- Diffed `scripts/verify.sh` and `scripts/build.sh` in full against the current worktree versions (not just trusted "these are full files from `012c78d`") — confirmed the only changes in both are the freshness wiring plus doc-comment updates; no unrelated hunks. Diffs quoted in a review comment below if useful, omitted here for length.
- Read all 679 lines of `check_dashboard_freshness.R` and all 378 of the test file end to end.
- Independently re-ran and re-verified every empirical claim the script's own header comment makes (see "What I verified" below) rather than accepting the comments as given.
- Found and corrected one factual error in the recovered work: its planned follow-up issue was going to say "six dashboards have no `build_info()` footer." I checked and it's **seven** — `macro-defense-rotation.qmd` (21 R chunks, a real content page, not a redirect stub) also has none. Filed the corrected issue as #697 (see below), not six.
- Actually ran `scripts/verify.sh` full mode to completion (previous attempts had reportedly stalled/been killed) and confirmed PASS with baseline-matching failures.
- Performed the "Check 1 actually fires" demonstration below, which had not been done.

## Extraction approach

`knitr::purl(documentation = 0, quiet = TRUE)` tangles each `.qmd`'s R chunks to a temp `.R` file, which is `parse()`'d (never evaluated) into an expression list, then walked for calls headed by `tar_read`, `tar_read_raw`, or `safe_tar_read` (bare or `pkg::fn` form), taking the first argument. **Not a regex over the `.qmd` text** — this repo already spent a whole session (#691→#696) on the cost of fragile regex-based extraction, and this script deliberately avoids repeating that.

I independently re-confirmed the extraction script's own claims against the current repo rather than trusting its comments:

- `grep -rnE "tar_read(_raw)?\(([^\"'a-zA-Z_.]|[a-zA-Z_.]+\()" docs/*.qmd"` → **no matches**, confirming every `tar_read()`/`tar_read_raw()` call across all 15 dashboards uses a string-literal or bare-symbol first argument — nothing the extractor can't statically resolve.
- The 4 files claimed to `purl()` to zero expressions (`drif.qmd`, `factor-max.qmd`, `jst-dashboard.qmd`, `negative-results.qmd`) each have `grep -c '\`\`\`{r' <file>` == 0 — genuinely-empty redirect stubs, not a broken extractor swallowing real chunks.
- `falsification.qmd`'s two inline-expression target references (`cg_dag` at line 806, `cg_caption` at line 986, both via `` `r { ... } ` `` inline syntax) are real and are **not** duplicated in any fenced chunk in that file — confirmed by grep. `knitr::purl()` does not tangle inline expressions (by design, no supported non-evaluating API for it), so this is a genuine, documented coverage gap, not an oversight. It affects two target names in one file; Check 1 cannot catch a dead reference to either, and (once Check 3 runs) those two targets are excluded from that page's own-targets staleness bound.

## An unresolvable reference aborts, never silently skips

Per `.claude/rules/fail-loud-not-null.md`, `.cdf_extract_read_targets()` calls `cli::cli_abort()` — not a silent skip — the moment a matched `tar_read`-family call's first argument is neither a string literal nor a bare symbol, and also aborts on a zero-argument call. Both paths have `expect_snapshot(error = TRUE, ...)` coverage. A page yielding **zero** target references (e.g. a redirect stub, or `index.qmd`, which purls to 27 expressions but references no targets) does **not** silently pass as "fresh" by omission — it is a legitimate zero-length entry in the per-page target map, distinguished from a broken extraction via `.cdf_has_r_chunk_fence()`: the script aborts only when `purl()` finds zero expressions **and** the raw source has at least one fenced R chunk (meaning `purl()` silently dropped something real). I re-verified this distinction is exercised by both directions of the test suite (`redirect stub, zero R chunks` passes cleanly; `chunk fence present but purl() extracts zero expressions` aborts).

## Three checks, where each is wired, and the exit-code contract

| Check | What | Needs a store? | Wired into | Failure mode |
|---|---|---|---|---|
| 1 — dead target references | `tar_read()`-family calls vs. `tar_manifest()` | No | `verify.sh` full mode | **Always** a hard failure (exit 1) |
| 2 — source-vs-render staleness | `.qmd` git commit date vs. `.html`'s | No | `verify.sh` full mode | Informational by default; `HD_FAIL_ON_STALE_DASHBOARDS=1` escalates |
| 3 — data staleness | page's own referenced targets' newest `tar_meta()` time vs. page render time (`build_info()` footer, else git-date fallback, labelled) | **Yes** | `scripts/build.sh` Step 3 (main checkout only) | Same escalation flag as Check 2 |

Check 1 is unconditional because a dead reference **will** break the next render — there's no legitimate reason to tolerate it. Checks 2/3 default to informational because #695's own evidence is that 8 of 15 dashboards are stale *right now* — defaulting staleness to a hard failure would turn `verify.sh`/`build.sh` red on `main` today, before the separate re-render PR lands. `HD_FAIL_ON_STALE_DASHBOARDS=1` is the documented, explicit escalation path once that PR ships.

Check 3 isn't in `verify.sh` because it needs a real `docs/_targets` store, which a worktree doesn't have and must not build (would race the main checkout's store — see `.claude/CLAUDE.md`). It's wired into `build.sh` Step 3 instead, running unconditionally alongside Step 2 (`check_pipeline_errors.R`) even after a `tar_make()` failure, for the same reason Step 2 does: `error = "continue"` means a crashed/partial build still leaves a store worth inspecting. `build.sh`'s exit-code contract (0/1/2) mirrors `check_pipeline_errors.R`'s existing pattern.

**I could not run Check 3** — no store in a worktree. I read all of Step 3's wiring in `build.sh` and reasoned about it (see "What I executed vs. reasoned about" below); I did not execute it.

## Timing

Measured directly (warm nix shell, `docs/_targets.R` at current `main`, 768 targets):

- Extraction (`knitr::purl()` across all 15 `.qmd` files): **0.24–0.35s**
- `targets::tar_manifest(docs/_targets.R)`: **6.51–7.24s**
- Check 1 + Check 2 combined added cost to `verify.sh` full mode: **~7–8s**
- `verify.sh --quick`: **unaffected** — confirmed by running it after this change; the freshness fragment is only spliced into the full-mode R script, `--quick`'s R script doesn't reference it at all, and the `--quick` output contains no mention of `check_dashboard_freshness.R`.

**My argument on whether 7–8s belongs in `verify.sh` full mode:** yes. `verify.sh` full mode already pays a near-identical cost for `tar_validate()` (6.7–6.9s, same order of magnitude, evaluating the same `docs/_targets.R`) as part of its existing structural checks, and full mode is dominated by the two `testthat` suites (root + package, several minutes total) — an extra 7–8s is a low-single-digit percentage addition to an already multi-minute run. `--quick` is the fast path for iterative work and stays exactly as fast as before this PR (verified above), which is where the 5-second-class budget actually matters. Check 1 could in principle share `tar_manifest()`'s cost with `tar_validate()`'s call, but `tar_validate()` returns `NULL` invisibly (confirmed by inspection) — there's no cheaper way to get the current target-name set, so paying the manifest cost twice in full mode (once for validate, once for manifest) is the real cost of this design, not a wasted one. I don't think Check 1 belongs anywhere else: it needs the current target list, which only exists after evaluating `docs/_targets.R`, and `verify.sh` full mode is the only place that already pays that price.

## Check 1 demonstration — it actually fires

Temporarily added a chunk `` `.demo_dead_ref_695 <- tar_read("no_such_target_xyz")` `` to `docs/index.qmd`, reran the script standalone:

```
=== Check 1: dead target references ===
FAIL: dead target references found (these WILL fail at render/tar_read time):
  [DEAD-REF] index.qmd -- references non-existent target(s): no_such_target_xyz
...
=== scripts/check_dashboard_freshness.R: FAIL ===
::VERIFY:DASHBOARD_FRESHNESS_STATUS:: 1
```

Reverted the chunk. `git diff --stat docs/index.qmd` after revert: **no output** (clean).

## What I executed vs. reasoned about

**Executed:**
- `check_dashboard_freshness.R` standalone (Check 1 + Check 2), against the real `docs/` tree, twice (clean, then with the injected dead reference above).
- Full `scripts/verify.sh` (foreground, to completion) — see output below.
- `scripts/verify.sh --quick` — confirmed unaffected timing/behaviour.
- All grep-based re-verifications of the script's own header-comment claims (extraction literal-only args, redirect-stub chunk counts, inline-expression coverage gap, footer-file count).

**Reasoned about, not executed:**
- `scripts/build.sh` Step 3 (`check_dashboard_freshness.R --data-staleness`) — needs a real `docs/_targets` store, which this worktree does not have and must not create. I read the wiring (capture/summary/exit-code handling) end to end and it mirrors the existing Step 2 pattern closely enough that I'm confident in it, but it has not actually run against a live store. Please run it in the main checkout before/after merge.

## `scripts/verify.sh` output (full mode, this branch, this commit)

```
=== scripts/verify.sh ===
Mode: full (parse + docs/_targets.R structural validate + root suite + package suite)
...
PASS: _targets.R parses
PASS: docs/_targets.R parses
PASS: docs/_targets.R is structurally valid (tar_validate, 6.72s)
PASS: testthat edition 3 active
PASS: dashboard freshness (scripts/check_dashboard_freshness.R Check 1 + Check 2)

=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly (3/3, unchanged)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly (1/1, unchanged)

=== scripts/verify.sh: PASS ===
```

Root suite: `total=625 failed=3 skipped=0` (up from the `012c78d` baseline of `total=590 failed=3 skipped=0` — the +35 is exactly the 35 new `test_that()` blocks in `tests/testthat/test-dashboard-freshness.R`, all passing). Package suite: `total=695 failed=1 skipped=15`, unchanged from baseline (this PR touches no package code). Both suites' failure **signatures** match baseline exactly — no regressions.

## Follow-up issue filed

#697 — 7 dashboards (not 6, correcting the recovered draft) have no `build_info()` footer, which degrades Check 3 to the git-commit-date fallback for exactly those pages. Not fixed here; #695's PR is detection-only and out of scope for touching dashboard content.

## Test plan

- [x] `scripts/verify.sh` full mode — PASS, baselines unchanged (see output above)
- [x] `scripts/verify.sh --quick` — PASS, unaffected timing
- [x] `parse("_targets.R")` and `parse("docs/_targets.R")` — both OK (part of verify.sh)
- [x] New tests (`tests/testthat/test-dashboard-freshness.R`, 35 `test_that` blocks) — all pass, part of the root suite run above
- [x] Manual Check 1 fire-and-revert demonstration — see above
- [ ] `scripts/build.sh` Step 3 against a real store — **not run**, needs the main checkout (see "What I executed vs. reasoned about")

Refs #695
