### PR TITLE
fix(cmr): join daily_rf on date, not stk_rf on ym (#722)

### DIFF
--- a/R/plan_commodities_mean_reversion.R
+++ b/R/plan_commodities_mean_reversion.R
@@ -109,15 +109,15 @@ plan_commodities_mean_reversion <- function() {
     # Sharpe, MDD, max DD duration (hd_dd_duration from risk_metrics.R).
 
     targets::tar_target(cmr_metrics_1m, {
-      .compute_cmr_metrics(cmr_portfolio_1m, lookback = "1m", stk_rf = stk_rf, ann_factor = 252L)
+      .compute_cmr_metrics(cmr_portfolio_1m, lookback = "1m", daily_rf = daily_rf, ann_factor = 252L)
     }),
 
     targets::tar_target(cmr_metrics_3m, {
-      .compute_cmr_metrics(cmr_portfolio_3m, lookback = "3m", stk_rf = stk_rf, ann_factor = 252L)
+      .compute_cmr_metrics(cmr_portfolio_3m, lookback = "3m", daily_rf = daily_rf, ann_factor = 252L)
     }),
 
     targets::tar_target(cmr_metrics_6m, {
-      .compute_cmr_metrics(cmr_portfolio_6m, lookback = "6m", stk_rf = stk_rf, ann_factor = 252L)
+      .compute_cmr_metrics(cmr_portfolio_6m, lookback = "6m", daily_rf = daily_rf, ann_factor = 252L)
     }),
 
 
@@ -190,28 +190,39 @@ plan_commodities_mean_reversion <- function() {
 # ── Internal helper ────────────────────────────────────────────────────────────
 # Not exported; called only within this plan's targets.
 
-#' Join a monthly risk-free series onto a CMR portfolio (#677)
+#' Join a daily risk-free series onto a CMR portfolio (#722)
 #'
-#' Mirrors \code{.ltr_join_rf()} in R/plan_ltr_momentum.R: joins on \code{ym}
-#' derived from \code{date}. As of #677 slice 3b the coverage policy itself
-#' lives in the shared \code{.join_rf_series()} (R/utils_metrics.R), which
-#' distinguishes THREE cases (leading / trailing / interior) -- see that
-#' function's roxygen for the full policy. A missing risk-free series must
-#' never be treated as zero -- see fail-loud-not-null.md.
+#' Mirrors \code{.tom_join_rf_daily()} in R/plan_turn_of_month.R and
+#' \code{.olmar_join_rf()} in R/plan_olmar.R: joins on \code{date} at DAILY
+#' granularity, not \code{ym} at monthly granularity -- CMR's portfolios are
+#' themselves daily series (#717; see the frequency note at the top of this
+#' file), so the risk-free series annualised alongside them with
+#' \code{ann_factor = 252L} must be daily too. Before #722, this function
+#' joined the MONTHLY \code{stk_rf} on \code{ym}, which produced a
+#' physically-impossible ~41% annualised risk-free rate (mean monthly rf
+#' multiplied by 252, the daily annualisation factor).
 #'
-#' @param df Tibble with a `ym` column already derived, and `net_ret`.
-#' @param stk_rf Tibble with columns `ym`, `rf_ret` (R/plan_stock_backtest.R).
+#' As of #677 slice 3b the coverage policy itself lives in the shared
+#' \code{.join_rf_series()} (R/utils_metrics.R), which distinguishes THREE
+#' cases (leading / trailing / interior) -- see that function's roxygen for
+#' the full policy. A missing risk-free series must never be treated as zero
+#' -- see fail-loud-not-null.md.
+#'
+#' @param df Tibble with a `date` column (CMR's daily portfolio), and
+#'   `net_ret`.
+#' @param daily_rf Tibble with columns `date`, `rf_ret` (the `daily_rf`
+#'   target, R/plan_stock_backtest.R).
 #' @param lookback Character. Lookback label, used only for error/warning text.
-#' @return `df` with `rf_ret` joined, trailing uncovered months removed.
+#' @return `df` with `rf_ret` joined, trailing uncovered dates removed.
 #' @noRd
-.cmr_join_rf <- function(df, stk_rf, lookback) {
+.cmr_join_rf <- function(df, daily_rf, lookback) {
   .join_rf_series(
-    df = df, rf = stk_rf, key = "ym",
-    label = ".cmr_join_rf", rf_label = "stk_rf",
-    rf_source = "R/plan_stock_backtest.R",
+    df = df, rf = daily_rf, key = "date",
+    label = ".cmr_join_rf", rf_label = "daily_rf",
+    rf_source = "the daily_rf target, R/plan_stock_backtest.R",
     df_label = paste0("CMR ", lookback, " portfolio"),
     strategy_label = paste0("CMR ", lookback),
-    period_noun = "month", check_key_col = FALSE
+    period_noun = "date"
   )
 }
 
@@ -291,12 +302,12 @@ plan_commodities_mean_reversion <- function() {
   invisible(NULL)
 }
 
-.compute_cmr_metrics <- function(portfolio_tbl, lookback, stk_rf, ann_factor = 252L) {
+.compute_cmr_metrics <- function(portfolio_tbl, lookback, daily_rf, ann_factor = 252L) {
   library(dplyr)
 
   df <- portfolio_tbl |>
     dplyr::filter(!is.na(.data$net_ret)) |>
-    dplyr::mutate(ym = format(as.Date(.data$date), "%Y-%m"))
+    dplyr::mutate(date = as.Date(.data$date))
 
   # #717 guard: declared ann_factor must match the observed frequency of
   # this portfolio's own dates, checked at the point ann_factor is supplied.
@@ -312,9 +323,11 @@ plan_commodities_mean_reversion <- function() {
     ))
   }
 
-  # #677: real Fama-French monthly rf (stk_rf), replacing the hardcoded
-  # "MANUAL: no source" 2%/yr assumption previously baked into monthly_rf.
-  df <- .cmr_join_rf(df, stk_rf, lookback = lookback)
+  # #722: real Fama-French DAILY rf (daily_rf), replacing the monthly stk_rf
+  # that was previously joined against this daily portfolio (#677 introduced
+  # the real rf but on the wrong frequency; #717 fixed ann_factor without
+  # fixing the rf join that #722 catches).
+  df <- .cmr_join_rf(df, daily_rf, lookback = lookback)
   n  <- nrow(df)  # may shrink if a trailing rf gap was trimmed above
 
   r  <- df$net_ret

--- a/R/utils_metrics.R
+++ b/R/utils_metrics.R
@@ -264,8 +264,9 @@ sharpe_ratio_rf <- function(ret, rf, periods_per_year = 12L, na.rm = TRUE) {
 #'   for cli's pluralisation (\code{{period_noun}{?s}}).
 #' @param check_key_col Logical. If \code{TRUE} (default), abort when `df`
 #'   has no `key` column. Callers that derive `key` themselves just before
-#'   calling (e.g. mom_prepeak deriving `ym` from `exec_date`), or that
-#'   already guarantee it by construction (e.g. CMR), pass `FALSE`.
+#'   calling (e.g. mom_prepeak deriving `ym` from `exec_date`) pass `FALSE`;
+#'   callers whose `df` already carries `key` by construction (e.g. CMR's
+#'   `date` column, since #722) leave it at the default `TRUE`.
 #' @param df_arg_name Character. Word used for `df` in the
 #'   missing-key-column message, e.g. \code{"port"}.
 #'

--- a/tests/testthat/_snaps/cmr-units.md
+++ b/tests/testthat/_snaps/cmr-units.md
@@ -4,17 +4,17 @@
       .cmr_join_rf(df, gapped_rf, lookback = "test")
     Condition
       Error in `.join_rf_series()`:
-      x 1 month inside stk_rf's own span have no risk-free rate (CMR test).
-      i Missing month: "2020-10".
-      i stk_rf spans 2020-01..2021-12, so this is a HOLE in the series, not a publication lag.
-      i Investigate the FF3 source (R/plan_stock_backtest.R) before trusting any CMR test Sharpe figure.
+      x 1 date inside daily_rf's own span have no risk-free rate (CMR test).
+      i Missing date: "2020-10-01".
+      i daily_rf spans 2020-01-01..2021-12-01, so this is a HOLE in the series, not a publication lag.
+      i Investigate the FF3 source (the daily_rf target, R/plan_stock_backtest.R) before trusting any CMR test Sharpe figure.
 
-# .cmr_join_rf aborts when stk_rf lacks required columns
+# .cmr_join_rf aborts when daily_rf lacks required columns
 
     Code
       .cmr_join_rf(df, bad_rf, lookback = "test")
     Condition
       Error in `.join_rf_series()`:
-      x .cmr_join_rf(): stk_rf is missing 1 required column: rf_ret.
-      i Expected a tibble with ym and rf_ret (R/plan_stock_backtest.R).
+      x .cmr_join_rf(): daily_rf is missing 1 required column: rf_ret.
+      i Expected a tibble with date and rf_ret (the daily_rf target, R/plan_stock_backtest.R).
 

--- a/tests/testthat/test-cmr-units.R
+++ b/tests/testthat/test-cmr-units.R
@@ -12,8 +12,16 @@
 #
 # Before #677: sharpe used an arithmetic-mean numerator and a hardcoded
 # "MANUAL: no source" 2%/yr risk-free assumption. After #677: geometric
-# numerator (sharpe_ratio_rf(), R/utils_metrics.R) and the real Fama-French
-# monthly rf (stk_rf target).
+# numerator (sharpe_ratio_rf(), R/utils_metrics.R) and a real Fama-French rf.
+#
+# #722: #677 joined the real rf, but on the wrong frequency -- the MONTHLY
+# stk_rf target against CMR's own DAILY portfolios (#717), producing a
+# physically-impossible ~41% annualised risk-free rate. Fixed by joining the
+# DAILY daily_rf target on `date` instead of stk_rf on `ym`. These fixture
+# names below use `daily_rf`/`date` throughout -- ann_factor = 12L in most
+# tests here is retained only as a convenient toy-fixture annualisation
+# constant (the toy portfolio has monthly-spaced dates), not because CMR
+# itself is monthly; CMR's production ann_factor is 252L (see #717).
 testthat::local_edition(3)
 
 # Path-checked pkgload — .compute_cmr_metrics() calls hd_dd_duration() from
@@ -38,20 +46,20 @@ toy_portfolio <- tibble::tibble(
   net_ret = c(rep(-0.05, 12L), rep(0.02, 12L))  # 12mo drawdown then recovery
 )
 
-toy_stk_rf <- tibble::tibble(
-  ym     = format(seq.Date(as.Date("2020-01-01"), by = "month", length.out = 24L), "%Y-%m"),
-  rf_ret = rep((1.02)^(1 / 12) - 1, 24L)  # ~2%/yr monthly rf -- matches the old hardcoded constant
+toy_daily_rf <- tibble::tibble(
+  date   = seq.Date(as.Date("2020-01-01"), by = "month", length.out = 24L),
+  rf_ret = rep((1.02)^(1 / 12) - 1, 24L)  # ~2%/yr monthly-equivalent rf -- matches the old hardcoded constant
 )
 
 test_that(".compute_cmr_metrics returns max_dd as decimal fraction (#336)", {
-  metrics <- .compute_cmr_metrics(toy_portfolio, lookback = "test", stk_rf = toy_stk_rf, ann_factor = 12L)
+  metrics <- .compute_cmr_metrics(toy_portfolio, lookback = "test", daily_rf = toy_daily_rf, ann_factor = 12L)
   expect_true(is.finite(metrics$max_dd))
   expect_gte(metrics$max_dd, -1)    # canonical decimal: in [-1, 0]
   expect_lte(metrics$max_dd, 0)
 })
 
 test_that(".compute_cmr_metrics returns cagr/vol as decimal fractions (#336)", {
-  metrics <- .compute_cmr_metrics(toy_portfolio, lookback = "test", stk_rf = toy_stk_rf, ann_factor = 12L)
+  metrics <- .compute_cmr_metrics(toy_portfolio, lookback = "test", daily_rf = toy_daily_rf, ann_factor = 12L)
   # Decimal CAGR for monthly returns near ±5% sits in (-1, 1); under the old
   # percent convention this would land in the (-100, 100) band.
   expect_gt(metrics$cagr, -1)
@@ -62,7 +70,7 @@ test_that(".compute_cmr_metrics returns cagr/vol as decimal fractions (#336)", {
 })
 
 test_that(".compute_cmr_metrics never returns the old percent magnitude (#336 regression)", {
-  metrics <- .compute_cmr_metrics(toy_portfolio, lookback = "test", stk_rf = toy_stk_rf, ann_factor = 12L)
+  metrics <- .compute_cmr_metrics(toy_portfolio, lookback = "test", daily_rf = toy_daily_rf, ann_factor = 12L)
   # Specific anti-regression: -100 was the old percent output for this kind
   # of monotone-loss path; the decimal equivalent is around -0.45.
   expect_false(metrics$max_dd < -1.0)
@@ -73,9 +81,9 @@ test_that(".compute_cmr_metrics never returns the old percent magnitude (#336 re
 # ── #677: geometric numerator, rf-deducted ──────────────────────────────────
 
 test_that(".compute_cmr_metrics sharpe matches sharpe_ratio_rf() exactly", {
-  metrics  <- .compute_cmr_metrics(toy_portfolio, lookback = "test", stk_rf = toy_stk_rf, ann_factor = 12L)
+  metrics  <- .compute_cmr_metrics(toy_portfolio, lookback = "test", daily_rf = toy_daily_rf, ann_factor = 12L)
   expected <- round(
-    sharpe_ratio_rf(toy_portfolio$net_ret, toy_stk_rf$rf_ret, periods_per_year = 12L)$sharpe,
+    sharpe_ratio_rf(toy_portfolio$net_ret, toy_daily_rf$rf_ret, periods_per_year = 12L)$sharpe,
     3
   )
   expect_equal(metrics$sharpe, expected)
@@ -88,12 +96,12 @@ test_that(".compute_cmr_metrics sharpe differs from the old arithmetic/hardcoded
     date    = seq.Date(as.Date("2018-01-01"), by = "month", length.out = 30L),
     net_ret = vol_ret
   )
-  vol_stk_rf <- tibble::tibble(
-    ym     = format(seq.Date(as.Date("2018-01-01"), by = "month", length.out = 30L), "%Y-%m"),
+  vol_daily_rf <- tibble::tibble(
+    date   = seq.Date(as.Date("2018-01-01"), by = "month", length.out = 30L),
     rf_ret = rep((1.02)^(1 / 12) - 1, 30L)
   )
 
-  new_sharpe <- .compute_cmr_metrics(vol_portfolio, lookback = "test", stk_rf = vol_stk_rf, ann_factor = 12L)$sharpe
+  new_sharpe <- .compute_cmr_metrics(vol_portfolio, lookback = "test", daily_rf = vol_daily_rf, ann_factor = 12L)$sharpe
 
   monthly_rf_old <- (1.02)^(1 / 12) - 1
   old_sharpe <- round((mean(vol_ret) - monthly_rf_old) / sd(vol_ret) * sqrt(12), 3)
@@ -101,9 +109,9 @@ test_that(".compute_cmr_metrics sharpe differs from the old arithmetic/hardcoded
   expect_false(isTRUE(all.equal(new_sharpe, old_sharpe)))
 })
 
-test_that(".cmr_join_rf trims a trailing uncovered month and warns (Fama-French publication lag)", {
-  short_rf <- toy_stk_rf[1:20, ]  # rf ends 4 months before the portfolio
-  df <- toy_portfolio |> dplyr::mutate(ym = format(as.Date(date), "%Y-%m"))
+test_that(".cmr_join_rf trims a trailing uncovered date and warns (Fama-French publication lag)", {
+  short_rf <- toy_daily_rf[1:20, ]  # rf ends 4 periods before the portfolio
+  df <- toy_portfolio |> dplyr::mutate(date = as.Date(date))
 
   expect_warning(joined <- .cmr_join_rf(df, short_rf, lookback = "test"), regexp = "Dropped")
   expect_equal(nrow(joined), 20L)
@@ -111,15 +119,15 @@ test_that(".cmr_join_rf trims a trailing uncovered month and warns (Fama-French 
 })
 
 test_that(".cmr_join_rf aborts on an INTERIOR gap (not a publication lag)", {
-  gapped_rf <- toy_stk_rf[-10, ]  # remove a month from the middle of rf's own span
-  df <- toy_portfolio |> dplyr::mutate(ym = format(as.Date(date), "%Y-%m"))
+  gapped_rf <- toy_daily_rf[-10, ]  # remove a period from the middle of rf's own span
+  df <- toy_portfolio |> dplyr::mutate(date = as.Date(date))
 
   expect_snapshot(error = TRUE, .cmr_join_rf(df, gapped_rf, lookback = "test"))
 })
 
-test_that(".cmr_join_rf aborts when stk_rf lacks required columns", {
-  df <- toy_portfolio |> dplyr::mutate(ym = format(as.Date(date), "%Y-%m"))
-  bad_rf <- tibble::tibble(ym = toy_stk_rf$ym)
+test_that(".cmr_join_rf aborts when daily_rf lacks required columns", {
+  df <- toy_portfolio |> dplyr::mutate(date = as.Date(date))
+  bad_rf <- tibble::tibble(date = toy_daily_rf$date)
 
   expect_snapshot(error = TRUE, .cmr_join_rf(df, bad_rf, lookback = "test"))
 })

--- a/tests/testthat/test-join-rf-series.R
+++ b/tests/testthat/test-join-rf-series.R
@@ -150,9 +150,12 @@ test_that("aborts when df has no key column and check_key_col is TRUE (default)"
 test_that("check_key_col = FALSE skips the key-column presence check", {
   # df already has ym present -- FALSE just skips the defensive check, so
   # behaviour is identical to the default when the column IS present (this
-  # is how CMR / mom_prepeak use it: they guarantee `ym` by construction
-  # before calling, mirroring their pre-#677-slice-3b behaviour of never
-  # checking for it at all).
+  # is how mom_prepeak uses it: it derives `ym` from `exec_date` immediately
+  # before calling, mirroring its pre-#677-slice-3b behaviour of never
+  # checking for it at all). CMR used check_key_col = FALSE here too before
+  # #722, when it derived `ym` the same way; #722 switched CMR to the daily
+  # `date` column that already exists on its portfolio by construction, so
+  # it now uses the default TRUE like .tom_join_rf_daily() / .olmar_join_rf().
   out <- .call_join(
     .mk_df_ym(c("2026-01", "2026-02")), .mk_rf_ym(c("2026-01", "2026-02")),
     .args_ym, check_key_col = FALSE


### PR DESCRIPTION
## Frequency confirmation (independent)

Read `stk_rf`'s definition (`R/plan_stock_backtest.R:585`): it is built from
`hd_factors(dataset = "FF3", frequency = "monthly")`, one row per `ym`
(character `"YYYY-MM"`). `daily_rf` (`R/plan_stock_backtest.R:627`) is built
from the same source at `frequency = "daily"`, one row per `date`. This
confirms the issue's claim independently from source, not just from the
observed `ann_rf = 0.407` symptom.

## The fix

`.compute_cmr_metrics()` (`R/plan_commodities_mean_reversion.R`) took a
`stk_rf` parameter and derived `ym` from the (actually daily, per #717)
portfolio dates to join on. `.cmr_join_rf()` hardcoded `key = "ym"`. Both are
changed:

- `.compute_cmr_metrics(portfolio_tbl, lookback, daily_rf, ann_factor)` —
  parameter renamed `stk_rf` → `daily_rf`; the function now coerces
  `df$date` to `Date` instead of deriving `ym`.
- `.cmr_join_rf(df, daily_rf, lookback)` — joins on `key = "date"` instead of
  `key = "ym"`, mirroring `.tom_join_rf_daily()` (`plan_turn_of_month.R`) and
  `.olmar_join_rf()` (`plan_olmar.R`), the two other daily strategies that
  already join `daily_rf` on `date`. `check_key_col` now defaults to `TRUE`
  (previously explicit `FALSE`) since `date` already exists on the portfolio
  tibble by construction — it does not need to be derived immediately before
  the call the way `ym` did, so the "caller guarantees the key column"
  escape hatch mom_prepeak still uses no longer applies to CMR.
- **Target dependency**: the three `cmr_metrics_{1m,3m,6m}` targets now
  depend on `daily_rf` instead of `stk_rf` (`daily_rf = daily_rf` in the
  call), so `cmr_summary` will rebuild when `daily_rf` changes and no longer
  rebuilds on `stk_rf` changes.

## Rf-frequency consistency table — all 16 strategies

Searched deliberately for a third instance of this defect class (shared rf
constant serving two frequencies), per the issue's request. Traced every
`stk_rf`/`daily_rf`/`.join_rf_series()` call site plus every strategy's
independently-sourced rf (where one exists) against its declared `frequency`
in `plan_strategy_names.R`.

| Strategy (`code_name`) | rf source | Join key | `ann_factor` used | Declared frequency | Consistent? |
|---|---|---|---|---|---|
| avoid_worst | `aw_daily_rf` (own daily FF rf, `plan_avoid_worst.R`) | `date` | 252 | daily | Yes |
| drif | own monthly RF factor row (`drif_daily`, `plan_drif.R`) | `ym` | 12 | monthly | Yes |
| fac_max | own monthly RF factor row (`fm_monthly`, `plan_factormax.R`) | `ym` | 12 | monthly | Yes |
| rsc | own daily FF3 rf (`hd_factors(..., "daily")`, `plan_risk_state.R`) | `date` | (daily) | daily | Yes |
| ltr | `stk_rf` via `.ltr_join_rf()` (`plan_ltr_momentum.R`) | `ym` | 12 | monthly | Yes |
| tom | `daily_rf` via `.tom_join_rf_daily()` (`plan_turn_of_month.R`) | `date` | 252 | daily | Yes |
| stk_max (+ hrp, hrp_adv variants) | `stk_rf` (`plan_stock_backtest.R`) | `ym` | 12 | monthly | Yes |
| stk_drif | `stk_rf` (`plan_stock_backtest.R`) | `ym` | 12 | monthly | Yes |
| xgb_drif | `stk_rf` (`plan_xgb_signal.R`) | `ym` | 12 | monthly | Yes |
| pso_optimal | `stk_rf` (`plan_portfolio_opt.R`) | `ym` | 12 | monthly | Yes |
| **cmr** | **`stk_rf` (BEFORE) → `daily_rf` (AFTER, this PR)** | **`ym` (BEFORE) → `date` (AFTER)** | 252 | daily | **No (this bug) → Yes** |
| mom_prepeak / mom_postpeak / mom_combined | `stk_rf` via `.mom_prepeak_join_rf()` (`plan_mom_prepeak.R`) | `ym` | 12 | monthly | Yes |
| ev_ebit | own FF factor row (`ev_portfolios$RF`, `plan_ev_ebit.R`) | (pre-joined monthly) | 12 | monthly | Yes |
| mf_tsm | own FF factor row (`mf_portfolios$RF`, `plan_managed_futures.R`) | (pre-joined monthly) | 12 | monthly | Yes |
| GTAA (`.bt_sharpe_rf`, `plan_backtest.R`) | `stk_rf` | `ym` | 12 | (monthly signal) | Yes |
| Alpha decay (`plan_alpha_decay.R`) | `stk_rf` | `ym` | (monthly signal) | (monthly) | Yes |

**No third instance found.** CMR was the only strategy joining a
frequency-mismatched rf series; every other daily strategy already uses
`date`-keyed daily rf and every monthly strategy uses `ym`-keyed monthly rf
(either the shared `stk_rf` or its own independently-sourced monthly FF
factor row).

## Test changes

`tests/testthat/test-cmr-units.R`:

- `toy_stk_rf` (keyed `ym`) renamed `toy_daily_rf` (keyed `date`); all
  `.compute_cmr_metrics()` calls updated to `daily_rf = toy_daily_rf`.
- `.cmr_join_rf` tests no longer derive `ym` before calling — they coerce
  `date` to `Date` instead (mirrors the production code path post-fix).
- `ann_factor = 12L` is retained in most tests as a toy-fixture
  annualisation constant only (the toy portfolio has monthly-spaced dates
  for readability) — this does **not** imply CMR itself is monthly; the
  production `ann_factor` for CMR is 252L (#717), unchanged by this PR.
- One `expect_snapshot(error = TRUE, ...)` regenerated
  (`tests/testthat/_snaps/cmr-units.md`) because the abort message now says
  "daily_rf" / "date" instead of "stk_rf" / "month" — verified the diff was
  wording-only (`testthat::snapshot_accept("cmr-units")` after visually
  confirming no substantive change).

`tests/testthat/test-join-rf-series.R`: comment-only fix — a comment
describing `check_key_col = FALSE` usage cited CMR as an example; CMR no
longer uses `FALSE` (see above), so the comment now names only mom_prepeak
and notes CMR's pre-#722 behaviour for context.

No test encoded the old (wrong) `ann_rf ≈ 0.407` or `sharpe ≈ -2.441`
values directly — those live only in the built leaderboard target, not in
`tests/testthat/`.

## Verification

`scripts/verify.sh` run in the project nix shell, foreground, to completion:

```
=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: ...
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target...
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison...

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

=== scripts/verify.sh: PASS ===
```

Root: `total=672 failed=3 skipped=0` — exact baseline match, 17/17 pass in
`test-cmr-units.R` including the regenerated snapshot. Package:
`total=695 failed=1 skipped=15` — exact baseline match.

## What I could not run

Per task scope, `tar_make()` is forbidden in this worktree, so I cannot
rebuild `cmr_summary` / the leaderboard to see the corrected `ann_rf`. The
issue's expected range (~2-3%/yr, plausible short-rate average 1992–2026)
is a prediction from the fix, not something I observed — please rebuild and
re-derive.

Refs #722, #635
