### PR TITLE
feat(dashboard-freshness): split staleness escalation + weekly enforcing job (#695)

### DIFF
--- a/.github/workflows/dashboard-freshness.yml
+++ b/.github/workflows/dashboard-freshness.yml
@@ -1,0 +1,104 @@
+name: Dashboard freshness (weekly)
+
+# Enforcement half of #695's escalation policy. Detection has existed since
+# #698 (scripts/check_dashboard_freshness.R); nothing ran it on a schedule or
+# failed on it until this workflow. HD_FAIL_ON_STALE_DASHBOARDS escalates
+# Check 2 and Check 3 differently (see that script's own header comment,
+# section "ESCALATION POLICY", for the full rationale):
+#   - Check 2 (source staleness -- a page's .qmd committed newer than its own
+#     .html) gets ZERO grace: a human edited a page and it never reached
+#     readers, which is wrong the moment it happens.
+#   - Check 3 (data staleness -- the pipeline rebuilt after a page rendered)
+#     gets a configurable grace period, HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS
+#     (default 14 days). Measured 2026-08-22: two pages became data-stale
+#     within 45.9 hours of a routine tar_make() that touched none of their
+#     own source -- a zero-grace threshold there would be permanently red.
+#
+# WEEKLY, NOT DAILY: re-rendering a stale page is a ~20-minute human act
+# (#695's own evidence -- the 9 pages flagged when this policy was written
+# took ~20 minutes of wall clock to re-render). A daily nag would arrive
+# faster than anyone could reasonably act on it and would be muted within a
+# fortnight -- the same fate #695 itself documents for a check nobody reads.
+# Monday morning gives the whole working week to act on whatever the
+# previous week left stale, mirroring link-audit.yml's own daily cadence but
+# scaled to a check whose fix is a deliberate human action (re-render +
+# review + commit), not link-audit's usually-passive "the target link came
+# back" or "fix the URL".
+#
+# CHECK 3 (DATA STALENESS) DOES NOT RUN HERE, AND CANNOT WITH THIS DESIGN.
+# It needs a real targets store (targets::tar_meta() against docs/_targets),
+# and a GitHub Actions runner starts with none. Building one here to run
+# Check 3 would mean running tar_make() against docs/_targets.R on every
+# scheduled run (#695's issue: recent full builds took real wall-clock time,
+# well past sensible workflow budgets) AND would produce a store that is
+# NOT the main checkout's -- see .claude/CLAUDE.md and the worktree-location
+# rule for why a second, unofficial store must never race the canonical one.
+# scripts/build.sh already refuses to run from anything but the main
+# checkout for the same reason; a CI runner is never the main checkout. This
+# workflow therefore enforces Check 1 (dead target references, always a hard
+# failure) and Check 2 (source staleness, zero grace once
+# HD_FAIL_ON_STALE_DASHBOARDS is set) ONLY. The 14-day Check 3 threshold is
+# enforced solely by a human running `scripts/build.sh --render` in the main
+# checkout -- there is no CI equivalent today. Treat a green run here as "no
+# dead target references, no unpublished source edits" -- NOT as "all
+# dashboard data is fresh"; only `scripts/build.sh` (main checkout) proves
+# that.
+#
+# A theoretical way to close this gap without building a store: commit a
+# small, versioned snapshot of tar_meta()'s relevant build-time columns
+# (target name + time) as a build artifact whenever the main checkout runs
+# scripts/build.sh, then have this workflow diff render times against that
+# snapshot instead of a live store. Not implemented -- it adds a second
+# provenance surface to keep in sync with the real store and was judged out
+# of scope for this PR; left here as a description, not a proposal to
+# silently pursue later.
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'      # weekly, Monday 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write               # to auto-file an issue on failure
+
+jobs:
+  dashboard-freshness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            trusted-users = root runner
+            extra-substituters = https://rstats-on-nix.cachix.org
+            extra-trusted-public-keys = rstats-on-nix.cachix.org-1:vdiiVgocg6WeJrODIqdprZRUrhi1JzhBnXv7aWI6+F0=
+
+      # Check 1 + Check 2 ONLY -- no store, no tar_make(). See header comment
+      # for why Check 3 (data staleness) cannot run here. HD_FAIL_ON_STALE_DASHBOARDS
+      # escalates Check 2 with zero grace; Check 1 (dead target references)
+      # is always a hard failure regardless of this env var.
+      - name: Check 1 (dead target refs) + Check 2 (source staleness, zero grace)
+        env:
+          HD_FAIL_ON_STALE_DASHBOARDS: "1"
+        run: |
+          nix develop --command Rscript scripts/check_dashboard_freshness.R \
+            | tee ./dashboard-freshness-out.md
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dashboard-freshness-output
+          path: ./dashboard-freshness-out.md
+          retention-days: 14
+
+      - name: Create issue on schedule failure
+        if: failure() && github.event_name == 'schedule'
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "dashboard-freshness: dead reference or unpublished source edit detected"
+          content-filepath: ./dashboard-freshness-out.md
+          labels: bug, theme:infra, dashboard-freshness

--- a/scripts/check_dashboard_freshness.R
+++ b/scripts/check_dashboard_freshness.R
@@ -176,10 +176,43 @@
 # non-regex alternative within knitr's public API) -- it is documented here,
 # at the one call site the gap affects, instead.
 #
+# ESCALATION POLICY (#695 rescope, decided 2026-08-22) -- Check 2 and Check 3
+# are DIFFERENT DEFECT CLASSES and get different grace periods, but a SINGLE
+# switch (HD_FAIL_ON_STALE_DASHBOARDS) turns escalation on for both, each
+# applying its own threshold:
+#   - Check 2 (source staleness -- a page's .qmd committed newer than its own
+#     .html) gets ZERO grace: a human edited a page and it never reached
+#     readers, which is unambiguously wrong the moment it happens, not after
+#     N days. Any amount of source staleness escalates once the switch is on.
+#   - Check 3 (data staleness -- the pipeline rebuilt after a page rendered)
+#     gets a configurable grace period, HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS
+#     (default 14 days, see .cdf_data_staleness_threshold_hours() below).
+#     Data staleness is the NORMAL consequence of any rebuild, not a mistake:
+#     measured 2026-08-22, two pages (falsification.qmd, european-overlay.qmd)
+#     became data-stale within 45.9 hours of a routine tar_make() run that
+#     touched none of their own source. A zero-grace threshold here would be
+#     permanently red days after every build, and a permanently red check is
+#     one nobody reads (exactly the failure mode the redirect-stub exclusion
+#     above was already added to prevent, applied to a second cause).
+#
+# ONE SWITCH, NOT TWO, is the deliberate choice here (over separate
+# HD_FAIL_ON_STALE_SOURCE / HD_FAIL_ON_STALE_DATA switches): the two checks
+# already answer two different questions with two different, independently
+# tunable thresholds (Check 2's is fixed at zero; Check 3's is
+# HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS) -- adding a second on/off switch on
+# top would let someone configure "escalate data staleness but not source
+# staleness," which is backwards: source staleness is the more clear-cut
+# defect of the two and should never be the one left unescalated. Fewer knobs
+# also means fewer states to reason about when reading a CI failure. The
+# counter-argument -- a project might genuinely want Check 3 enforcement
+# (e.g. in the new weekly workflow) without Check 2 enforcement, or vice
+# versa, and a single switch cannot express that -- is real, but no caller of
+# this script has needed that split yet; add a second switch if one does.
+#
 # EXIT CODES:
 #   0  ran clean: no dead target references (Check 1 -- ALWAYS a hard
 #      failure when found, see below), and no staleness escalated to a
-#      failure (see HD_FAIL_ON_STALE_DASHBOARDS below).
+#      failure (see the ESCALATION POLICY section above).
 #   1  a real problem was found and treated as a failure:
 #        - Check 1 always fails the run when it finds a dead reference --
 #          confirmed today: zero instances, so this does not turn a green
@@ -187,16 +220,19 @@
 #          the live leaderboard is missing two merged features precisely
 #          because nothing else in the repo detects it), not a style
 #          preference, so it is not gated behind an opt-in flag.
-#        - Check 2/Check 3 staleness is REPORTED but does NOT fail the run
-#          by default -- ~8 of 15 dashboards are stale RIGHT NOW (#695's own
-#          evidence), so defaulting staleness to a hard failure would turn
-#          verify.sh/build.sh red on main until #695's separate re-render PR
-#          lands. Set HD_FAIL_ON_STALE_DASHBOARDS=1 (any of "1"/"true"/"yes",
+#        - Check 2 (source staleness) and Check 3 (data staleness) are both
+#          REPORTED but do NOT fail the run by default -- ~8 of 15 dashboards
+#          were stale under one measure or the other when this script
+#          shipped (#695's own evidence), so defaulting staleness to a hard
+#          failure would turn verify.sh/build.sh red on main until the
+#          re-render half of #695 landed (it has -- see #702). Set
+#          HD_FAIL_ON_STALE_DASHBOARDS=1 (any of "1"/"true"/"yes",
 #          case-insensitive -- see .cdf_env_flag_true(), which exists
 #          specifically because `isTRUE(as.logical(Sys.getenv(...)))` is a
 #          known footgun: as.logical("1") is NA, not TRUE, per
-#          .claude/rules/fail-loud-not-null.md) to escalate staleness to a
-#          hard failure once the re-render half of #695 is done. This is the
+#          .claude/rules/fail-loud-not-null.md) to escalate: Check 2 always
+#          (zero grace) and Check 3 once a page's gap exceeds
+#          HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS (default 14). This is the
 #          explicit, documented escalation path -- not an unwritten
 #          intention.
 #   2  could not run the check(s) at all: knitr::purl()/parse() failed or
@@ -209,11 +245,19 @@
 #     scripts/verify.sh's full mode calls, but embedded via source() into
 #     its existing Rscript process rather than spawned as a second process
 #     (see the cost note above) -- run this file directly only for a
-#     standalone/manual check.
+#     standalone/manual check. This is ALSO the only mode a CI runner can use
+#     (no store -- see .github/workflows/dashboard-freshness.yml, which runs
+#     this mode weekly with HD_FAIL_ON_STALE_DASHBOARDS=1 and therefore
+#     enforces Check 1 + Check 2 only; it CANNOT enforce Check 3, see that
+#     workflow's header comment).
 #   nix develop --command Rscript scripts/check_dashboard_freshness.R --data-staleness
 #     Additionally runs Check 3. MAIN CHECKOUT ONLY in practice (needs a
 #     real docs/_targets store) -- this is what scripts/build.sh calls,
-#     after scripts/check_pipeline_errors.R.
+#     after scripts/check_pipeline_errors.R. There is currently no CI
+#     equivalent (see .github/workflows/dashboard-freshness.yml's header
+#     comment for why); the HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS grace
+#     period is therefore enforced only when a human (or a future CI job that
+#     solves the store problem) runs this locally.
 #
 # This file is also source()'d directly by
 # tests/testthat/test-dashboard-freshness.R to unit-test the extractor
@@ -513,6 +557,49 @@ suppressPackageStartupMessages({
   tolower(val) %in% c("1", "true", "yes")
 }
 
+# Default grace period (days) for Check 3 (data staleness) before it
+# escalates to a hard failure under HD_FAIL_ON_STALE_DASHBOARDS=1 -- see the
+# "ESCALATION POLICY" section in this file's header comment for the full
+# rationale (a rebuild is the normal consequence of the pipeline moving on;
+# Check 2/source staleness gets NO such grace period).
+.CDF_DEFAULT_DATA_STALENESS_THRESHOLD_DAYS <- 14
+
+# Reads HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS, defaulting to
+# .CDF_DEFAULT_DATA_STALENESS_THRESHOLD_DAYS days, and returns it in HOURS
+# (the unit .cdf_check_data_staleness() already reports gaps in, via
+# gap_hrs). Aborts loudly -- never silently falls back to the default -- on a
+# set-but-unparseable or negative value, per
+# .claude/rules/fail-loud-not-null.md: a misconfigured threshold must stop
+# the run, not silently mask the misconfiguration with a value nobody chose.
+.cdf_data_staleness_threshold_hours <- function() {
+  var_name <- "HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS"
+  raw <- Sys.getenv(var_name, unset = "")
+  if (!nzchar(raw)) {
+    return(.CDF_DEFAULT_DATA_STALENESS_THRESHOLD_DAYS * 24)
+  }
+  days <- suppressWarnings(as.numeric(raw))
+  if (is.na(days) || days < 0) {
+    default_days <- .CDF_DEFAULT_DATA_STALENESS_THRESHOLD_DAYS
+    cli::cli_abort(c(
+      "x" = "{.envvar {var_name}} is set to {.val {raw}}, which is not a non-negative number of days.",
+      "i" = "Unset it to use the default ({.val {default_days}} days), or set it to a non-negative number."
+    ))
+  }
+  days * 24
+}
+
+# Returns the subset of `data_stale`'s page names whose gap_hrs exceeds
+# `threshold_hrs`. Pure logic, no I/O -- factored out from the driver so it
+# can be unit-tested directly against a synthetic `data_stale` list (#695
+# rescope: "data staleness under the threshold does not fail; data staleness
+# over the threshold does"), rather than only indirectly through a full
+# .cdf_main() run (which needs a real manifest/store and is not unit-tested
+# elsewhere in this file either). `data_stale` is shaped like
+# .cdf_check_data_staleness()'s return value: page basename -> list(gap_hrs=, source=).
+.cdf_data_staleness_over_threshold <- function(data_stale, threshold_hrs) {
+  names(data_stale)[vapply(data_stale, function(d) d$gap_hrs > threshold_hrs, logical(1))]
+}
+
 # Last commit time (POSIXct, seconds resolution) of `abs_path` under
 # `repo_root`, via `git log -1 --format=%ct` (committer date, unix epoch --
 # avoids ISO-8601 timezone-offset parsing entirely). Returns NA (POSIXct) if
@@ -796,11 +883,11 @@ suppressPackageStartupMessages({
       ))
     }
     if (.cdf_env_flag_true("HD_FAIL_ON_STALE_DASHBOARDS")) {
-      cat("HD_FAIL_ON_STALE_DASHBOARDS is set -- treating source staleness as a hard failure.\n")
+      cat("HD_FAIL_ON_STALE_DASHBOARDS is set -- treating source staleness as a hard failure (zero grace period; see script header \"ESCALATION POLICY\").\n")
       overall_status <- 1
     } else {
       cat("NOTE: staleness is reported but does NOT fail this run by default (see script header for rationale).\n")
-      cat("      Set HD_FAIL_ON_STALE_DASHBOARDS=1 to escalate this to a hard failure.\n")
+      cat("      Set HD_FAIL_ON_STALE_DASHBOARDS=1 to escalate this to a hard failure (zero grace -- any source staleness escalates).\n")
     }
   }
 
@@ -848,12 +935,28 @@ suppressPackageStartupMessages({
           page, d$gap_hrs, d$source
         ))
       }
+      threshold_hrs <- .cdf_data_staleness_threshold_hours()
+      threshold_days <- threshold_hrs / 24
+      over_threshold <- .cdf_data_staleness_over_threshold(data_stale, threshold_hrs)
       if (.cdf_env_flag_true("HD_FAIL_ON_STALE_DASHBOARDS")) {
-        cat("HD_FAIL_ON_STALE_DASHBOARDS is set -- treating data staleness as a hard failure.\n")
-        overall_status <- 1
+        if (length(over_threshold) > 0) {
+          cat(sprintf(
+            "HD_FAIL_ON_STALE_DASHBOARDS is set -- %d of %d stale page(s) exceed the %.0f-day data-staleness grace period (HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS), treating as a hard failure: %s\n",
+            length(over_threshold), length(data_stale), threshold_days, paste(over_threshold, collapse = ", ")
+          ))
+          overall_status <- 1
+        } else {
+          cat(sprintf(
+            "HD_FAIL_ON_STALE_DASHBOARDS is set, but all %d stale page(s) are within the %.0f-day data-staleness grace period -- not escalating.\n",
+            length(data_stale), threshold_days
+          ))
+        }
       } else {
         cat("NOTE: data staleness is reported but does NOT fail this run by default (see script header for rationale).\n")
-        cat("      Set HD_FAIL_ON_STALE_DASHBOARDS=1 to escalate this to a hard failure.\n")
+        cat(sprintf(
+          "      Set HD_FAIL_ON_STALE_DASHBOARDS=1 to escalate page(s) past the %.0f-day grace period (HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS) to a hard failure.\n",
+          threshold_days
+        ))
       }
     }
   }

--- a/tests/testthat/_snaps/dashboard-freshness.md
+++ b/tests/testthat/_snaps/dashboard-freshness.md
@@ -56,6 +56,24 @@
       i Looked for it relative to 'toy_parent.qmd''s own directory (Quarto's include-resolution rule).
       i A dead include target fails at Quarto render time; fix the path or restore the file.
 
+# .cdf_data_staleness_threshold_hours aborts informatively on an unparseable value (#695 rescope, fail-loud-not-null.md)
+
+    Code
+      .cdf_data_staleness_threshold_hours()
+    Condition
+      Error in `.cdf_data_staleness_threshold_hours()`:
+      x `HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS` is set to "not-a-number", which is not a non-negative number of days.
+      i Unset it to use the default (14 days), or set it to a non-negative number.
+
+# .cdf_data_staleness_threshold_hours aborts informatively on a negative value
+
+    Code
+      .cdf_data_staleness_threshold_hours()
+    Condition
+      Error in `.cdf_data_staleness_threshold_hours()`:
+      x `HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS` is set to "-1", which is not a non-negative number of days.
+      i Unset it to use the default (14 days), or set it to a non-negative number.
+
 # key .cdf_* function signatures are stable
 
     Code
@@ -142,6 +160,22 @@
       args(.cdf_git_last_commit_time)
     Output
       function (abs_path, repo_root) 
+      NULL
+
+---
+
+    Code
+      args(.cdf_data_staleness_threshold_hours)
+    Output
+      function () 
+      NULL
+
+---
+
+    Code
+      args(.cdf_data_staleness_over_threshold)
+    Output
+      function (data_stale, threshold_hrs) 
       NULL
 
 ---

--- a/tests/testthat/test-dashboard-freshness.R
+++ b/tests/testthat/test-dashboard-freshness.R
@@ -643,6 +643,75 @@ test_that(".cdf_check_data_staleness surfaces unknown (never-built) references v
   expect_equal(noted[["toy_dashboard.qmd"]], "never_built_target")
 })
 
+# ── Escalation policy (#695 rescope) ────────────────────────────────────────
+# Check 2 (source staleness) gets ZERO grace once HD_FAIL_ON_STALE_DASHBOARDS
+# is set; Check 3 (data staleness) gets a configurable grace period via
+# HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS (default 14 days). See this file's
+# "ESCALATION POLICY" header comment for the full rationale.
+
+test_that(".cdf_check_source_staleness flags a page stale even when the gap is a single hour (zero grace at the detection level, #695 rescope)", {
+  # There is no minimum-age parameter to .cdf_check_source_staleness() --
+  # unlike Check 3's threshold, ANY positive gap is reported stale. This pins
+  # that as a deliberate fact: Check 2 escalation (tested at the .cdf_main()
+  # driver level is impractical here -- it needs a real manifest/store, see
+  # this file's header comment on why .cdf_main() itself is not unit-tested)
+  # has nothing to gate on except "is `stale` non-empty", which this proves
+  # is true for even a tiny gap.
+  repo <- .make_scratch_git_repo()
+  .commit_file_at(repo, "toy_dashboard.html", "old render", "2026-01-01T00:00:00")
+  .commit_file_at(repo, "toy_dashboard.qmd", "```{r}\n1+1\n```", "2026-01-01T01:00:00")
+  result <- .cdf_check_source_staleness(file.path(repo, "toy_dashboard.qmd"), repo)
+  expect_equal(names(result$stale), "toy_dashboard.qmd")
+  expect_equal(result$stale[["toy_dashboard.qmd"]], 1 / 24, tolerance = 0.01)
+})
+
+test_that(".cdf_data_staleness_threshold_hours defaults to 14 days when the env var is unset", {
+  withr::local_envvar(c(HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS = NA))
+  expect_equal(.cdf_data_staleness_threshold_hours(), 14 * 24)
+})
+
+test_that(".cdf_data_staleness_threshold_hours honours HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS when set", {
+  withr::local_envvar(c(HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS = "7"))
+  expect_equal(.cdf_data_staleness_threshold_hours(), 7 * 24)
+  withr::local_envvar(c(HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS = "0"))
+  expect_equal(.cdf_data_staleness_threshold_hours(), 0)
+})
+
+test_that(".cdf_data_staleness_threshold_hours aborts informatively on an unparseable value (#695 rescope, fail-loud-not-null.md)", {
+  withr::local_envvar(c(HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS = "not-a-number"))
+  expect_snapshot(error = TRUE, .cdf_data_staleness_threshold_hours())
+})
+
+test_that(".cdf_data_staleness_threshold_hours aborts informatively on a negative value", {
+  withr::local_envvar(c(HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS = "-1"))
+  expect_snapshot(error = TRUE, .cdf_data_staleness_threshold_hours())
+})
+
+test_that(".cdf_data_staleness_over_threshold does not flag a page whose gap is under the threshold", {
+  data_stale <- list("toy_dashboard.qmd" = list(gap_hrs = 100, source = "build_info() footer"))
+  expect_equal(.cdf_data_staleness_over_threshold(data_stale, threshold_hrs = 14 * 24), character(0))
+})
+
+test_that(".cdf_data_staleness_over_threshold flags a page whose gap is over the threshold", {
+  data_stale <- list("toy_dashboard.qmd" = list(gap_hrs = 400, source = "build_info() footer"))
+  expect_equal(.cdf_data_staleness_over_threshold(data_stale, threshold_hrs = 14 * 24), "toy_dashboard.qmd")
+})
+
+test_that(".cdf_data_staleness_over_threshold is a strict >, not >=, at the boundary", {
+  data_stale <- list("toy_dashboard.qmd" = list(gap_hrs = 336, source = "build_info() footer"))
+  expect_equal(.cdf_data_staleness_over_threshold(data_stale, threshold_hrs = 336), character(0))
+  data_stale_over <- list("toy_dashboard.qmd" = list(gap_hrs = 336.1, source = "build_info() footer"))
+  expect_equal(.cdf_data_staleness_over_threshold(data_stale_over, threshold_hrs = 336), "toy_dashboard.qmd")
+})
+
+test_that(".cdf_data_staleness_over_threshold partitions a mix of under- and over-threshold pages correctly", {
+  data_stale <- list(
+    "under.qmd" = list(gap_hrs = 45.9, source = "build_info() footer"), # #695's own measured gap
+    "over.qmd"  = list(gap_hrs = 1524, source = "build_info() footer") # #695's own measured worst-case gap
+  )
+  expect_equal(.cdf_data_staleness_over_threshold(data_stale, threshold_hrs = 14 * 24), "over.qmd")
+})
+
 # ── Function signature stability (catches API drift, snapshot-test-policy.md) ──
 
 test_that("key .cdf_* function signatures are stable", {
@@ -657,5 +726,7 @@ test_that("key .cdf_* function signatures are stable", {
   expect_snapshot(args(.cdf_check_data_staleness))
   expect_snapshot(args(.cdf_page_render_time))
   expect_snapshot(args(.cdf_git_last_commit_time))
+  expect_snapshot(args(.cdf_data_staleness_threshold_hours))
+  expect_snapshot(args(.cdf_data_staleness_over_threshold))
   expect_snapshot(args(.cdf_main))
 })


### PR DESCRIPTION
## Summary

Implements the escalation policy #695 was rescoped to decide: split
`HD_FAIL_ON_STALE_DASHBOARDS` into two grace periods (source staleness =
zero, data staleness = 14-day threshold), and add a weekly workflow that
actually runs the escalating checker instead of leaving it as an unset
switch.

Refs #695

## Part 1 — split the two staleness kinds

`scripts/check_dashboard_freshness.R`:

- Check 2 (source staleness — a page's `.qmd` committed newer than its own
  `.html`) keeps **zero grace**: a human edit that never reached readers is
  wrong the moment it happens, not after N days. Functionally unchanged
  from before this PR — I made the "zero grace" property explicit in the
  header comment and in the escalation message text, and added a test
  (`.cdf_check_source_staleness flags a page stale even when the gap is a
  single hour`) pinning that there is no minimum-age parameter.
- Check 3 (data staleness — the pipeline rebuilt after a page rendered) now
  gets a configurable grace period via `HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS`
  (default **14 days**). Measured 2026-08-22: two pages
  (`falsification.qmd`, `european-overlay.qmd`) became data-stale within
  **45.9 hours** of a routine `tar_make()` that touched neither page's own
  source. A zero-grace threshold there would be permanently red days after
  every build — the exact "check nobody reads" failure mode #695 already
  named for redirect stubs, recurring for a second reason.
- Invalid `HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS` (unparseable, negative)
  aborts loudly rather than silently falling back to the default
  (`.claude/rules/fail-loud-not-null.md`).

### One switch, not two (the decision this issue asked me to make and argue)

I kept a **single** `HD_FAIL_ON_STALE_DASHBOARDS` switch, with each check
applying its own threshold (Check 2 fixed at zero, Check 3 configurable),
rather than adding separate `HD_FAIL_ON_STALE_SOURCE` /
`HD_FAIL_ON_STALE_DATA` switches.

Argument for: the two checks already differ by *threshold*, which is the
axis that actually needs tuning (Check 3's grace period is genuinely a
judgment call; Check 2's is not — it should always be zero). A second on/off
switch on top would let someone configure "escalate data staleness but not
source staleness," which inverts the priority — source staleness is the
clearer-cut defect of the two and is the one that should never be left
unescalated. Fewer knobs is also fewer states for a reader of a CI failure
to reason about.

Argument against (stated in the code comment, not acted on): a caller might
genuinely want Check 3 enforcement without Check 2 enforcement, or vice
versa — e.g. the new weekly workflow enforces Check 2 but structurally
*cannot* run Check 3 at all (see Part 2), so in this specific case the
single switch's "escalates both" semantics only ever bites on Check 2
in CI. If a caller needs the split, add a second switch then; nobody has
needed it yet.

## Part 2 — weekly enforcing workflow

`.github/workflows/dashboard-freshness.yml`, modelled on `link-audit.yml`
(same nix-installer-action config, same `permissions:` block, same
`peter-evans/create-issue-from-file@v5` failure-issue pattern, same artifact
upload).

- **Weekly** (Monday 08:00 UTC), not daily: re-rendering a stale page is a
  ~20-minute human act (#695's own evidence re-rendering the 9 pages it
  originally flagged). A daily nag would arrive faster than anyone could act
  on it and would be muted within a fortnight — the exact fate #695
  documents for a check nobody reads, now for a schedule instead of a
  filter.
- Runs `scripts/check_dashboard_freshness.R` (Check 1 + Check 2 only) with
  `HD_FAIL_ON_STALE_DASHBOARDS=1`.

### Check 3 (data staleness) does not run in CI — stated plainly

**This is a real, permanent limitation, not a TODO.** Check 3 needs a real
`targets` store (`tar_meta()` against `docs/_targets`); a GitHub Actions
runner starts with none, and building one here would mean running the full
`tar_make()` on every scheduled run (expensive) AND producing a store that
is *not* the main checkout's — exactly the race `scripts/build.sh` already
refuses to risk by declining to run from a linked worktree (see
`.claude/CLAUDE.md` and the `worktree-location` rule; a CI runner is never
the main checkout either).

So: **this workflow enforces "no dead references, no unpublished source
edits" — not "all dashboard data is fresh."** The 14-day Check 3 threshold
is enforced only when a human runs `scripts/build.sh --render` in the main
checkout. I did not implement a way to close this gap. One I can describe
but am not proposing to build silently: commit a small snapshot of
`tar_meta()`'s target-name + build-time columns as a build artifact
whenever `scripts/build.sh` runs in the main checkout, then have this
workflow diff page render-times against that snapshot instead of a live
store. That adds a second provenance surface to keep in sync with the real
store, which is why I left it as a description in the workflow's header
comment rather than building it.

## Part 3 — `scripts/verify.sh` deliberately untouched

`verify.sh` answers "is *this change* correct?" — it runs per-change, in
worktrees, by agents. Whether previously-published HTML has gone stale has
nothing to do with that question. Wiring staleness in as a failure there
would train everyone to see a red `verify.sh` and shrug it off, which costs
the gate that actually catches real regressions (parse errors, structural
DAG breaks, dead target references, test failures). I made no change to
`verify.sh`'s existing informational-only dashboard-freshness reporting.

## Tests

Extended `tests/testthat/test-dashboard-freshness.R` (`local_edition(3)`
already at the top):

- `.cdf_check_source_staleness` still flags a page stale at a 1-hour gap —
  pins zero grace at the detection layer.
- `.cdf_data_staleness_threshold_hours()`: defaults to 14 days when unset;
  honours `HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS` when set (including `0`);
  aborts (snapshot-tested) on an unparseable or negative value.
- `.cdf_data_staleness_over_threshold()` (new, extracted for testability):
  under-threshold not flagged, over-threshold flagged, strict `>` at the
  boundary, and a mixed under/over partition using #695's own measured gaps
  (45.9h under, 1524h over the 14-day/336h line).
- New function signatures added to the existing signature-stability
  snapshot block.

Caught one real bug in review: my first draft of the threshold-abort
message used `{.val {.CDF_DEFAULT_DATA_STALENESS_THRESHOLD_DAYS}}`, which
`cli` >=3.4.0 rejects (a `{}` literal cannot start with a dot). Fixed by
assigning to a local variable before interpolating. Caught by running the
new tests before committing, not by inspection.

## Verify

**1. Checker against the real tree, both with and without the escalation switch:**

Without (`nix develop --command Rscript scripts/check_dashboard_freshness.R`):
```
--- targets::tar_manifest(docs/_targets.R): 768 targets (8.02s) ---

=== Check 1: dead target references ===
PASS: no dead target references across 15 page(s), 138 distinct target reference(s)

=== Check 2: source-vs-render staleness (git commit date, .qmd vs .html) ===
  [STUB] excluded 4 redirect stub page(s) -- no R chunks + <meta refresh> marker; their .qmd will always postdate their .html, so reporting them STALE forever is not a real signal: drif.qmd, factor-max.qmd, jst-dashboard.qmd, negative-results.qmd
PASS: no page's .qmd source is newer than its committed .html

=== scripts/check_dashboard_freshness.R: PASS ===
::VERIFY:DASHBOARD_FRESHNESS_STATUS:: 0
```

With `HD_FAIL_ON_STALE_DASHBOARDS=1` — identical result (nothing is
currently source-stale, so the switch doesn't change the outcome today):
```
=== Check 1: dead target references ===
PASS: no dead target references across 15 page(s), 138 distinct target reference(s)

=== Check 2: source-vs-render staleness (git commit date, .qmd vs .html) ===
  [STUB] excluded 4 redirect stub page(s) -- ... drif.qmd, factor-max.qmd, jst-dashboard.qmd, negative-results.qmd
PASS: no page's .qmd source is newer than its committed .html

=== scripts/check_dashboard_freshness.R: PASS ===
::VERIFY:DASHBOARD_FRESHNESS_STATUS:: 0
```

Check 1's numbers are unchanged (138 refs / 15 pages / 0 dead) and Check 2
still passes with the same 4 stubs excluded — extraction was not touched by
this PR.

**2. Workflow YAML parses** — confirmed with
`yaml::read_yaml(".github/workflows/dashboard-freshness.yml")`: `on:` keys
resolve to `schedule` (cron `0 8 * * 1`) + `workflow_dispatch`,
`permissions:` resolves to `contents: read, issues: write`, and the
`dashboard-freshness` job has 5 steps and `timeout-minutes: 15`. (`yaml`
package renders the `on:` key as boolean `TRUE` per the YAML 1.1
bareword-boolean quirk — the same happens for every other workflow in this
repo when read the same way; GitHub's own parser special-cases `on:` and is
unaffected.) `actionlint` is not available in this environment, so I could
not run a GitHub-Actions-schema-aware validator — this is a real gap, not a
claim of full coverage.

**3. `scripts/verify.sh`**, foreground, full run:
```
=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

=== scripts/verify.sh: PASS ===
```
Both baselines match exactly (root `failed=3 skipped=0`, package
`failed=1 skipped=15`) — the new tests I added all pass; no failure
signatures changed.

**4. Could not trigger the workflow itself** — I have no way to fire a
`workflow_dispatch` or wait for the Monday cron from this worktree/PR. What
I *did* execute: the underlying R logic (`check_dashboard_freshness.R`) run
directly with the exact env var the workflow sets, and the workflow YAML
parsed structurally. What I reasoned about rather than ran: the `nix
develop --command Rscript ...` step inside the actual GitHub Actions runner
environment (DeterminateSystems nix installer, ubuntu-latest, the
`rstats-on-nix` cache) — I'm relying on `link-audit.yml`'s and
`r-tests.yml`'s use of the identical installer config as precedent that
this pattern works in this repo's CI; the `create-issue-from-file` failure
path (labels auto-create on first fire, per `link-audit.yml`'s `deploy`/
`link-audit` labels which don't exist as repo labels today either); and the
artifact-upload step, none of which I can exercise locally.

## Test plan

- [x] `scripts/verify.sh` full run — PASS, baselines match exactly
- [x] `scripts/check_dashboard_freshness.R` run directly, with and without
      `HD_FAIL_ON_STALE_DASHBOARDS=1` — both PASS, Check 1/2 numbers unchanged
- [x] New unit tests for the threshold helpers (default, override, abort,
      boundary) and the zero-grace source-staleness case
- [x] Workflow YAML structurally parses
- [ ] Cannot verify the workflow actually fires in GitHub Actions from this PR
