### PR TITLE
fix(scripts): resolve Quarto {{< include >}} in dashboard-freshness extractor

### DIFF
--- a/scripts/check_dashboard_freshness.R
+++ b/scripts/check_dashboard_freshness.R
@@ -79,7 +79,10 @@
 #     ZERO targets -- confirmed legitimate (a landing page with no
 #     tar_read-family calls at all), and is NOT flagged, because the
 #     fence-vs-zero-expression check (not a zero-target-reference check) is
-#     what distinguishes "broken" from "genuinely nothing here".
+#     what distinguishes "broken" from "genuinely nothing here". This
+#     per-file purl()+parse() step now lives in .cdf_purl_and_extract();
+#     .cdf_extract_qmd_targets() wraps it with include resolution (see
+#     "QUARTO {{< include >}} RESOLUTION" below).
 #   - Every tar_read()/tar_read_raw() call's first argument across all 15
 #     files is a character literal or a bare symbol (0 calls with the target
 #     name in a variable/expression) -- confirmed via
@@ -103,6 +106,37 @@
 # non-empty for falsification.qmd specifically ("cg_dag", "cg_caption" --
 # see the inline-expression limitation below), so the wrapper cannot be
 # ignored without a real coverage gap.
+#
+# QUARTO {{< include >}} RESOLUTION (closed 2026-08-20, #695 follow-up) --
+# knitr::purl() tangles only the fenced chunks physically present in the
+# file it is HANDED. It does not resolve Quarto's `{{< include path.qmd >}}`
+# shortcode (that expansion happens inside quarto render's own pandoc
+# preprocessing, never inside knitr), so a tar_read() living in an included
+# file was previously invisible to Check 1 and Check 3 -- SILENTLY: no
+# error, no log line, nothing. Verified empirically 2026-08-20 with a
+# synthetic parent.qmd containing only `{{< include child.qmd >}}` (child.qmd
+# has one fenced `tar_read()` chunk): knitr::purl(parent.qmd) tangles to an
+# EMPTY file (zero expressions), and .cdf_has_r_chunk_fence(parent.qmd) is
+# FALSE (the fence lives in child.qmd, not parent.qmd) -- so the old
+# zero-expressions-but-no-fence branch treated it exactly like index.qmd's
+# legitimate "no code here" case and never flagged the hidden tar_read().
+# .cdf_extract_qmd_targets() now resolves every `{{< include >}}` directive
+# in a page (.cdf_extract_include_paths(), a raw-text regex -- Quarto
+# shortcodes are not knitr chunks, so there is no purl()-based way to find
+# them; this is NOT the tar_read-extraction regex ruled out above, it only
+# locates WHICH FILES to also purl()) and recurses the SAME
+# purl()+parse()-based .cdf_purl_and_extract() into each one, transitively,
+# unioning target references into the including page's set. A `visited`
+# accumulator prevents a circular include graph from recursing forever.
+# Per .claude/rules/fail-loud-not-null.md, an include directive whose target
+# file does not exist is a hard cli_abort() (.cdf_resolve_include_path()),
+# never a silent skip -- a dead include fails at Quarto render time too, so
+# treating it as "nothing to see here" would just move the surprise later.
+# Confirmed against the real repo 2026-08-20: docs/_includes/ contains
+# exactly one file (build-info-footer.qmd), it has zero tar_read calls, and
+# exactly one page (docs/macro-defense-rotation.qmd:710) includes it -- so
+# this gap is provably empty today; the fix exists so the NEXT include that
+# adds a tar_read() does not repeat the silent-miss pattern.
 #
 # KNOWN LIMITATION -- inline R expressions (single-backtick `` `r { ... } ``
 # `` syntax, as opposed to fenced ```{r} chunks) are NOT tangled by
@@ -254,11 +288,83 @@ suppressPackageStartupMessages({
   any(grepl("^```\\{r", lines))
 }
 
-# Purls `qmd_path`'s R chunks to a temp file, parses it (no evaluation), and
-# returns the unique set of target names referenced via .CDF_READ_FN_NAMES.
-# Aborts if purl()/parse() itself fails, or if purl() extracts zero
-# expressions from a file that plainly has R chunks (see header comment).
-.cdf_extract_qmd_targets <- function(qmd_path) {
+# ---------------------------------------------------------------------------
+# Quarto {{< include >}} resolution (#695 follow-up -- knitr::purl() tangles
+# only the fenced chunks physically present in the file it is handed; it
+# does NOT resolve Quarto's `{{< include path.qmd >}}` shortcode, so a
+# tar_read() living inside an included file was previously invisible to both
+# Check 1 (dead references) and Check 3 (data staleness) -- silently, with
+# no error and no log line. Verified empirically 2026-08-20:
+# knitr::purl() on a synthetic parent.qmd containing only
+# `{{< include child.qmd >}}` (child.qmd has one fenced tar_read() chunk)
+# purls to a completely empty file -- zero expressions, and
+# .cdf_has_r_chunk_fence(parent.qmd) is FALSE (the fence lives in child.qmd,
+# not parent.qmd), so the old code took the SAME "legitimate empty page"
+# path as index.qmd and never flagged anything. This section closes that gap
+# by resolving each include directive to its target file and recursing the
+# SAME purl()+parse() extraction into it, per fail-loud-not-null.md: a
+# missing include target aborts, it is never silently skipped.
+# ---------------------------------------------------------------------------
+
+# Matches a Quarto include shortcode `{{< include PATH >}}`, where PATH is
+# either a bare unquoted token (no spaces/`>`) or a double-quoted string
+# (may contain spaces). Both forms are part of Quarto's shortcode grammar;
+# the one real usage in this repo today
+# (docs/macro-defense-rotation.qmd:710) is the unquoted form. This is
+# regex-on-raw-text, same category as .cdf_has_r_chunk_fence() above --
+# Quarto shortcodes are not knitr chunks and purl() never sees them, so
+# there is no purl()-based way to locate them. This is NOT the
+# tar_read-extraction regex the header comment's "EXTRACTION APPROACH"
+# section rules out -- that restriction is about resolving WHICH targets a
+# chunk reads (still purl()+parse()-only, unchanged below); this regex only
+# locates WHICH FILES to also purl().
+.CDF_INCLUDE_RE <- '\\{\\{<\\s*include\\s+(?:"([^"]+)"|([^\\s>]+))\\s*>\\}\\}'
+
+# Returns the raw (unresolved) include path string(s) found in `qmd_path`'s
+# text, in the order they appear, NOT deduplicated and NOT yet resolved to
+# absolute paths (path resolution happens in .cdf_resolve_include_path()).
+# character(0) if the file contains no include shortcode.
+.cdf_extract_include_paths <- function(qmd_path) {
+  text <- paste(readLines(qmd_path, warn = FALSE), collapse = "\n")
+  whole_matches <- regmatches(text, gregexpr(.CDF_INCLUDE_RE, text, perl = TRUE))[[1]]
+  if (length(whole_matches) == 0) {
+    return(character(0))
+  }
+  groups <- regmatches(whole_matches, regexec(.CDF_INCLUDE_RE, whole_matches, perl = TRUE))
+  vapply(groups, function(g) if (nzchar(g[2])) g[2] else g[3], character(1))
+}
+
+# Resolves `raw_path` (as it appeared in an include shortcode inside
+# `including_path`) to an absolute path, the way Quarto itself resolves
+# includes: relative to the directory of the file that CONTAINS the
+# directive (not relative to the top-level page being rendered, and not
+# relative to the repo root). Aborts if the resolved file does not exist --
+# per .claude/rules/fail-loud-not-null.md, a dead include target must stop
+# the check; it must never be silently treated as "nothing to extract here".
+.cdf_resolve_include_path <- function(raw_path, including_path) {
+  resolved <- file.path(dirname(including_path), raw_path)
+  resolved <- normalizePath(resolved, mustWork = FALSE)
+  if (!file.exists(resolved)) {
+    # NOTE: the message deliberately shows only `raw_path` (as written in the
+    # include directive) and basename(including_path) -- NEVER the resolved
+    # absolute path, which lives under a volatile tempdir in tests and would
+    # break snapshot portability across machines/CI runs (portable-build-artifacts).
+    cli::cli_abort(c(
+      "x" = "{.file {basename(including_path)}} includes {.file {raw_path}}, but that file does not exist.",
+      "i" = "Looked for it relative to {.file {basename(including_path)}}'s own directory (Quarto's include-resolution rule).",
+      "i" = "A dead include target fails at Quarto render time; fix the path or restore the file."
+    ))
+  }
+  resolved
+}
+
+# Purls a single file's R chunks to a temp file, parses it (no evaluation),
+# and returns the unique set of target names referenced via
+# .CDF_READ_FN_NAMES in THIS FILE ONLY (no include recursion -- that is
+# layered on by .cdf_extract_qmd_targets() below). Aborts if purl()/parse()
+# itself fails, or if purl() extracts zero expressions from a file that
+# plainly has R chunks (see header comment).
+.cdf_purl_and_extract <- function(qmd_path) {
   qmd_basename <- basename(qmd_path)
   tmp_dir <- tempfile("dashboard_freshness_")
   dir.create(tmp_dir)
@@ -298,6 +404,34 @@ suppressPackageStartupMessages({
   }
 
   .cdf_extract_read_targets(exprs, qmd_basename)
+}
+
+# Purls `qmd_path`'s own R chunks AND recurses into every file it reaches
+# via `{{< include >}}` (directly or transitively), returning the union of
+# target names referenced anywhere in that include tree. `visited` (a
+# character vector of already-processed absolute paths, internal use only)
+# guards against a circular include graph re-processing a file forever --
+# not expected in this repo today, but cheap to guard against structurally
+# rather than assume away.
+.cdf_extract_qmd_targets <- function(qmd_path, visited = character(0)) {
+  qmd_path <- normalizePath(qmd_path, mustWork = FALSE)
+  if (qmd_path %in% visited) {
+    return(character(0))
+  }
+  visited <- c(visited, qmd_path)
+
+  own_targets <- .cdf_purl_and_extract(qmd_path)
+
+  include_paths <- .cdf_extract_include_paths(qmd_path)
+  included_targets <- unlist(
+    lapply(include_paths, function(raw_path) {
+      resolved <- .cdf_resolve_include_path(raw_path, qmd_path)
+      .cdf_extract_qmd_targets(resolved, visited)
+    }),
+    use.names = FALSE
+  )
+
+  unique(c(own_targets, included_targets))
 }
 
 # Sorted docs/*.qmd paths under `docs_dir`.

--- a/tests/testthat/_snaps/dashboard-freshness.md
+++ b/tests/testthat/_snaps/dashboard-freshness.md
@@ -22,7 +22,7 @@
     Code
       .cdf_extract_qmd_targets(file)
     Condition
-      Error in `.cdf_extract_qmd_targets()`:
+      Error in `.cdf_purl_and_extract()`:
       x knitr::purl() extracted zero R expressions from 'toy_dashboard.qmd', but the file contains R chunk fence(s).
       i This is more likely a broken extractor (e.g. a non-r engine, an unusual chunk header) than a page with no code.
       i Investigate before trusting this check; do not add an exception without confirming the file genuinely has no executable R.
@@ -36,12 +36,32 @@
       x knitr::purl() failed on 'toy_dashboard.qmd'.
       i cannot open the connection
 
+# .cdf_resolve_include_path aborts informatively when the include target does not exist (#695 follow-up)
+
+    Code
+      .cdf_resolve_include_path("toy_missing_child.qmd", including)
+    Condition
+      Error in `.cdf_resolve_include_path()`:
+      x 'toy_dashboard.qmd' includes 'toy_missing_child.qmd', but that file does not exist.
+      i Looked for it relative to 'toy_dashboard.qmd''s own directory (Quarto's include-resolution rule).
+      i A dead include target fails at Quarto render time; fix the path or restore the file.
+
+# .cdf_extract_qmd_targets aborts when a page includes a file that does not exist (#695 follow-up)
+
+    Code
+      .cdf_extract_qmd_targets(parent)
+    Condition
+      Error in `.cdf_resolve_include_path()`:
+      x 'toy_parent.qmd' includes 'toy_missing_child.qmd', but that file does not exist.
+      i Looked for it relative to 'toy_parent.qmd''s own directory (Quarto's include-resolution rule).
+      i A dead include target fails at Quarto render time; fix the path or restore the file.
+
 # key .cdf_* function signatures are stable
 
     Code
       args(.cdf_extract_qmd_targets)
     Output
-      function (qmd_path) 
+      function (qmd_path, visited = character(0)) 
       NULL
 
 ---
@@ -50,6 +70,30 @@
       args(.cdf_extract_read_targets)
     Output
       function (exprs, qmd_basename) 
+      NULL
+
+---
+
+    Code
+      args(.cdf_extract_include_paths)
+    Output
+      function (qmd_path) 
+      NULL
+
+---
+
+    Code
+      args(.cdf_resolve_include_path)
+    Output
+      function (raw_path, including_path) 
+      NULL
+
+---
+
+    Code
+      args(.cdf_purl_and_extract)
+    Output
+      function (qmd_path) 
       NULL
 
 ---

--- a/tests/testthat/test-dashboard-freshness.R
+++ b/tests/testthat/test-dashboard-freshness.R
@@ -163,6 +163,158 @@ test_that(".cdf_extract_qmd_targets aborts informatively when knitr::purl() itse
   expect_snapshot(error = TRUE, .cdf_extract_qmd_targets(missing_file))
 })
 
+# ── .cdf_extract_include_paths() ────────────────────────────────────────────
+
+test_that(".cdf_extract_include_paths finds the unquoted bare-path form (the one real usage in this repo)", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_dashboard.qmd")
+  writeLines(c(
+    "---", "title: Parent", "---", "",
+    "{{< include _includes/build-info-footer.qmd >}}"
+  ), file)
+  expect_equal(.cdf_extract_include_paths(file), "_includes/build-info-footer.qmd")
+})
+
+test_that(".cdf_extract_include_paths finds the double-quoted form", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_dashboard.qmd")
+  writeLines(c(
+    "---", "title: Parent", "---", "",
+    '{{< include "path with space.qmd" >}}'
+  ), file)
+  expect_equal(.cdf_extract_include_paths(file), "path with space.qmd")
+})
+
+test_that(".cdf_extract_include_paths returns character(0) for a page with no include directive", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_dashboard.qmd")
+  writeLines(c("---", "title: Parent", "---", "", "Just prose, no includes."), file)
+  expect_equal(.cdf_extract_include_paths(file), character(0))
+})
+
+test_that(".cdf_extract_include_paths finds multiple include directives", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_dashboard.qmd")
+  writeLines(c(
+    "---", "title: Parent", "---", "",
+    "{{< include one.qmd >}}", "", "{{< include two.qmd >}}"
+  ), file)
+  expect_equal(.cdf_extract_include_paths(file), c("one.qmd", "two.qmd"))
+})
+
+# ── .cdf_resolve_include_path() ─────────────────────────────────────────────
+
+test_that(".cdf_resolve_include_path resolves relative to the INCLUDING file's directory, not the cwd", {
+  dir <- withr::local_tempdir()
+  including <- file.path(dir, "toy_dashboard.qmd")
+  writeLines("parent", including)
+  target <- file.path(dir, "toy_child.qmd")
+  writeLines("child", target)
+  resolved <- .cdf_resolve_include_path("toy_child.qmd", including)
+  expect_equal(normalizePath(resolved), normalizePath(target))
+})
+
+test_that(".cdf_resolve_include_path aborts informatively when the include target does not exist (#695 follow-up)", {
+  dir <- withr::local_tempdir()
+  including <- file.path(dir, "toy_dashboard.qmd")
+  writeLines("parent", including)
+  expect_snapshot(error = TRUE, .cdf_resolve_include_path("toy_missing_child.qmd", including))
+})
+
+# ── .cdf_extract_qmd_targets() -- {{< include >}} resolution (#695 follow-up) ──
+# The gap this closes: knitr::purl() never sees a target file's contents
+# through a Quarto include shortcode, so a tar_read() living only inside an
+# included file was previously invisible to Check 1/Check 3. These tests use
+# FIXED basenames per file (toy_parent.qmd / toy_child.qmd / toy_grandchild.qmd)
+# so any future cli_abort() snapshot stays portable (portable-build-artifacts).
+
+test_that(".cdf_extract_qmd_targets sees a tar_read() that lives only inside an included file", {
+  dir <- withr::local_tempdir()
+  parent <- file.path(dir, "toy_parent.qmd")
+  child <- file.path(dir, "toy_child.qmd")
+  writeLines(c(
+    "---", "title: Parent", "---", "",
+    "```{r}", "#| label: parent-chunk", "x <- 1", "```", "",
+    "{{< include toy_child.qmd >}}"
+  ), parent)
+  writeLines(c(
+    "```{r}", "#| label: child-chunk",
+    'y <- tar_read("included_target")',
+    "```"
+  ), child)
+  expect_equal(.cdf_extract_qmd_targets(parent), "included_target")
+})
+
+test_that(".cdf_extract_qmd_targets sees a tar_read() through a NESTED include chain (parent -> child -> grandchild)", {
+  dir <- withr::local_tempdir()
+  parent <- file.path(dir, "toy_parent.qmd")
+  child <- file.path(dir, "toy_child.qmd")
+  grandchild <- file.path(dir, "toy_grandchild.qmd")
+  writeLines(c("---", "title: Parent", "---", "", "{{< include toy_child.qmd >}}"), parent)
+  writeLines(c("{{< include toy_grandchild.qmd >}}"), child)
+  writeLines(c(
+    "```{r}", "#| label: grandchild-chunk",
+    'z <- tar_read("nested_target")',
+    "```"
+  ), grandchild)
+  expect_equal(.cdf_extract_qmd_targets(parent), "nested_target")
+})
+
+test_that(".cdf_extract_qmd_targets unions the parent's own targets with its include's targets", {
+  dir <- withr::local_tempdir()
+  parent <- file.path(dir, "toy_parent.qmd")
+  child <- file.path(dir, "toy_child.qmd")
+  writeLines(c(
+    "---", "title: Parent", "---", "",
+    "```{r}", "#| label: parent-chunk",
+    'a <- tar_read("parent_target")',
+    "```", "",
+    "{{< include toy_child.qmd >}}"
+  ), parent)
+  writeLines(c(
+    "```{r}", "#| label: child-chunk",
+    'b <- tar_read("child_target")',
+    "```"
+  ), child)
+  expect_equal(
+    sort(.cdf_extract_qmd_targets(parent)),
+    c("child_target", "parent_target")
+  )
+})
+
+test_that(".cdf_extract_qmd_targets aborts when a page includes a file that does not exist (#695 follow-up)", {
+  dir <- withr::local_tempdir()
+  parent <- file.path(dir, "toy_parent.qmd")
+  writeLines(c(
+    "---", "title: Parent", "---", "",
+    "{{< include toy_missing_child.qmd >}}"
+  ), parent)
+  expect_snapshot(error = TRUE, .cdf_extract_qmd_targets(parent))
+})
+
+test_that(".cdf_extract_qmd_targets does not infinite-loop on a circular include graph", {
+  dir <- withr::local_tempdir()
+  parent <- file.path(dir, "toy_parent.qmd")
+  child <- file.path(dir, "toy_child.qmd")
+  writeLines(c(
+    "---", "title: Parent", "---", "",
+    "```{r}", "#| label: parent-chunk",
+    'a <- tar_read("parent_target")',
+    "```", "",
+    "{{< include toy_child.qmd >}}"
+  ), parent)
+  writeLines(c(
+    "```{r}", "#| label: child-chunk",
+    'b <- tar_read("child_target")',
+    "```", "",
+    "{{< include toy_parent.qmd >}}"
+  ), child)
+  expect_equal(
+    sort(.cdf_extract_qmd_targets(parent)),
+    c("child_target", "parent_target")
+  )
+})
+
 # ── .cdf_env_flag_true() ───────────────────────────────────────────────────
 # Exists specifically because isTRUE(as.logical(Sys.getenv(...))) is a known
 # footgun -- as.logical("1") is NA, not TRUE (.claude/rules/fail-loud-not-null.md).
@@ -368,6 +520,9 @@ test_that(".cdf_check_data_staleness surfaces unknown (never-built) references v
 test_that("key .cdf_* function signatures are stable", {
   expect_snapshot(args(.cdf_extract_qmd_targets))
   expect_snapshot(args(.cdf_extract_read_targets))
+  expect_snapshot(args(.cdf_extract_include_paths))
+  expect_snapshot(args(.cdf_resolve_include_path))
+  expect_snapshot(args(.cdf_purl_and_extract))
   expect_snapshot(args(.cdf_check_dead_references))
   expect_snapshot(args(.cdf_check_source_staleness))
   expect_snapshot(args(.cdf_check_data_staleness))


### PR DESCRIPTION
## Summary

`scripts/check_dashboard_freshness.R`'s extractor uses `knitr::purl()` to tangle each `docs/*.qmd` file and walk the resulting expressions for `tar_read()`/`tar_read_raw()`/`safe_tar_read()` calls. `knitr::purl()` only tangles the fenced chunks physically present in the file it is handed — it does not resolve Quarto's `{{< include path.qmd >}}` shortcode (that expansion happens inside `quarto render`'s own pandoc preprocessing, never inside knitr). So a `tar_read()` living only inside an included file was silently invisible to both Check 1 (dead references) and Check 3 (data staleness), with no error and no log line.

## Verifying the gap before fixing it

Confirmed against the real repo (2026-08-20):

- `docs/_includes/` contains exactly one file, `build-info-footer.qmd`.
- It contains zero `tar_read` calls.
- Exactly one page uses an include at all: `docs/macro-defense-rotation.qmd:710`.

So the gap was provably empty right now — the defect was the silence, not a currently-live bug. Confirmed the mechanism empirically with a synthetic fixture: `knitr::purl()` on a `parent.qmd` containing only `{{< include child.qmd >}}` (where `child.qmd` has one fenced `tar_read()` chunk) tangles to a completely empty file (zero expressions). `.cdf_has_r_chunk_fence(parent.qmd)` is `FALSE` (the fence lives in `child.qmd`, not `parent.qmd`), so the old zero-expressions-but-no-fence branch treated it exactly like `index.qmd`'s legitimate "no code here" case and never flagged the hidden reference.

## Design chosen: (a) resolve and extract

Went with resolve-and-extract over abort-on-include-with-tar_read, since it removes the limitation rather than merely announcing it, and stayed clean to implement:

- `.cdf_extract_include_paths()` — a raw-text regex locating `{{< include ... >}}` shortcodes (both the bare-unquoted and double-quoted forms). This is **not** the `tar_read`-extraction regex the script's header comment rules out — that restriction is about resolving *which targets* a chunk reads (still `purl()`+`parse()`-only, unchanged); this regex only locates *which files* to also `purl()`. Same category as the pre-existing `.cdf_has_r_chunk_fence()`, which is also raw-text regex.
- `.cdf_resolve_include_path()` — resolves relative to the *including file's own directory*, the way Quarto itself resolves includes (not relative to the top-level page or the repo root). Per `.claude/rules/fail-loud-not-null.md`, a dead include target `cli_abort()`s — it is never silently skipped, since a broken include fails at Quarto render time too.
- The old `.cdf_extract_qmd_targets()` per-file purl+parse logic moved unchanged into a new `.cdf_purl_and_extract()`. `.cdf_extract_qmd_targets()` now wraps it: extracts the page's own targets, resolves every include directive, and recurses the same extraction into each included file transitively, unioning the results. A `visited` accumulator (default-valued, invisible to existing callers) guards against a circular include graph recursing forever.

## Demonstrations

**1. It fires.** Created a temporary `docs/_includes/tmp_demo_dead.qmd` with a `tar_read("no_such_target_xyz")` chunk, referenced it from `docs/index.qmd` via a temporary `{{< include >}}` line, and ran Check 1 against the real tree:

```
=== Check 1: dead target references ===
FAIL: dead target references found (these WILL fail at render/tar_read time):
  [DEAD-REF] index.qmd -- references non-existent target(s): no_such_target_xyz
```

Previously this reference was completely invisible — `index.qmd` purls with no fenced chunks of its own containing it, and the include was never resolved. Reverted; confirmed `git status --porcelain` and `git diff --stat` both clean afterward (no leftover temp file, no residual edit).

**2. A live reference in an included file is now counted.** Repeated with a real, currently-unreferenced target (`vix_daily`, picked by diffing `tar_manifest()$name` against the current referenced set) instead of a dead one:

```
=== Check 1: dead target references ===
PASS: no dead target references across 15 page(s), 139 distinct target reference(s)
```

Baseline (unmodified tree, confirmed both before and after the two demos): `PASS: no dead target references across 15 page(s), 138 distinct target reference(s)` — the count is 138 in this PR (up from before #695 landed) and rises to 139 only when a page's include tree gains a real, previously-uncounted reference. Reverted; confirmed clean again.

**3. No false positive.** The unmodified tree — including the real `build-info-footer.qmd` include — still `PASS`es Check 1 at exactly 138, both as a standalone run and inside the full `scripts/verify.sh`.

## Timing

Check 1's `tar_manifest()` cost dominates (~6.7-8.9s across runs in this PR, same order as the pre-existing ~7.5s documented in the script's own header) — extraction itself (purl+parse across all 15 pages, now including the one real include) measured **0.30-0.38s**, materially unchanged from before this PR (there is exactly one real include in the repo today, so the added recursion does one extra `purl()` call).

## Tests

Extended `tests/testthat/test-dashboard-freshness.R` with fixed-basename synthetic fixtures under `withr::local_tempdir()` (`toy_parent.qmd`, `toy_child.qmd`, `toy_grandchild.qmd`) covering:

- `.cdf_extract_include_paths()`: bare-unquoted form, double-quoted form, no-include case, multiple includes.
- `.cdf_resolve_include_path()`: resolves relative to the including file's directory; aborts (snapshot) on a missing target.
- `.cdf_extract_qmd_targets()`: sees a `tar_read()` that lives only in an included file; sees one through a **nested** include chain (parent → child → grandchild); unions the parent's own targets with its include's; aborts (snapshot) on a dead include target; does not infinite-loop on a **circular** include graph (parent ↔ child, each referencing a real target — both targets still collected exactly once).

Every new `cli_abort()` has `expect_snapshot(error = TRUE, ...)` coverage per `.claude/rules/snapshot-test-policy.md`. Caught and fixed one bug via the snapshot itself during development: my first draft of `.cdf_resolve_include_path()`'s abort message interpolated the resolved absolute path (which lives under a volatile tempdir in tests) — non-portable across machines/CI runs. Fixed to show only `raw_path` and `basename(including_path)`, matching this file's existing basename-only convention (see header comment / `portable-build-artifacts`). Also caught a `cli`/glue brace-escaping bug: writing the literal shortcode `{{< include >}}` inside a `{.code ...}` cli interpolation loses a brace pair (glue treats `{{`/`}}` as literal-brace escapes) — reworded to avoid it rather than deal with quadruple-brace escaping.

Also extended the function-signature-stability block (`.cdf_extract_qmd_targets` gained a `visited = character(0)` parameter; added `.cdf_extract_include_paths`, `.cdf_resolve_include_path`, `.cdf_purl_and_extract`).

## Verification

`scripts/verify.sh` (foreground, full mode):

```
::VERIFY:ROOT_SUMMARY:: total=636 failed=3 skipped=0
::VERIFY:PKG_SUMMARY:: total=695 failed=1 skipped=15
=== scripts/verify.sh: PASS ===
```

Root suite total rose from the documented baseline of 625 to 636 (+11, from the new tests above) — failure signatures match the known baseline exactly (`test-crypto-momentum.R::C1`, `test-qa-summary-deps.R::qa_summary declares every *_metrics target...`, `test-stock-backtest.R::raw POSIXct vs Date comparison...`), skip count unchanged at 0. Package suite is untouched by this PR and matches its baseline exactly: total=695, failed=1, skipped=15.

## Scope

This PR is detection-only, per #695's Option A (same as the parent script). It does not touch the re-render/publish half of #695 — that is out of scope here and is being handled separately.

Refs #695
