### PR TITLE
fix(macro-defense-rotation): adjusted -> adjusted_close (#325 rename)

### DIFF
--- a/docs/macro-defense-rotation.qmd
+++ b/docs/macro-defense-rotation.qmd
@@ -146,7 +146,7 @@ Normalised price history of the 4 defensive ETFs + SPY benchmark since 2007, reb
 prices <- tar_read(bt_prices) |>
   filter(ticker != "BIL") |>  # exclude cash proxy from price chart
   group_by(ticker) |>
-  mutate(normalised = adjusted / first(adjusted) * 100) |>
+  mutate(normalised = adjusted_close / first(adjusted_close) * 100) |>
   ungroup()
 
 n_tickers <- length(unique(prices$ticker))


### PR DESCRIPTION
## Summary

Source fix only — `docs/macro-defense-rotation.qmd:149` referenced a bare
`adjusted` column that has not existed since the #325 rename. No re-render, no
`.html` committed; that happens separately in the main checkout, which has the
`docs/_targets` store this worktree does not.

## How I verified the schema without a store

I cannot read `docs/_targets` from a worktree (no store here), so I verified
from source instead of trusting the issue's claim:

- `R/plan_backtest.R:93-105` — the `bt_prices` target ends with
  `dplyr::select(ticker, date, close, adjusted_close)`. That is the live
  producing code, not a snapshot.
- `R/plan_backtest.R:110-116` — the very next target, `bt_returns`, consumes
  `bt_prices` and correctly references `adjusted_close` (`ret = adjusted_close /
  dplyr::lag(adjusted_close) - 1`), confirming the rename is already in effect
  package-wide and `bt_prices` is not mid-migration.

This matches the issue's reported live schema (`ticker, date, close,
adjusted_close`, 1373 rows) exactly, from two independent source locations.

## The fix

`docs/macro-defense-rotation.qmd:149`:

```r
# before
mutate(normalised = adjusted / first(adjusted) * 100) |>
# after
mutate(normalised = adjusted_close / first(adjusted_close) * 100) |>
```

## Repo-wide search (issue steps 3 and 4)

**Step 3 — other bare `adjusted` column references in `docs/*.qmd`:**
`grep -rnE "\badjusted\b" docs/*.qmd` (word-boundary, so `adjusted_close` does
not self-match) across all 15+ dashboard files. Only two files' worth of hits:
`macro-defense-rotation.qmd:149` (the code reference, now fixed) and
`macro-defense-rotation.qmd:682-683`, plus scattered hits in
`avoid-worst-days.qmd`, `falsification.qmd`, `evidence.qmd`, `leaderboard.qmd`,
`index.qmd`, `jst-dashboard.qmd`, `quiz.qmd`, `momentum-prepeak.qmd`. Every one
of those is prose — "risk-adjusted", "cost-adjusted", "drawdown-adjusted",
"break-adjusted" — not an R column symbol. **Negative result: no other
`docs/*.qmd` file has this defect.**

**Step 4 — other columns #325 renamed:** #325's own PR (#332) file list and
`packages/historicaldata/inst/COLUMN_NAMING.md` both confirm the rename was
`adjusted -> adjusted_close` only — no other column was in scope. I also cross-
checked against the more recent #669/#670 (which fixed 12 `R/plan_*.R`
consumers of the same #325 divergence: `bt_prices`, `bt_returns`, `etf_daily`,
`etf_monthly`, `aw_daily_returns`, `cb_vs_spy`, `gdn_vs_spy`, `spy_returns`,
`multi_asset_returns`, `equity_with_adv`, `olmar_prices`, `rsc_data`, plus
targets in `plan_factormax.R`/`plan_nyt_sentiment.R`/`plan_quiz.R`/
`plan_vix_macro_overlay.R`). `grep -l` for `tar_read()` of any of those target
names across `docs/*.qmd` returns only `macro-defense-rotation.qmd` — no other
dashboard reads any of the 12 targets #670 touched. **Negative result: no
other renamed column is referenced anywhere in `docs/*.qmd`.**

## What I did NOT verify

`scripts/verify.sh` does not render `.qmd` files, so it cannot prove this fix
actually works — it only proves the pipeline still parses/validates and the
test suites are unchanged. **The only real proof is a successful render**,
which needs the `docs/_targets` store this worktree does not have. I could not
run that end-to-end. Recommend re-rendering
`macro-defense-rotation.qmd` in the main checkout (alongside the other #695
work already in progress there) and confirming the price-history chunk builds
without `object 'adjusted' not found`.

## Verify

`scripts/verify.sh`, foreground, full mode — PASS, baselines unchanged:

```
=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly

::VERIFY:ROOT_SUMMARY:: total=625 failed=3 skipped=0
::VERIFY:PKG_SUMMARY:: total=695 failed=1 skipped=15
=== scripts/verify.sh: PASS ===
```

Matches the expected baselines exactly (root `total=625 failed=3 skipped=0`,
package `total=695 failed=1 skipped=15`) — this `.qmd`-only edit moved
neither.

## Out of scope (deliberately not built)

#699 proposes schema snapshots (`expect_snapshot_value()` on dashboard-read
target `names()`) as the durable fix for this class of failure. Not started
here — separate, larger piece of work. One observation for that follow-up: it
should probably snapshot the schema of every target any `docs/*.qmd` actually
`tar_read()`s (the same 138-target surface `check_dashboard_freshness.R`
Check 1 already extracts), not just the 12 targets #670 happened to fix —
otherwise the next drift in an untouched target repeats this exact failure
mode on a different column.

## Test plan

- [x] `scripts/verify.sh` (foreground, full) passes, baselines unchanged
- [x] Repo-wide word-boundary search confirms no other `docs/*.qmd` file has
      a bare `adjusted` column reference
- [x] Cross-checked against every target #670 renamed — only this dashboard
      reads any of them
- [ ] Render `macro-defense-rotation.qmd` in the main checkout (needs the real
      `docs/_targets` store — not available in this worktree)

Refs #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)
