### PR TITLE
fix(dashboard-freshness): validate threshold unconditionally + normalise tzone in Check 3

### DIFF
--- a/scripts/check_dashboard_freshness.R
+++ b/scripts/check_dashboard_freshness.R
@@ -565,6 +565,30 @@ suppressPackageStartupMessages({
 # Shared helpers
 # ---------------------------------------------------------------------------
 
+# Forces a POSIXct vector's `tzone` attribute to "UTC" WITHOUT altering the
+# instant(s) it represents. POSIXct's underlying value is always epoch
+# seconds (timezone-independent); the `tzone` attribute only controls how the
+# value FORMATS for display, so reassigning it is a pure relabelling, never a
+# time shift -- `unclass()` of the result is identical to `unclass()` of the
+# input. Call this immediately before comparing/subtracting two POSIXct
+# values that may carry different EXPLICIT `tzone` attributes: R's
+# `Ops.POSIXt` (`>`, `<`, `==`, ...) and `difftime()` both route through
+# `.check_tzones()`, which warns ("'tzone' attributes are inconsistent")
+# whenever both operands carry a non-NULL `tzone` attribute and those
+# attributes differ -- even when the comparison is already numerically
+# correct (#714). Concretely: the committed metadata snapshot's times are
+# parsed with an explicit `tz = "UTC"` (.cdf_parse_snapshot_time()); a page's
+# render time is parsed with an explicit `tz = Sys.timezone()`
+# (.cdf_page_render_time()) -- comparing the two unmodified warns on every
+# snapshot-backed Check 3 run. `targets::tar_meta()`'s live-store times carry
+# NO explicit `tzone` attribute, which is why the live-store path never
+# warned: `.check_tzones()` only compares attributes that are actually
+# present, and a single explicit attribute plus a NULL one is not a mismatch.
+.cdf_force_utc_tzone <- function(t) {
+  attr(t, "tzone") <- "UTC"
+  t
+}
+
 # Parses an env var as a boolean flag against a fixed, explicit vocabulary --
 # NEVER `isTRUE(as.logical(Sys.getenv(...)))`: as.logical("1") is NA, not
 # TRUE, which would silently default the flag OFF. See
@@ -995,9 +1019,21 @@ suppressPackageStartupMessages({
     render <- .cdf_page_render_time(html_path, repo_root)
     if (is.na(render$time)) next
 
-    if (max_target_time > render$time) {
+    # Normalise both operands' `tzone` attribute to "UTC" before comparing --
+    # `max_target_time` may come from the committed snapshot (explicit
+    # tz="UTC") or a live store (no explicit tzone); `render$time` always
+    # carries an explicit tz=Sys.timezone(). Left unmodified, the snapshot
+    # path's mismatched explicit attributes make every comparison/difftime()
+    # below warn ("'tzone' attributes are inconsistent", #714) -- this does
+    # NOT change either value's underlying instant (see
+    # .cdf_force_utc_tzone()), so the comparison outcome and gap_hrs are
+    # unchanged, only the warning is gone.
+    max_target_time_utc <- .cdf_force_utc_tzone(max_target_time)
+    render_time_utc <- .cdf_force_utc_tzone(render$time)
+
+    if (max_target_time_utc > render_time_utc) {
       stale[[base]] <- list(
-        gap_hrs = as.numeric(difftime(max_target_time, render$time, units = "hours")),
+        gap_hrs = as.numeric(difftime(max_target_time_utc, render_time_utc, units = "hours")),
         source = render$source
       )
     }
@@ -1032,6 +1068,26 @@ suppressPackageStartupMessages({
 # with whatever status this function returns, since those are each their
 # own standalone process with nothing left to run afterward.
 .cdf_main <- function(data_staleness = FALSE, repo_root = here::here()) {
+  # Validate HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS whenever it is SET,
+  # unconditionally -- INDEPENDENT of `data_staleness` (#710). Previously
+  # this call lived only inside the `if (data_staleness)` branch far below
+  # (originally ~L938, now the Check 3 section), so a malformed value was
+  # silently ignored in the mode that is hardest to reach a real store from:
+  # default mode (Check 1 + Check 2 only), which is exactly what the weekly
+  # dashboard-freshness workflow and scripts/verify.sh both run. Setting the
+  # env var is an expression of intent regardless of which checks execute
+  # this session; per .claude/rules/fail-loud-not-null.md ("validate at
+  # every boundary, in both directions"), an unparseable or negative value
+  # must abort here too, not only when --data-staleness happens to also be
+  # passed. .cdf_data_staleness_threshold_hours() itself already no-ops
+  # (returns the default silently) when the var is unset -- see its own
+  # `nzchar(raw)` guard -- so this call is safe to make unconditionally; the
+  # return value is discarded here on purpose, this call exists solely for
+  # its validation side effect. Check 3 below still calls it again when it
+  # actually needs the parsed threshold, which is cheap and deterministic
+  # given the same env var.
+  .cdf_data_staleness_threshold_hours()
+
   docs_dir <- file.path(repo_root, "docs")
 
   cat("=== scripts/check_dashboard_freshness.R ===\n")

--- a/tests/testthat/_snaps/dashboard-freshness.md
+++ b/tests/testthat/_snaps/dashboard-freshness.md
@@ -74,6 +74,15 @@
       x `HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS` is set to "-1", which is not a non-negative number of days.
       i Unset it to use the default (14 days), or set it to a non-negative number.
 
+# .cdf_main aborts on a malformed HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS in DEFAULT mode, not only under --data-staleness (#710)
+
+    Code
+      .cdf_main(data_staleness = FALSE, repo_root = "/nonexistent-repo-root-for-this-test")
+    Condition
+      Error in `.cdf_data_staleness_threshold_hours()`:
+      x `HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS` is set to "banana", which is not a non-negative number of days.
+      i Unset it to use the default (14 days), or set it to a non-negative number.
+
 # .cdf_write_meta_snapshot aborts if a real target collides with the reserved sentinel name
 
     Code

--- a/tests/testthat/test-dashboard-freshness.R
+++ b/tests/testthat/test-dashboard-freshness.R
@@ -625,6 +625,53 @@ test_that(".cdf_check_data_staleness cannot flag a redirect stub: end-to-end, a 
   expect_equal(result, list())
 })
 
+test_that(".cdf_force_utc_tzone relabels tzone without altering the underlying instant (#714)", {
+  local_time <- as.POSIXct("2026-01-01 12:00:00", tz = "America/New_York")
+  utc_labelled <- .cdf_force_utc_tzone(local_time)
+  expect_equal(attr(utc_labelled, "tzone"), "UTC")
+  # as.numeric() strips every attribute, leaving the raw epoch-seconds value
+  # -- proving the relabel changes only the `tzone` attribute (which governs
+  # print formatting), never the instant itself. (unclass() alone is NOT a
+  # valid check here: it strips only the `class` attribute, `tzone` is a
+  # separate, unrelated attribute unclass() leaves untouched.)
+  expect_equal(as.numeric(utc_labelled), as.numeric(local_time))
+})
+
+test_that(".cdf_check_data_staleness against a snapshot-style (explicit tz='UTC') meta_time emits ZERO tzone warnings and matches the live-store-style (no explicit tzone) answer (#714)", {
+  repo <- .make_scratch_git_repo()
+  html <- "<html><body><strong>Built</strong> 2026-01-01 00:00:00</body></html>"
+  qmd_path <- .commit_file_at(repo, "toy_dashboard.qmd", "source", "2026-01-01T00:00:00")
+  .commit_file_at(repo, "toy_dashboard.html", html, "2026-01-01T00:00:00")
+  page_targets <- list("toy_dashboard.qmd" = "some_target")
+
+  # "Live store"-style meta_time: no explicit tzone attribute, the shape
+  # targets::tar_meta() returns -- this is the path #714 confirmed never
+  # warned.
+  meta_time_live <- stats::setNames(
+    as.POSIXct("2026-01-05 00:00:00", tz = Sys.timezone()),
+    "some_target"
+  )
+  attr(meta_time_live, "tzone") <- NULL
+  result_live <- expect_no_warning(
+    .cdf_check_data_staleness(qmd_path, page_targets, meta_time_live, repo)
+  )
+
+  # "Snapshot"-style meta_time: explicit tz="UTC", exactly what
+  # .cdf_parse_snapshot_time() produces -- this is the path #714 found
+  # emitting ten 'tzone attributes are inconsistent' warnings.
+  meta_time_snapshot <- stats::setNames(
+    as.POSIXct("2026-01-05 00:00:00", tz = "UTC"),
+    "some_target"
+  )
+  result_snapshot <- expect_no_warning(
+    .cdf_check_data_staleness(qmd_path, page_targets, meta_time_snapshot, repo)
+  )
+
+  expect_equal(result_snapshot, result_live)
+  expect_equal(names(result_snapshot), "toy_dashboard.qmd")
+  expect_equal(result_snapshot[["toy_dashboard.qmd"]]$gap_hrs, 96, tolerance = 0.1)
+})
+
 test_that(".cdf_check_data_staleness surfaces unknown (never-built) references via note_fn without failing", {
   repo <- .make_scratch_git_repo()
   html <- paste0("<html><body><strong>Built</strong> 2026-01-01 00:00:00</body></html>")
@@ -685,6 +732,20 @@ test_that(".cdf_data_staleness_threshold_hours aborts informatively on an unpars
 test_that(".cdf_data_staleness_threshold_hours aborts informatively on a negative value", {
   withr::local_envvar(c(HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS = "-1"))
   expect_snapshot(error = TRUE, .cdf_data_staleness_threshold_hours())
+})
+
+test_that(".cdf_main aborts on a malformed HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS in DEFAULT mode, not only under --data-staleness (#710)", {
+  # Pins the #710 fix: .cdf_data_staleness_threshold_hours() validation now
+  # runs as literally the FIRST statement inside .cdf_main(), before
+  # docs_dir/repo_root are touched -- so this aborts before doing anything
+  # that needs a real repo, and repo_root need not point at a real checkout.
+  # Before the fix, this call ran clean (no output, no abort) because
+  # data_staleness = FALSE meant the validating call was never reached.
+  withr::local_envvar(c(HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS = "banana"))
+  expect_snapshot(
+    error = TRUE,
+    .cdf_main(data_staleness = FALSE, repo_root = "/nonexistent-repo-root-for-this-test")
+  )
 })
 
 test_that(".cdf_data_staleness_over_threshold does not flag a page whose gap is under the threshold", {


### PR DESCRIPTION
## Summary

Two related defects in `scripts/check_dashboard_freshness.R`, fixed together
since they live in the same file.

### Part A — threshold validated only in `--data-staleness` mode

`.cdf_data_staleness_threshold_hours()` was called only inside the
`if (data_staleness)` block, so `HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS` was
validated only when Check 3 ran. A malformed value (e.g. `banana`) passed
silently in default mode — the mode `scripts/verify.sh` and, in some
configurations, the weekly workflow run.

**Fix:** the validating call now happens as the literal first statement
inside `.cdf_main()`, unconditionally. `.cdf_data_staleness_threshold_hours()`
already no-ops (returns the default) when the var is unset, via its own
`nzchar(raw)` guard, so calling it unconditionally is safe — the abort only
fires when the var is *set* to something unparseable or negative. This is the
pattern `.claude/rules/fail-loud-not-null.md` prescribes ("validate at every
boundary, in both directions").

**Before:**
```
$ HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS=banana Rscript scripts/check_dashboard_freshness.R
=== scripts/check_dashboard_freshness.R: PASS ===   # silent — no complaint at all
```

**After:**
```
$ HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS=banana Rscript scripts/check_dashboard_freshness.R
Error in `.cdf_data_staleness_threshold_hours()`:
✖ `HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS` is set to "banana", which is
  not a non-negative number of days.
ℹ Unset it to use the default (14 days), or set it to a non-negative number.
Execution halted
```

A valid value still works cleanly in both modes (verified: default mode
Check 1 = 138 refs/15 pages/0 dead, Check 2 PASS with 4 stubs excluded — no
change from before).

### Part B — 10 `tzone` warnings on the snapshot-backed Check 3 path

Running `--data-staleness` against the committed
`docs/_targets_meta_snapshot.csv` (no live store — the CI path from #713)
emitted ten `'tzone' attributes are inconsistent` warnings. The live-store
path emitted none.

**Root cause:** `.cdf_parse_snapshot_time()` parses the snapshot's times with
an explicit `tz = "UTC"`; `.cdf_page_render_time()` parses a page's render
time with an explicit `tz = Sys.timezone()`. Comparing/subtracting two
POSIXct values that each carry a *different, explicit* `tzone` attribute
triggers R's `.check_tzones()` warning, even though the comparison is
numerically correct — `targets::tar_meta()`'s live-store times carry no
explicit `tzone` at all, which is why that path never warned (only one
side's attribute is present, so nothing to compare).

**Fix:** added `.cdf_force_utc_tzone()`, applied at the comparison/`difftime()`
site in `.cdf_check_data_staleness()`. It only reassigns the `tzone`
*attribute* — POSIXct's underlying value is always epoch seconds, so this
never shifts the instant, only removes the mismatched label. No re-parsing,
no re-interpretation of the wall-clock strings.

**Before/after, run against the committed snapshot (this worktree has no
`docs/_targets` store — that is the path in question):**

Before (from #714's own repro): 10× `In .check_tzones(e1, e2) : 'tzone'
attributes are inconsistent`.

After:
```
=== Check 3: data staleness (page render time vs newest tar_meta() time of its own targets) ===
Check 3 data source: COMMITTED SNAPSHOT (.../docs/_targets_meta_snapshot.csv)
  generated_at=2026-08-22 18:43:20 UTC, age=0.6h (max allowed 168.0h / 7 day(s), HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS)
STALE: 2 page(s) have target data newer than their rendered output:
  [DATA-STALE] falsification.qmd -- referenced target(s) rebuilt 45.9 hour(s) after render (render time source: build_info() footer)
  [DATA-STALE] leaderboard.qmd -- referenced target(s) rebuilt 45.9 hour(s) after render (render time source: build_info() footer)
=== scripts/check_dashboard_freshness.R: PASS ===
```
Zero warnings in the full output. **Verdict is byte-identical to before the
fix** — same two pages (`falsification.qmd`, `leaderboard.qmd`), same 45.9h
gap for both — confirming the tz fix changed only the attribute, not the
arithmetic.

## Tests added

- `.cdf_force_utc_tzone relabels tzone without altering the underlying
  instant (#714)` — proves the relabel is a pure attribute change
  (`as.numeric()` unchanged).
- `.cdf_check_data_staleness against a snapshot-style (explicit tz='UTC')
  meta_time emits ZERO tzone warnings and matches the live-store-style (no
  explicit tzone) answer (#714)` — wraps both the live-store-shaped and
  snapshot-shaped `meta_time` inputs in `expect_no_warning()` and asserts
  identical results, so a future change that reintroduces the mismatch is
  caught by CI, not by a human running the script by hand.
- `.cdf_main aborts on a malformed HD_STALE_DASHBOARD_DATA_THRESHOLD_DAYS in
  DEFAULT mode, not only under --data-staleness (#710)` — pins the fix at the
  `.cdf_main()` driver level; validation runs before `docs_dir`/`repo_root`
  are ever touched, so the test needs no real repo.

## Verification

- Check 1: `138 refs / 15 pages / 0 dead` — unchanged.
- Check 2: PASS, 4 stubs excluded — unchanged.
- `scripts/verify.sh` (full, foreground): root `total=672 failed=3 skipped=0`,
  package `total=695 failed=1 skipped=15` — both match the documented
  baselines exactly, `PASS: failures match the known baseline exactly` for
  both suites.
- `tests/testthat/test-dashboard-freshness.R`: 82 test groups, all pass, one
  new snapshot accepted (the new `.cdf_main` abort message).

Refs #710, #714
