### PR TITLE
fix(cmr): remaining ann_factor=12 instances after #720 — plus 3 found by deliberate search (#717)

### DIFF
--- a/R/plan_commodities_mean_reversion.R
+++ b/R/plan_commodities_mean_reversion.R
@@ -82,7 +82,12 @@ plan_commodities_mean_reversion <- function() {
     }),
 
 
-    # ── Monthly net returns (thin wrappers for falsification bridge) ──────
+    # ── Daily net returns (thin wrappers for falsification bridge) ────────
+    # #717: these are the SAME net_ret column as cmr_portfolio_1m/3m/6m
+    # (one row per date, ~252 obs/year) with no monthly resampling -- despite
+    # the misleading name/comment this file previously carried. Consumers
+    # (plan_falsification.R, plan_structural_breaks.R) must use ann_factor/
+    # ppy = 252, not 12.
 
     targets::tar_target(cmr_returns_1m, {
       cmr_portfolio_1m |>
@@ -433,7 +438,14 @@ plan_commodities_mean_reversion <- function() {
     }
 
     # Record SSR + top5pct stability metrics (#400 PR 5/6).
-    # Monthly series: w = 36 rolling windows, ann_factor = 12.
+    # #717: CMR's returns are daily (see file header + .assert_cmr_ann_factor()
+    # above), not monthly. w = ann_factor = 252 matches every other daily
+    # strategy's call site (avoid_worst, turn_of_month, risk_state all pass
+    # w = 252L, ann_factor = 252L; the monthly strategies -- drif, factormax,
+    # ltr_momentum, xgb_signal, portfolio_opt, stock_backtest, mom_prepeak --
+    # all pass w = 36L, ann_factor = 12L). hd_record_stability_metrics()'s own
+    # @param w roxygen doc states this exact convention: "Typical choices: 252
+    # (daily) or 36 (monthly)."
     port <- portfolio_list[[p]]
     if (!is.null(port) && is.data.frame(port) && "net_ret" %in% names(port)) {
       rets <- port$net_ret
@@ -442,8 +454,8 @@ plan_commodities_mean_reversion <- function() {
           con        = con,
           run_uuid   = uu,
           returns    = rets,
-          w          = 36L,
-          ann_factor = 12L
+          w          = 252L,
+          ann_factor = 252L
         )
       }
     }

--- a/R/plan_falsification.R
+++ b/R/plan_falsification.R
@@ -596,7 +596,11 @@ plan_falsification <- function() {
 
     # ═══════════════════════════════════════════════════════════════════
     # Per-strategy tests: cmr (Commodities Mean Reversion — #138)
-    # Monthly strategy. Three lookback variants (1m, 3m, 6m).
+    # #717: DAILY strategy (~252 obs/year), despite this section's original
+    # "monthly" framing -- cmr_returns_*m is the raw daily net_ret series,
+    # not a monthly resample (see plan_commodities_mean_reversion.R header).
+    # Three lookback *signal* variants (1m, 3m, 6m); all three produce daily
+    # return series.
     # Bridge targets fals_cmr_input_*m live in plan_commodities_mean_reversion.R
     # via the cmr_returns_*m targets.
     # Note: FF alpha test is omitted for CMR — the commodity universe does
@@ -614,7 +618,7 @@ plan_falsification <- function() {
 
     # ── 1m lookback ──────────────────────────────────────────────────────
     targets::tar_target(fals_hac_cmr_1m, {
-      hd_hac_sharpe(cmr_returns_1m$strategy_ret, ann_factor = 12L)
+      hd_hac_sharpe(cmr_returns_1m$strategy_ret, ann_factor = 252L)
     }),
     targets::tar_target(fals_wn_cmr_1m, {
       ret   <- cmr_returns_1m$strategy_ret
@@ -677,12 +681,12 @@ plan_falsification <- function() {
       )
     }),
     targets::tar_target(fals_dsr_cmr_1m, {
-      hd_deflated_sharpe(cmr_returns_1m$strategy_ret, K_trials = 3L, ann_factor = 12L)
+      hd_deflated_sharpe(cmr_returns_1m$strategy_ret, K_trials = 3L, ann_factor = 252L)
     }),
 
     # ── 3m lookback ──────────────────────────────────────────────────────
     targets::tar_target(fals_hac_cmr_3m, {
-      hd_hac_sharpe(cmr_returns_3m$strategy_ret, ann_factor = 12L)
+      hd_hac_sharpe(cmr_returns_3m$strategy_ret, ann_factor = 252L)
     }),
     targets::tar_target(fals_wn_cmr_3m, {
       ret   <- cmr_returns_3m$strategy_ret
@@ -745,12 +749,12 @@ plan_falsification <- function() {
       )
     }),
     targets::tar_target(fals_dsr_cmr_3m, {
-      hd_deflated_sharpe(cmr_returns_3m$strategy_ret, K_trials = 3L, ann_factor = 12L)
+      hd_deflated_sharpe(cmr_returns_3m$strategy_ret, K_trials = 3L, ann_factor = 252L)
     }),
 
     # ── 6m lookback ──────────────────────────────────────────────────────
     targets::tar_target(fals_hac_cmr_6m, {
-      hd_hac_sharpe(cmr_returns_6m$strategy_ret, ann_factor = 12L)
+      hd_hac_sharpe(cmr_returns_6m$strategy_ret, ann_factor = 252L)
     }),
     targets::tar_target(fals_wn_cmr_6m, {
       ret   <- cmr_returns_6m$strategy_ret
@@ -813,7 +817,7 @@ plan_falsification <- function() {
       )
     }),
     targets::tar_target(fals_dsr_cmr_6m, {
-      hd_deflated_sharpe(cmr_returns_6m$strategy_ret, K_trials = 3L, ann_factor = 12L)
+      hd_deflated_sharpe(cmr_returns_6m$strategy_ret, K_trials = 3L, ann_factor = 252L)
     }),
 
     # ── CMR falsification summary (standalone; not in main fals_summary) ──

--- a/R/plan_strategy_names.R
+++ b/R/plan_strategy_names.R
@@ -60,12 +60,14 @@ plan_strategy_names <- function() {
         frequency = c(
           "daily", "monthly", "monthly", "daily", "monthly", "daily",
           "monthly", "monthly", "monthly", "monthly",
-          "monthly",
+          # #717: cmr (position 11) is daily, not monthly -- the 37-series
+          # universe is 96% Yahoo daily futures/ETF rows (see #717/#720).
+          "daily",
           "monthly", "monthly", "monthly",
           "monthly",
           "monthly"
         ),
-        ann_factor = c(252L, 12L, 12L, 252L, 12L, 252L, 12L, 12L, 12L, 12L, 12L,
+        ann_factor = c(252L, 12L, 12L, 252L, 12L, 252L, 12L, 12L, 12L, 12L, 252L,
                        12L, 12L, 12L, 12L, 12L),
         vignette_url = c(
           "avoid-worst-days.html", "drif.html", "factor-max.html",

--- a/R/plan_structural_breaks.R
+++ b/R/plan_structural_breaks.R
@@ -29,7 +29,7 @@
 #   xgb_drif_portfolio     — monthly XGB DRIF portfolio (col: port_ret)
 #   olmar_portfolio        — daily OLMAR-1 portfolio (col: net_ret)
 #   fals_tom_input         — daily TOM overlay (col: strategy_ret)
-#   fals_cmr_input         — monthly CMR 3m (col: strategy_ret)
+#   fals_cmr_input         — daily CMR 3m (col: strategy_ret; #717)
 #   mom_prepeak_returns    — monthly Mom Pre-Peak L/S (col: ret_ls, date: exec_date)
 #   mom_postpeak_returns   — monthly Mom Post-Peak L/S (col: ret_ls, date: exec_date)
 #   mom_combined_returns   — monthly Mom 12-2 L/S (col: ret_ls, date: exec_date)
@@ -134,7 +134,8 @@ plan_structural_breaks <- function() {
           `Risk State`    = extract_series(fals_rsc_input),
           # TOM is daily (fals_tom_input: date + strategy_ret)
           TOM             = extract_series(fals_tom_input),
-          # CMR is monthly (fals_cmr_input = cmr_returns_3m: date + strategy_ret)
+          # CMR is daily (#717; fals_cmr_input = cmr_returns_3m: date + strategy_ret,
+          # the raw net_ret series -- no monthly resampling despite the name)
           CMR             = extract_series(fals_cmr_input),
           # Mom strategies are monthly (exec_date + ret_ls)
           `Mom Pre-Peak`  = extract_series(mom_prepeak_returns,
@@ -158,7 +159,7 @@ plan_structural_breaks <- function() {
           `Avoid Worst`  = 252L,
           `Risk State`   = 252L,
           TOM            = 252L,
-          CMR            = 12L,
+          CMR            = 252L,  # #717: daily, not monthly
           `Mom Pre-Peak` = 12L,  `Mom Post-Peak` = 12L,
           `Mom 12-2`     = 12L
         )

--- a/packages/historicaldata/R/commodities_mean_reversion.R
+++ b/packages/historicaldata/R/commodities_mean_reversion.R
@@ -10,7 +10,13 @@
 # Signal at month t uses returns through t-1 only (look-ahead-safe).
 # Execution: signal at t -> trade at t+1 close (t+1 execution discipline).
 #
-# Data: monthly commodity prices (37 series, 1992-2026, ann_factor=12).
+# Data: 37-series commodity universe (1992-2026); #717: the merged universe
+#   is daily-dominated (ann_factor=252), not monthly (ann_factor=12) despite
+#   this file's "monthly"/lookback_months naming throughout -- see
+#   R/plan_commodities_mean_reversion.R's file header for the source
+#   evidence. `lookback_months` here counts unique dates in the merged
+#   universe (one row per date), not calendar months; cosmetic-only fix,
+#   left un-renamed per #720's note (shared with commodities_momentum.R).
 # Universe re-uses commodities_returns from plan_commodities_momentum.R.
 
 

--- a/packages/historicaldata/tests/testthat/test-register-runs-stability.R
+++ b/packages/historicaldata/tests/testthat/test-register-runs-stability.R
@@ -75,8 +75,8 @@
     short_name              = "CMR",
     long_name               = "Commodities Mean Reversion",
     asset_class             = "commodities",
-    frequency               = "monthly",
-    ann_factor              = 12L,
+    frequency               = "daily",  # #717: matches R/plan_strategy_names.R
+    ann_factor              = 252L,
     directionality          = factor("long_short",
                                levels = c("long_only", "long_short",
                                           "market_neutral", "overlay")),
@@ -124,12 +124,20 @@
   )
 }
 
-.make_cmr_portfolio <- function(n = 100L) {
+.make_cmr_portfolio <- function(n = 300L) {
+  # #717: CMR's real return series is daily (~252 obs/year), not monthly --
+  # .cmr_register_runs() now calls hd_record_stability_metrics(w = 252L,
+  # ann_factor = 252L) to match. n = 300 gives 300 - 252 + 1 = 49 complete
+  # rolling windows, enough for hd_sharpe_stability_ratio() to return
+  # non-NA ssr/ssr_mean_sharpe/ssr_se -- the previous n = 100L (monthly-
+  # dated fixture, w = 36L pre-#717) is too short for a w = 252L window and
+  # produces < 8 stability rows (NA metric_value rows are dropped by
+  # hd_metric_record(), not written).
   set.seed(7L)
-  gross <- rnorm(n, 0, 0.04)
-  cost  <- rep(0.002, n)
+  gross <- rnorm(n, 0, 0.01)
+  cost  <- rep(0.0002, n)
   tibble::tibble(
-    date      = seq.Date(as.Date("2015-01-31"), by = "month", length.out = n),
+    date      = seq.Date(as.Date("2015-01-02"), by = "day", length.out = n),
     gross_ret = gross,
     cost      = cost,
     net_ret   = gross - cost,

--- a/tests/testthat/test-register-runs-tier3.R
+++ b/tests/testthat/test-register-runs-tier3.R
@@ -59,10 +59,12 @@ source(here::here("R/plan_portfolio_opt.R"))
     frequency = c(
       "daily", "monthly", "monthly", "daily", "monthly", "daily",
       "monthly", "monthly", "monthly", "monthly",
-      "monthly", "monthly", "monthly", "monthly"
+      # #717: cmr (position 11) is daily, not monthly -- matches
+      # R/plan_strategy_names.R's corrected declaration.
+      "daily", "monthly", "monthly", "monthly"
     ),
     ann_factor = c(252L, 12L, 12L, 252L, 12L, 252L, 12L, 12L, 12L, 12L,
-                   12L, 12L, 12L, 12L),
+                   252L, 12L, 12L, 12L),
     vignette_url = c(
       "avoid-worst-days.html", "drif.html", "factor-max.html",
       "leaderboard.html", "leaderboard.html", "turn-of-month.html",
@@ -199,12 +201,18 @@ test_that(".cmr_register_runs schema and row counts are stable", {
     max_dd_duration = c(12L, 10L, 9L)
   )
 
-  # portfolio_list: one tibble per lookback with net_ret column
-  n_months <- 48L
+  # portfolio_list: one tibble per lookback with net_ret column.
+  # #717: n = 300 daily obs (not 48 monthly) -- .cmr_register_runs() now
+  # calls hd_record_stability_metrics(w = 252L, ann_factor = 252L), so the
+  # fixture needs >= 252 rows for a complete rolling window; a shorter
+  # series produces 0 windows, which drops the NA-valued ssr/ssr_mean_sharpe/
+  # ssr_se/ssr_lag_nw rows in hd_metric_record() and desyncs the
+  # n_metric_rows snapshot below (< 8 stability rows instead of 8).
+  n_days <- 300L
   make_port <- function() {
     tibble::tibble(
-      date    = seq.Date(as.Date("2018-01-31"), by = "month", length.out = n_months),
-      net_ret = rnorm(n_months, -0.002, 0.04)
+      date    = seq.Date(as.Date("2018-01-02"), by = "day", length.out = n_days),
+      net_ret = rnorm(n_days, -0.0002, 0.01)
     )
   }
 
@@ -232,7 +240,7 @@ test_that(".cmr_register_runs schema and row counts are stable", {
   expect_equal(nrow(q$strat), 1L)
   expect_equal(q$strat$strategy_id, "cmr")
   expect_equal(q$strat$asset_class, "commodities")
-  expect_equal(q$strat$frequency, "monthly")
+  expect_equal(q$strat$frequency, "daily")  # #717
   expect_equal(q$strat$lifecycle, "stable")
 
   # bt.run: one row per partition (1m, 3m, 6m)


### PR DESCRIPTION
Follow-up to #720: the remaining `ann_factor = 12` instances for CMR, plus three the
deliberate search turned up.

**Provenance note:** the agent that wrote this commit died on an API error
immediately before opening the PR. The work was committed and pushed intact; this
body is reconstructed by me from the diff, and every claim below is one I verified
directly rather than transcribed from a report that does not exist.

## What #720 left

#720 fixed CMR's metrics path (`ann_factor` 12 → 252, `n_months` → `n_days`, and a
reconciliation guard at the supply point). It flagged two further instances and
correctly declined to touch them. A deliberate search for a third — asked for
precisely because the first two were found incidentally, which is weak evidence of
completeness — found three more.

| # | location | was | now |
|---|---|---|---|
| 1 | `R/plan_strategy_names.R` position 11 | `frequency = "monthly"`, `ann_factor = 12L` | `"daily"`, `252L` |
| 2 | `R/plan_commodities_mean_reversion.R` stability call | `w = 36L, ann_factor = 12L` | `w = 252L, ann_factor = 252L` |
| 3 | `R/plan_structural_breaks.R` | `CMR = 12L` | `CMR = 252L` |
| 4 | `R/plan_falsification.R` | section framed as a monthly strategy | daily |
| 5 | `packages/historicaldata/R/commodities_mean_reversion.R` header | "monthly commodity prices ... ann_factor=12" | daily-dominated universe |

## The root of 3 and 4, which is the interesting part

`cmr_returns_1m/3m/6m` were labelled **"Monthly net returns (thin wrappers for
falsification bridge)"**. They are the *same daily `net_ret` series* as
`cmr_portfolio_*`, with no resampling anywhere. The comment was simply wrong.

Those targets feed the falsification suite and structural-break detection, so CMR's
null-environment tests and break detection were both running at the wrong
periodicity — via a misleading comment, in two subsystems that never touched the
original constant. That is how a single mislabelled series propagates: consumers
trust the name.

## Verified independently before merging

**The off-by-one risk in `strategy_names`.** Three parallel vectors with inline
comments between elements; a misaligned edit would silently corrupt a *different*
strategy's declaration with no obvious symptom. I evaluated the actual vectors via
an AST parse rather than reading the diff:

```
lengths: 16 16 16
pos 11: cmr / daily / 252
```

All three aligned, every other row unchanged and sensible (`avoid_worst`, `rsc`,
`tom` daily; the rest monthly).

**The `w = 252` choice.** I had speculated ~756 in the dispatch, reasoning "3 years
of daily data". That was wrong, and the commit is right: every daily strategy in the
repo passes `w = 252L` (`avoid_worst`, `turn_of_month`, `risk_state`), every monthly
one `w = 36L`, and `hd_record_stability_metrics()`'s own roxygen documents exactly
that — *"Typical choices: 252 (daily) or 36 (monthly)."* House convention, checked
against the code, beats my arithmetic. Recording it because an agent following a bad
suggestion from me would have been the easier path.

**`scripts/verify.sh`**: PASS, root `672/3/0`, package `695/1/15`, both signatures at
baseline.

## Not done

`tar_make()` — so the corrected CMR figures are not yet visible on the leaderboard,
and #635's σ is still marked unconfirmed. I will rebuild and re-derive.

`STRATEGY_OBS_ANN_FACTOR` in open PR #716 still declares CMR as 12 and is now stale;
I will rebase that branch rather than have it edited from here.

Refs #717, #635.
