### PR TITLE
rules: correct detection-power figures to 6 of 8 after the #727 rebuild

### DIFF
--- a/.claude/rules/detection-power-required.md
+++ b/.claude/rules/detection-power-required.md
@@ -3,21 +3,31 @@
 ## Source
 
 [#726](https://github.com/JohnGavin/historical/issues/726). The first live run of the
-`hd_detection_power()` columns showed that **five of the seven computable
-positive-Sharpe strategies on the leaderboard cannot be distinguished from zero by
-their own samples**, two of them by more than an order of magnitude:
+`hd_detection_power()` columns showed that **six of the eight positive-Sharpe
+strategies on the leaderboard cannot be distinguished from zero by their own
+samples**, two of them by more than an order of magnitude:
 
 | strategy | sharpe | have (yrs) | need (yrs) | shortfall |
 |---|---:|---:|---:|---:|
-| Value (HML) | 0.068 | 62.7 | 1337 | 21× |
-| Factor DRIF | 0.076 | 57.6 | 1067 | 19× |
-| Mom Pre-Peak | 0.226 | 53.1 | 121 | 2.3× |
-| LTR | 0.330 | 21.2 | 57 | 2.7× |
-| Managed Futures | 0.477 | 18.9 | 27 | 1.4× |
+| Value (HML) | 0.068 | 62.7 | 1337.1 | 21× |
+| Factor DRIF | 0.076 | 57.6 | 1067.2 | 19× |
+| Mom Pre-Peak | 0.226 | 53.1 | 121.1 | 2.3× |
+| Risk State | 0.252 | 33.2 | 97.4 | 2.9× |
+| LTR | 0.330 | 21.2 | 56.9 | 2.7× |
+| Managed Futures | 0.477 | 18.9 | 27.3 | 1.4× |
+
+Only Avoid Worst (0.620, needs 16.1 of 33.1 available) and OLMAR-1 (0.780, needs 10.2
+of 16.1) clear the bar.
 
 Value (HML) has one of the longest samples in the repo and is still 21× short. No
 attainable sample fixes that. The metric had existed as leaderboard column 60 of 61
 and had never been read.
+
+Risk State is the row worth remembering. It first appeared as *not computable* — its
+`months` arrived NA because `calc_metrics()` computed `n_obs` and discarded it one
+line before returning. Filling that blank did not add a reassuring seventh row; it
+added a sixth adverse one. **The NA was standing in for a verdict, and the verdict was
+against us.** That is the argument for requirement 1 below in a single case.
 
 ## When This Applies
 


### PR DESCRIPTION
The rule merged in #729 carried the pre-#727 figures. The rebuild has since falsified
them, in the direction that matters.

## What changed

#729 said **five of seven computable**, with Risk State listed as *not computable*
(its `months` was NA).

#727 fixed the root cause — `calc_metrics()` in `R/plan_risk_state.R` computed
`n_obs = length(ret_vec)` for its own use and never returned it. With that fixed and
the pipeline rebuilt clean (**772 targets inspected, 0 errored**), Risk State
resolved to:

| | |
|---|---|
| sharpe | 0.252 |
| available | 8355 daily obs = 33.2 years |
| required | **97.4 years** |
| verdict | **underpowered** |

So the headline is **six of eight**, not five of seven. Only Avoid Worst and OLMAR-1
clear the bar.

## Why this is worth a commit of its own rather than a quiet edit

Filling the blank did not add a reassuring seventh row. It added a sixth adverse one.
The NA had been standing in for a verdict, and the verdict was against us.

That is requirement 1 of the rule — *every positive-Sharpe row must carry a non-NA
verdict* — demonstrated in a single case, so it is now in the rule's Source section
as the worked example rather than left as an abstraction. A rule that argues for
closing NA holes is more convincing when it can point at the one hole that was closed
and show that the answer underneath was unfavourable.

## Provenance

Every figure here is read from the rebuilt store, not carried forward from the earlier
table. The `need (yrs)` column is now quoted to one decimal to match what the store
actually holds (1337.1, 1067.2, 121.1, 97.4, 56.9, 27.3) rather than the rounded
values in #729.

Prose only — no code, nothing to build.

Refs #726, #727.
