### PR TITLE
fix(cmr): correct ann_factor from monthly (12) to daily (252) (#717)

### DIFF
--- a/R/plan_commodities_mean_reversion.R
+++ b/R/plan_commodities_mean_reversion.R
@@ -11,7 +11,16 @@
 #
 # Data: re-uses commodities_raw + commodities_returns from
 #       plan_commodities_momentum.R (DO NOT re-define those targets here).
-# Frequency: monthly (ann_factor = 12).
+# Frequency: DAILY (ann_factor = 252). #717: the universe mixes 13 FRED
+#   monthly price indexes with 24 Yahoo Finance daily futures/ETF series
+#   (scripts/fetch_commodities.R); the 24 daily series dominate the merged
+#   `date` column (~96% of rows; measured 2026-08-22: 147821 total rows,
+#   142426 from `source == "yahoo"`), so cmr_portfolio_1m/3m/6m -- one row
+#   per unique date in the combined universe -- are themselves daily series
+#   (median gap between dates = 1 day), not monthly, despite every function
+#   in this file being named/commented as if they were. Verified against
+#   scripts/fetch_commodities.R + data/raw/commodities.parquet directly for
+#   #717, not merely re-asserted from this comment's own prior (wrong) text.
 # Look-ahead safety: signal at t uses returns through t-1 only.
 # Execution: signal at t -> trade at t+1 close.
 # Transaction cost: 0.2% per trade (same as commodity momentum, #134).
@@ -95,15 +104,15 @@ plan_commodities_mean_reversion <- function() {
     # Sharpe, MDD, max DD duration (hd_dd_duration from risk_metrics.R).
 
     targets::tar_target(cmr_metrics_1m, {
-      .compute_cmr_metrics(cmr_portfolio_1m, lookback = "1m", stk_rf = stk_rf, ann_factor = 12L)
+      .compute_cmr_metrics(cmr_portfolio_1m, lookback = "1m", stk_rf = stk_rf, ann_factor = 252L)
     }),
 
     targets::tar_target(cmr_metrics_3m, {
-      .compute_cmr_metrics(cmr_portfolio_3m, lookback = "3m", stk_rf = stk_rf, ann_factor = 12L)
+      .compute_cmr_metrics(cmr_portfolio_3m, lookback = "3m", stk_rf = stk_rf, ann_factor = 252L)
     }),
 
     targets::tar_target(cmr_metrics_6m, {
-      .compute_cmr_metrics(cmr_portfolio_6m, lookback = "6m", stk_rf = stk_rf, ann_factor = 12L)
+      .compute_cmr_metrics(cmr_portfolio_6m, lookback = "6m", stk_rf = stk_rf, ann_factor = 252L)
     }),
 
 
@@ -201,18 +210,98 @@ plan_commodities_mean_reversion <- function() {
   )
 }
 
-.compute_cmr_metrics <- function(portfolio_tbl, lookback, stk_rf, ann_factor = 12L) {
+#' Reconcile a declared `ann_factor` against the observed date frequency
+#'
+#' Guard from #717 (fail-loud-not-null.md Required Pattern 5): computes the
+#' median gap between the distinct, sorted dates in \code{dates} and aborts
+#' if that gap is inconsistent with \code{ann_factor}. This is deliberately
+#' placed at the point where \code{ann_factor} is SUPPLIED to
+#' \code{.compute_cmr_metrics()} -- not buried in the CAGR/vol arithmetic
+#' further down -- so a future caller that passes the wrong constant fails
+#' immediately, on the value it got wrong, rather than producing a
+#' plausible-looking but silently mis-annualised number (exactly what
+#' happened with \code{ann_factor = 12L} against CMR's actually-daily data).
+#'
+#' Uses the MEDIAN gap, not the mean or min: commodity data has real gaps
+#' (weekends, holidays, and -- because CMR's universe mixes 24 Yahoo daily
+#' futures/ETF series with 13 FRED monthly indexes, #717 -- occasional
+#' months where only the sparser monthly series print). The median is
+#' robust to that without a hand-tuned outlier filter. Bands are
+#' deliberately wide (e.g. daily tolerates gaps up to 3 days) to absorb long
+#' weekends/holiday clusters without false-positiving on a genuine daily
+#' series; they are not so wide that a real classification error (e.g.
+#' monthly data declared daily) would slip through undetected.
+#'
+#' @param dates A date vector (one entry per observation; duplicates and
+#'   unsorted input are handled).
+#' @param ann_factor Integer. The annualisation factor about to be used.
+#' @param lookback Character. Lookback label, used only for the abort message.
+#' @return `NULL`, invisibly. Called for its abort side effect.
+#' @noRd
+.assert_cmr_ann_factor <- function(dates, ann_factor, lookback) {
+  d <- sort(unique(as.Date(dates)))
+  if (length(d) < 3L) {
+    # Too few points for a frequency to be meaningfully observed.
+    return(invisible(NULL))
+  }
+  gaps <- as.numeric(diff(d))
+  median_gap <- stats::median(gaps)
+
+  expected_ann_factor <- dplyr::case_when(
+    median_gap <= 3   ~ 252L,  # daily (business days; weekends widen some gaps)
+    median_gap <= 10  ~ 52L,   # weekly
+    median_gap <= 45  ~ 12L,   # monthly
+    median_gap <= 135 ~ 4L,    # quarterly
+    TRUE ~ NA_integer_
+  )
+
+  if (is.na(expected_ann_factor)) {
+    cli::cli_abort(c(
+      "x" = paste0(
+        "CMR {lookback}: cannot classify the observed data frequency ",
+        "against declared ann_factor {ann_factor}."
+      ),
+      "i" = paste0(
+        "Median gap between observation dates is {median_gap} day{?s}, ",
+        "which does not match a recognised daily/weekly/monthly/quarterly band."
+      ),
+      "i" = "See .claude/rules/fail-loud-not-null.md Required Pattern 5."
+    ))
+  }
+
+  if (expected_ann_factor != ann_factor) {
+    cli::cli_abort(c(
+      "x" = paste0(
+        "CMR {lookback}: declared ann_factor ({ann_factor}) disagrees with ",
+        "the observed data frequency."
+      ),
+      "i" = paste0(
+        "Median gap between observation dates is {median_gap} day{?s}, ",
+        "consistent with ann_factor = {expected_ann_factor}, not {ann_factor}."
+      ),
+      "i" = "This is the reconciliation guard added for #717 -- see .claude/rules/fail-loud-not-null.md Required Pattern 5."
+    ))
+  }
+
+  invisible(NULL)
+}
+
+.compute_cmr_metrics <- function(portfolio_tbl, lookback, stk_rf, ann_factor = 252L) {
   library(dplyr)
 
   df <- portfolio_tbl |>
     dplyr::filter(!is.na(.data$net_ret)) |>
     dplyr::mutate(ym = format(as.Date(.data$date), "%Y-%m"))
 
+  # #717 guard: declared ann_factor must match the observed frequency of
+  # this portfolio's own dates, checked at the point ann_factor is supplied.
+  .assert_cmr_ann_factor(df$date, ann_factor, lookback)
+
   n <- nrow(df)
 
   if (n < 12L) {
     return(tibble::tibble(
-      lookback = lookback, n_months = n,
+      lookback = lookback, n_days = n,
       sharpe = NA_real_, cagr = NA_real_, vol = NA_real_, ann_rf = NA_real_,
       max_dd = NA_real_, avg_dd_duration = NA_real_, max_dd_duration = NA_real_
     ))
@@ -250,7 +339,7 @@ plan_commodities_mean_reversion <- function() {
   # belongs to the consumer (DT::datatable, plot label), not the producer.
   tibble::tibble(
     lookback        = lookback,
-    n_months        = n,
+    n_days          = n,
     sharpe          = round(sharpe, 3),
     cagr            = round(cagr, 4),
     vol             = round(vol, 4),
@@ -318,11 +407,16 @@ plan_commodities_mean_reversion <- function() {
     uuids[i] <- uu
 
     # PR 3/4 — record long-form metrics for this partition.
-    # Units (#640): cagr/vol/max_dd are decimal fractions per the "Unit
-    # convention (#336)" comment above, sharpe is a scale-free ratio,
-    # n_months is a count. avg_dd_duration/max_dd_duration are drawdown
-    # lengths measured in the return series' own periodicity (months, for
-    # CMR's monthly returns) — classified as "count" (periods), not "days".
+    # Units (#640, corrected #717): cagr/vol/max_dd are decimal fractions per
+    # the "Unit convention (#336)" comment above, sharpe is a scale-free
+    # ratio, n_days is a count. avg_dd_duration/max_dd_duration are drawdown
+    # lengths measured in the return series' own periodicity (days, for
+    # CMR's daily returns, #717) — classified as "count" (periods), not
+    # "days" [hd_metric_units()'s "days" unit type], matching the same
+    # count-of-periods convention every other daily strategy in this
+    # registry uses for its own period column (e.g. tom_units/aw_units
+    # classify n_days as "count", not "days" -- R/plan_turn_of_month.R,
+    # R/plan_avoid_worst.R).
     # ann_rf (#677 slice 4, #691) is a decimal fraction, same convention as
     # cagr (round(sr$ann_rf, 4) above, never *100).
     row <- cmr_summary[cmr_summary$lookback == p, , drop = FALSE]
@@ -330,7 +424,7 @@ plan_commodities_mean_reversion <- function() {
       metric_cols <- setdiff(names(row), "lookback")
       wide <- row[, metric_cols, drop = FALSE]
       cmr_units <- c(
-        n_months = "count", sharpe = "ratio", cagr = "fraction",
+        n_days = "count", sharpe = "ratio", cagr = "fraction",
         vol = "fraction", max_dd = "fraction",
         avg_dd_duration = "count", max_dd_duration = "count",
         ann_rf = "fraction"

--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -124,14 +124,16 @@ plan_leaderboard <- function() {
       # We create one synthetic "Full Period" row = the best lookback.
       # Source: R/plan_commodities_mean_reversion.R:210-221 already stores
       # cagr/vol/max_dd as FRACTION (documented convention, #336) -- no
-      # conversion needed here.
+      # conversion needed here. Column is n_days, not n_months (#717: CMR's
+      # data is daily, not monthly -- same explicit-rename pattern as
+      # .norm_tom/.norm_aw below, which map their own n_days into `months`).
       .norm_cmr <- function(m) {
         if (is.null(m) || nrow(m) == 0) return(NULL)
         best <- m |> filter(!is.na(sharpe)) |> arrange(desc(sharpe)) |> slice(1)
         if (nrow(best) == 0L) return(NULL)
         best |> transmute(
           period = "Full Period",
-          months = n_months,
+          months = n_days,
           cagr   = cagr,
           vol    = vol,
           sharpe = sharpe,

--- a/packages/historicaldata/tests/testthat/test-register-runs-stability.R
+++ b/packages/historicaldata/tests/testthat/test-register-runs-stability.R
@@ -110,9 +110,11 @@
 }
 
 .make_cmr_summary <- function() {
+  # Column is n_days, not n_months (#717: CMR's underlying data is daily,
+  # not monthly -- .compute_cmr_metrics() renamed the column at source).
   tibble::tibble(
     lookback        = c("1m", "3m", "6m"),
-    n_months        = c(100L, 98L, 95L),
+    n_days          = c(100L, 98L, 95L),
     sharpe          = c(-0.21, -0.18, -0.15),
     cagr            = c(-2.1, -1.8, -1.5),
     vol             = c(12.0, 11.5, 11.0),

--- a/tests/testthat/test-register-runs-tier3.R
+++ b/tests/testthat/test-register-runs-tier3.R
@@ -186,9 +186,11 @@ test_that(".cmr_register_runs schema and row counts are stable", {
   strategy_names <- .make_strategy_names_t3()
 
   # cmr_summary shape: lookback + metrics columns (decimal fractions per #336)
+  # Column is n_days, not n_months (#717: CMR's underlying data is daily,
+  # not monthly -- .compute_cmr_metrics() renamed the column at source).
   cmr_summary <- tibble::tibble(
     lookback        = c("1m", "3m", "6m"),
-    n_months        = c(48L, 48L, 48L),
+    n_days          = c(48L, 48L, 48L),
     sharpe          = c(-0.42, -0.31, -0.25),
     cagr            = c(-0.04, -0.03, -0.02),
     vol             = c(0.18, 0.17, 0.16),


### PR DESCRIPTION
## Summary

Fixes the CMR annualisation defect described in #717: `.compute_cmr_metrics()`
was called with `ann_factor = 12L` (monthly) against a return series that is
actually daily, understating vol ~4.6x and annualising CAGR over ~566 years
instead of ~27.

## Independent frequency confirmation

I did not take the issue's measurement on trust — I traced the data from
source and reconstructed `cmr_portfolio_1m` independently.

**`scripts/fetch_commodities.R`** fetches two sources into
`data/raw/commodities.parquet`: 20 FRED IMF price indexes (monthly) and 24
Yahoo Finance futures/ETF tickers (daily). Reading the raw parquet directly:

```
total rows: 147821
fred_imf:     5395 rows, 13 series, median 12.0 obs/year (monthly)
yahoo:      142426 rows, 24 series, median 251 obs/year  (daily)
```

The daily Yahoo series are ~96% of all rows. `calculate_commodity_returns()`,
`hd_commodity_mr_signal()`, and `hd_commodity_mr_portfolio()` all key on the
raw `date` column with no periodicity assumption — they treat every unique
date in the merged universe as one period. So the CMR portfolio is a daily
series in practice, not because any function says so, but because the
daily-dominated input drives it.

I reproduced `cmr_portfolio_1m` end-to-end (`calculate_commodity_returns()` →
`hd_commodity_mr_signal(lookback_months = 1L)` →
`hd_commodity_mr_portfolio(n_long=10, n_short=10, cost_bps=20)`) against the
live `data/raw/commodities.parquet` in this worktree:

```
rows: 6920
date range: 1992-03-01 to 2026-08-20  (span 34.5 years)
median gap between dates: 1 day
obs per year: 200.8
```

This matches the issue's cited numbers almost exactly (issue: 6852 rows to
2026-05-14; mine goes 3 months further since more Yahoo data has landed) —
**confirmed, not merely re-asserted**. The premise is correct.

## Changes

1. **`ann_factor = 252L`** in `.compute_cmr_metrics()`'s default parameter and
   at the three `cmr_metrics_1m/3m/6m` call sites
   (`R/plan_commodities_mean_reversion.R`).
2. **Renamed `n_months` → `n_days`** at source (both return branches of
   `.compute_cmr_metrics()`) and at every downstream consumer:
   - `.norm_cmr()` in `R/plan_leaderboard.R` (`months = n_months` →
     `months = n_days`) — same explicit-rename pattern `.norm_tom`/`.norm_aw`
     already use for their own daily counts.
   - The `cmr_units` registry map inside `.cmr_register_runs()`.
3. **Fixed the file header comment** (`R/plan_commodities_mean_reversion.R:14`,
   was `# Frequency: monthly (ann_factor = 12).`) — replaced with the daily
   frequency and the source evidence (FRED/Yahoo split, row counts) inline,
   so the next reader (human or agent) doesn't get misled the way #716's
   author was.
4. **`cmr_units` map**: confirmed nothing else in the map was wrong.
   `avg_dd_duration`/`max_dd_duration` stay classified `"count"` (not
   `hd_metric_units()`'s `"days"` unit) — I checked precedent: TOM and Avoid
   Worst are both genuinely-daily strategies and their own `n_days` columns
   are classified `"count"` too (`R/plan_turn_of_month.R`,
   `R/plan_avoid_worst.R`), so I kept CMR consistent with that established
   convention rather than inventing a new one. Updated the surrounding
   comment, which wrongly said "months, for CMR's monthly returns".

## Reconciliation guard (fail-loud-not-null.md Required Pattern 5)

Added `.assert_cmr_ann_factor(dates, ann_factor, lookback)`, called at the
top of `.compute_cmr_metrics()` — at the point `ann_factor` is *supplied*,
not buried in the CAGR/vol arithmetic further down.

It computes the **median** gap between the distinct sorted dates in the
portfolio (median, not mean/min, because commodity data has real gaps —
weekends, holidays, and occasional months where only the sparser FRED
series print) and maps it to an expected `ann_factor` via wide tolerance
bands (daily ≤3d → 252, weekly ≤10d → 52, monthly ≤45d → 12, quarterly
≤135d → 4). Aborts via `cli::cli_abort()` if the declared value disagrees,
or if the gap doesn't fall in any recognised band.

Verified directly (not just by unit test):

| Input | ann_factor | Result |
|---|---|---|
| Real `cmr_portfolio_1m` (daily) | 252L | passes |
| Real `cmr_portfolio_1m` (daily) | 12L | **aborts**: `"declared ann_factor (12) disagrees with the observed data frequency... consistent with ann_factor = 252, not 12"` |
| Toy monthly fixture (`test-cmr-units.R`, `seq.Date(by="month")`) | 12L | passes |

**Scope**: this is CMR-specific (`.assert_cmr_ann_factor`, `@noRd` in
`R/plan_commodities_mean_reversion.R`), per your instruction to keep it
scoped to CMR's helper. It is **not** directly reusable as-is elsewhere —
it's a small, self-contained function (median-gap → band → compare), so
generalising it to a shared helper other strategies' metrics functions
could call is straightforward mechanically, but I haven't done that here
since you said you're designing the general version separately.

## Tests / snapshots that changed

Two hidden dependents broke when `cmr_units`'s key changed from `n_months`
to `n_days` — both are synthetic test fixtures that hand-build a
`cmr_summary`-shaped tibble bypassing `.compute_cmr_metrics()` entirely, so
they didn't get the rename automatically:

1. `tests/testthat/test-register-runs-tier3.R` — `.cmr_register_runs schema
   and row counts are stable`. Fixture's `cmr_summary` had a literal
   `n_months` column; renamed to `n_days` (values unchanged, `c(48L, 48L,
   48L)`). This test only checks schema/row-counts/idempotency, not the
   count's numeric meaning, so no other change needed.
2. `packages/historicaldata/tests/testthat/test-register-runs-stability.R`
   — `cmr_register_runs writes 8 stability rows per lookback partition` and
   `cmr_register_runs with empty portfolio_list writes 0 stability rows`.
   Same fix: `.make_cmr_summary()`'s `n_months` column renamed to `n_days`
   (values unchanged, `c(100L, 98L, 95L)`).

**Why these are correct, not just silenced**: before the rename, both tests
failed with a **new hard `cli_abort`** from `hd_metric_record()` /
`.hd_validate_metric_units()` — the wide-form tibble had a numeric column
(`n_months`) with no matching entry in the renamed `cmr_units` vector, so
unit lookup returned `NA` and `.hd_validate_metric_units()` aborted
("Missing metric_unit for metric n_months"). This is not a re-encoding of a
wrong value — it's a column-name/schema fixture keeping pace with a
production rename, and I verified the abort message before and after to
confirm the mechanism, not just the outcome.

No other test in the repo references `n_months` in a CMR context — I
grepped explicitly. `test-cmr-units.R`'s toy fixtures use genuinely monthly
`seq.Date(by = "month")` dates and pass `ann_factor = 12L` explicitly; they
are unaffected by both the production `ann_factor` change (they don't rely
on the default) and the new guard (their declared 12L matches their actual
monthly spacing). `test-leaderboard-unit-scale.R` and
`test-leaderboard-coverage.R` each have their own **local, hand-duplicated**
copies of `.norm_cmr`/`.norm_mf`/`.norm_value` (by design — see their own
header comments) rather than sourcing `R/plan_leaderboard.R`, so they were
never affected.

## Related, discovered but NOT fixed (flagging per your instructions)

- **`R/plan_strategy_names.R`** — the project's single-source-of-truth
  strategy table still declares `cmr`'s `frequency = "monthly"` and
  `ann_factor = 12L` (row 11), which feeds `bt.strategy.frequency` /
  `bt.strategy.ann_factor` via `.cmr_register_runs()`. This is the same
  defect in a different file. I did not touch it because (a) it wasn't in
  your enumerated fix list, and (b) you said #716 needs a per-strategy
  periodicity table and to flag rather than edit if #716's CMR row must
  change — this table looks like exactly the kind of data #716 might read.
  Recommend a coordinated follow-up.
- **`.cmr_register_runs()`'s stability-metric call** (same file, ~line
  350ish) hardcodes `hd_record_stability_metrics(..., w = 36L, ann_factor =
  12L)` for CMR's SSR/top5pct rolling stability metrics, with a comment
  "Monthly series: w = 36 rolling windows, ann_factor = 12." Same root
  cause, not in the enumerated 4-item fix, left alone.
- `calculate_commodity_returns()` / `hd_commodity_mr_signal()` internals
  still name variables `monthly_ret`, `cumret`, etc. — cosmetic, shared with
  the momentum plan (#134), out of scope for this issue.

## Verification

`scripts/verify.sh`, foreground, full run:

```
root suite:    PASS — matches baseline exactly (failed=3, skipped=0)
package suite: PASS — matches baseline exactly (failed=1, skipped=15),
               after the 2 fixture renames above (both were NEW failures
               before the rename, not baseline)
```

Baselines per `.claude/CLAUDE.md`: root `failed=3 skipped=0`, package
`failed=1 skipped=15` — both hold.

## What I could not do

Could not run `tar_make()` (forbidden in this worktree scope) — cannot show
the corrected leaderboard row for CMR, and cannot re-derive #635's
budget-neutral sigma. That's for you to rebuild in the main checkout, per
your instructions.

Refs #717, #635
