### PR TITLE
fix(scripts): exclude redirect stubs from Check 2 dashboard staleness (#695)

### DIFF
--- a/scripts/check_dashboard_freshness.R
+++ b/scripts/check_dashboard_freshness.R
@@ -36,7 +36,16 @@
 #     manifest, no target extraction -- just `git log -1 --format=%ct`, ~30
 #     calls, measured well under a second. Runs in verify.sh full mode
 #     alongside Check 1 (kept together as one "dashboard freshness" report
-#     rather than splitting across --quick/full).
+#     rather than splitting across --quick/full). REDIRECT STUBS (#695
+#     follow-up) are excluded from this check's staleness verdict: a page
+#     whose entire content is "this page has moved" (see
+#     .cdf_is_redirect_stub() below) has its .qmd permanently postdate its
+#     .html, because nobody re-renders a redirect -- reporting that as STALE
+#     forever is not a real signal, it is noise that trains readers to stop
+#     reading the report. Exclusion is NEVER silent: every excluded page is
+#     still named in the output (per .claude/rules/fail-loud-not-null.md,
+#     "report, do not hide" -- filtering a real check's output must stay
+#     observable, or the filter itself becomes the next undetected defect).
 #   Check 3 (data staleness) -- for each docs/*.qmd, compare its page-render
 #     time (parsed from the committed .html's build_info() "Built" footer,
 #     falling back to the .html's own git commit date when no footer is
@@ -48,7 +57,15 @@
 #     is NOT part of verify.sh; it runs only under --data-staleness, called
 #     from scripts/build.sh after scripts/check_pipeline_errors.R, in the
 #     MAIN CHECKOUT ONLY (a worktree has no store and must not build one that
-#     could race the main checkout's -- see .claude/CLAUDE.md).
+#     could race the main checkout's -- see .claude/CLAUDE.md). Redirect
+#     stubs need NO explicit exclusion here (#695 follow-up): a stub purls to
+#     zero R expressions, so .cdf_collect_page_targets() maps it to
+#     character(0) referenced targets, and .cdf_check_data_staleness()
+#     already `next`s past any page with zero references -- a page that
+#     reads nothing cannot have stale data. This is structural (a
+#     consequence of stubs referencing no targets), not a name- or
+#     redirect-marker-based filter like Check 2's, so it needs no code
+#     change and no separate "excluded" report line.
 #
 # EXTRACTION APPROACH -- knitr::purl(), not regex on the .qmd text. This repo
 # spent a whole session (#691->#696) on the cost of fragile ad-hoc
@@ -286,6 +303,40 @@ suppressPackageStartupMessages({
 .cdf_has_r_chunk_fence <- function(qmd_path) {
   lines <- readLines(qmd_path, warn = FALSE)
   any(grepl("^```\\{r", lines))
+}
+
+# Matches the `<meta http-equiv="refresh" ...>` tag every redirect stub in
+# this repo carries (verified 2026-08-20 against drif.qmd, factor-max.qmd,
+# jst-dashboard.qmd, negative-results.qmd -- all four, identically).
+.CDF_REDIRECT_META_RE <- '<meta\\s+http-equiv="refresh"'
+
+# TRUE if `qmd_path` is a "redirect stub" page (#695 follow-up): its whole
+# purpose is to send a reader elsewhere, so its .qmd will ALWAYS postdate its
+# .html (nobody re-renders a page whose entire content is "this page has
+# moved") -- Check 2 (source-vs-render staleness) treats this as a real,
+# permanent, uninteresting signal and excludes it rather than reporting it as
+# STALE forever.
+#
+# Requires BOTH conditions, deliberately -- NOT ".cdf_has_r_chunk_fence() ==
+# FALSE" alone:
+#   1. No fenced R chunk (a real dashboard always has at least one).
+#   2. The actual redirect mechanism these pages use: a
+#      `<meta http-equiv="refresh" ...>` tag.
+# "No R chunks" alone is necessary but not sufficient. A hypothetical future
+# page with genuinely no R chunks and no redirect (e.g. a pure-prose landing
+# section) would be silently dropped from Check 2's staleness reporting by
+# the weaker test -- which is exactly the failure mode
+# .claude/rules/fail-loud-not-null.md exists to prevent: an exclusion rule
+# that is too loose turns a real staleness signal into a hidden one. Testing
+# for the meta-refresh tag -- the mechanism itself, not a name-based
+# allowlist on the four known stubs -- also means a FUTURE fifth stub of the
+# same shape is detected automatically, without editing this script.
+.cdf_is_redirect_stub <- function(qmd_path) {
+  if (.cdf_has_r_chunk_fence(qmd_path)) {
+    return(FALSE)
+  }
+  text <- paste(readLines(qmd_path, warn = FALSE), collapse = "\n")
+  grepl(.CDF_REDIRECT_META_RE, text, perl = TRUE)
 }
 
 # ---------------------------------------------------------------------------
@@ -541,13 +592,24 @@ suppressPackageStartupMessages({
 # Returns a named list: page basename -> gap in days (.qmd commit time minus
 # .html commit time) for every page whose .qmd is newer than its .html.
 # Pages with no git history for the .qmd, or no .html counterpart at all,
-# are reported separately by the caller (not silently dropped).
-.cdf_check_source_staleness <- function(qmd_files, repo_root) {
+# are reported separately by the caller (not silently dropped). Pages that
+# `is_stub_fn` identifies as redirect stubs (#695 follow-up) are excluded
+# from `stale`/`no_html`/`untracked` entirely and returned instead in
+# `excluded_stub` -- see .cdf_is_redirect_stub() for why. `excluded_stub` is
+# always returned, never silently dropped, so the caller can name every
+# excluded page: filtering a check's output must stay observable
+# (.claude/rules/fail-loud-not-null.md, "report, do not hide").
+.cdf_check_source_staleness <- function(qmd_files, repo_root, is_stub_fn = .cdf_is_redirect_stub) {
   stale <- list()
   no_html <- character(0)
   untracked <- character(0)
+  excluded_stub <- character(0)
   for (f in qmd_files) {
     base <- basename(f)
+    if (is_stub_fn(f)) {
+      excluded_stub <- c(excluded_stub, base)
+      next
+    }
     html_path <- sub("\\.qmd$", ".html", f)
     qmd_time <- .cdf_git_last_commit_time(f, repo_root)
     if (is.na(qmd_time)) {
@@ -567,7 +629,7 @@ suppressPackageStartupMessages({
       stale[[base]] <- as.numeric(difftime(qmd_time, html_time, units = "days"))
     }
   }
-  list(stale = stale, no_html = no_html, untracked = untracked)
+  list(stale = stale, no_html = no_html, untracked = untracked, excluded_stub = excluded_stub)
 }
 
 # ---------------------------------------------------------------------------
@@ -706,19 +768,26 @@ suppressPackageStartupMessages({
 
   cat("\n=== Check 2: source-vs-render staleness (git commit date, .qmd vs .html) ===\n")
   src_stale <- .cdf_check_source_staleness(qmd_files, repo_root)
+  if (length(src_stale$excluded_stub) > 0) {
+    cat(sprintf(
+      "  [STUB] excluded %d redirect stub page(s) -- no R chunks + <meta refresh> marker; their .qmd will always postdate their .html, so reporting them STALE forever is not a real signal: %s\n",
+      length(src_stale$excluded_stub), paste(src_stale$excluded_stub, collapse = ", ")
+    ))
+  }
   for (base in src_stale$untracked) {
     cat(sprintf("  [SKIP] %s -- not tracked by git; cannot assess staleness\n", base))
   }
   for (base in src_stale$no_html) {
     cat(sprintf("  [NO-HTML] %s -- no committed .html counterpart found\n", base))
   }
+  n_checked <- length(qmd_files) - length(src_stale$excluded_stub)
   if (length(src_stale$stale) == 0) {
     cat("PASS: no page's .qmd source is newer than its committed .html\n")
   } else {
     ordered <- names(src_stale$stale)[order(-unlist(src_stale$stale))]
     cat(sprintf(
       "STALE: %d of %d page(s) have .qmd source newer than their committed .html:\n",
-      length(src_stale$stale), length(qmd_files)
+      length(src_stale$stale), n_checked
     ))
     for (page in ordered) {
       cat(sprintf(

--- a/tests/testthat/_snaps/dashboard-freshness.md
+++ b/tests/testthat/_snaps/dashboard-freshness.md
@@ -107,9 +107,17 @@
 ---
 
     Code
+      args(.cdf_is_redirect_stub)
+    Output
+      function (qmd_path) 
+      NULL
+
+---
+
+    Code
       args(.cdf_check_source_staleness)
     Output
-      function (qmd_files, repo_root) 
+      function (qmd_files, repo_root, is_stub_fn = .cdf_is_redirect_stub) 
       NULL
 
 ---

--- a/tests/testthat/test-dashboard-freshness.R
+++ b/tests/testthat/test-dashboard-freshness.R
@@ -101,6 +101,56 @@ test_that(".cdf_has_r_chunk_fence is FALSE for a pure-prose page", {
   expect_false(.cdf_has_r_chunk_fence(file))
 })
 
+# ── .cdf_is_redirect_stub() (#695 follow-up) ────────────────────────────────
+# Requires BOTH no-R-chunk-fence AND the <meta http-equiv="refresh"> marker
+# -- see the function's own comment in check_dashboard_freshness.R for why
+# "no R chunks" alone is not used as the test.
+
+test_that(".cdf_is_redirect_stub is TRUE for a drif.qmd-style redirect stub", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_dashboard.qmd")
+  writeLines(c(
+    "---", "title: Redirect stub", "---", "",
+    "> **This page has moved.**", "",
+    "Redirecting automatically…", "",
+    '<meta http-equiv="refresh" content="0; url=elsewhere.html">',
+    '<script>window.location.href = "elsewhere.html";</script>'
+  ), file)
+  expect_true(.cdf_is_redirect_stub(file))
+})
+
+test_that(".cdf_is_redirect_stub is FALSE for a page with no R chunks and no redirect marker (pins the #695 decision)", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_dashboard.qmd")
+  writeLines(c(
+    "---", "title: Bare prose page", "---", "",
+    "Just prose, no chunks, and definitely no redirect to anywhere."
+  ), file)
+  expect_false(.cdf_has_r_chunk_fence(file)) # would wrongly qualify under the weaker test
+  expect_false(.cdf_is_redirect_stub(file))
+})
+
+test_that(".cdf_is_redirect_stub is FALSE for a page that has R chunks, even if it also carries a meta-refresh tag", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_dashboard.qmd")
+  writeLines(c(
+    "---", "title: Not actually a stub", "---", "",
+    "```{r}", "1 + 1", "```", "",
+    '<meta http-equiv="refresh" content="30">'
+  ), file)
+  expect_false(.cdf_is_redirect_stub(file))
+})
+
+test_that(".cdf_is_redirect_stub is FALSE for a normal dashboard page (has chunks, no redirect marker)", {
+  dir <- withr::local_tempdir()
+  file <- file.path(dir, "toy_dashboard.qmd")
+  writeLines(c(
+    "---", "title: Real dashboard", "---", "",
+    "```{r}", 'a <- tar_read("some_target")', "```"
+  ), file)
+  expect_false(.cdf_is_redirect_stub(file))
+})
+
 # ── .cdf_extract_qmd_targets() ─────────────────────────────────────────────
 # End-to-end: knitr::purl() + parse() + .cdf_extract_read_targets(), against
 # small synthetic .qmd fixtures under a fixed basename.
@@ -441,6 +491,57 @@ test_that(".cdf_check_source_staleness reports an untracked .qmd separately from
   expect_equal(result$untracked, "toy_dashboard.qmd")
 })
 
+# ── .cdf_check_source_staleness() -- redirect stub exclusion (#695 follow-up) ──
+
+test_that(".cdf_check_source_staleness excludes a redirect stub from staleness, but names it in excluded_stub", {
+  repo <- .make_scratch_git_repo()
+  # Same shape as the real drif.qmd/factor-max.qmd/etc: old .html, much
+  # newer .qmd -- which would be flagged STALE under the pre-#695 logic.
+  .commit_file_at(repo, "toy_dashboard.html", "old render", "2026-01-01T00:00:00")
+  stub_content <- c(
+    "> **This page has moved.**",
+    '<meta http-equiv="refresh" content="0; url=elsewhere.html">'
+  )
+  .commit_file_at(repo, "toy_dashboard.qmd", stub_content, "2026-01-15T00:00:00")
+  result <- .cdf_check_source_staleness(file.path(repo, "toy_dashboard.qmd"), repo)
+  expect_equal(result$stale, list())
+  expect_equal(result$no_html, character(0))
+  expect_equal(result$untracked, character(0))
+  expect_equal(result$excluded_stub, "toy_dashboard.qmd")
+})
+
+test_that(".cdf_check_source_staleness excludes a stub while still flagging a genuinely stale real page alongside it", {
+  repo <- .make_scratch_git_repo()
+  .commit_file_at(repo, "toy_stub.html", "old render", "2026-01-01T00:00:00")
+  stub_content <- c(
+    "> **This page has moved.**",
+    '<meta http-equiv="refresh" content="0; url=elsewhere.html">'
+  )
+  .commit_file_at(repo, "toy_stub.qmd", stub_content, "2026-01-15T00:00:00")
+
+  .commit_file_at(repo, "toy_real.html", "old render", "2026-01-01T00:00:00")
+  .commit_file_at(repo, "toy_real.qmd", "```{r}\n1+1\n```", "2026-01-20T00:00:00")
+
+  result <- .cdf_check_source_staleness(
+    c(file.path(repo, "toy_stub.qmd"), file.path(repo, "toy_real.qmd")),
+    repo
+  )
+  expect_equal(result$excluded_stub, "toy_stub.qmd")
+  expect_equal(names(result$stale), "toy_real.qmd")
+})
+
+test_that(".cdf_check_source_staleness does NOT exclude a stale page with no R chunks and no redirect marker (pins the #695 decision)", {
+  repo <- .make_scratch_git_repo()
+  .commit_file_at(repo, "toy_dashboard.html", "old render", "2026-01-01T00:00:00")
+  # No R chunk fence, but also no redirect marker -- must be treated as a
+  # normal page, i.e. still reported STALE, not silently excluded.
+  .commit_file_at(repo, "toy_dashboard.qmd", "Just prose, no chunks, no redirect.", "2026-01-15T00:00:00")
+  result <- .cdf_check_source_staleness(file.path(repo, "toy_dashboard.qmd"), repo)
+  expect_equal(result$excluded_stub, character(0))
+  expect_equal(names(result$stale), "toy_dashboard.qmd")
+  expect_equal(result$stale[["toy_dashboard.qmd"]], 14, tolerance = 0.1)
+})
+
 # ── .cdf_page_render_time() ─────────────────────────────────────────────────
 
 test_that(".cdf_page_render_time reads the build_info() footer timestamp when present", {
@@ -497,6 +598,33 @@ test_that(".cdf_check_data_staleness skips pages with no referenced targets", {
   expect_equal(result, list())
 })
 
+test_that(".cdf_check_data_staleness cannot flag a redirect stub: end-to-end, a stub purls to zero targets and is therefore always skipped (#695 follow-up)", {
+  # Confirms Check 3 needs NO stub-specific exclusion logic: a stub's own
+  # .cdf_extract_qmd_targets() output feeds page_targets, and it is always
+  # character(0) (see .cdf_extract_qmd_targets 'redirect stub' test above),
+  # which .cdf_check_data_staleness() already `next`s past. This wires the
+  # real extractor's output into the check, rather than hand-constructing an
+  # empty page_targets entry as the generic test above does.
+  dir <- withr::local_tempdir()
+  stub_file <- file.path(dir, "toy_stub.qmd")
+  writeLines(c(
+    "> **This page has moved.**",
+    '<meta http-equiv="refresh" content="0; url=elsewhere.html">'
+  ), stub_file)
+  extracted <- .cdf_extract_qmd_targets(stub_file)
+  expect_equal(extracted, character(0))
+
+  repo <- .make_scratch_git_repo()
+  qmd_path <- .commit_file_at(repo, "toy_stub.qmd", "stub source", "2026-01-01T00:00:00")
+  page_targets <- list("toy_stub.qmd" = extracted)
+  # Even a target rebuilt long after any plausible render time cannot matter,
+  # because the stub references nothing -- there is no known_refs entry to
+  # compare against.
+  meta_time <- stats::setNames(as.POSIXct("2099-01-01", tz = Sys.timezone()), "unrelated_target")
+  result <- .cdf_check_data_staleness(qmd_path, page_targets, meta_time, repo)
+  expect_equal(result, list())
+})
+
 test_that(".cdf_check_data_staleness surfaces unknown (never-built) references via note_fn without failing", {
   repo <- .make_scratch_git_repo()
   html <- paste0("<html><body><strong>Built</strong> 2026-01-01 00:00:00</body></html>")
@@ -524,6 +652,7 @@ test_that("key .cdf_* function signatures are stable", {
   expect_snapshot(args(.cdf_resolve_include_path))
   expect_snapshot(args(.cdf_purl_and_extract))
   expect_snapshot(args(.cdf_check_dead_references))
+  expect_snapshot(args(.cdf_is_redirect_stub))
   expect_snapshot(args(.cdf_check_source_staleness))
   expect_snapshot(args(.cdf_check_data_staleness))
   expect_snapshot(args(.cdf_page_render_time))


### PR DESCRIPTION
## Summary

Excludes the 4 redirect stub pages (`drif.qmd`, `factor-max.qmd`, `jst-dashboard.qmd`, `negative-results.qmd`) from Check 2 (source-vs-render staleness) in `scripts/check_dashboard_freshness.R`, per the second decision left open in #695's rescoping comment. Their `.qmd` will always postdate their `.html` — nobody re-renders a page whose entire content is "this page has moved" — so reporting them STALE forever was permanent noise, exactly the shape of check that stops being read.

## Detection decision

`.cdf_is_redirect_stub(qmd_path)` requires **both**:

1. `.cdf_has_r_chunk_fence()` is `FALSE` (no fenced R chunk), **and**
2. the page's raw text contains the actual redirect mechanism these pages use: `<meta http-equiv="refresh" ...>`.

I did **not** use "no R chunks" alone. That weaker test is necessary but not sufficient: a hypothetical future page with genuinely no R chunks and no redirect (e.g. a bare prose section) would be silently dropped from Check 2's staleness reporting under the weaker test — precisely the failure mode `.claude/rules/fail-loud-not-null.md` exists to prevent (an exclusion rule that is too loose turns a real signal into a hidden one). Testing for the meta-refresh tag — the mechanism itself, not a name-based allowlist on the four known stubs — also means a *future* fifth stub of the same shape is detected automatically, without editing this script.

New test pins this decision: `.cdf_check_source_staleness does NOT exclude a stale page with no R chunks and no redirect marker` — a synthetic page with zero chunks and no meta tag is still reported STALE, not excluded.

## Which checks it applies to

- **Check 2 (source staleness)** — modified. `.cdf_check_source_staleness()` gained an `is_stub_fn` parameter (default `.cdf_is_redirect_stub`) and now returns an `excluded_stub` list element alongside `stale`/`no_html`/`untracked`.
- **Check 3 (data staleness)** — **unmodified, confirmed unaffected by test**. A stub purls to zero R expressions, so `.cdf_collect_page_targets()` maps it to `character(0)` referenced targets, and `.cdf_check_data_staleness()` already `next`s past any page with zero references — a page that reads nothing cannot have stale data. This is structural (a consequence of `page_targets`), not a name- or marker-based filter, so it needs no code change. New test `.cdf_check_data_staleness cannot flag a redirect stub: end-to-end...` wires the real extractor's output (not a hand-built empty vector) into the check to confirm this holds for an actual stub fixture.
- **Check 1 (dead references)** — untouched, verified unchanged (138/15/0, see below).

## Report, do not hide

Excluded pages are never silently dropped. Check 2 now prints, before the PASS/STALE verdict:

```
  [STUB] excluded 4 redirect stub page(s) -- no R chunks + <meta refresh> marker; their .qmd will always postdate their .html, so reporting them STALE forever is not a real signal: drif.qmd, factor-max.qmd, jst-dashboard.qmd, negative-results.qmd
```

The `STALE: N of M page(s)` denominator was also adjusted (`M` = total pages minus excluded stubs) so it reads as "of the pages actually checked", not "of all pages including 4 that can never pass".

## Before / after (real repo, no store needed)

**Before** (`origin/main`'s `scripts/check_dashboard_freshness.R`, run against this worktree's current `docs/`):

```
=== Check 1: dead target references ===
PASS: no dead target references across 15 page(s), 138 distinct target reference(s)

=== Check 2: source-vs-render staleness (git commit date, .qmd vs .html) ===
STALE: 4 of 15 page(s) have .qmd source newer than their committed .html:
  [STALE] drif.qmd -- source is 33.9 day(s) newer than its rendered .html
  [STALE] factor-max.qmd -- source is 33.9 day(s) newer than its rendered .html
  [STALE] jst-dashboard.qmd -- source is 33.9 day(s) newer than its rendered .html
  [STALE] negative-results.qmd -- source is 33.9 day(s) newer than its rendered .html
```

**After** (this branch):

```
=== Check 1: dead target references ===
PASS: no dead target references across 15 page(s), 138 distinct target reference(s)

=== Check 2: source-vs-render staleness (git commit date, .qmd vs .html) ===
  [STUB] excluded 4 redirect stub page(s) -- no R chunks + <meta refresh> marker; their .qmd will always postdate their .html, so reporting them STALE forever is not a real signal: drif.qmd, factor-max.qmd, jst-dashboard.qmd, negative-results.qmd
PASS: no page's .qmd source is newer than its committed .html
```

**Check 1's 138 distinct target references across 15 pages, 0 dead is unchanged** — confirmed identical in both runs above, run back-to-back against the same worktree state. Extraction logic (`.cdf_extract_qmd_targets` / `.cdf_extract_read_targets`) was not touched by this PR.

## Tests

Extended `tests/testthat/test-dashboard-freshness.R`:

- 4 new unit tests for `.cdf_is_redirect_stub()`: true-positive (drif.qmd-style), false for chunk-less non-redirect prose (pins the decision above), false for a page with chunks even if it also carries a meta-refresh tag, false for a normal dashboard page.
- 3 new tests for `.cdf_check_source_staleness()`: a stub is excluded and named in `excluded_stub`; a stub is excluded while a genuinely stale *real* page alongside it is still flagged; a chunk-less non-redirect page is *not* excluded and is still reported STALE (pins the decision).
- 1 new end-to-end test for `.cdf_check_data_staleness()` confirming a real stub fixture (via `.cdf_extract_qmd_targets()`, not a hand-built empty vector) is structurally skipped.
- Updated the function-signature-stability snapshot test to cover the new `.cdf_is_redirect_stub` function and `.cdf_check_source_staleness`'s new `is_stub_fn` parameter; snapshot file regenerated via `testthat::snapshot_accept()`.

All new/modified tests pass; ran `tests/testthat/test-dashboard-freshness.R` standalone (all green, 0 failures) before and after snapshot regeneration.

## `scripts/verify.sh` (foreground, full)

```
PASS: _targets.R parses
PASS: docs/_targets.R parses
PASS: docs/_targets.R is structurally valid (tar_validate, 7.45s)
PASS: testthat edition 3 active
PASS: dashboard freshness (scripts/check_dashboard_freshness.R Check 1 + Check 2)

=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly (test-crypto-momentum.R, test-qa-summary-deps.R, test-stock-backtest.R)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly (test-mom-prepeak-portfolio.R)

=== scripts/verify.sh: PASS ===
```

Root `failed=3 skipped=0`, package `failed=1 skipped=15` — both match the documented baselines in `.claude/CLAUDE.md` exactly; only the new passing tests were added.

Refs #695 — leaving it open per the issue's own note: the escalation-policy decision (`HD_FAIL_ON_STALE_DASHBOARDS`) is still undecided.
