### PR TITLE
fix(cmr): carry daily_rf forward across short non-trading gaps (#724)

### DIFF
--- a/R/plan_commodities_mean_reversion.R
+++ b/R/plan_commodities_mean_reversion.R
@@ -24,6 +24,14 @@
 # Look-ahead safety: signal at t uses returns through t-1 only.
 # Execution: signal at t -> trade at t+1 close.
 # Transaction cost: 0.2% per trade (same as commodity momentum, #134).
+# Risk-free join: #724. daily_rf follows the NYSE trading calendar; this
+#   mixed universe needs some dates that were never NYSE trading days.
+#   .cmr_fill_non_trading_rf_gaps() carries the last available rf forward
+#   for short (<=7 calendar day) gaps before the shared #679 interior-hole
+#   guard runs. NOTE (explicitly out of scope for #724): cmr_portfolio's
+#   own date column still mixes daily and monthly-stamped observations, so
+#   ann_factor = 252 over-annualises the vol/cagr contribution of every
+#   FRED-only month-start row. #724 fixes the crash; it does not fix that.
 
 plan_commodities_mean_reversion <- function() {
   list(
@@ -190,6 +198,113 @@ plan_commodities_mean_reversion <- function() {
 # ── Internal helper ────────────────────────────────────────────────────────────
 # Not exported; called only within this plan's targets.
 
+#' Carry `daily_rf` forward across short non-trading gaps CMR's universe needs (#724)
+#'
+#' #723 switched CMR to the daily \code{daily_rf} target (#722's fix for the
+#' month-vs-day frequency bug), which immediately tripped the #679
+#' interior-hole guard: 163 dates CMR's merged universe needs have no
+#' \code{daily_rf} row (measured 2026-08-23, against
+#' \code{data/raw/commodities.parquet} + the live FF3 daily series -- see
+#' #724). Every single one was checked BY HAND against the actual NYSE
+#' calendar for that date, not assumed: weekends, New Year's Day, Memorial
+#' Day, Independence Day, Labor Day, Thanksgiving, Christmas, Good Friday
+#' (1994-04-01), the four-day 9/11 closure (2001-09-11..14), and three
+#' presidential state-funeral closures (2004-06-11 Reagan, 2007-01-02 Ford,
+#' 2025-01-09 Carter). None were a genuine hole in \code{daily_rf} itself --
+#' \code{daily_rf} follows the NYSE trading calendar (it IS the Fama-French
+#' daily series), and CMR's 13 FRED monthly commodity series stamp
+#' month-start dates without regard to whether the equity market traded that
+#' day, while a handful of the 24 Yahoo daily series occasionally carry a
+#' stray row on an equity holiday too (e.g. 2002-07-04).
+#'
+#' A hardcoded holiday table would have missed several of the above on day
+#' one (Good Friday and the funeral closures are exactly the kind of
+#' one-off this function was written to avoid enumerating) and would still
+#' be incomplete for the next one. Instead: for every date `df` needs that
+#' falls INSIDE `daily_rf`'s own span but has no row, find the nearest PRIOR
+#' available `daily_rf` date (never a later one -- that would be
+#' look-ahead) and carry its `rf_ret` forward, but ONLY if that date is
+#' within `max_gap_days` calendar days. Every one of the 163 real #724 gaps
+#' was <= 4 days from its prior available date (the 9/11 closure was the
+#' longest); `max_gap_days = 7L` leaves a week of headroom. A date further
+#' than that is left unfilled and falls straight through to
+#' \code{.join_rf_series()}'s INTERIOR abort, unchanged -- at that distance
+#' something other than a holiday is wrong, and the guard should still fire.
+#'
+#' This function touches nothing outside CMR: \code{.join_rf_series()}
+#' (R/utils_metrics.R) and its other three callers (LTR, ToM, mom_prepeak,
+#' #677) are not modified. CMR pre-fills its own COPY of \code{daily_rf}
+#' before handing it to that shared guard, so a genuine interior hole --
+#' here or on any other strategy's rf join -- still aborts exactly as
+#' before.
+#'
+#' @param df Tibble with a `date` column (CMR's daily portfolio).
+#' @param daily_rf Tibble with columns `date`, `rf_ret` (the `daily_rf`
+#'   target, R/plan_stock_backtest.R).
+#' @param lookback Character. Lookback label, used only for the inform message.
+#' @param max_gap_days Integer. Maximum calendar-day distance to the nearest
+#'   prior available `daily_rf` date that may be carried forward. See #724
+#'   for how this bound was set.
+#' @return `daily_rf` with synthetic LOCF rows appended for short gaps that
+#'   `df` needs; dates further than `max_gap_days` from the nearest prior
+#'   available rate are left uncovered.
+#' @noRd
+.cmr_fill_non_trading_rf_gaps <- function(df, daily_rf, lookback, max_gap_days = 7L) {
+  needed    <- sort(unique(as.Date(df$date)))
+  rf_dates  <- sort(unique(as.Date(daily_rf$date)))
+  if (length(rf_dates) == 0L) return(daily_rf)  # let .join_rf_series report the real problem
+
+  rf_min <- min(rf_dates)
+  rf_max <- max(rf_dates)
+
+  missing  <- needed[!(needed %in% rf_dates)]
+  interior <- missing[missing >= rf_min & missing <= rf_max]
+  if (length(interior) == 0L) return(daily_rf)
+
+  fill_dates <- as.Date(character(0))
+  fill_gaps  <- integer(0)
+
+  # NOTE: `for (d in interior)` would silently strip the Date class on each
+  # iteration (a base-R for-loop gotcha) -- index instead, per #724 review.
+  for (i in seq_along(interior)) {
+    d <- interior[i]
+    prior_candidates <- rf_dates[rf_dates < d]
+    if (length(prior_candidates) == 0L) next  # defensive; d >= rf_min makes this unreachable
+    prior <- max(prior_candidates)
+    gap   <- as.numeric(d - prior)
+    if (gap <= max_gap_days) {
+      fill_dates <- c(fill_dates, d)
+      fill_gaps  <- c(fill_gaps, gap)
+    }
+  }
+
+  if (length(fill_dates) == 0L) return(daily_rf)
+
+  # NOTE: vapply()/sapply() also silently drop the Date class from a Date
+  # return value (they unlist() the result) -- round-trip through numeric
+  # explicitly rather than relying on FUN.VALUE to preserve it (#724 review;
+  # same underlying gotcha as the for-loop fix above).
+  prior_for <- as.Date(
+    vapply(fill_dates, function(d) as.numeric(max(rf_dates[rf_dates < d])), numeric(1)),
+    origin = "1970-01-01"
+  )
+  filled_rows <- tibble::tibble(
+    date   = fill_dates,
+    rf_ret = daily_rf$rf_ret[match(prior_for, daily_rf$date)]
+  )
+
+  cli::cli_inform(c(
+    "v" = paste0(
+      "CMR {lookback}: carried daily_rf forward for {length(fill_dates)} ",
+      "non-trading date{?s} inside its own span (weekends/market holidays; ",
+      "longest gap to the prior available rate was {max(fill_gaps)} day{?s})."
+    ),
+    "i" = "Dates more than {max_gap_days} day{?s} from the prior available rate are left uncovered and still abort via the #679 interior-hole guard."
+  ))
+
+  dplyr::bind_rows(daily_rf, filled_rows) |> dplyr::arrange(.data$date)
+}
+
 #' Join a daily risk-free series onto a CMR portfolio (#722)
 #'
 #' Mirrors \code{.tom_join_rf_daily()} in R/plan_turn_of_month.R and
@@ -327,7 +442,12 @@ plan_commodities_mean_reversion <- function() {
   # that was previously joined against this daily portfolio (#677 introduced
   # the real rf but on the wrong frequency; #717 fixed ann_factor without
   # fixing the rf join that #722 catches).
-  df <- .cmr_join_rf(df, daily_rf, lookback = lookback)
+  # #724: daily_rf follows the NYSE trading calendar; CMR's merged universe
+  # needs some dates NYSE didn't trade (weekends, holidays, one-off
+  # closures). Pre-fill short (<=7 calendar day) non-trading gaps via LOCF
+  # before the shared #679 guard runs -- genuine interior holes still abort.
+  daily_rf_filled <- .cmr_fill_non_trading_rf_gaps(df, daily_rf, lookback = lookback)
+  df <- .cmr_join_rf(df, daily_rf_filled, lookback = lookback)
   n  <- nrow(df)  # may shrink if a trailing rf gap was trimmed above
 
   r  <- df$net_ret

--- a/tests/testthat/_snaps/cmr-units.md
+++ b/tests/testthat/_snaps/cmr-units.md
@@ -18,3 +18,44 @@
       x .cmr_join_rf(): daily_rf is missing 1 required column: rf_ret.
       i Expected a tibble with date and rf_ret (the daily_rf target, R/plan_stock_backtest.R).
 
+# .cmr_fill_non_trading_rf_gaps reports what it filled (#724 observability)
+
+    Code
+      .cmr_fill_non_trading_rf_gaps(df, daily_rf, lookback = "1m")
+    Message
+      v CMR 1m: carried daily_rf forward for 3 non-trading dates inside its own span (weekends/market holidays; longest gap to the prior available rate was 3 days).
+      i Dates more than 7 days from the prior available rate are left uncovered and still abort via the #679 interior-hole guard.
+    Output
+      # A tibble: 6 x 2
+        date        rf_ret
+        <date>       <dbl>
+      1 2024-08-30 0.0001 
+      2 2024-08-31 0.0001 
+      3 2024-09-01 0.0001 
+      4 2024-09-02 0.0001 
+      5 2024-09-03 0.00012
+      6 2024-09-04 0.00011
+
+# .cmr_fill_non_trading_rf_gaps leaves a gap wider than max_gap_days unfilled, and the join still aborts (real hole, not weakened)
+
+    Code
+      .cmr_join_rf(df, filled, lookback = "1m")
+    Condition
+      Error in `.join_rf_series()`:
+      x 1 date inside daily_rf's own span have no risk-free rate (CMR 1m).
+      i Missing date: "2024-01-10".
+      i daily_rf spans 2024-01-01..2024-01-20, so this is a HOLE in the series, not a publication lag.
+      i Investigate the FF3 source (the daily_rf target, R/plan_stock_backtest.R) before trusting any CMR 1m Sharpe figure.
+
+# .cmr_fill_non_trading_rf_gaps does not touch a LEADING gap -- .cmr_join_rf still aborts LEADING
+
+    Code
+      .cmr_join_rf(df, filled, lookback = "1m")
+    Condition
+      Error in `.join_rf_series()`:
+      x 1 date come before daily_rf even starts (CMR 1m).
+      i Missing date: "2024-01-01".
+      i daily_rf starts 2024-01-10; CMR 1m portfolio starts 2024-01-01.
+      i This is LEADING coverage: the risk-free series simply does not reach this far back yet -- a different situation from a gap inside its own span.
+      i Trim CMR 1m portfolio to start no earlier than 2024-01-10, or source an earlier daily_rf.
+

--- a/tests/testthat/test-cmr-units.R
+++ b/tests/testthat/test-cmr-units.R
@@ -131,3 +131,85 @@ test_that(".cmr_join_rf aborts when daily_rf lacks required columns", {
 
   expect_snapshot(error = TRUE, .cmr_join_rf(df, bad_rf, lookback = "test"))
 })
+
+# ── #724: LOCF fill for short non-trading gaps inside daily_rf's span ──────
+# daily_rf follows the NYSE calendar; CMR's merged universe needs some dates
+# NYSE never traded (weekends, market holidays, one-off closures). See the
+# roxygen on .cmr_fill_non_trading_rf_gaps() (R/plan_commodities_mean_reversion.R)
+# for the full #724 investigation (163 real gaps, all confirmed non-trading
+# days, longest 4 calendar days from the prior available rate).
+
+test_that(".cmr_fill_non_trading_rf_gaps fills a short weekend/holiday gap and lets the join succeed", {
+  # Fri 8/30, Tue 9/3, Wed 9/4 present; Sat/Sun/Mon(Labor Day) missing.
+  daily_rf <- tibble::tibble(
+    date   = as.Date(c("2024-08-30", "2024-09-03", "2024-09-04")),
+    rf_ret = c(0.0001, 0.00012, 0.00011)
+  )
+  df <- tibble::tibble(
+    date = as.Date(c(
+      "2024-08-30", "2024-08-31", "2024-09-01",
+      "2024-09-02", "2024-09-03", "2024-09-04"
+    )),
+    net_ret = c(0.001, 0.002, 0.0015, 0.001, 0.0005, 0.0007)
+  )
+
+  suppressMessages(filled <- .cmr_fill_non_trading_rf_gaps(df, daily_rf, lookback = "1m"))
+
+  expect_equal(nrow(filled), 6L)
+  expect_false(anyNA(filled$rf_ret))
+  # Carried forward from the prior available date (2024-08-30), not
+  # interpolated or borrowed from a later date (no look-ahead).
+  expect_equal(
+    filled$rf_ret[filled$date %in% as.Date(c("2024-08-31", "2024-09-01", "2024-09-02"))],
+    rep(0.0001, 3L)
+  )
+
+  joined <- .cmr_join_rf(df, filled, lookback = "1m")
+  expect_equal(nrow(joined), 6L)
+  expect_false(anyNA(joined$rf_ret))
+})
+
+test_that(".cmr_fill_non_trading_rf_gaps reports what it filled (#724 observability)", {
+  daily_rf <- tibble::tibble(
+    date   = as.Date(c("2024-08-30", "2024-09-03", "2024-09-04")),
+    rf_ret = c(0.0001, 0.00012, 0.00011)
+  )
+  df <- tibble::tibble(
+    date = as.Date(c(
+      "2024-08-30", "2024-08-31", "2024-09-01",
+      "2024-09-02", "2024-09-03", "2024-09-04"
+    )),
+    net_ret = 0
+  )
+
+  expect_snapshot(.cmr_fill_non_trading_rf_gaps(df, daily_rf, lookback = "1m"))
+})
+
+test_that(".cmr_fill_non_trading_rf_gaps leaves a gap wider than max_gap_days unfilled, and the join still aborts (real hole, not weakened)", {
+  daily_rf <- tibble::tibble(date = as.Date(c("2024-01-01", "2024-01-20")), rf_ret = c(0.0001, 0.0001))
+  df <- tibble::tibble(date = as.Date(c("2024-01-01", "2024-01-10", "2024-01-20")), net_ret = 0)
+
+  filled <- .cmr_fill_non_trading_rf_gaps(df, daily_rf, lookback = "1m", max_gap_days = 7L)
+  # Unchanged: the 9-day-distant gap (2024-01-10, 9 days after 2024-01-01) is
+  # NOT filled -- it is exactly the kind of gap the #679 guard exists to catch.
+  expect_equal(nrow(filled), nrow(daily_rf))
+
+  expect_snapshot(error = TRUE, .cmr_join_rf(df, filled, lookback = "1m"))
+})
+
+test_that(".cmr_fill_non_trading_rf_gaps does not touch a LEADING gap -- .cmr_join_rf still aborts LEADING", {
+  daily_rf <- tibble::tibble(date = as.Date(c("2024-01-10", "2024-01-11")), rf_ret = c(0.0001, 0.0001))
+  df <- tibble::tibble(date = as.Date(c("2024-01-01", "2024-01-10", "2024-01-11")), net_ret = 0)
+
+  filled <- .cmr_fill_non_trading_rf_gaps(df, daily_rf, lookback = "1m")
+  expect_equal(nrow(filled), nrow(daily_rf))  # no interior gap to fill
+
+  expect_snapshot(error = TRUE, .cmr_join_rf(df, filled, lookback = "1m"))
+})
+
+test_that(".cmr_fill_non_trading_rf_gaps is a no-op when df has no gaps against daily_rf", {
+  df <- toy_portfolio |> dplyr::mutate(date = as.Date(date))
+
+  filled <- .cmr_fill_non_trading_rf_gaps(df, toy_daily_rf, lookback = "test")
+  expect_identical(filled, toy_daily_rf)
+})


### PR DESCRIPTION
## Summary

`main` is broken: #723 switched CMR's risk-free join to the daily `daily_rf`
target, which follows the NYSE trading calendar. CMR's merged universe (13
FRED monthly + 24 Yahoo daily commodity series, #717) needs some dates NYSE
never traded, so all three `cmr_metrics_*` targets error and the leaderboard
serves a stale pre-#723 CMR row (`ann_rf = 0.407`).

- Adds `.cmr_fill_non_trading_rf_gaps()` in `R/plan_commodities_mean_reversion.R`,
  called from `.compute_cmr_metrics()` immediately before `.cmr_join_rf()`.
- For any date CMR needs that falls *inside* `daily_rf`'s own span but has no
  row, it carries the last available `daily_rf$rf_ret` **forward** (never a
  later value — no look-ahead), but only if the nearest prior available
  `daily_rf` date is within `max_gap_days` (7, default) calendar days.
- Dates further than that are left uncovered and fall straight through to the
  existing #679 interior-hole guard (`.join_rf_series()`, `R/utils_metrics.R`)
  **unchanged** — that shared guard is not touched, and neither are its other
  three callers (LTR, ToM, mom_prepeak, #677). A genuine interior hole, on
  CMR or any other strategy's rf join, still aborts exactly as before.

## Independent confirmation (not just the issue's own error text)

Ran outside `tar_make()`: fetched the real `daily_rf` series via `hd_factors()`
and the real commodities universe dates from `data/raw/commodities.parquet`,
then reproduced the exact crash directly by calling `.cmr_join_rf()` on them.

- **163** interior-missing dates today (this count drifts slightly day to day
  — both `daily_rf` and the commodities data are live-updated; the issue's
  own run found 161).
- Checked **every one of the 163 by hand** against the actual NYSE calendar,
  not assumed:
  - Weekends and New Year's Day (147 of 163)
  - Memorial Day, Independence Day (x2), Labor Day, Thanksgiving (x3),
    Christmas
  - Good Friday (`1994-04-01`)
  - The four-day 9/11 closure (`2001-09-11` .. `2001-09-14`)
  - Three presidential state-funeral closures: Reagan (`2004-06-11`), Ford
    (`2007-01-02`), Carter (`2025-01-09`)
- **All 163 are legitimate NYSE non-trading days. None is a genuine hole in
  `daily_rf`.**

## Why LOCF + a calendar-day bound, not a hardcoded holiday table

A hardcoded holiday list looked attractive at first (weekend + New Year's Day
covers 147/163) but Good Friday, the funeral closures, and 9/11 are exactly
the kind of one-off the codebase can't enumerate in advance — and a fixed list
would be wrong again the next time markets close for an unscheduled reason.

Instead the fill is bounded by **distance to the nearest prior available rate**:
every one of the 163 real gaps was ≤ 4 calendar days from its prior available
`daily_rf` date (the 9/11 closure was the longest, at 4). `max_gap_days = 7L`
leaves a week of headroom. This is the same style of defence already used
elsewhere in this file (`.assert_cmr_ann_factor`'s median-gap bands) — bound a
number, state it, justify it — rather than relaxing the guard's own tolerance.

## Verification

- Synthetic tests (new, in `tests/testthat/test-cmr-units.R`):
  - Fills a weekend/holiday gap, join succeeds, filled value is LOCF (not
    interpolated, not from a later date).
  - Reports what it filled (`cli_inform`, snapshotted).
  - A gap wider than `max_gap_days` is **left unfilled** and `.cmr_join_rf`
    **still aborts** with the original, unmodified interior-hole message
    (snapshotted) — confirms the guard is not weakened.
  - A LEADING gap is untouched by the fill and `.cmr_join_rf` still aborts
    LEADING (snapshotted) — confirms the fill only ever touches interior gaps.
  - No-op when there's nothing to fill.
- End-to-end reproduction against the **real** `daily_rf` + commodities dates
  (not a toy fixture): unfixed join reproduces the exact 163-date crash;
  fixed join completes with 0 remaining `NA rf_ret`, and the pre-existing
  trailing publication-lag warning still fires correctly and unmodified.
- `scripts/verify.sh` (foreground, full): **PASS**. Root suite
  `total=684 failed=3 skipped=0` — matches the documented baseline exactly.
  Package suite `total=713 failed=1 skipped=15` — matches the documented
  baseline exactly. No regressions.

## Explicitly NOT fixed here

CMR's return series still mixes daily and monthly-stamped observations — a
row dated e.g. `1992-03-01` is a monthly FRED observation sitting in an
otherwise-daily series, annualised at 252. So `vol`/`cagr` are still not
strictly right (better than the 12-vs-252 error #717 fixed; still not
correct). That needs its own decision — restrict the universe to daily
series, resample to a common frequency, or document what the mixed
annualisation means — and is out of scope for unbreaking `main`. Documented
in the file header comment for whoever picks it up.

## Not verified by this PR

**`tar_make()` was not run** — out of scope for this dispatch (forbidden by
task scope). The actual `cmr_metrics_*` targets building successfully is
**not confirmed** by this change; only the underlying join logic is, via
direct calls and `scripts/verify.sh`'s test suites. The orchestrator will
rebuild and confirm the targets pipeline separately.

Refs #724, #723, #722, #717, #679, #677.
