### PR TITLE
ci(data-poll): preflight-validate HF_TOKEN before publish-macro-daily work

### DIFF
--- a/.github/workflows/data-poll.yml
+++ b/.github/workflows/data-poll.yml
@@ -246,6 +246,29 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
 
+      # Fail in seconds, not after ~4 minutes of setup + build (#705). An
+      # empty HF_TOKEN keeps the existing graceful "not configured" path
+      # below untouched; a SET token that whoami-v2 rejects (expired,
+      # revoked, wrong scope) means the build that follows is wasted work —
+      # the parquet cannot be published either way, so stop before spending
+      # runner minutes on setup-r/apt-get/R-install/build_macro_daily.R.
+      - name: Preflight — validate HF_TOKEN before any build work
+        if: env.HF_TOKEN != ''
+        run: |
+          set -euo pipefail
+          # -o /dev/null: never capture/echo the response body just in case
+          # it ever changed shape to include anything sensitive. Only the
+          # HTTP status is inspected. -H passes the token but the value is
+          # masked by Actions' log redaction; no -v, no echo of $HF_TOKEN.
+          status=$(curl -s -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer ${HF_TOKEN}" \
+            https://huggingface.co/api/whoami-v2)
+          if [ "$status" != "200" ]; then
+            echo "::error::HF_TOKEN is invalid or expired — https://huggingface.co/api/whoami-v2 returned HTTP $status instead of 200. Publishing to HuggingFace would fail with this token, so failing now rather than after ~4 minutes of setup and build. Rotate it: (1) generate a new token with write access to JohnGavin/finance-data at https://huggingface.co/settings/tokens, (2) gh secret set HF_TOKEN --repo JohnGavin/historical."
+            exit 1
+          fi
+          echo "HF_TOKEN preflight OK — whoami-v2 returned 200."
+
       # The poll jobs commit their parquets during this same run, so the
       # checkout above predates them.
       - name: Pull the parquets the poll just committed


### PR DESCRIPTION
## Summary

Refs #705, Problem 1 only ("the check happens after the work"). Problem 2
(warn before the expiry date) is deliberately not attempted here — see
"What I did not build" below.

`publish-macro-daily` previously guarded only against an **empty** `HF_TOKEN`.
A set-but-invalid/expired token was indistinguishable from a valid one until
the final "Publish to HuggingFace" step, after ~4 minutes of
`setup-r`/`apt-get install`/R-package-install/`build_macro_daily.R` had
already run for nothing — the parquet cannot be published either way once the
token is bad.

## What changed

Added a "Preflight — validate HF_TOKEN before any build work" step in
`.github/workflows/data-poll.yml`, job `publish-macro-daily`, placed
**immediately after `actions/checkout@v4`** — before the
"Pull the parquets the poll just committed" step and before `setup-r`. That
placement is deliberate: it is the earliest point in the job, so an
invalid/expired token now fails in seconds rather than after every other
step has already spent runner time.

### The three token states, and current behaviour

| `HF_TOKEN` | Behaviour |
|---|---|
| unset / empty | Unchanged. `if: env.HF_TOKEN != ''` is false, the preflight step is skipped entirely, build proceeds, publish steps are skipped, the existing "Report when publishing is not configured" step fires. I did not touch this path. |
| set and valid | Preflight calls `whoami-v2`, gets HTTP 200, prints `HF_TOKEN preflight OK`, job proceeds exactly as before. |
| set but invalid/expired | Preflight calls `whoami-v2`, gets a non-200 status, emits `::error::` naming the problem and the rotation steps, `exit 1` — job stops before `setup-r`, before any apt/R install, before the build. |

### How I confirmed whoami-v2's behaviour

I did not trust the issue's suggestion blindly — I ran it against the live
endpoint myself (not from inside the workflow; a local `curl`, sandboxed to
avoid touching any real credential):

- **No `Authorization` header at all** → `HTTP 401`, body
  `{"error":"Invalid username or password."}`
- **A deliberately invented, non-existent bearer value of my own choosing**
  (never a real token, never obtained from this repo's secrets) → `HTTP 401`,
  same body shape.

Both confirm the endpoint distinguishes "no/bad credential" from "credential
accepted" via HTTP status alone, which is all the preflight checks — it never
parses or depends on the response body shape (see "no leakage" below). I did
**not** and could not test the 200/valid-token path, since that requires a
real, currently-valid `HF_TOKEN`, which I was explicitly told not to obtain
or use. I'm relying on `whoami-v2` being the same endpoint the `huggingface_hub`
Python library's own `whoami()` call uses for auth verification — it is the
standard, documented way to cheaply check "is this bearer token accepted",
and requires no `pip install` (a bare `curl`, sub-second, vs. the ~4 minutes
the rest of the job costs before failing today).

### Publish-only vs. all jobs

Preflight was added **only** to `publish-macro-daily`. I grepped the whole
repo for `HF_TOKEN`:

```
.github/workflows/data-poll.yml:243:      HF_TOKEN: ${{ secrets.HF_TOKEN }}
.github/workflows/data-poll.yml:276/280/290: if: env.HF_TOKEN != '' / == ''
scripts/upload_hf.sh: reads HF_TOKEN as one of two auth sources (env var, or `hf`'s own cached login)
```

`data-poll.yml` is the only workflow file referencing it at all, and within
that file it is scoped to the `publish-macro-daily` job's `env:` block —
neither `plan` nor `poll` reference or need it. So publish-only is correct,
not just an assumption: nothing else in the repo reads `HF_TOKEN`.

### No secret leakage

- `curl -H "Authorization: Bearer ${HF_TOKEN}"` — the value is masked by
  Actions' log redaction (it's already a registered secret via
  `secrets.HF_TOKEN` at the job level), but nothing in this step relies on
  that masking to stay safe: no `-v`, no `echo "$HF_TOKEN"`, no debug print
  of the header.
- The response body goes to `/dev/null` (`-o /dev/null`) — only the numeric
  `%{http_code}` is captured and inspected. Even if HF's error body ever
  changed shape, nothing here reads it.
- The `::error::` message names the *token's role* (what it's for, how to
  rotate it) — never its value.

## What I could not test

- The **200/valid-token** path — requires a real, currently-valid `HF_TOKEN`,
  which I was told not to obtain or use. Reasoned about, not executed.
- The **preflight running inside Actions** itself — this PR is unmerged, so
  the step hasn't executed in CI yet. What I did verify locally: the YAML
  parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/data-poll.yml'))"`
  → `YAML OK`), and the `curl`/status-code logic against the real
  `whoami-v2` endpoint with both no-header and bogus-bearer inputs (both
  `401`, as shown above).
- `scripts/verify.sh` — not run. It's the project's R-package/pipeline
  verification suite (parse `_targets.R`, `testthat`, edition checks); this
  change touches only workflow YAML and has no R surface for it to exercise,
  so running it would prove nothing about this change.

## Problem 2 — explicitly not attempted

Per the task, I did not implement the expiry-warning half. I did not probe
whether `whoami-v2`'s `auth` object exposes an expiration field (that would
require calling it with a real token, which I was told not to do) — so I
have no finding to report for #705 either way. That decision (does the field
exist, and if not, the "create tokens without expiry" policy fallback the
issue names) is left for #705 to stay open on.
