### PR TITLE
fix(leaderboard): close detection-power NA hole + add multiple-testing-corrected columns (#726 items 3+4)

### DIFF
--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -107,7 +107,7 @@ STRATEGY_OBS_ANN_FACTOR <- tibble::tibble(
     "R/plan_portfolio_opt.R (ann_vol <- sd(port_ret) * sqrt(12))",
     "This file's own .norm_olmar() comment ('daily ann_factor'); OLMAR (Li & Hoi 2012) rebalances daily",
     "R/plan_turn_of_month.R:368 ('TOM is a daily strategy (sqrt(252) annualisation)')",
-    "R/plan_risk_state.R calc_metrics(periods_per_year = 252L default); rsc_metrics has no months/n_days column at all, so this row's `months` is always NA -- included for completeness/future-proofing",
+    "R/plan_risk_state.R calc_metrics(periods_per_year = 252L default); calc_metrics() now returns n_obs (#726 item 3), renamed to `months` by .norm_rsc() below -- previously this row's `months` was always NA because rsc_metrics had no months/n_days column at all",
     "R/plan_avoid_worst.R (ann_factor = 252L throughout, e.g. .aw_sharpe_rf_full())"
   )
 )
@@ -209,11 +209,18 @@ plan_leaderboard <- function() {
       # plan_risk_state.R:calc_metrics().
       # Source: R/plan_risk_state.R:270-273 stores cagr/vol/max_dd as PERCENT
       # (round(x * 100, 2)) -- convert to fraction.
+      # #726 item 3: rsc_metrics now carries n_obs (raw observation count,
+      # added to calc_metrics() in R/plan_risk_state.R) -- renamed to
+      # `months` here, same convention as .norm_aw()'s n_days rename below,
+      # so the detection-power diagnostic (#711 Gap 1) below can finally
+      # compute a real verdict for this row instead of silently NA-ing on a
+      # missing `months` column (#726's "close the NA hole" finding).
       .norm_rsc <- function(m) {
         if (is.null(m) || nrow(m) == 0) return(NULL)
         m |>
           filter(strategy == "SPY_overlay") |>
           select(-strategy) |>
+          rename(months = n_obs) |>
           mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100,
                  ann_rf = ann_rf / 100)
       }
@@ -747,34 +754,108 @@ plan_leaderboard <- function() {
       # hd_detection_power() has no power calculation for a non-positive
       # claimed effect, so "underpowered" is not a meaningful question for
       # a strategy that isn't even claiming a positive edge in this row).
+      # Every row where sharpe > 0 is expected to end up with a non-NA verdict
+      # here -- R/plan_qa_gates.R's check_leaderboard_detection_power_values()
+      # (S20, #726 item 3) aborts the pipeline if one doesn't, naming which of
+      # the three possible NA paths (months missing/too short, or
+      # hd_detection_power() itself failing inside the tryCatch below) is
+      # responsible, so a future gap like Risk State's (months was never
+      # populated -- see .norm_rsc() and the STRATEGY_OBS_ANN_FACTOR comment
+      # above) fails loudly instead of surviving silently forever.
+      #
+      # detection_min_n_years_mt / detection_underpowered_mt (#726 item 4):
+      # the SAME calculation, but at alpha = 0.05 / k_eff_strat instead of the
+      # single-test alpha = 0.05 above -- the Bonferroni multiple-testing
+      # correction hd_detection_power()'s own roxygen "Assumptions and
+      # limits" section already suggests combining with
+      # hd_strat_keff_vertox(), and which #726's issue text argues nothing
+      # currently applies. k_eff_strat is joined from strat_deflated_sharpe
+      # earlier in this target (see "Deflated Sharpe" section above) and, as
+      # of this table, strat_deflated_sharpe only has one row per column in
+      # that section's `col_map` (Stock MAX, Stock DRIF, Factor MAX, Factor
+      # DRIF) -- every OTHER strategy's k_eff_strat is NA after the left_join,
+      # not because the multiple-testing correction doesn't apply to them
+      # (it does -- #726 names Value (HML) and Factor DRIF specifically) but
+      # because strat_keff_vertox()/strategy_correlation's correlation matrix
+      # is itself only computed over those four columns. Rather than guess a
+      # k_eff_strat for strategies outside that matrix, the `_mt` columns are
+      # deliberately NA wherever k_eff_strat is NA or < 1 (a k_eff_strat below
+      # 1 would WIDEN alpha, the opposite of a Bonferroni correction, and
+      # cannot be a valid effective-test count) -- an explicit, commented
+      # default per fail-loud-not-null.md's "Required Pattern" item 2, not a
+      # silent coercion, and S20 only asserts `_mt` coverage where k_eff_strat
+      # is actually non-NA (see check_leaderboard_detection_power_values()).
+      # Widening strat_corr_matrix's coverage to every strategy is out of
+      # scope here (#726 lists it as neither item 3 nor item 4) and is left
+      # as a follow-up.
       all_metrics <- all_metrics |>
         dplyr::left_join(STRATEGY_OBS_ANN_FACTOR, by = "strategy")
 
-      .detection_diag_row <- function(sr, n, af) {
-        if (is.na(sr) || is.na(n) || is.na(af) || sr <= 0 || n < 2) {
-          return(tibble::tibble(
+      # Defensive: strat_deflated_sharpe's join above is itself guarded by
+      # `!is.null(strat_deflated_sharpe) && nrow(strat_deflated_sharpe) > 0`,
+      # so k_eff_strat may not exist as a column at all (e.g. in a partial
+      # test harness that omits that upstream target) -- pmap_dfr below needs
+      # every element to be a real vector, not a NULL, so backfill NA here.
+      if (!"k_eff_strat" %in% names(all_metrics)) {
+        all_metrics$k_eff_strat <- NA_real_
+      }
+
+      .detection_diag_row <- function(sr, n, af, keff) {
+        single <- if (is.na(sr) || is.na(n) || is.na(af) || sr <= 0 || n < 2) {
+          tibble::tibble(
             detection_min_n_years  = NA_real_,
             detection_underpowered = NA
-          ))
+          )
+        } else {
+          dp <- tryCatch(
+            historicaldata::hd_detection_power(sharpe_annual = sr, n_obs = n, ann_factor = af),
+            error = function(e) NULL
+          )
+          if (is.null(dp)) {
+            tibble::tibble(
+              detection_min_n_years  = NA_real_,
+              detection_underpowered = NA
+            )
+          } else {
+            tibble::tibble(
+              detection_min_n_years  = dp$min_n_years,
+              detection_underpowered = dp$underpowered
+            )
+          }
         }
-        dp <- tryCatch(
-          historicaldata::hd_detection_power(sharpe_annual = sr, n_obs = n, ann_factor = af),
-          error = function(e) NULL
-        )
-        if (is.null(dp)) {
-          return(tibble::tibble(
-            detection_min_n_years  = NA_real_,
-            detection_underpowered = NA
-          ))
+
+        mt <- if (is.na(sr) || is.na(n) || is.na(af) || sr <= 0 || n < 2 ||
+                    is.na(keff) || keff < 1) {
+          tibble::tibble(
+            detection_min_n_years_mt  = NA_real_,
+            detection_underpowered_mt = NA
+          )
+        } else {
+          dp_mt <- tryCatch(
+            historicaldata::hd_detection_power(
+              sharpe_annual = sr, n_obs = n, ann_factor = af, alpha = 0.05 / keff
+            ),
+            error = function(e) NULL
+          )
+          if (is.null(dp_mt)) {
+            tibble::tibble(
+              detection_min_n_years_mt  = NA_real_,
+              detection_underpowered_mt = NA
+            )
+          } else {
+            tibble::tibble(
+              detection_min_n_years_mt  = dp_mt$min_n_years,
+              detection_underpowered_mt = dp_mt$underpowered
+            )
+          }
         }
-        tibble::tibble(
-          detection_min_n_years  = dp$min_n_years,
-          detection_underpowered = dp$underpowered
-        )
+
+        dplyr::bind_cols(single, mt)
       }
 
       detection_diag <- purrr::pmap_dfr(
-        list(all_metrics$sharpe, all_metrics$months, all_metrics$obs_ann_factor),
+        list(all_metrics$sharpe, all_metrics$months, all_metrics$obs_ann_factor,
+             all_metrics$k_eff_strat),
         .detection_diag_row
       )
 

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -1348,6 +1348,147 @@ check_leaderboard_detection_power_coverage <- function(leaderboard, obs_ann_fact
 }
 
 
+#' Assert every positive-Sharpe leaderboard row has a detection-power verdict
+#' (S20)
+#'
+#' Closes the NA hole #726 found in the detection-power diagnostic
+#' (\code{.detection_diag_row()}, R/plan_leaderboard.R, #711 Gap 1): that
+#' function returns NA for \code{detection_min_n_years}/
+#' \code{detection_underpowered} through THREE distinct paths -- (a)
+#' \code{sharpe} is NA or non-positive (the one-sided test has no positive
+#' effect to detect -- excluded from this gate by construction, since it
+#' only inspects rows with \code{sharpe > 0}), (b) \code{months} is NA or
+#' \code{< 2} (an unusable sample length), or (c)
+#' \code{historicaldata::hd_detection_power()} itself errors inside the
+#' \code{tryCatch}. \code{check_leaderboard_detection_power_coverage()} (S19,
+#' above) only guards the INPUT to this diagnostic -- that every strategy has
+#' a declared row in \code{STRATEGY_OBS_ANN_FACTOR} -- not that the
+#' diagnostic actually produced a value. Risk State passed S19 (it IS in
+#' \code{STRATEGY_OBS_ANN_FACTOR}, declared 252) while still landing on path
+#' (b) forever, because \code{rsc_metrics} never carried a \code{months}
+#' column at all until #726 item 3's fix to \code{calc_metrics()}
+#' (R/plan_risk_state.R) -- exactly the \code{fail-loud-not-null.md} pattern
+#' of a guard scoped to the input that failed last time rather than to the
+#' property actually wanted: "every positive-Sharpe row has a detection
+#' verdict."
+#'
+#' A second, independent assertion (per #726 item 4) covers the
+#' multiple-testing-corrected columns \code{detection_min_n_years_mt}/
+#' \code{detection_underpowered_mt} (alpha = 0.05 / \code{k_eff_strat}
+#' instead of the single-test alpha = 0.05): this is only checked for rows
+#' where \code{k_eff_strat} is itself usable (non-NA and >= 1) -- see the
+#' \code{.detection_diag_row()} comment in R/plan_leaderboard.R for why
+#' \code{k_eff_strat} is deliberately NA for most strategies today (it is
+#' only populated for the four columns \code{strat_deflated_sharpe} covers),
+#' which is an explicit, documented default per fail-loud-not-null.md's
+#' Required Pattern item 2, not something this gate treats as a defect.
+#'
+#' Both assertions name the offending \code{strategy}/\code{period} pairs and
+#' state which NA path applies, per fail-loud-not-null.md's requirement that
+#' an aborting message name the offending value and the field it came from --
+#' "some rows are NA" is not an acceptable message on its own.
+#'
+#' @param leaderboard Tibble with at least \code{strategy}, \code{period},
+#'   \code{sharpe}, \code{months}, \code{detection_min_n_years},
+#'   \code{detection_underpowered}, \code{detection_min_n_years_mt},
+#'   \code{detection_underpowered_mt}, \code{k_eff_strat} columns (the
+#'   output of the \code{leaderboard} target).
+#' @return \code{TRUE} invisibly on success.
+#' @noRd
+check_leaderboard_detection_power_values <- function(leaderboard) {
+  required_cols <- c(
+    "strategy", "period", "sharpe", "months",
+    "detection_min_n_years", "detection_underpowered",
+    "detection_min_n_years_mt", "detection_underpowered_mt", "k_eff_strat"
+  )
+  missing_cols <- setdiff(required_cols, names(leaderboard))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "Leaderboard is missing {length(missing_cols)} required column(s): {missing_cols}.",
+      "i" = paste0(
+        "check_leaderboard_detection_power_values() (S20) requires strategy, ",
+        "period, sharpe, months, detection_min_n_years, detection_underpowered, ",
+        "detection_min_n_years_mt, detection_underpowered_mt, k_eff_strat."
+      )
+    ))
+  }
+
+  positive <- !is.na(leaderboard$sharpe) & leaderboard$sharpe > 0
+
+  # ── Assertion 1: single-test verdict must be non-NA for every positive-
+  # Sharpe row -- the property #726 actually wants, not merely the S19 input
+  # check. Names which of paths (b)/(c) is responsible for each offender.
+  single_missing <- positive &
+    (is.na(leaderboard$detection_min_n_years) | is.na(leaderboard$detection_underpowered))
+
+  if (any(single_missing)) {
+    idx <- which(single_missing)
+    months_bad <- is.na(leaderboard$months[idx]) | leaderboard$months[idx] < 2
+    reason <- ifelse(
+      months_bad,
+      "months is NA or < 2 (path b: unusable sample length)",
+      paste0(
+        "hd_detection_power() produced no value despite a usable months (path c: ",
+        "the tryCatch in R/plan_leaderboard.R's .detection_diag_row() caught an error)"
+      )
+    )
+    offenders <- sprintf(
+      "  %s / %s -- sharpe = %s, months = %s -- %s",
+      leaderboard$strategy[idx], leaderboard$period[idx],
+      format(leaderboard$sharpe[idx], digits = 3),
+      ifelse(is.na(leaderboard$months[idx]), "NA", format(leaderboard$months[idx], digits = 4)),
+      reason
+    )
+    cli::cli_abort(c(
+      "x" = paste0(
+        "Leaderboard has ", length(idx),
+        " row(s) with sharpe > 0 but no detection-power verdict (#726):"
+      ),
+      setNames(offenders, rep("i", length(offenders))),
+      "i" = paste0(
+        "check_leaderboard_detection_power_values() (S20) requires every ",
+        "positive-Sharpe row to have a non-NA detection_min_n_years/",
+        "detection_underpowered -- fix the offending strategy's source ",
+        "metrics target (path b: publish a real months/n_days/n_obs column) ",
+        "or investigate the hd_detection_power() error (path c)."
+      )
+    ))
+  }
+
+  # ── Assertion 2: multiple-testing-corrected verdict must be non-NA
+  # wherever k_eff_strat is itself usable (#726 item 4).
+  mt_applicable <- positive & !is.na(leaderboard$k_eff_strat) & leaderboard$k_eff_strat >= 1
+  mt_missing <- mt_applicable &
+    (is.na(leaderboard$detection_min_n_years_mt) | is.na(leaderboard$detection_underpowered_mt))
+
+  if (any(mt_missing)) {
+    idx <- which(mt_missing)
+    offenders <- sprintf(
+      "  %s / %s -- sharpe = %s, k_eff_strat = %s",
+      leaderboard$strategy[idx], leaderboard$period[idx],
+      format(leaderboard$sharpe[idx], digits = 3),
+      format(leaderboard$k_eff_strat[idx], digits = 4)
+    )
+    cli::cli_abort(c(
+      "x" = paste0(
+        "Leaderboard has ", length(idx),
+        " row(s) with sharpe > 0 and a usable k_eff_strat but no multiple-",
+        "testing-corrected detection-power verdict (#726 item 4):"
+      ),
+      setNames(offenders, rep("i", length(offenders))),
+      "i" = paste0(
+        "check_leaderboard_detection_power_values() (S20) requires ",
+        "detection_min_n_years_mt/detection_underpowered_mt to be non-NA ",
+        "whenever k_eff_strat is non-NA and >= 1 -- see the alpha = 0.05 / ",
+        "keff tryCatch in R/plan_leaderboard.R's .detection_diag_row()."
+      )
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+
 # ---- QA gate plan ----
 
 plan_qa_gates <- function() {
@@ -1735,6 +1876,25 @@ plan_qa_gates <- function() {
       command = {
         check_leaderboard_detection_power_coverage(leaderboard, STRATEGY_OBS_ANN_FACTOR)
         cli::cli_inform(c("v" = "qa_leaderboard_detection_power_coverage: S19 passed (all strategies have a declared periodicity)"))
+        TRUE
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: every positive-Sharpe leaderboard row has a non-NA
+    # detection-power verdict, both single-test and (where k_eff_strat is
+    # usable) multiple-testing-corrected (S20, #726 items 3+4). S19 above
+    # only guards the diagnostic's INPUT (a declared periodicity); this gate
+    # asserts the property actually wanted -- that the diagnostic produced a
+    # value -- and names which of the diagnostic's three NA paths applies.
+    # See check_leaderboard_detection_power_values() roxygen for the full
+    # rationale, including why Risk State passed S19 while still landing on
+    # NA forever until #726 item 3's calc_metrics() fix.
+    targets::tar_target(
+      qa_leaderboard_detection_power_values,
+      command = {
+        check_leaderboard_detection_power_values(leaderboard)
+        cli::cli_inform(c("v" = "qa_leaderboard_detection_power_values: S20 passed (every positive-Sharpe row has a detection-power verdict)"))
         TRUE
       },
       cue = targets::tar_cue(mode = "always")

--- a/R/plan_risk_state.R
+++ b/R/plan_risk_state.R
@@ -348,7 +348,20 @@ plan_risk_state <- function() {
           hac_tstat = round(hac$hac_tstat, 3),
           hac_sharpe = round(hac$naive_sharpe, 3),
           window_start = min(date_vec),
-          window_end   = max(date_vec)
+          window_end   = max(date_vec),
+          # n_obs (#726 item 3): raw observation count backing this row --
+          # `years` above is derived from it but was never itself exposed,
+          # which is why R/plan_leaderboard.R's .norm_rsc() had nothing to
+          # rename into `months` and every SPY_overlay row's detection-power
+          # diagnostic (.detection_diag_row()) was silently NA regardless of
+          # sharpe. Same periodicity as periods_per_year (days for the
+          # SPY_overlay/SPY_buyhold rows this file's default 252L covers;
+          # months for the DRIF_raw/DRIF_overlay/FacMAX_raw/FacMAX_overlay
+          # rows called with periods_per_year = 12L below) -- consistent with
+          # how every other strategy's `months` column is actually a raw
+          # period count, not literally months (see the
+          # STRATEGY_OBS_ANN_FACTOR comment in R/plan_leaderboard.R).
+          n_obs     = length(ret_vec)
         )
       }
 
@@ -848,7 +861,11 @@ plan_risk_state <- function() {
   # risk-free-adjusted column added alongside the pre-existing `hac_sharpe`
   # -- both need a unit or hd_metric_record() aborts loud per #640). ann_rf
   # (#677 slice 4, #691) is PERCENT, same convention as cagr
-  # (round(sr_result$ann_rf * 100, 2) above).
+  # (round(sr_result$ann_rf * 100, 2) above). n_obs (#726 item 3) is a raw
+  # observation COUNT, not a ratio/percent -- hd_metric_record()'s wide-form
+  # path treats every numeric column as a candidate metric (see
+  # .normalise_metric_long()'s `is_num` filter), so it needs a unit here too
+  # or the same #640 abort fires for it.
   full_row <- rsc_metrics[
     rsc_metrics$strategy == "SPY_overlay" & rsc_metrics$period == "Full Period",
     , drop = FALSE
@@ -858,7 +875,7 @@ plan_risk_state <- function() {
     rsc_units <- c(
       cagr = "percent", vol = "percent", max_dd = "percent",
       sharpe = "ratio", hac_tstat = "ratio", hac_sharpe = "ratio",
-      ann_rf = "percent"
+      ann_rf = "percent", n_obs = "count"
     )
     historicaldata::hd_metric_record(
       con, uu, full_row[, metric_cols, drop = FALSE], units = rsc_units

--- a/tests/testthat/_snaps/leaderboard-detection-power-values.md
+++ b/tests/testthat/_snaps/leaderboard-detection-power-values.md
@@ -1,0 +1,39 @@
+# check_leaderboard_detection_power_values throws and names path (b) when months is NA/<2
+
+    Code
+      check_leaderboard_detection_power_values(months_na_leaderboard)
+    Condition
+      Error in `check_leaderboard_detection_power_values()`:
+      x Leaderboard has 1 row(s) with sharpe > 0 but no detection-power verdict (#726):
+      i  Risk State / Full Period -- sharpe = 0.252, months = NA -- months is NA or < 2 (path b: unusable sample length)
+      i check_leaderboard_detection_power_values() (S20) requires every positive-Sharpe row to have a non-NA detection_min_n_years/detection_underpowered -- fix the offending strategy's source metrics target (path b: publish a real months/n_days/n_obs column) or investigate the hd_detection_power() error (path c).
+
+# check_leaderboard_detection_power_values throws and names path (c) when months is usable but the verdict is still NA
+
+    Code
+      check_leaderboard_detection_power_values(power_fail_leaderboard)
+    Condition
+      Error in `check_leaderboard_detection_power_values()`:
+      x Leaderboard has 1 row(s) with sharpe > 0 but no detection-power verdict (#726):
+      i  LTR / Full Period -- sharpe = 0.33, months = 254 -- hd_detection_power() produced no value despite a usable months (path c: the tryCatch in R/plan_leaderboard.R's .detection_diag_row() caught an error)
+      i check_leaderboard_detection_power_values() (S20) requires every positive-Sharpe row to have a non-NA detection_min_n_years/detection_underpowered -- fix the offending strategy's source metrics target (path b: publish a real months/n_days/n_obs column) or investigate the hd_detection_power() error (path c).
+
+# check_leaderboard_detection_power_values throws when k_eff_strat is usable but the mt verdict is NA
+
+    Code
+      check_leaderboard_detection_power_values(mt_missing_leaderboard)
+    Condition
+      Error in `check_leaderboard_detection_power_values()`:
+      x Leaderboard has 1 row(s) with sharpe > 0 and a usable k_eff_strat but no multiple-testing-corrected detection-power verdict (#726 item 4):
+      i  Factor DRIF / Full Period -- sharpe = 0.076, k_eff_strat = 4.847
+      i check_leaderboard_detection_power_values() (S20) requires detection_min_n_years_mt/detection_underpowered_mt to be non-NA whenever k_eff_strat is non-NA and >= 1 -- see the alpha = 0.05 / keff tryCatch in R/plan_leaderboard.R's .detection_diag_row().
+
+# check_leaderboard_detection_power_values throws when leaderboard is missing required columns
+
+    Code
+      check_leaderboard_detection_power_values(bad)
+    Condition
+      Error in `check_leaderboard_detection_power_values()`:
+      x Leaderboard is missing 1 required column(s): months.
+      i check_leaderboard_detection_power_values() (S20) requires strategy, period, sharpe, months, detection_min_n_years, detection_underpowered, detection_min_n_years_mt, detection_underpowered_mt, k_eff_strat.
+

--- a/tests/testthat/test-leaderboard-detection-power-values.R
+++ b/tests/testthat/test-leaderboard-detection-power-values.R
@@ -1,0 +1,159 @@
+testthat::local_edition(3)
+# Tests for check_leaderboard_detection_power_values() — QA gate S20 (#726 items 3+4)
+#
+# The function is defined in R/plan_qa_gates.R. It closes the NA hole #726
+# found in R/plan_leaderboard.R's .detection_diag_row(): S19
+# (check_leaderboard_detection_power_coverage(), see the sibling test file
+# test-leaderboard-detection-power-coverage.R) only guards the diagnostic's
+# INPUT (a declared row in STRATEGY_OBS_ANN_FACTOR); it does not check that
+# the diagnostic actually produced a value. S20 asserts the property #726
+# wants: every row with sharpe > 0 has a non-NA detection_min_n_years /
+# detection_underpowered, and (where k_eff_strat is itself usable) a non-NA
+# detection_min_n_years_mt / detection_underpowered_mt.
+#
+# Background (#726): Risk State passed S19 (it IS in STRATEGY_OBS_ANN_FACTOR,
+# declared 252) while its months column was always NA -- rsc_metrics never
+# carried an observation-count column until #726 item 3's calc_metrics()
+# fix (R/plan_risk_state.R). S20 is the gate that would have caught that gap
+# at pipeline time instead of it surviving silently.
+
+source(here::here("R/plan_qa_gates.R"))
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+# All positive-Sharpe rows have a verdict. "OLMAR-1" / Training has a
+# negative sharpe with an NA verdict -- deliberately included to prove the
+# gate correctly ignores non-positive-Sharpe rows (path a, #726's own text:
+# "underpowered is not a meaningful question for a strategy that isn't even
+# claiming a positive edge"). "Value (HML)" has k_eff_strat = NA, so its mt
+# columns are legitimately NA too (#726 item 4's documented guard) and must
+# NOT trip the mt assertion.
+good_leaderboard <- tibble::tibble(
+  strategy                   = c("OLMAR-1", "OLMAR-1",     "Value (HML)"),
+  period                     = c("Full Period", "Training", "Full Period"),
+  sharpe                     = c(0.78, -0.20, 0.068),
+  months                     = c(4000, 2000, 750),
+  detection_min_n_years      = c(10, NA_real_, 1337),
+  detection_underpowered     = c(FALSE, NA, TRUE),
+  detection_min_n_years_mt   = c(12, NA_real_, NA_real_),
+  detection_underpowered_mt  = c(FALSE, NA, NA),
+  k_eff_strat                = c(4.847, 4.847, NA_real_)
+)
+
+# Path (b): Risk State's actual #726 shape -- sharpe > 0, months NA.
+months_na_leaderboard <- tibble::tibble(
+  strategy                   = "Risk State",
+  period                     = "Full Period",
+  sharpe                     = 0.252,
+  months                     = NA_real_,
+  detection_min_n_years      = NA_real_,
+  detection_underpowered     = NA,
+  detection_min_n_years_mt   = NA_real_,
+  detection_underpowered_mt  = NA,
+  k_eff_strat                = NA_real_
+)
+
+# Path (c): months is usable (present, >= 2) but hd_detection_power() still
+# produced no value -- e.g. the tryCatch in .detection_diag_row() caught an
+# error.
+power_fail_leaderboard <- tibble::tibble(
+  strategy                   = "LTR",
+  period                     = "Full Period",
+  sharpe                     = 0.330,
+  months                     = 254,
+  detection_min_n_years      = NA_real_,
+  detection_underpowered     = NA,
+  detection_min_n_years_mt   = NA_real_,
+  detection_underpowered_mt  = NA,
+  k_eff_strat                = NA_real_
+)
+
+# #726 item 4: single-test verdict is fine, but k_eff_strat IS usable
+# (>= 1, non-NA) and the mt columns are still NA -- must trip the mt
+# assertion even though the single-test assertion passes.
+mt_missing_leaderboard <- tibble::tibble(
+  strategy                   = "Factor DRIF",
+  period                     = "Full Period",
+  sharpe                     = 0.076,
+  months                     = 691,
+  detection_min_n_years      = 1067,
+  detection_underpowered     = TRUE,
+  detection_min_n_years_mt   = NA_real_,
+  detection_underpowered_mt  = NA,
+  k_eff_strat                = 4.847
+)
+
+# ── Tests: single-test assertion ────────────────────────────────────────────
+
+test_that("check_leaderboard_detection_power_values passes when every positive-Sharpe row has a verdict", {
+  expect_true(check_leaderboard_detection_power_values(good_leaderboard))
+})
+
+test_that("check_leaderboard_detection_power_values ignores non-positive-Sharpe rows entirely", {
+  # The NA verdict on the negative-sharpe "OLMAR-1 / Training" row in
+  # good_leaderboard must not trip the gate -- confirmed by the pass above,
+  # this test isolates that one row to make the intent explicit.
+  only_negative <- good_leaderboard[good_leaderboard$strategy == "OLMAR-1" &
+                                       good_leaderboard$period == "Training", ]
+  expect_true(check_leaderboard_detection_power_values(only_negative))
+})
+
+test_that("check_leaderboard_detection_power_values throws and names path (b) when months is NA/<2", {
+  expect_error(
+    check_leaderboard_detection_power_values(months_na_leaderboard),
+    regexp = "Risk State"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_detection_power_values(months_na_leaderboard)
+  )
+})
+
+test_that("check_leaderboard_detection_power_values throws and names path (c) when months is usable but the verdict is still NA", {
+  expect_error(
+    check_leaderboard_detection_power_values(power_fail_leaderboard),
+    regexp = "LTR"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_detection_power_values(power_fail_leaderboard)
+  )
+})
+
+# ── Tests: multiple-testing-corrected assertion (#726 item 4) ──────────────
+
+test_that("check_leaderboard_detection_power_values throws when k_eff_strat is usable but the mt verdict is NA", {
+  expect_error(
+    check_leaderboard_detection_power_values(mt_missing_leaderboard),
+    regexp = "Factor DRIF"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_detection_power_values(mt_missing_leaderboard)
+  )
+})
+
+test_that("check_leaderboard_detection_power_values does not require mt columns when k_eff_strat is NA", {
+  # power_fail_leaderboard has k_eff_strat = NA and NA mt columns -- would
+  # wrongly trip the mt assertion if it didn't guard on k_eff_strat's own
+  # usability. Isolate that shape with a passing single-test verdict so only
+  # the mt guard is under test.
+  fixture <- power_fail_leaderboard
+  fixture$detection_min_n_years  <- 57
+  fixture$detection_underpowered <- TRUE
+  expect_true(check_leaderboard_detection_power_values(fixture))
+})
+
+# ── Tests: required columns ─────────────────────────────────────────────────
+
+test_that("check_leaderboard_detection_power_values throws when leaderboard is missing required columns", {
+  bad <- dplyr::select(good_leaderboard, -months)
+  expect_error(
+    check_leaderboard_detection_power_values(bad),
+    regexp = "months"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_detection_power_values(bad)
+  )
+})

--- a/tests/testthat/test-leaderboard-unit-scale.R
+++ b/tests/testthat/test-leaderboard-unit-scale.R
@@ -152,6 +152,46 @@ test_that(".norm_tom converts percent-native source metrics to fraction", {
   expect_equal(res$sharpe, 0.28)  # sharpe is scale-free, never converted
 })
 
+.norm_rsc_test <- function(m) {
+  if (is.null(m) || nrow(m) == 0) return(NULL)
+  m |>
+    dplyr::filter(strategy == "SPY_overlay") |>
+    dplyr::select(-strategy) |>
+    dplyr::rename(months = n_obs) |>
+    dplyr::mutate(cagr = cagr / 100, vol = vol / 100, max_dd = max_dd / 100,
+                  ann_rf = ann_rf / 100)
+}
+
+# n_obs (#726 item 3): rsc_metrics' calc_metrics() (R/plan_risk_state.R) now
+# publishes a raw observation count -- previously absent entirely, which is
+# why the real .norm_rsc()'s `months` column was always NA (see the
+# STRATEGY_OBS_ANN_FACTOR comment in R/plan_leaderboard.R and QA gate S20,
+# test-leaderboard-detection-power-values.R).
+synthetic_rsc_metrics <- tibble::tibble(
+  strategy   = c("SPY_buyhold", "SPY_overlay"),
+  period     = c("Full Period", "Full Period"),
+  cagr       = c(9.80, 11.30),
+  vol        = c(16.00, 13.20),
+  sharpe     = c(0.40, 0.55),
+  ann_rf     = c(1.80, 1.80),
+  max_dd     = c(-30.00, -22.00),
+  hac_tstat  = c(1.9, 2.5),
+  hac_sharpe = c(0.59, 0.83),
+  n_obs      = c(4000L, 4000L)
+)
+
+test_that(".norm_rsc converts percent-native source metrics to fraction and renames n_obs to months (#726 item 3)", {
+  res <- .norm_rsc_test(synthetic_rsc_metrics)
+  expect_equal(nrow(res), 1L)
+  expect_equal(res$cagr, 0.1130, tolerance = 1e-8)
+  expect_equal(res$vol, 0.1320, tolerance = 1e-8)
+  expect_equal(res$max_dd, -0.2200, tolerance = 1e-8)
+  expect_equal(res$ann_rf, 0.0180, tolerance = 1e-8)
+  expect_true("months" %in% names(res))
+  expect_false("n_obs" %in% names(res))
+  expect_equal(res$months, 4000L)
+})
+
 .norm_mom_sibling_test <- function(m) {
   if (is.null(m) || nrow(m) == 0) return(NULL)
   m |>

--- a/tests/testthat/test-plan-risk-state-sharpe.R
+++ b/tests/testthat/test-plan-risk-state-sharpe.R
@@ -80,6 +80,43 @@ test_that("rsc_metrics: SPY_overlay Full Period row has both sharpe and hac_shar
   expect_false(isTRUE(all.equal(full_row$sharpe, full_row$hac_sharpe)))
 })
 
+test_that("rsc_metrics: calc_metrics() now publishes n_obs, the raw observation count (#726 item 3)", {
+  # #726: rsc_metrics had no months/n_obs/n_days column at all, so
+  # R/plan_leaderboard.R's .norm_rsc() had nothing to rename into `months`
+  # and the SPY_overlay row's detection-power diagnostic
+  # (.detection_diag_row(), R/plan_leaderboard.R) was silently NA forever
+  # regardless of sharpe -- QA gate S20 (check_leaderboard_detection_power_
+  # values(), R/plan_qa_gates.R) now catches that gap at pipeline time. This
+  # test guards the root-cause fix: n_obs must equal the actual number of
+  # non-NA return observations backing each row, for every strategy variant
+  # calc_metrics() produces (not just SPY_overlay).
+  cmd <- .target_command(plan_risk_state(), "rsc_metrics")
+  inputs <- .toy_rsc_inputs(n_days = 500L, rf_val = 0.0001)
+
+  result <- .eval_command(
+    cmd,
+    hd_hac_sharpe       = .mock_hac_sharpe,
+    sharpe_ratio_rf     = sharpe_ratio_rf,
+    rsc_params          = list(oos_start = as.Date("2019-01-01"), test_end = as.Date("2019-06-30")),
+    rsc_portfolio       = inputs$port,
+    rsc_overlay_drif    = inputs$overlay,
+    rsc_overlay_fac_max = inputs$overlay
+  )
+
+  expect_true("n_obs" %in% names(result))
+  expect_false(any(is.na(result$n_obs)))
+
+  full_row <- result[result$strategy == "SPY_overlay" & result$period == "Full Period", ]
+  expect_equal(nrow(full_row), 1L)
+  # Full Period spans the whole 500-day toy series -- no NAs injected by
+  # .toy_rsc_inputs(), so n_obs must equal n_days exactly.
+  expect_equal(full_row$n_obs, 500L)
+
+  training_row <- result[result$strategy == "SPY_overlay" & result$period == "Training", ]
+  expect_equal(nrow(training_row), 1L)
+  expect_true(training_row$n_obs < full_row$n_obs)
+})
+
 test_that("rsc_metrics: DRIF_raw/FacMAX_raw rows have a real sharpe now rf_ret is wired (#677 slice 2)", {
   cmd <- .target_command(plan_risk_state(), "rsc_metrics")
   inputs <- .toy_rsc_inputs(n_days = 500L)


### PR DESCRIPTION
## Summary

Refs #726 -- implements items **3** and **4** of the proposal list only.
Items 1, 2, and 5 are deliberately NOT implemented in this PR, so #726 stays
open.

### Item 3 -- close the NA hole

`.detection_diag_row()` (`R/plan_leaderboard.R`) can return NA for
`detection_min_n_years`/`detection_underpowered` through three paths: (a)
`sharpe` NA/<=0, (b) `months` NA/<2, (c) `hd_detection_power()` erroring
inside the `tryCatch`. The existing gate S19
(`check_leaderboard_detection_power_coverage`) only guards the *input* to
the diagnostic (every strategy has a declared periodicity in
`STRATEGY_OBS_ANN_FACTOR`) -- not that the diagnostic actually produced a
value. Risk State passed S19 while landing on path (b) forever.

**Root cause found and fixed, not papered over.** `rsc_metrics`'
`calc_metrics()` (`R/plan_risk_state.R`) already computed a `years` variable
internally (`years <- length(ret_vec) / periods_per_year`) but never
exposed the underlying observation count in its output tibble -- so
`rsc_metrics` literally had no `months`/`n_days` column for `.norm_rsc()`
(`R/plan_leaderboard.R`) to rename from. Fix:

- `calc_metrics()` now returns `n_obs = length(ret_vec)`.
- `.rsc_register_runs()`'s `rsc_units` gains `n_obs = "count"` (the
  wide-form path of `hd_metric_record()` treats every numeric column as a
  metric candidate needing a declared unit -- confirmed by reading
  `.normalise_metric_long()` in `packages/historicaldata/R/registry_metrics.R`).
- `.norm_rsc()` now renames `n_obs` -> `months`.

New QA gate **S20** (`check_leaderboard_detection_power_values()`,
`R/plan_qa_gates.R`) asserts the property #726 actually wants: every
leaderboard row with `sharpe > 0` has a non-NA
`detection_min_n_years`/`detection_underpowered`. The abort message names
the offending `strategy`/`period` pairs and distinguishes path (b) from
path (c) per `.claude/rules/fail-loud-not-null.md` ("name the offending
value and the field it came from" -- "some rows are NA" is not acceptable
on its own).

### Item 4 -- multiple-testing-corrected columns

`.detection_diag_row()` now also computes `detection_min_n_years_mt` /
`detection_underpowered_mt` at `alpha = 0.05 / k_eff_strat`, alongside the
existing single-test columns (both are reported, per the issue: "the
single-test number is the charitable case and it already fails").

**Guard and disclosed limitation.** The `_mt` columns are deliberately NA
wherever `k_eff_strat` is NA or `< 1`. This is not a cosmetic guard: reading
the actual join, `k_eff_strat` is populated from `strat_deflated_sharpe`,
which itself only has one row per strategy in `col_map = c(stk_max =
"Stock MAX", stk_drif = "Stock DRIF", fac_max = "Factor MAX", fac_drif =
"Factor DRIF")` -- **four of the ~17 leaderboard strategies**. Every other
strategy (including Value (HML) and several others #726 names directly)
currently has `k_eff_strat = NA` and therefore NA `_mt` columns. This is a
pre-existing limitation of `strat_keff_vertox`/`strategy_correlation`'s
correlation matrix (computed over only those four columns), not a defect
introduced here, and expanding that coverage is out of scope for items 3/4
-- I did not widen it. S20 only asserts `_mt` coverage where `k_eff_strat`
is itself usable, so this NA is not silently miscategorised as a defect by
the gate. Flagging this as worth a follow-up issue since it materially
limits item 4's practical value until `k_eff_strat` covers more strategies.

## What I verified (with output)

Ran `scripts/verify.sh` in full mode, foreground, to completion:

```
::VERIFY:PARSE_OK::
::VERIFY:DOCS_PARSE_OK:: TRUE
::VERIFY:TAR_VALIDATE_OK:: TRUE
...
=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

=== scripts/verify.sh: PASS ===
```

Root suite total=693 (up from baseline by the ~10 new `test_that` blocks
added here), 0 new failures. Package suite total=713, 0 new failures, skip
count matches the documented baseline exactly. `parse("_targets.R")` and
`parse("docs/_targets.R")` both succeeded, and `tar_validate()` confirmed
`docs/_targets.R` is structurally sound with the new S20 target wired in.

New tests added:
- `tests/testthat/test-leaderboard-detection-power-values.R` (new file, 8
  `test_that` blocks): S20's single-test assertion (pass, path-b failure,
  path-c failure, negative-Sharpe rows correctly ignored), S20's
  multiple-testing assertion (usable-`k_eff_strat` failure, NA-`k_eff_strat`
  correctly not required), and the required-columns check. `expect_snapshot`
  coverage on all four `cli_abort()` messages per
  `.claude/rules/snapshot-test-policy.md`; new snapshot file committed
  (`tests/testthat/_snaps/leaderboard-detection-power-values.md`).
- `tests/testthat/test-plan-risk-state-sharpe.R`: regression test against
  the real `rsc_metrics` target command confirming `n_obs` is now present,
  non-NA, and correctly counts observations per period/strategy row.
- `tests/testthat/test-leaderboard-unit-scale.R`: added `.norm_rsc_test`
  (the file already documented `.norm_rsc` in its header comment as one of
  the helpers it mirrors, but had no actual test for it before this PR).

## What I did NOT verify

**`tar_make()` was not run**, per the task instructions -- the main
checkout holds the live store and a concurrent build from this worktree
would risk corrupting it. This means:

- S20's actual pass/fail outcome against the real, currently-built
  leaderboard is unverified by this PR. Given #726's own table, I expect
  most previously-underpowered rows to already have non-NA verdicts (the
  gap was specifically Risk State), so S20 should pass once the pipeline is
  rebuilt -- but this is an expectation, not a verified fact.
- Whether the Risk State `months` fix produces a plausible, non-NA
  `detection_min_n_years`/`detection_underpowered` against the real
  `rsc_portfolio` data (rather than the synthetic 500-day toy fixture in
  the unit tests) is unverified.
- The `_mt` columns' actual values against the real `k_eff_strat = 4.847`
  are unverified beyond the toy-fixture/unit-test level.

These should be checked by whoever runs the next `tar_make()` in the main
checkout, ideally cross-referenced against S20's pass/fail output.

## Test plan

- [x] `scripts/verify.sh` (full mode) -- PASS, output quoted above
- [x] New unit tests for S20 (single-test + mt assertions, both failure
      paths, required columns)
- [x] Regression test for `calc_metrics()`'s new `n_obs` column
- [ ] `tar_make()` against the real store (main checkout, not this PR) to
      confirm S20 passes and the `_mt` columns look sane on real data
