### PR TITLE
fix(link-audit): raise retry-wait-time, throttle live crawl (#703)

### DIFF
--- a/.github/workflows/link-audit.yml
+++ b/.github/workflows/link-audit.yml
@@ -45,6 +45,13 @@ jobs:
             extra-substituters = https://rstats-on-nix.cachix.org
             extra-trusted-public-keys = rstats-on-nix.cachix.org-1:vdiiVgocg6WeJrODIqdprZRUrhi1JzhBnXv7aWI6+F0=
 
+      # Retry budget (both steps, #703): lychee --help documents
+      # --retry-wait-time only as "Minimum wait time in seconds between
+      # retries of failed requests" — it does not document an exponential
+      # backoff schedule on top of that minimum, so we do not assume one.
+      # wait-time=5 with max-retries=3 guarantees a floor of ~15s spent
+      # retrying a failing link before it's given up on (possibly more, if
+      # lychee backs off further — --help is silent on that).
       - name: Lychee — in-repo HTML pre-deploy check
         if: github.event_name == 'push'
         run: |
@@ -54,7 +61,7 @@ jobs:
             --max-redirects 5 \
             --max-concurrency 8 \
             --max-retries 3 \
-            --retry-wait-time 2 \
+            --retry-wait-time 5 \
             --accept 200,206,403,429 \
             --output ./lychee-out.md \
             --format markdown \
@@ -62,6 +69,15 @@ jobs:
             './docs/**/*.qmd' \
             './*.md'
 
+      # --max-concurrency lowered to 2 for THIS step only (live crawl against
+      # a single host, johngavin.github.io). #703's failure was a single 503
+      # on our own Pages origin among 455 checks fanning out from 9 seed
+      # pages — consistent with, but not confirmed as, our own crawl
+      # rate-limiting the origin; this is a precaution against a SUSPECTED
+      # cause on one observed sample, not a proven fix. Falsification: if a
+      # future scheduled run still 503s on this asset despite the larger
+      # retry budget above, the rate-limit theory is wrong and the cause
+      # lies elsewhere (see PR body).
       - name: Lychee — live Pages crawl (scheduled / manual)
         if: github.event_name != 'push'
         run: |
@@ -69,13 +85,13 @@ jobs:
             --no-progress \
             --verbose \
             --max-redirects 5 \
-            --max-concurrency 8 \
+            --max-concurrency 2 \
             --max-retries 3 \
-            --retry-wait-time 2 \
+            --retry-wait-time 5 \
             --accept 200,206,403,429 \
             --output ./lychee-out.md \
             --format markdown \
-            --base 'https://johngavin.github.io/historical/' \
+            --base-url 'https://johngavin.github.io/historical/' \
             'https://johngavin.github.io/historical/' \
             'https://johngavin.github.io/historical/leaderboard.html' \
             'https://johngavin.github.io/historical/falsification.html' \


### PR DESCRIPTION
## Diagnosis

Refs #703. The scheduled `link-audit` run (`32457472244`, 2026-08-21T07:10Z)
failed on a single link out of 455 checked: `[503]
https://johngavin.github.io/historical/falsification_files/figure-html/wstab-plot-1.png`
(448 successful, 2 redirected, 3 excluded, 1 unsupported, 1 error).

The asset itself is healthy: curled 3 times, `200` / 132554 bytes every time.
That rules out a genuinely broken/missing file — this looks like a transient
origin hiccup (Pages returning 503 momentarily) rather than a dead link.

## Established vs inferred — kept explicit

An earlier attempt at this fix (from a different worktree/session, never
opened as a PR) included a comment claiming a specific "observed" 2/4/8-second
retry schedule for the old flags. That claim does not hold up: the only
occurrence of "retry" in the failing run's log is the flag being echoed back,
not an actual retry event, and `lychee --help` documents `--retry-wait-time`
only as *"Minimum wait time in seconds between retries of failed requests"* —
it says nothing about exponential backoff on top of that minimum. This PR's
comments state only what's established (a documented minimum, hence a floor
on total retry time) and are explicit that anything beyond that floor is
unknown, not a specific schedule.

## Changes to `.github/workflows/link-audit.yml`

1. **`--retry-wait-time 2` → `5`** on both lychee steps (in-repo pre-deploy
   and live Pages crawl). Since this is documented as a *minimum* wait, `5`
   with `--max-retries 3` guarantees a floor of ~15s spent retrying a failing
   link before giving up — possibly more if lychee backs off further, which
   `--help` doesn't confirm either way.
2. **`--max-concurrency 8` → `2`** on the live Pages crawl step *only* (the
   `if: github.event_name != 'push'` step). The in-repo pre-deploy step stays
   at 8 — it crawls local files, not a remote origin. This is a precaution
   against a *suspected* cause (our own crawl putting rate-limiting pressure
   on the Pages origin), based on a single observed sample, not a confirmed
   fix. **Falsification:** if a future scheduled run still hits a 503 on this
   or another asset despite the larger retry budget above, the rate-limit
   theory is wrong and the cause lies elsewhere (upstream Pages instability,
   CDN edge issue, etc.) — worth revisiting at that point rather than adding
   more retry/concurrency tuning blindly.
3. **`--base` → `--base-url`** on the live crawl step, clearing a deprecation
   warning already present in the failing run's log. No effect on pre-deploy
   step (it doesn't use `--base`).
4. **Did NOT add 503 to `--accept`.** 503 means the origin is unavailable;
   accepting it would silently turn a genuine Pages outage into a green run,
   which defeats the purpose of the audit.

## Measurements (run by the orchestrator prior to this dispatch)

**Failing run** (`32457472244`, scheduled, 2026-08-21T07:10Z): 455 links
checked — 448 successful, 2 redirected, 3 excluded, 1 unsupported, 1 error
(the 503 above).

**Asset health check:** curled the failing URL 3 times — `200`, 132554 bytes,
every time.

**Local run with the new flags** (concurrency 2, retry-wait-time 5,
`--base-url`), against the live site, all 9 seed URLs:

```
elapsed: 43 seconds
Total 476 | Successful 470 | Timeouts 0 | Redirected 2
Excluded 3 | Unknown 0 | Errors 0 | Unsupported 1
```

Two things worth drawing out:

- 43s sits comfortably inside the job's 15-minute timeout, so lowering
  concurrency to 2 costs nothing meaningful in wall-clock time.
- The link count went **up** (455 → 476), not down. That matters because a
  *drop* after switching `--base` → `--base-url` would have meant the flag
  rename silently stopped discovering some links — a regression that would
  look exactly like a clean, faster run.

I have not personally re-run this local crawl in this session; the numbers
above were measured by the orchestrator before dispatching this fix.

## Verification

`scripts/verify.sh` is not meaningful for a workflow-YAML-only change (it
exercises the R package/test suite, not GitHub Actions config) and was not
run. The YAML was validated with `python3 -c "import yaml; yaml.safe_load(...)"`,
which parsed cleanly.

## Note on issue references

This PR references #703 for context only. Disposition of that issue (kept
open for monitoring vs archived) is a separate judgment call for the user —
not something this PR triggers automatically.
