### PR TITLE
rules: detection power is a first-class metric, not a diagnostic column

### DIFF
--- a/.claude/rules/detection-power-required.md
+++ b/.claude/rules/detection-power-required.md
@@ -1,0 +1,114 @@
+# Rule: Detection Power Is a First-Class Metric, Not a Diagnostic Column
+
+## Source
+
+[#726](https://github.com/JohnGavin/historical/issues/726). The first live run of the
+`hd_detection_power()` columns showed that **five of the seven computable
+positive-Sharpe strategies on the leaderboard cannot be distinguished from zero by
+their own samples**, two of them by more than an order of magnitude:
+
+| strategy | sharpe | have (yrs) | need (yrs) | shortfall |
+|---|---:|---:|---:|---:|
+| Value (HML) | 0.068 | 62.7 | 1337 | 21× |
+| Factor DRIF | 0.076 | 57.6 | 1067 | 19× |
+| Mom Pre-Peak | 0.226 | 53.1 | 121 | 2.3× |
+| LTR | 0.330 | 21.2 | 57 | 2.7× |
+| Managed Futures | 0.477 | 18.9 | 27 | 1.4× |
+
+Value (HML) has one of the longest samples in the repo and is still 21× short. No
+attainable sample fixes that. The metric had existed as leaderboard column 60 of 61
+and had never been read.
+
+## When This Applies
+
+Any claim that a strategy has an edge — a Sharpe, an alpha, an information ratio, a
+hit rate above chance — made from a finite sample. That is every strategy row on
+every leaderboard, every partition, and every new-strategy proposal.
+
+## CRITICAL: State the required sample before reporting the observed effect
+
+The failure mode is not computing a wrong number. It is reporting a correct number in
+a format that implies it means something it does not. A Sharpe of 0.068 with a
+confidence interval, a p-value and a rank position is presented as a measurement. On
+a sample 21× too short it is closer to a coin flip with three decimal places.
+
+> **A Sharpe reported without its detection requirement is an incomplete claim.**
+
+The two belong adjacent. Separated by fifty columns, the first is read without the
+second — which is exactly what happened for as long as the column existed.
+
+## Required
+
+| # | Requirement |
+|---|---|
+| 1 | Every positive-Sharpe row **must** carry a non-NA detection verdict. Enforced by QA gate **S20** (`qa_leaderboard_detection_power_values`). Three NA paths exist — `sharpe <= 0`, `months` missing, `hd_detection_power()` erroring — and the gate asserts the *property*, not any one path. |
+| 2 | Where a strategy is underpowered, that fact is reported **beside** its Sharpe, not in a distant column. |
+| 3 | NA on a **negative-Sharpe** row means *not applicable* (the one-sided test has no positive effect to detect). NA anywhere else means *not computed* and is a defect. These must not render identically — see [#728](https://github.com/JohnGavin/historical/issues/728). |
+| 4 | A new strategy states its **expected** Sharpe and the sample it would need **before** being backtested, not after. Detection power is a design constraint, not a post-hoc autopsy. |
+| 5 | Report the multiple-testing-corrected requirement alongside the single-test one. The single-test figure (`alpha = 0.05`) is the charitable case; if a strategy fails there, the correction is academic — but where it passes, the corrected figure is the one that matters. |
+
+## Interaction with allocation
+
+Detectability is one of the seven provenance facts in
+[#719](https://github.com/JohnGavin/historical/issues/719) Layer 2. The gating rule
+that follows from #726:
+
+> **A strategy may not receive gross above 1.0× while `detection_underpowered` is
+> TRUE or NA.**
+
+This is not a claim that an underpowered strategy is *bad*. Detection power is about
+what a sample can **show**, not about what is **true** — a genuine 0.07 Sharpe edge
+remains an edge whether or not 62 years can prove it. The claim is narrower and much
+harder to argue with: **we cannot currently tell, and levering on what we cannot tell
+is the error.** The right failure message is not "CMR is bad" but "we do not yet know
+CMR well enough to lever it."
+
+## Interaction with the null-testing work
+
+A signal-null test ([#718](https://github.com/JohnGavin/historical/issues/718)) on an
+underpowered sample tells you close to nothing: the test has no power to reject on
+the *real* signal either, so a null that fails to reject is uninformative rather than
+reassuring. Detection power should gate **which strategies are worth running signal
+nulls on** — otherwise the null framework spends its budget on samples that cannot
+answer.
+
+The same logic applies to any significance machinery. **A significance test
+conditioned on an undetectable effect returns a confident answer to a question the
+data cannot address.**
+
+## Forbidden Patterns
+
+| Pattern | Why wrong | Fix |
+|---|---|---|
+| Ranking strategies by Sharpe without showing which are detectable | Implies a comparability the power calculation denies | Report the verdict beside the rank |
+| Treating a blank rigour cell as "not applicable" | It usually means "not computed" — the opposite claim | Distinguish the two (#728) |
+| "The sample is short but the Sharpe is high, so it's fine" | High Sharpe *lowers* the requirement, but the arithmetic decides, not the intuition | Compute `T_min`; it is one function call |
+| Allocating gross on an underpowered Sharpe | Sizing on a number the sample cannot support | #719 Layer 2 gate |
+| Weakening S20 so the current data passes | The gate being right and the data being wrong is the *correct* state | Fix the data; PR #727's Risk State root-cause fix is the worked example |
+| Adding a strategy, then asking whether it was detectable | Post-hoc; the answer arrives after the effort is spent | Requirement 4 — state it up front |
+
+## Self-test
+
+Before publishing or acting on any reported edge:
+
+> **How long a sample would this effect need, and do we have it?**
+
+If that question has not been answered numerically, the edge has not been reported —
+only its point estimate has.
+
+## Related
+
+- `.claude/rules/fail-loud-not-null.md` — NA-as-silence; requirements 1 and 3 are that
+  rule applied to the reporting layer
+- `.claude/rules/backtest-robustness.md` — `K_eff_strat` / deflated Sharpe; the
+  multiple-testing correction requirement 5 refers to
+- `.claude/rules/underperformance-prior.md` — the complement: how long underperformance
+  can run *without* being evidence against a strategy
+- `.claude/rules/cross-geography-pervasiveness.md` — replication as the other answer to
+  a sample too short to be decisive on its own
+- `historicaldata::hd_detection_power()` — the implementation, with its derivation
+- [#726](https://github.com/JohnGavin/historical/issues/726) — the finding
+- [#728](https://github.com/JohnGavin/historical/issues/728) — rigour-column coverage
+- [#719](https://github.com/JohnGavin/historical/issues/719) — provenance facts gating the allocator
+- [#718](https://github.com/JohnGavin/historical/issues/718) — signal nulls
+- [#711](https://github.com/JohnGavin/historical/issues/711) — origin of the diagnostic


### PR DESCRIPTION
The standing-practice half of #726. The issue records the finding; this records what
we do about it every time from now on, so it does not depend on anyone remembering
the session it came from.

## Why a rule and not just the issue

The detection-power columns shipped in #716 and were correct from the first commit.
They then sat unread as leaderboard columns 60 and 61 until this session ran them.
Filing another issue is the same bet that failed — that a correct number in an
obscure place gets read.

The rule states the requirement in a form that is checkable at the moment of use:

> **A Sharpe reported without its detection requirement is an incomplete claim.**

## What it fixes in the reasoning, not just the process

Two distinctions the rule is careful about, because both are easy to get wrong in the
direction of overclaiming:

**Detection power is not a verdict on the strategy.** It is about what a sample can
*show*, not what is *true*. A genuine 0.07 Sharpe edge stays an edge whether or not
62 years can prove it. So the rule's gating language is "we do not yet know CMR well
enough to lever it", not "CMR is bad" — the narrower claim is also the one that is
much harder to argue with.

**NA is two different things.** On a negative-Sharpe row it genuinely means *not
applicable* — the one-sided test has no positive effect to detect. Anywhere else it
means *not computed*, which is a defect. The rule requires these not render
identically, which is `fail-loud-not-null` applied one layer up: the null-ish state
here is absence of a computation, and the consumer is a human reading a table.

## Contents

Five numbered requirements (S20 coverage; adjacency to the Sharpe; the
not-computed/not-applicable split; expected-Sharpe-before-backtest; report the
multiple-testing-corrected figure alongside the single-test one), the >1.0× gross
gate for #719 Layer 2, the #718 interaction, six forbidden patterns, and a one-line
self-test.

The #718 interaction is the non-obvious one and is worth calling out: a signal-null
test on an underpowered sample is *uninformative rather than reassuring*, because the
test has no power to reject on the real signal either. So detection power should gate
which strategies are worth spending null-test budget on, not run alongside it.

## Verified

- All five cross-referenced rule files exist in `.claude/rules/`:
  `backtest-robustness.md`, `cross-geography-pervasiveness.md`,
  `fail-loud-not-null.md`, `underperformance-prior.md`.
- Every figure in the table is from the current store (771 targets, 0 errored),
  Full Period rows, read directly rather than transcribed.
- Prose only — no code, no pipeline surface, nothing to build.

## Related work in flight

PR #727 implements #726 items 3 and 4 (the S20 gate and the corrected columns).
#728 records why item 4 lands mostly inert as specified: `k_eff_strat` exists for
only 4 of 17 strategies, and for just 1 of the 8 claiming a positive Sharpe.

Refs #726, #727, #728, #719, #718, #711.
