### PR TITLE
fix(leaderboard): widen deflated-Sharpe/K_eff to 11/17 strategies, leaderboard-wide K_eff + S21 gate (#728 items 1,2,4)

### DIFF
--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -536,7 +536,9 @@ plan_leaderboard <- function() {
         all_metrics <- all_metrics |>
           left_join(
             strat_deflated_sharpe |>
-              select(strategy, deflated_sharpe, dsr_pvalue, k_eff_strat),
+              select(strategy, deflated_sharpe, dsr_pvalue,
+                     k_eff_leaderboard, k_raw_leaderboard,
+                     k_eff_family, k_raw_family),
             by = "strategy"
           )
       }
@@ -763,41 +765,45 @@ plan_leaderboard <- function() {
       # populated -- see .norm_rsc() and the STRATEGY_OBS_ANN_FACTOR comment
       # above) fails loudly instead of surviving silently forever.
       #
-      # detection_min_n_years_mt / detection_underpowered_mt (#726 item 4):
-      # the SAME calculation, but at alpha = 0.05 / k_eff_strat instead of the
-      # single-test alpha = 0.05 above -- the Bonferroni multiple-testing
-      # correction hd_detection_power()'s own roxygen "Assumptions and
-      # limits" section already suggests combining with
-      # hd_strat_keff_vertox(), and which #726's issue text argues nothing
-      # currently applies. k_eff_strat is joined from strat_deflated_sharpe
-      # earlier in this target (see "Deflated Sharpe" section above) and, as
-      # of this table, strat_deflated_sharpe only has one row per column in
-      # that section's `col_map` (Stock MAX, Stock DRIF, Factor MAX, Factor
-      # DRIF) -- every OTHER strategy's k_eff_strat is NA after the left_join,
-      # not because the multiple-testing correction doesn't apply to them
-      # (it does -- #726 names Value (HML) and Factor DRIF specifically) but
-      # because strat_keff_vertox()/strategy_correlation's correlation matrix
-      # is itself only computed over those four columns. Rather than guess a
-      # k_eff_strat for strategies outside that matrix, the `_mt` columns are
-      # deliberately NA wherever k_eff_strat is NA or < 1 (a k_eff_strat below
-      # 1 would WIDEN alpha, the opposite of a Bonferroni correction, and
-      # cannot be a valid effective-test count) -- an explicit, commented
-      # default per fail-loud-not-null.md's "Required Pattern" item 2, not a
-      # silent coercion, and S20 only asserts `_mt` coverage where k_eff_strat
-      # is actually non-NA (see check_leaderboard_detection_power_values()).
-      # Widening strat_corr_matrix's coverage to every strategy is out of
-      # scope here (#726 lists it as neither item 3 nor item 4) and is left
-      # as a follow-up.
+      # detection_min_n_years_mt / detection_underpowered_mt (#726 item 4,
+      # widened by #728 items 1+2): the SAME calculation, but at
+      # alpha = 0.05 / k_eff_leaderboard instead of the single-test
+      # alpha = 0.05 above -- the Bonferroni multiple-testing correction
+      # hd_detection_power()'s own roxygen "Assumptions and limits" section
+      # already suggests combining with hd_strat_keff_vertox(). Before #728
+      # this used k_eff_strat (now k_eff_family), the FAMILY-scoped count --
+      # #728's finding was that this made the correction "mostly cosmetic":
+      # Bonferroni-correcting alpha by a family-scoped K can only fire where
+      # that K exists, so 7 of the 8 positive-Sharpe rows never got a
+      # corrected verdict. k_eff_leaderboard is joined from
+      # strat_deflated_sharpe earlier in this target (see "Deflated Sharpe"
+      # section above) and is now populated for every strategy in
+      # STRAT_RETURNS_WIDE_CODES (plan_strategy_correlation.R) -- 11 of 17,
+      # up from 4. The remaining 6 (CMR, OLMAR-1, TOM, Risk State, Avoid
+      # Worst, PSO Optimal) are genuine, documented exclusions -- see that
+      # constant's comment -- not something this target guesses a value
+      # for. The `_mt` columns are deliberately NA wherever
+      # k_eff_leaderboard is NA or < 1 (a K below 1 would WIDEN alpha, the
+      # opposite of a Bonferroni correction, and cannot be a valid
+      # effective-test count) -- an explicit, commented default per
+      # fail-loud-not-null.md's "Required Pattern" item 2, not a silent
+      # coercion, and S20 only asserts `_mt` coverage where
+      # k_eff_leaderboard is actually non-NA (see
+      # check_leaderboard_detection_power_values()). S21 (#728 item 4,
+      # R/plan_qa_gates.R) separately asserts deflated_sharpe/dsr_pvalue/
+      # k_eff_leaderboard coverage for every positive-Sharpe strategy, with
+      # an explicit exemption table for the 6 genuine exclusions.
       all_metrics <- all_metrics |>
         dplyr::left_join(STRATEGY_OBS_ANN_FACTOR, by = "strategy")
 
       # Defensive: strat_deflated_sharpe's join above is itself guarded by
       # `!is.null(strat_deflated_sharpe) && nrow(strat_deflated_sharpe) > 0`,
-      # so k_eff_strat may not exist as a column at all (e.g. in a partial
-      # test harness that omits that upstream target) -- pmap_dfr below needs
-      # every element to be a real vector, not a NULL, so backfill NA here.
-      if (!"k_eff_strat" %in% names(all_metrics)) {
-        all_metrics$k_eff_strat <- NA_real_
+      # so k_eff_leaderboard may not exist as a column at all (e.g. in a
+      # partial test harness that omits that upstream target) -- pmap_dfr
+      # below needs every element to be a real vector, not a NULL, so
+      # backfill NA here.
+      if (!"k_eff_leaderboard" %in% names(all_metrics)) {
+        all_metrics$k_eff_leaderboard <- NA_real_
       }
 
       .detection_diag_row <- function(sr, n, af, keff) {
@@ -855,7 +861,7 @@ plan_leaderboard <- function() {
 
       detection_diag <- purrr::pmap_dfr(
         list(all_metrics$sharpe, all_metrics$months, all_metrics$obs_ann_factor,
-             all_metrics$k_eff_strat),
+             all_metrics$k_eff_leaderboard),
         .detection_diag_row
       )
 
@@ -887,32 +893,93 @@ plan_leaderboard <- function() {
     # ── Vertox K_eff_strat: correlation-aware effective strategy count ────────
     # Uses strat_corr_matrix from plan_strategy_correlation (available as dep).
     # seed = 160 for reproducibility (issue #160).
+    #
+    # FAMILY SCOPE (#728): this K_eff is computed over the 5-strategy family
+    # in strat_corr_matrix (stk_max, stk_drif, fac_max, fac_drif, ltr) --
+    # NOT the full leaderboard. Surfaced below as `k_eff_family`, distinct
+    # from `k_eff_leaderboard` (plan_strategy_correlation.R's
+    # strat_keff_vertox_leaderboard, scoped to the 11-strategy
+    # STRAT_RETURNS_WIDE_CODES) so no consumer can conflate "effective tests
+    # within one family" with "effective tests across the whole
+    # leaderboard" -- #728's core finding was that the two had been
+    # conflated under one ambiguous name, `k_eff_strat`. Published
+    # deflated_sharpe/dsr_pvalue below now use the leaderboard-wide scope;
+    # k_eff_family is kept only as informational context for the family
+    # subset.
     targets::tar_target(strat_keff_vertox, {
       historicaldata::hd_strat_keff_vertox(strat_corr_matrix, n_sim = 20000L, seed = 160L)
     }),
 
-    # ── Deflated Sharpe per strategy (#160) ───────────────────────────────────
-    # K_trials = K_eff_strat (Vertox correlation-aware count, rounded to integer),
-    # NOT raw M=4: correlated strategies → raw count over-penalises.
-    # ann_factor = 12 (monthly returns in port_returns).
-    # col_map keys match port_returns column names; values match leaderboard labels.
+    # ── Deflated Sharpe per strategy (#160, widened by #728 items 1+2) ────────
+    # K_trials = k_eff_leaderboard (strat_keff_vertox_leaderboard,
+    # plan_strategy_correlation.R) -- the LEADERBOARD-WIDE correlation-aware
+    # effective strategy count -- NOT the family-scoped strat_keff_vertox
+    # this target used before #728, and NOT a raw strategy count:
+    # correlated strategies over-penalise a raw count, and a family-scoped
+    # count understates the true multiplicity a reader faces when ranking
+    # all 17 strategies against each other on one leaderboard. See #728
+    # ("k_eff_strat = 4.847 is the effective number of tested strategies
+    # within the factor/stock MAX/DRIF family... The multiplicity that
+    # should deflate any individual Sharpe is the leaderboard-wide one").
+    #
+    # Source return series come from strat_returns_wide
+    # (plan_strategy_correlation.R), which already aligns every strategy in
+    # STRAT_RETURNS_WIDE_CODES onto a common ym spine via full_join (not
+    # inner_join -- see that target's comment, and fail-loud-not-null.md).
+    # col_map here mirrors that constant; every strategy NOT in col_map is a
+    # genuine, documented exclusion (daily frequency, or PSO Optimal's
+    # linear-combination circularity) -- see STRAT_RETURNS_WIDE_CODES's
+    # comment in plan_strategy_correlation.R, not an oversight. That leaves
+    # 11 of 17 leaderboard strategies covered here (#728 item 1), up from 4
+    # before this change: CMR, OLMAR-1, TOM, Risk State, Avoid Worst, and
+    # PSO Optimal remain NA on deflated_sharpe/dsr_pvalue/k_eff_leaderboard,
+    # each for the documented reason above -- not fabricated coverage.
+    #
+    # ann_factor = 12 for every row: every strategy in col_map is
+    # monthly-frequency (that is precisely why it qualifies for
+    # strat_returns_wide -- see STRAT_RETURNS_WIDE_CODES's comment).
+    #
+    # k_eff_family / k_raw_family are populated ONLY for the original
+    # 5-strategy family (NA elsewhere) -- informational context, no longer
+    # used to compute deflated_sharpe/dsr_pvalue (#728 item 2).
     targets::tar_target(strat_deflated_sharpe, {
       library(dplyr)
-      k_eff <- max(1L, round(strat_keff_vertox))
-      col_map <- c(stk_max = "Stock MAX", stk_drif = "Stock DRIF",
-                   fac_max = "Factor MAX", fac_drif = "Factor DRIF")
+
+      col_map <- c(
+        stk_max         = "Stock MAX",
+        stk_drif        = "Stock DRIF",
+        fac_max         = "Factor MAX",
+        fac_drif        = "Factor DRIF",
+        ltr             = "LTR",
+        xgb_drif        = "XGB DRIF",
+        mom_prepeak     = "Mom Pre-Peak",
+        mom_postpeak    = "Mom Post-Peak",
+        mom_combined    = "Mom 12-2",
+        value_hml       = "Value (HML)",
+        managed_futures = "Managed Futures"
+      )
+      family_cols <- c("stk_max", "stk_drif", "fac_max", "fac_drif", "ltr")
+
+      k_eff_lb  <- max(1, round(strat_keff_vertox_leaderboard))
+      k_raw_lb  <- nrow(strat_corr_matrix_leaderboard)
+      k_eff_fam <- max(1L, round(strat_keff_vertox))
+      k_raw_fam <- nrow(strat_corr_matrix)
+
       bind_rows(lapply(names(col_map), function(col) {
-        r <- port_returns[[col]]
+        r <- strat_returns_wide[[col]]
         r <- r[!is.na(r)]
-        d <- historicaldata::hd_deflated_sharpe(r, K_trials = k_eff, ann_factor = 12L)
+        d <- historicaldata::hd_deflated_sharpe(r, K_trials = k_eff_lb, ann_factor = 12L)
+        is_family <- col %in% family_cols
         tibble::tibble(
-          strategy        = unname(col_map[[col]]),
-          naive_sharpe    = d$naive_sharpe,
-          deflated_sharpe = d$dsr,
-          dsr_pvalue      = d$dsr_pvalue,
-          dsr_haircut_pct = d$haircut_pct,
-          k_eff_strat     = strat_keff_vertox,
-          k_raw           = nrow(strat_corr_matrix)
+          strategy          = unname(col_map[[col]]),
+          naive_sharpe      = d$naive_sharpe,
+          deflated_sharpe   = d$dsr,
+          dsr_pvalue        = d$dsr_pvalue,
+          dsr_haircut_pct   = d$haircut_pct,
+          k_eff_leaderboard = strat_keff_vertox_leaderboard,
+          k_raw_leaderboard = k_raw_lb,
+          k_eff_family      = if (is_family) k_eff_fam else NA_real_,
+          k_raw_family      = if (is_family) k_raw_fam else NA_integer_
         )
       }))
     })

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -1372,16 +1372,26 @@ check_leaderboard_detection_power_coverage <- function(leaderboard, obs_ann_fact
 #' property actually wanted: "every positive-Sharpe row has a detection
 #' verdict."
 #'
-#' A second, independent assertion (per #726 item 4) covers the
-#' multiple-testing-corrected columns \code{detection_min_n_years_mt}/
-#' \code{detection_underpowered_mt} (alpha = 0.05 / \code{k_eff_strat}
-#' instead of the single-test alpha = 0.05): this is only checked for rows
-#' where \code{k_eff_strat} is itself usable (non-NA and >= 1) -- see the
+#' A second, independent assertion (per #726 item 4, widened by #728 items
+#' 1+2) covers the multiple-testing-corrected columns
+#' \code{detection_min_n_years_mt}/\code{detection_underpowered_mt}
+#' (alpha = 0.05 / \code{k_eff_leaderboard} instead of the single-test
+#' alpha = 0.05): this is only checked for rows where
+#' \code{k_eff_leaderboard} is itself usable (non-NA and >= 1) -- see the
 #' \code{.detection_diag_row()} comment in R/plan_leaderboard.R for why
-#' \code{k_eff_strat} is deliberately NA for most strategies today (it is
-#' only populated for the four columns \code{strat_deflated_sharpe} covers),
-#' which is an explicit, documented default per fail-loud-not-null.md's
-#' Required Pattern item 2, not something this gate treats as a defect.
+#' \code{k_eff_leaderboard} is deliberately NA for some strategies today (it
+#' is populated for the 11 strategies in
+#' \code{STRAT_RETURNS_WIDE_CODES}, R/plan_strategy_correlation.R -- up from
+#' 4 before #728 -- and NA for the 6 genuine, documented exclusions listed
+#' on that constant: CMR, OLMAR-1, TOM, Risk State, Avoid Worst are
+#' daily-frequency; PSO Optimal is a linear combination of already-included
+#' series), which is an explicit, documented default per
+#' fail-loud-not-null.md's Required Pattern item 2, not something this gate
+#' treats as a defect. This column was named \code{k_eff_strat} before
+#' #728; it was renamed alongside the scope widening so the family-scoped
+#' and leaderboard-wide counts cannot be confused (see
+#' \code{k_eff_family}/\code{k_eff_leaderboard} in
+#' R/plan_leaderboard.R's \code{strat_deflated_sharpe}).
 #'
 #' Both assertions name the offending \code{strategy}/\code{period} pairs and
 #' state which NA path applies, per fail-loud-not-null.md's requirement that
@@ -1391,7 +1401,7 @@ check_leaderboard_detection_power_coverage <- function(leaderboard, obs_ann_fact
 #' @param leaderboard Tibble with at least \code{strategy}, \code{period},
 #'   \code{sharpe}, \code{months}, \code{detection_min_n_years},
 #'   \code{detection_underpowered}, \code{detection_min_n_years_mt},
-#'   \code{detection_underpowered_mt}, \code{k_eff_strat} columns (the
+#'   \code{detection_underpowered_mt}, \code{k_eff_leaderboard} columns (the
 #'   output of the \code{leaderboard} target).
 #' @return \code{TRUE} invisibly on success.
 #' @noRd
@@ -1399,7 +1409,7 @@ check_leaderboard_detection_power_values <- function(leaderboard) {
   required_cols <- c(
     "strategy", "period", "sharpe", "months",
     "detection_min_n_years", "detection_underpowered",
-    "detection_min_n_years_mt", "detection_underpowered_mt", "k_eff_strat"
+    "detection_min_n_years_mt", "detection_underpowered_mt", "k_eff_leaderboard"
   )
   missing_cols <- setdiff(required_cols, names(leaderboard))
   if (length(missing_cols) > 0L) {
@@ -1408,7 +1418,7 @@ check_leaderboard_detection_power_values <- function(leaderboard) {
       "i" = paste0(
         "check_leaderboard_detection_power_values() (S20) requires strategy, ",
         "period, sharpe, months, detection_min_n_years, detection_underpowered, ",
-        "detection_min_n_years_mt, detection_underpowered_mt, k_eff_strat."
+        "detection_min_n_years_mt, detection_underpowered_mt, k_eff_leaderboard."
       )
     ))
   }
@@ -1456,33 +1466,190 @@ check_leaderboard_detection_power_values <- function(leaderboard) {
   }
 
   # ── Assertion 2: multiple-testing-corrected verdict must be non-NA
-  # wherever k_eff_strat is itself usable (#726 item 4).
-  mt_applicable <- positive & !is.na(leaderboard$k_eff_strat) & leaderboard$k_eff_strat >= 1
+  # wherever k_eff_leaderboard is itself usable (#726 item 4, #728 items 1+2).
+  mt_applicable <- positive & !is.na(leaderboard$k_eff_leaderboard) & leaderboard$k_eff_leaderboard >= 1
   mt_missing <- mt_applicable &
     (is.na(leaderboard$detection_min_n_years_mt) | is.na(leaderboard$detection_underpowered_mt))
 
   if (any(mt_missing)) {
     idx <- which(mt_missing)
     offenders <- sprintf(
-      "  %s / %s -- sharpe = %s, k_eff_strat = %s",
+      "  %s / %s -- sharpe = %s, k_eff_leaderboard = %s",
       leaderboard$strategy[idx], leaderboard$period[idx],
       format(leaderboard$sharpe[idx], digits = 3),
-      format(leaderboard$k_eff_strat[idx], digits = 4)
+      format(leaderboard$k_eff_leaderboard[idx], digits = 4)
     )
     cli::cli_abort(c(
       "x" = paste0(
         "Leaderboard has ", length(idx),
-        " row(s) with sharpe > 0 and a usable k_eff_strat but no multiple-",
-        "testing-corrected detection-power verdict (#726 item 4):"
+        " row(s) with sharpe > 0 and a usable k_eff_leaderboard but no ",
+        "multiple-testing-corrected detection-power verdict (#726 item 4):"
       ),
       setNames(offenders, rep("i", length(offenders))),
       "i" = paste0(
         "check_leaderboard_detection_power_values() (S20) requires ",
         "detection_min_n_years_mt/detection_underpowered_mt to be non-NA ",
-        "whenever k_eff_strat is non-NA and >= 1 -- see the alpha = 0.05 / ",
-        "keff tryCatch in R/plan_leaderboard.R's .detection_diag_row()."
+        "whenever k_eff_leaderboard is non-NA and >= 1 -- see the ",
+        "alpha = 0.05 / keff tryCatch in R/plan_leaderboard.R's ",
+        ".detection_diag_row()."
       )
     ))
+  }
+
+  invisible(TRUE)
+}
+
+
+#' Declared exemptions from deflated-Sharpe / K_eff coverage (S21, #728 item 4)
+#'
+#' Per \code{.claude/rules/fail-loud-not-null.md}: "the absence of a reason
+#' is what fails". A leaderboard strategy with a positive Full-Period Sharpe
+#' but no \code{deflated_sharpe}/\code{dsr_pvalue}/\code{k_eff_leaderboard}
+#' is either a genuine, documented data-coverage limit (declared here, with
+#' a written reason) or a bug that \code{check_leaderboard_deflated_sharpe_coverage()}
+#' (S21, below) must abort on -- never a silent NA that looks identical to
+#' the exempted case.
+#'
+#' These six strategies are exactly \code{STRAT_RETURNS_WIDE_CODES}'s
+#' complement (R/plan_strategy_correlation.R) among the 17 leaderboard
+#' strategies -- see that constant's comment for the underlying reasoning;
+#' the \code{reason} column here restates it per-strategy so this table is
+#' self-contained without a second file open.
+#' @noRd
+DEFLATED_SHARPE_EXEMPTIONS <- tibble::tibble(
+  strategy = c("CMR", "OLMAR-1", "TOM", "Risk State", "Avoid Worst", "PSO Optimal"),
+  reason = c(
+    paste0(
+      "Daily-frequency return series (ann_factor = 252, STRATEGY_OBS_ANN_FACTOR, ",
+      "R/plan_leaderboard.R). strat_returns_wide (R/plan_strategy_correlation.R) ",
+      "only aligns monthly series -- mixing daily and monthly series into one ",
+      "correlation matrix requires an aggregation step that risks the ",
+      "look-ahead bias described in #215."
+    ),
+    paste0(
+      "Daily-frequency return series (ann_factor = 252, same reason as CMR ",
+      "above -- OLMAR (Li & Hoi 2012) rebalances daily)."
+    ),
+    paste0(
+      "Daily-frequency return series (ann_factor = 252, same reason as CMR ",
+      "above -- R/plan_turn_of_month.R uses sqrt(252) annualisation)."
+    ),
+    paste0(
+      "Daily-frequency return series (ann_factor = 252, same reason as CMR ",
+      "above -- R/plan_risk_state.R's calc_metrics() defaults to ",
+      "periods_per_year = 252L)."
+    ),
+    paste0(
+      "Daily-frequency return series (ann_factor = 252, same reason as CMR ",
+      "above -- R/plan_avoid_worst.R uses ann_factor = 252L throughout)."
+    ),
+    paste0(
+      "PSO Optimal is not an independent data source: it is ",
+      "port_optimal_weights %*% c(stk_max, stk_drif, fac_max, fac_drif) (the ",
+      "'PSO Optimal' block in R/plan_leaderboard.R's leaderboard target) -- a ",
+      "linear combination of four series already covered. Including a ",
+      "near-collinear combination alongside its own components adds no ",
+      "independent information and risks a near-singular correlation matrix ",
+      "in hd_strat_keff_vertox()'s Cholesky step."
+    )
+  )
+)
+
+
+#' Assert deflated-Sharpe / K_eff coverage for every positive-Sharpe
+#' leaderboard strategy, or a documented exemption (S21, #728 item 4)
+#'
+#' Follows the same shape as \code{check_leaderboard_detection_power_values()}
+#' (S20) above: a positive Full-Period Sharpe with no
+#' \code{deflated_sharpe}/\code{dsr_pvalue}/\code{k_eff_leaderboard} verdict
+#' either has a written reason in \code{DEFLATED_SHARPE_EXEMPTIONS} above, or
+#' the gate aborts naming the offending strategy and column. #728 found that
+#' \code{deflated_sharpe} covered only 4 of 17 strategies and, of the 8
+#' strategies claiming a positive Full-Period Sharpe, only 1 (Factor DRIF)
+#' had any multiple-testing correction at all -- the wrong seven were
+#' missing (the ones a reader is most likely to act on). #728 items 1+2
+#' widen coverage to 11 of 17 (R/plan_strategy_correlation.R's
+#' STRAT_RETURNS_WIDE_CODES); this gate is what keeps that count from
+#' silently regressing back down.
+#'
+#' Scoped to \code{period == "Full Period"}: \code{deflated_sharpe} is a
+#' full-sample statistic broadcast to every period row (see the "Deflated
+#' Sharpe" join comment in R/plan_leaderboard.R's \code{leaderboard} target),
+#' so checking every period row would just re-check the same value once per
+#' partition and produce misleading per-period "offenders" for what is
+#' actually a single per-strategy gap.
+#'
+#' Deliberately scoped to the \code{deflated_sharpe}/\code{dsr_pvalue}/
+#' \code{k_eff_leaderboard} family -- the columns #728 items 1+2 directly
+#' fix -- not the full set of "rigour columns" named in #728's issue text
+#' (\code{hac_sharpe}, \code{wf_corr}, \code{sharpe_ci_lo}/\code{_hi},
+#' \code{incremental_sharpe}, \code{ssr} each have their own, different
+#' coverage story and would need their own exemption audit; out of scope
+#' for this gate, flagged as follow-up work in the #728 PR report).
+#'
+#' @param leaderboard Tibble with at least \code{strategy}, \code{period},
+#'   \code{sharpe}, \code{deflated_sharpe}, \code{dsr_pvalue},
+#'   \code{k_eff_leaderboard} columns (the output of the \code{leaderboard}
+#'   target).
+#' @param exemptions Tibble with \code{strategy}/\code{reason} columns --
+#'   \code{DEFLATED_SHARPE_EXEMPTIONS} above.
+#' @return \code{TRUE} invisibly on success.
+#' @noRd
+check_leaderboard_deflated_sharpe_coverage <- function(leaderboard, exemptions = DEFLATED_SHARPE_EXEMPTIONS) {
+  required_cols <- c("strategy", "period", "sharpe", "deflated_sharpe", "dsr_pvalue", "k_eff_leaderboard")
+  missing_cols <- setdiff(required_cols, names(leaderboard))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "Leaderboard is missing {length(missing_cols)} required column(s): {missing_cols}.",
+      "i" = paste0(
+        "check_leaderboard_deflated_sharpe_coverage() (S21) requires strategy, ",
+        "period, sharpe, deflated_sharpe, dsr_pvalue, k_eff_leaderboard."
+      )
+    ))
+  }
+  if (!all(c("strategy", "reason") %in% names(exemptions))) {
+    cli::cli_abort(c(
+      "x" = "exemptions table is missing required column(s): strategy, reason.",
+      "i" = "check_leaderboard_deflated_sharpe_coverage() (S21) requires DEFLATED_SHARPE_EXEMPTIONS' strategy/reason columns."
+    ))
+  }
+
+  full_period <- leaderboard$period == "Full Period"
+  positive <- full_period & !is.na(leaderboard$sharpe) & leaderboard$sharpe > 0
+
+  missing_dsr <- positive &
+    (is.na(leaderboard$deflated_sharpe) | is.na(leaderboard$dsr_pvalue) | is.na(leaderboard$k_eff_leaderboard))
+
+  if (any(missing_dsr)) {
+    idx <- which(missing_dsr)
+    exempted <- leaderboard$strategy[idx] %in% exemptions$strategy
+    offender_idx <- idx[!exempted]
+
+    if (length(offender_idx) > 0L) {
+      offenders <- sprintf(
+        "  %s / %s -- sharpe = %s (no declared exemption in DEFLATED_SHARPE_EXEMPTIONS)",
+        leaderboard$strategy[offender_idx], leaderboard$period[offender_idx],
+        format(leaderboard$sharpe[offender_idx], digits = 3)
+      )
+      cli::cli_abort(c(
+        "x" = paste0(
+          "Leaderboard has ", length(offender_idx),
+          " Full Period row(s) with sharpe > 0 but no deflated_sharpe/",
+          "dsr_pvalue/k_eff_leaderboard verdict AND no declared exemption (#728 item 4):"
+        ),
+        setNames(offenders, rep("i", length(offenders))),
+        "i" = paste0(
+          "check_leaderboard_deflated_sharpe_coverage() (S21) requires every ",
+          "positive-Sharpe Full Period row to have a non-NA deflated_sharpe/",
+          "dsr_pvalue/k_eff_leaderboard verdict, or a written reason in ",
+          "DEFLATED_SHARPE_EXEMPTIONS (R/plan_qa_gates.R) -- fix the offending ",
+          "strategy's coverage in STRAT_RETURNS_WIDE_CODES ",
+          "(R/plan_strategy_correlation.R) or add a documented exemption. ",
+          "Per fail-loud-not-null.md, the absence of a reason is what fails, ",
+          "not the NA itself."
+        )
+      ))
+    }
   }
 
   invisible(TRUE)
@@ -1882,8 +2049,8 @@ plan_qa_gates <- function() {
     ),
 
     # QA gate: every positive-Sharpe leaderboard row has a non-NA
-    # detection-power verdict, both single-test and (where k_eff_strat is
-    # usable) multiple-testing-corrected (S20, #726 items 3+4). S19 above
+    # detection-power verdict, both single-test and (where k_eff_leaderboard
+    # is usable) multiple-testing-corrected (S20, #726 items 3+4). S19 above
     # only guards the diagnostic's INPUT (a declared periodicity); this gate
     # asserts the property actually wanted -- that the diagnostic produced a
     # value -- and names which of the diagnostic's three NA paths applies.
@@ -1895,6 +2062,27 @@ plan_qa_gates <- function() {
       command = {
         check_leaderboard_detection_power_values(leaderboard)
         cli::cli_inform(c("v" = "qa_leaderboard_detection_power_values: S20 passed (every positive-Sharpe row has a detection-power verdict)"))
+        TRUE
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: every positive-Sharpe Full Period leaderboard strategy has a
+    # non-NA deflated_sharpe/dsr_pvalue/k_eff_leaderboard verdict, or a
+    # written reason in DEFLATED_SHARPE_EXEMPTIONS (S21, #728 item 4).
+    # #728 found deflated_sharpe covered only 4 of 17 strategies -- and of
+    # the 8 strategies claiming a positive Full-Period Sharpe, only 1
+    # (Factor DRIF) had any multiple-testing correction. #728 items 1+2
+    # widened coverage to 11 of 17; this gate is what keeps that count from
+    # silently regressing. Expected to fail on the current, unrebuilt store
+    # until a fresh tar_make() picks up the widened strat_deflated_sharpe --
+    # see check_leaderboard_deflated_sharpe_coverage() roxygen for the full
+    # rationale and scoping notes.
+    targets::tar_target(
+      qa_leaderboard_deflated_sharpe_coverage,
+      command = {
+        check_leaderboard_deflated_sharpe_coverage(leaderboard, DEFLATED_SHARPE_EXEMPTIONS)
+        cli::cli_inform(c("v" = "qa_leaderboard_deflated_sharpe_coverage: S21 passed (every positive-Sharpe Full Period strategy has a deflated-Sharpe verdict or a declared exemption)"))
         TRUE
       },
       cue = targets::tar_cue(mode = "always")

--- a/R/plan_strategy_correlation.R
+++ b/R/plan_strategy_correlation.R
@@ -30,6 +30,131 @@ CORR_MIN_OBS  <- 12L
 # Redundancy threshold: |r| >= this with a better-Sharpe peer → flag as redundant
 REDUNDANCY_THRESH <- 0.80
 
+# ── Leaderboard-wide return alignment (#728 items 1+2) ──────────────────────
+#
+# strat_corr_matrix above (and the K_eff it feeds, strat_keff_vertox) is
+# scoped to a 5-strategy FAMILY: stk_max, stk_drif, fac_max, fac_drif, ltr.
+# #728 found that this family scope is what the leaderboard's
+# `deflated_sharpe`/`dsr_pvalue`/k_eff columns actually correct for -- not
+# the 17-strategy leaderboard itself -- which understates the true
+# multiple-testing multiplicity for every strategy on the board.
+#
+# STRAT_RETURNS_WIDE_CODES names every strategy this widened alignment
+# covers, using the same code_name vocabulary as port_returns/strat_cols
+# above. Deliberately NOT all 17 leaderboard strategies -- two genuine,
+# documented data constraints (#728 item 1: "if it is a genuine data
+# constraint... say so precisely and leave those NA rather than fabricating
+# inputs"):
+#
+#   1. DAILY-frequency strategies (CMR, OLMAR-1, TOM, Risk State, Avoid
+#      Worst; ann_factor = 252 in STRATEGY_OBS_ANN_FACTOR,
+#      R/plan_leaderboard.R) are excluded, same reason
+#      strat_returns_aligned above already excludes avoid_worst/risk_state:
+#      mixing daily and monthly series into one correlation matrix requires
+#      an aggregation step that risks the look-ahead bias described in #215.
+#      A future daily-frequency alignment target is a separate project.
+#   2. PSO Optimal is excluded: it is not an independent data source. It is
+#      port_optimal_weights %*% c(stk_max, stk_drif, fac_max, fac_drif) (see
+#      the "PSO Optimal" block in plan_leaderboard.R's `leaderboard`
+#      target) -- a linear combination of four series already in this
+#      matrix. Including a near-collinear combination alongside its own
+#      components adds no independent information and risks a near-singular
+#      correlation matrix in hd_strat_keff_vertox()'s Cholesky step.
+#
+# That leaves 11 of 17 strategies covered here (up from the family's 4-5).
+STRAT_RETURNS_WIDE_CODES <- c(
+  "stk_max", "stk_drif", "fac_max", "fac_drif", "ltr", "xgb_drif",
+  "mom_prepeak", "mom_postpeak", "mom_combined", "value_hml",
+  "managed_futures"
+)
+
+#' Full-join a list of per-strategy return tables onto a common `ym` spine
+#' (#728 items 1+2)
+#'
+#' Split out as a plain, unit-testable function for the same reason as
+#' \code{.build_wide_corr_matrix()} below: it is the exact mechanism that
+#' fixes the fail-loud-not-null.md "inner_join across strategy series"
+#' defect for strat_returns_wide -- each element of \code{parts} is joined
+#' with \code{dplyr::full_join(by = "ym")}, so a `ym` present in one part but
+#' absent from another produces an NA cell for the missing part, never a
+#' dropped row for the parts that DO have data that month.
+#'
+#' @param parts List of tibbles, each with a `ym` column plus exactly one
+#'   strategy return column.
+#' @return A single tibble with one `ym` column (the union of every part's
+#'   `ym` values) plus one column per part.
+#' @noRd
+.full_join_return_spine <- function(parts) {
+  Reduce(function(x, y) dplyr::full_join(x, y, by = "ym"), parts)
+}
+
+
+#' Correlation-aware effective-count matrix builder (#728 item 2)
+#'
+#' Shared by strat_corr_matrix_leaderboard below. Split out as a plain
+#' function (rather than left inline in the tar_target()) so it is directly
+#' unit-testable on synthetic data -- the embedded-in-tar_target() logic
+#' elsewhere in this file has no test coverage today (grep confirms no
+#' test file references strat_returns_aligned/strat_corr_matrix), and #728
+#' item 2's leaderboard-wide correlation matrix is exactly the kind of
+#' silent-NA-propagation risk fail-loud-not-null.md warns about.
+#'
+#' Uses `use = "pairwise.complete.obs"`, NOT a complete-case pre-filter,
+#' because the caller's return table (strat_returns_wide) legitimately
+#' contains NA where a strategy has no history for that month -- a
+#' complete-case filter here would silently shrink the sample to the
+#' shortest-history strategy's overlap window, the exact
+#' fail-loud-not-null.md "inner_join across strategy series" defect shape,
+#' just expressed as a filter instead of a join.
+#'
+#' @param ret_tbl Tibble with one column per strategy code_name (may contain
+#'   NA) plus any other columns (e.g. `ym`); non-code_name columns are
+#'   ignored.
+#' @param cols Character vector of code_names (columns of `ret_tbl`) to
+#'   include, subject to `min_obs` below.
+#' @param min_obs Minimum non-NA observations required for a column to be
+#'   included; columns below this are dropped rather than propagating NA
+#'   into the correlation matrix.
+#' @return A square, symmetric, unit-diagonal correlation matrix. Aborts
+#'   (does not silently return NA cells) if a *pairwise* overlap between two
+#'   included columns is too sparse for `stats::cor()` to compute a finite
+#'   value -- see the fail-loud-not-null.md `cli_abort` requirement.
+#' @noRd
+.build_wide_corr_matrix <- function(ret_tbl, cols, min_obs = CORR_MIN_OBS) {
+  enough_obs <- vapply(
+    cols,
+    function(col) sum(!is.na(ret_tbl[[col]])) >= min_obs,
+    logical(1L)
+  )
+  cols <- cols[enough_obs]
+
+  if (length(cols) < 2L) {
+    cli::cli_abort(c(
+      "x" = "Need at least 2 strategies with >= {min_obs} observations to compute the leaderboard-wide correlation matrix.",
+      "i" = "Got {length(cols)} qualifying strategy/strategies: {paste(cols, collapse = ', ')}."
+    ))
+  }
+
+  ret_mat <- as.matrix(ret_tbl[, cols, drop = FALSE])
+  cor_mat <- stats::cor(ret_mat, use = "pairwise.complete.obs")
+  rownames(cor_mat) <- cols
+  colnames(cor_mat) <- cols
+
+  if (anyNA(cor_mat)) {
+    bad <- which(is.na(cor_mat), arr.ind = TRUE)
+    bad_pairs <- unique(apply(bad, 1L, function(r) {
+      paste(sort(cols[r]), collapse = " / ")
+    }))
+    cli::cli_abort(c(
+      "x" = "Leaderboard-wide correlation matrix has {length(bad_pairs)} NA pairwise cell(s).",
+      "i" = "Pair(s) with insufficient pairwise overlap: {paste(bad_pairs, collapse = '; ')}.",
+      "i" = "stats::cor(use = 'pairwise.complete.obs') returns NA when two columns share fewer than 2 non-NA rows in common -- fix by widening the shared history or excluding the offending strategy (with a documented reason, per fail-loud-not-null.md), not by dropping the NA silently."
+    ))
+  }
+
+  cor_mat
+}
+
 plan_strategy_correlation <- function() {
   list(
 
@@ -207,6 +332,102 @@ plan_strategy_correlation <- function() {
         select(code_name, strategy_label, correlation_max, redundant, incremental_sharpe)
 
       result
+    }),
+
+    # ── Leaderboard-wide return alignment (#728 items 1+2) ───────────────────
+    # Widens strat_returns_aligned's scope from 5 strategies to the 11 named
+    # in STRAT_RETURNS_WIDE_CODES above. Deliberately uses full_join (spine =
+    # union of every ym across all sources), NOT inner_join: an inner_join
+    # across N series lets any one series' shorter history truncate every
+    # other series to its overlap window -- the forbidden pattern in
+    # .claude/rules/fail-loud-not-null.md ("One series' gap silently deletes
+    # the period for all of them"). NA cells here are real (a strategy has
+    # no return that month) and are handled downstream by
+    # .build_wide_corr_matrix()'s pairwise-complete correlation, not by
+    # dropping rows.
+    targets::tar_target(strat_returns_wide, {
+      library(dplyr)
+
+      base <- port_returns |>
+        select(ym, stk_max, stk_drif, fac_max, fac_drif) |>
+        filter(if_any(c(stk_max, stk_drif, fac_max, fac_drif), ~ !is.na(.x)))
+
+      # LTR: same ym-from-date derivation as strat_returns_aligned above.
+      ltr_col <- ltr_portfolio |>
+        filter(!is.na(port_ret)) |>
+        mutate(ym = format(as.Date(date), "%Y-%m")) |>
+        select(ym, ltr = port_ret)
+
+      # XGB DRIF: xgb_drif_portfolio already carries ym (R/plan_xgb_signal.R
+      # derives it from stk_monthly, same convention as port_returns).
+      xgb_col <- xgb_drif_portfolio |>
+        filter(!is.na(port_ret)) |>
+        select(ym, xgb_drif = port_ret)
+
+      # Mom Pre-Peak / Post-Peak / 12-2: returns tables key on exec_date
+      # (the trade's actual execution date), not ym -- see
+      # .mom_prepeak_compute_returns() in R/plan_mom_prepeak.R.
+      mom_prepeak_col <- mom_prepeak_returns |>
+        filter(!is.na(ret_ls)) |>
+        mutate(ym = format(as.Date(exec_date), "%Y-%m")) |>
+        select(ym, mom_prepeak = ret_ls)
+
+      mom_postpeak_col <- mom_postpeak_returns |>
+        filter(!is.na(ret_ls)) |>
+        mutate(ym = format(as.Date(exec_date), "%Y-%m")) |>
+        select(ym, mom_postpeak = ret_ls)
+
+      mom_combined_col <- mom_combined_returns |>
+        filter(!is.na(ret_ls)) |>
+        mutate(ym = format(as.Date(exec_date), "%Y-%m")) |>
+        select(ym, mom_combined = ret_ls)
+
+      # Value (HML): ev_portfolios$ret_value_hml, keyed on date (R/plan_ev_ebit.R).
+      value_hml_col <- ev_portfolios |>
+        filter(!is.na(ret_value_hml)) |>
+        mutate(ym = format(as.Date(date), "%Y-%m")) |>
+        select(ym, value_hml = ret_value_hml)
+
+      # Managed Futures: mf_portfolios$ret_ls (the canonical long-short MOP
+      # 2012 series -- see mf_underperformance_periods's own comment,
+      # R/plan_managed_futures.R), keyed on date.
+      managed_futures_col <- mf_portfolios |>
+        filter(!is.na(ret_ls)) |>
+        mutate(ym = format(as.Date(date), "%Y-%m")) |>
+        select(ym, managed_futures = ret_ls)
+
+      parts <- list(
+        base, ltr_col, xgb_col, mom_prepeak_col, mom_postpeak_col,
+        mom_combined_col, value_hml_col, managed_futures_col
+      )
+
+      .full_join_return_spine(parts) |>
+        arrange(ym)
+    }),
+
+    # ── Leaderboard-wide correlation matrix (#728 item 2 CONTRACT) ───────────
+    # Same shape as strat_corr_matrix above (square, symmetric, unit
+    # diagonal, code_name row/colnames) but scoped to
+    # STRAT_RETURNS_WIDE_CODES instead of the 5-strategy family, and built
+    # via .build_wide_corr_matrix() (pairwise-complete, NOT complete-case).
+    targets::tar_target(strat_corr_matrix_leaderboard, {
+      .build_wide_corr_matrix(
+        strat_returns_wide, STRAT_RETURNS_WIDE_CODES, min_obs = CORR_MIN_OBS
+      )
+    }),
+
+    # ── Leaderboard-wide Vertox K_eff (#728 items 1+2) ────────────────────────
+    # Distinct from strat_keff_vertox (family-scoped, 5 strategies) above --
+    # this is the number surfaced on the leaderboard as `k_eff_leaderboard`
+    # (R/plan_leaderboard.R's strat_deflated_sharpe), named apart from the
+    # family-scoped `k_eff_family` so no consumer can confuse "effective
+    # tests within one family" with "effective tests across the whole
+    # leaderboard" (#728's core finding). seed = 160 matches
+    # strat_keff_vertox above for reproducibility (issue #160).
+    targets::tar_target(strat_keff_vertox_leaderboard, {
+      historicaldata::hd_strat_keff_vertox(
+        strat_corr_matrix_leaderboard, n_sim = 20000L, seed = 160L
+      )
     })
   )
 }

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -753,19 +753,19 @@ if (!is.null(boot_ci)) {
 
 #### Deflated Sharpe
 
-The Deflated Sharpe Ratio (<abbr title="Deflated Sharpe Ratio: Sharpe adjusted for non-normality (skewness, kurtosis) and multiple testing across K trials — Lopez de Prado 2018">DSR</abbr>) adjusts the naive Sharpe for both non-normality of returns (skewness and kurtosis) and multiple testing, answering the question: given that we tested K strategies, is this Sharpe ratio statistically significant? The multiple-testing penalty uses the Vertox correlation-aware effective count K_eff_strat (not the raw count M = 4), because the 4 strategies are correlated — using the raw count would over-penalise and reject strategies that carry genuine independent signal. See [Lopez de Prado (2018)](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2460551) for the DSR derivation and [Vertox — The Effective Number of Tested Strategies](https://www.vertoxquant.com/p/the-effective-number-of-tested-strategies) for the K_eff_strat methodology.
+The Deflated Sharpe Ratio (<abbr title="Deflated Sharpe Ratio: Sharpe adjusted for non-normality (skewness, kurtosis) and multiple testing across K trials — Lopez de Prado 2018">DSR</abbr>) adjusts the naive Sharpe for both non-normality of returns (skewness and kurtosis) and multiple testing, answering the question: given that we tested K strategies, is this Sharpe ratio statistically significant? The multiple-testing penalty uses the Vertox correlation-aware effective count K_eff_leaderboard, computed across every strategy in the leaderboard-wide correlation matrix (not the raw strategy count, and not the narrower per-family K_eff_family this table used before #728) — see [Lopez de Prado (2018)](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2460551) for the DSR derivation and [Vertox — The Effective Number of Tested Strategies](https://www.vertoxquant.com/p/the-effective-number-of-tested-strategies) for the K_eff methodology. Coverage is 11 of 17 leaderboard strategies (#728 items 1+2); the remaining 6 are genuine, documented exclusions (daily-frequency series, or PSO Optimal's linear-combination circularity) — see `STRAT_RETURNS_WIDE_CODES` in `R/plan_strategy_correlation.R`.
 
 ```{r}
 #| label: deflated-sharpe
 x <- safe_tar_read("strat_deflated_sharpe")
 if (!is.null(x)) {
-  keff <- round(x$k_eff_strat[1], 2)
-  kraw <- x$k_raw[1]
+  keff <- round(x$k_eff_leaderboard[1], 2)
+  kraw <- x$k_raw_leaderboard[1]
   cap <- paste0(
     "Deflated Sharpe (Lopez de Prado 2018). ",
-    "Multiple-testing penalty uses Vertox K_eff_strat = ", keff,
+    "Multiple-testing penalty uses Vertox K_eff_leaderboard = ", keff,
     " effective strategies vs ", kraw,
-    " raw — the 4 strategies are correlated, so the raw count over-penalises. ",
+    " raw — strategies are correlated, so the raw count over-penalises. ",
     "DSR adjusts for skewness, kurtosis, and the effective number of trials."
   )
   display <- x |>

--- a/tests/testthat/_snaps/leaderboard-deflated-sharpe-coverage.md
+++ b/tests/testthat/_snaps/leaderboard-deflated-sharpe-coverage.md
@@ -1,0 +1,20 @@
+# check_leaderboard_deflated_sharpe_coverage throws and names the offending strategy when no exemption exists
+
+    Code
+      check_leaderboard_deflated_sharpe_coverage(offender_leaderboard,
+        test_exemptions)
+    Condition
+      Error in `check_leaderboard_deflated_sharpe_coverage()`:
+      x Leaderboard has 1 Full Period row(s) with sharpe > 0 but no deflated_sharpe/dsr_pvalue/k_eff_leaderboard verdict AND no declared exemption (#728 item 4):
+      i  New Strategy / Full Period -- sharpe = 0.33 (no declared exemption in DEFLATED_SHARPE_EXEMPTIONS)
+      i check_leaderboard_deflated_sharpe_coverage() (S21) requires every positive-Sharpe Full Period row to have a non-NA deflated_sharpe/dsr_pvalue/k_eff_leaderboard verdict, or a written reason in DEFLATED_SHARPE_EXEMPTIONS (R/plan_qa_gates.R) -- fix the offending strategy's coverage in STRAT_RETURNS_WIDE_CODES (R/plan_strategy_correlation.R) or add a documented exemption. Per fail-loud-not-null.md, the absence of a reason is what fails, not the NA itself.
+
+# check_leaderboard_deflated_sharpe_coverage throws when leaderboard is missing required columns
+
+    Code
+      check_leaderboard_deflated_sharpe_coverage(bad, test_exemptions)
+    Condition
+      Error in `check_leaderboard_deflated_sharpe_coverage()`:
+      x Leaderboard is missing 1 required column(s): deflated_sharpe.
+      i check_leaderboard_deflated_sharpe_coverage() (S21) requires strategy, period, sharpe, deflated_sharpe, dsr_pvalue, k_eff_leaderboard.
+

--- a/tests/testthat/_snaps/leaderboard-detection-power-values.md
+++ b/tests/testthat/_snaps/leaderboard-detection-power-values.md
@@ -18,15 +18,15 @@
       i  LTR / Full Period -- sharpe = 0.33, months = 254 -- hd_detection_power() produced no value despite a usable months (path c: the tryCatch in R/plan_leaderboard.R's .detection_diag_row() caught an error)
       i check_leaderboard_detection_power_values() (S20) requires every positive-Sharpe row to have a non-NA detection_min_n_years/detection_underpowered -- fix the offending strategy's source metrics target (path b: publish a real months/n_days/n_obs column) or investigate the hd_detection_power() error (path c).
 
-# check_leaderboard_detection_power_values throws when k_eff_strat is usable but the mt verdict is NA
+# check_leaderboard_detection_power_values throws when k_eff_leaderboard is usable but the mt verdict is NA
 
     Code
       check_leaderboard_detection_power_values(mt_missing_leaderboard)
     Condition
       Error in `check_leaderboard_detection_power_values()`:
-      x Leaderboard has 1 row(s) with sharpe > 0 and a usable k_eff_strat but no multiple-testing-corrected detection-power verdict (#726 item 4):
-      i  Factor DRIF / Full Period -- sharpe = 0.076, k_eff_strat = 4.847
-      i check_leaderboard_detection_power_values() (S20) requires detection_min_n_years_mt/detection_underpowered_mt to be non-NA whenever k_eff_strat is non-NA and >= 1 -- see the alpha = 0.05 / keff tryCatch in R/plan_leaderboard.R's .detection_diag_row().
+      x Leaderboard has 1 row(s) with sharpe > 0 and a usable k_eff_leaderboard but no multiple-testing-corrected detection-power verdict (#726 item 4):
+      i  Factor DRIF / Full Period -- sharpe = 0.076, k_eff_leaderboard = 4.847
+      i check_leaderboard_detection_power_values() (S20) requires detection_min_n_years_mt/detection_underpowered_mt to be non-NA whenever k_eff_leaderboard is non-NA and >= 1 -- see the alpha = 0.05 / keff tryCatch in R/plan_leaderboard.R's .detection_diag_row().
 
 # check_leaderboard_detection_power_values throws when leaderboard is missing required columns
 
@@ -35,5 +35,5 @@
     Condition
       Error in `check_leaderboard_detection_power_values()`:
       x Leaderboard is missing 1 required column(s): months.
-      i check_leaderboard_detection_power_values() (S20) requires strategy, period, sharpe, months, detection_min_n_years, detection_underpowered, detection_min_n_years_mt, detection_underpowered_mt, k_eff_strat.
+      i check_leaderboard_detection_power_values() (S20) requires strategy, period, sharpe, months, detection_min_n_years, detection_underpowered, detection_min_n_years_mt, detection_underpowered_mt, k_eff_leaderboard.
 

--- a/tests/testthat/_snaps/strategy-correlation-wide.md
+++ b/tests/testthat/_snaps/strategy-correlation-wide.md
@@ -1,0 +1,9 @@
+# .build_wide_corr_matrix aborts (does not silently return NA) when fewer than 2 columns qualify
+
+    Code
+      .build_wide_corr_matrix(ret_tbl, "only_col", min_obs = 12L)
+    Condition
+      Error in `.build_wide_corr_matrix()`:
+      x Need at least 2 strategies with >= 12 observations to compute the leaderboard-wide correlation matrix.
+      i Got 1 qualifying strategy/strategies: only_col.
+

--- a/tests/testthat/test-leaderboard-deflated-sharpe-coverage.R
+++ b/tests/testthat/test-leaderboard-deflated-sharpe-coverage.R
@@ -1,0 +1,132 @@
+testthat::local_edition(3)
+# Tests for check_leaderboard_deflated_sharpe_coverage() — QA gate S21
+# (#728 item 4)
+#
+# The function is defined in R/plan_qa_gates.R alongside
+# DEFLATED_SHARPE_EXEMPTIONS. It follows the same "coverage or a documented
+# exemption" shape as S19/S20 (see test-leaderboard-detection-power-*.R):
+# a positive Full-Period Sharpe with no deflated_sharpe/dsr_pvalue/
+# k_eff_leaderboard verdict either has a written reason in
+# DEFLATED_SHARPE_EXEMPTIONS, or the gate aborts.
+#
+# Background (#728): deflated_sharpe covered only 4 of 17 leaderboard
+# strategies before items 1+2 widened it to 11 (see
+# R/plan_strategy_correlation.R's STRAT_RETURNS_WIDE_CODES). This gate is
+# what keeps that count from silently regressing -- and, per
+# fail-loud-not-null.md, ensures any remaining gap either has a written
+# reason or fails the pipeline loudly.
+
+source(here::here("R/plan_qa_gates.R"))
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+# Small, self-contained exemption table (independent of the real
+# DEFLATED_SHARPE_EXEMPTIONS so these tests do not silently start passing/
+# failing if that table's strategy list changes).
+test_exemptions <- tibble::tibble(
+  strategy = "Avoid Worst",
+  reason   = "daily-frequency series; test fixture"
+)
+
+# "Factor DRIF" and "Value (HML)" both have full deflated-Sharpe coverage.
+# "Avoid Worst" has a positive sharpe and no verdict, but IS in
+# test_exemptions -- must not trip the gate. A Training-period row with a
+# positive sharpe and no verdict is included to prove the gate ignores
+# non-Full-Period rows (deflated_sharpe is a full-sample statistic
+# broadcast to every period row, so per-period gaps are not meaningful).
+good_leaderboard <- tibble::tibble(
+  strategy          = c("Factor DRIF", "Factor DRIF", "Value (HML)", "Avoid Worst", "Avoid Worst"),
+  period            = c("Full Period", "Training",    "Full Period", "Full Period", "Training"),
+  sharpe            = c(0.076,          0.10,           0.068,        0.620,         0.55),
+  deflated_sharpe   = c(0.05,           NA_real_,       0.03,         NA_real_,      NA_real_),
+  dsr_pvalue        = c(0.4,            NA_real_,       0.6,          NA_real_,      NA_real_),
+  k_eff_leaderboard = c(9.2,            NA_real_,       9.2,          NA_real_,      NA_real_)
+)
+
+# "New Strategy" has a positive Full-Period sharpe, no deflated-Sharpe
+# verdict, and NO declared exemption -- the #728 regression this gate
+# exists to catch.
+offender_leaderboard <- tibble::tibble(
+  strategy          = c("Factor DRIF", "New Strategy"),
+  period            = c("Full Period", "Full Period"),
+  sharpe            = c(0.076,          0.330),
+  deflated_sharpe   = c(0.05,           NA_real_),
+  dsr_pvalue        = c(0.4,            NA_real_),
+  k_eff_leaderboard = c(9.2,            NA_real_)
+)
+
+# ── Tests: coverage-or-exemption assertion ──────────────────────────────────
+
+test_that("check_leaderboard_deflated_sharpe_coverage passes when every positive-Sharpe Full Period row has a verdict or exemption", {
+  expect_true(
+    check_leaderboard_deflated_sharpe_coverage(good_leaderboard, test_exemptions)
+  )
+})
+
+test_that("check_leaderboard_deflated_sharpe_coverage ignores non-Full-Period rows entirely", {
+  # Factor DRIF/Training has a positive sharpe and NA verdict in
+  # good_leaderboard, with no matching exemption -- must not trip the gate
+  # because deflated_sharpe is a full-sample statistic, not a per-period one.
+  only_training <- good_leaderboard[good_leaderboard$period == "Training", ]
+  expect_true(check_leaderboard_deflated_sharpe_coverage(only_training, test_exemptions))
+})
+
+test_that("check_leaderboard_deflated_sharpe_coverage throws and names the offending strategy when no exemption exists", {
+  expect_error(
+    check_leaderboard_deflated_sharpe_coverage(offender_leaderboard, test_exemptions),
+    regexp = "New Strategy"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_deflated_sharpe_coverage(offender_leaderboard, test_exemptions)
+  )
+})
+
+test_that("check_leaderboard_deflated_sharpe_coverage does not throw for an exempted strategy even with all three columns NA", {
+  exempt_only <- good_leaderboard[good_leaderboard$strategy == "Avoid Worst" &
+                                     good_leaderboard$period == "Full Period", ]
+  expect_true(check_leaderboard_deflated_sharpe_coverage(exempt_only, test_exemptions))
+})
+
+# ── Tests: required columns ─────────────────────────────────────────────────
+
+test_that("check_leaderboard_deflated_sharpe_coverage throws when leaderboard is missing required columns", {
+  bad <- dplyr::select(good_leaderboard, -deflated_sharpe)
+  expect_error(
+    check_leaderboard_deflated_sharpe_coverage(bad, test_exemptions),
+    regexp = "deflated_sharpe"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_deflated_sharpe_coverage(bad, test_exemptions)
+  )
+})
+
+test_that("check_leaderboard_deflated_sharpe_coverage throws when exemptions table is missing required columns", {
+  bad_exemptions <- dplyr::select(test_exemptions, -reason)
+  expect_error(
+    check_leaderboard_deflated_sharpe_coverage(good_leaderboard, bad_exemptions),
+    regexp = "reason"
+  )
+})
+
+# ── DEFLATED_SHARPE_EXEMPTIONS itself ────────────────────────────────────────
+
+test_that("DEFLATED_SHARPE_EXEMPTIONS has strategy/reason columns with no blank reasons", {
+  expect_true(all(c("strategy", "reason") %in% names(DEFLATED_SHARPE_EXEMPTIONS)))
+  expect_true(all(nzchar(DEFLATED_SHARPE_EXEMPTIONS$reason)))
+})
+
+test_that("DEFLATED_SHARPE_EXEMPTIONS lists exactly the six documented STRAT_RETURNS_WIDE_CODES exclusions", {
+  expect_setequal(
+    DEFLATED_SHARPE_EXEMPTIONS$strategy,
+    c("CMR", "OLMAR-1", "TOM", "Risk State", "Avoid Worst", "PSO Optimal")
+  )
+})
+
+test_that("DEFLATED_SHARPE_EXEMPTIONS has no duplicate strategy rows", {
+  expect_equal(
+    nrow(DEFLATED_SHARPE_EXEMPTIONS),
+    dplyr::n_distinct(DEFLATED_SHARPE_EXEMPTIONS$strategy)
+  )
+})

--- a/tests/testthat/test-leaderboard-detection-power-values.R
+++ b/tests/testthat/test-leaderboard-detection-power-values.R
@@ -8,7 +8,7 @@ testthat::local_edition(3)
 # INPUT (a declared row in STRATEGY_OBS_ANN_FACTOR); it does not check that
 # the diagnostic actually produced a value. S20 asserts the property #726
 # wants: every row with sharpe > 0 has a non-NA detection_min_n_years /
-# detection_underpowered, and (where k_eff_strat is itself usable) a non-NA
+# detection_underpowered, and (where k_eff_leaderboard is itself usable) a non-NA
 # detection_min_n_years_mt / detection_underpowered_mt.
 #
 # Background (#726): Risk State passed S19 (it IS in STRATEGY_OBS_ANN_FACTOR,
@@ -25,7 +25,7 @@ source(here::here("R/plan_qa_gates.R"))
 # negative sharpe with an NA verdict -- deliberately included to prove the
 # gate correctly ignores non-positive-Sharpe rows (path a, #726's own text:
 # "underpowered is not a meaningful question for a strategy that isn't even
-# claiming a positive edge"). "Value (HML)" has k_eff_strat = NA, so its mt
+# claiming a positive edge"). "Value (HML)" has k_eff_leaderboard = NA, so its mt
 # columns are legitimately NA too (#726 item 4's documented guard) and must
 # NOT trip the mt assertion.
 good_leaderboard <- tibble::tibble(
@@ -37,7 +37,7 @@ good_leaderboard <- tibble::tibble(
   detection_underpowered     = c(FALSE, NA, TRUE),
   detection_min_n_years_mt   = c(12, NA_real_, NA_real_),
   detection_underpowered_mt  = c(FALSE, NA, NA),
-  k_eff_strat                = c(4.847, 4.847, NA_real_)
+  k_eff_leaderboard          = c(4.847, 4.847, NA_real_)
 )
 
 # Path (b): Risk State's actual #726 shape -- sharpe > 0, months NA.
@@ -50,7 +50,7 @@ months_na_leaderboard <- tibble::tibble(
   detection_underpowered     = NA,
   detection_min_n_years_mt   = NA_real_,
   detection_underpowered_mt  = NA,
-  k_eff_strat                = NA_real_
+  k_eff_leaderboard          = NA_real_
 )
 
 # Path (c): months is usable (present, >= 2) but hd_detection_power() still
@@ -65,10 +65,10 @@ power_fail_leaderboard <- tibble::tibble(
   detection_underpowered     = NA,
   detection_min_n_years_mt   = NA_real_,
   detection_underpowered_mt  = NA,
-  k_eff_strat                = NA_real_
+  k_eff_leaderboard          = NA_real_
 )
 
-# #726 item 4: single-test verdict is fine, but k_eff_strat IS usable
+# #726 item 4: single-test verdict is fine, but k_eff_leaderboard IS usable
 # (>= 1, non-NA) and the mt columns are still NA -- must trip the mt
 # assertion even though the single-test assertion passes.
 mt_missing_leaderboard <- tibble::tibble(
@@ -80,7 +80,7 @@ mt_missing_leaderboard <- tibble::tibble(
   detection_underpowered     = TRUE,
   detection_min_n_years_mt   = NA_real_,
   detection_underpowered_mt  = NA,
-  k_eff_strat                = 4.847
+  k_eff_leaderboard          = 4.847
 )
 
 # ── Tests: single-test assertion ────────────────────────────────────────────
@@ -122,7 +122,7 @@ test_that("check_leaderboard_detection_power_values throws and names path (c) wh
 
 # ── Tests: multiple-testing-corrected assertion (#726 item 4) ──────────────
 
-test_that("check_leaderboard_detection_power_values throws when k_eff_strat is usable but the mt verdict is NA", {
+test_that("check_leaderboard_detection_power_values throws when k_eff_leaderboard is usable but the mt verdict is NA", {
   expect_error(
     check_leaderboard_detection_power_values(mt_missing_leaderboard),
     regexp = "Factor DRIF"
@@ -133,9 +133,9 @@ test_that("check_leaderboard_detection_power_values throws when k_eff_strat is u
   )
 })
 
-test_that("check_leaderboard_detection_power_values does not require mt columns when k_eff_strat is NA", {
-  # power_fail_leaderboard has k_eff_strat = NA and NA mt columns -- would
-  # wrongly trip the mt assertion if it didn't guard on k_eff_strat's own
+test_that("check_leaderboard_detection_power_values does not require mt columns when k_eff_leaderboard is NA", {
+  # power_fail_leaderboard has k_eff_leaderboard = NA and NA mt columns -- would
+  # wrongly trip the mt assertion if it didn't guard on k_eff_leaderboard's own
   # usability. Isolate that shape with a passing single-test verdict so only
   # the mt guard is under test.
   fixture <- power_fail_leaderboard

--- a/tests/testthat/test-strategy-correlation-wide.R
+++ b/tests/testthat/test-strategy-correlation-wide.R
@@ -1,0 +1,111 @@
+testthat::local_edition(3)
+# Tests for the leaderboard-wide correlation helpers added by #728 items 1+2
+# (R/plan_strategy_correlation.R): .full_join_return_spine() and
+# .build_wide_corr_matrix(), plus STRAT_RETURNS_WIDE_CODES itself.
+#
+# Both functions are split out as plain, unit-testable functions specifically
+# because the rest of this file's logic lives embedded inside tar_target()
+# calls, which have no test coverage today (no existing test file references
+# strat_returns_aligned/strat_corr_matrix/strat_corr_augment) -- and #728
+# item 2's leaderboard-wide correlation matrix is exactly the kind of silent
+# NA-propagation risk fail-loud-not-null.md warns about, so it gets direct
+# test coverage instead of only pipeline-time observation.
+
+source(here::here("R/plan_strategy_correlation.R"))
+
+# ── .full_join_return_spine(): fail-loud-not-null.md fix ───────────────────
+
+test_that(".full_join_return_spine keeps every part's rows -- a gap in one series does not drop another's data", {
+  # Series A has 3 months, series B only has the first 2 -- an inner_join
+  # would drop 2026-03 entirely (the exact fail-loud-not-null.md "One
+  # series' gap silently deletes the period for all of them" defect).
+  a <- tibble::tibble(ym = c("2026-01", "2026-02", "2026-03"), a = c(0.01, 0.02, 0.03))
+  b <- tibble::tibble(ym = c("2026-01", "2026-02"), b = c(0.10, 0.20))
+
+  out <- .full_join_return_spine(list(a, b))
+
+  expect_equal(nrow(out), 3L)
+  expect_equal(out$ym, c("2026-01", "2026-02", "2026-03"))
+  expect_true(is.na(out$b[out$ym == "2026-03"]))
+  # Series A's 2026-03 value survives even though B has no data that month.
+  expect_equal(out$a[out$ym == "2026-03"], 0.03)
+})
+
+test_that(".full_join_return_spine unions ym values across all parts, not just the first", {
+  a <- tibble::tibble(ym = "2026-01", a = 0.01)
+  b <- tibble::tibble(ym = "2026-06", b = 0.02)
+  c <- tibble::tibble(ym = "2026-12", c = 0.03)
+
+  out <- .full_join_return_spine(list(a, b, c))
+
+  expect_setequal(out$ym, c("2026-01", "2026-06", "2026-12"))
+  expect_equal(nrow(out), 3L)
+})
+
+# ── .build_wide_corr_matrix() ───────────────────────────────────────────────
+
+test_that(".build_wide_corr_matrix returns a square, symmetric, unit-diagonal matrix matching stats::cor()", {
+  set.seed(728)
+  n <- 100L
+  ret_tbl <- tibble::tibble(
+    x = rnorm(n), y = rnorm(n), z = rnorm(n)
+  )
+  out <- .build_wide_corr_matrix(ret_tbl, c("x", "y", "z"), min_obs = 12L)
+
+  expect_equal(dim(out), c(3L, 3L))
+  expect_equal(rownames(out), c("x", "y", "z"))
+  expect_equal(colnames(out), c("x", "y", "z"))
+  expect_equal(unname(diag(out)), rep(1, 3L))
+  expect_true(max(abs(out - t(out))) < 1e-12)
+  expect_equal(out, stats::cor(as.matrix(ret_tbl[, c("x", "y", "z")])), ignore_attr = TRUE)
+})
+
+test_that(".build_wide_corr_matrix drops columns below min_obs instead of propagating their NA", {
+  set.seed(729)
+  n <- 100L
+  ret_tbl <- tibble::tibble(
+    plenty_a = rnorm(n),
+    plenty_b = rnorm(n),
+    sparse   = c(rnorm(5L), rep(NA_real_, n - 5L))  # only 5 non-NA, below default min_obs
+  )
+  out <- .build_wide_corr_matrix(ret_tbl, c("plenty_a", "plenty_b", "sparse"), min_obs = 12L)
+
+  # "sparse" dropped entirely -- 2x2 matrix, not a 3x3 with NA cells.
+  expect_equal(dim(out), c(2L, 2L))
+  expect_setequal(rownames(out), c("plenty_a", "plenty_b"))
+})
+
+test_that(".build_wide_corr_matrix aborts (does not silently return NA) when fewer than 2 columns qualify", {
+  ret_tbl <- tibble::tibble(only_col = rnorm(50L))
+  expect_error(
+    .build_wide_corr_matrix(ret_tbl, "only_col", min_obs = 12L),
+    regexp = "at least 2 strategies"
+  )
+  expect_snapshot(
+    error = TRUE,
+    .build_wide_corr_matrix(ret_tbl, "only_col", min_obs = 12L)
+  )
+})
+
+test_that(".build_wide_corr_matrix aborts and names the pair when pairwise overlap is too sparse for stats::cor()", {
+  # x and y each individually clear min_obs, but they share only 1
+  # non-NA row in common -- stats::cor(use = "pairwise.complete.obs")
+  # returns NA for that pair, which must fail loudly, not silently.
+  n <- 20L
+  ret_tbl <- tibble::tibble(
+    x = c(rnorm(n), rep(NA_real_, n)),
+    y = c(rep(NA_real_, n), rnorm(n - 1L), 1)
+  )
+  # Overlap: only the very last row is non-NA on both sides.
+  expect_error(
+    .build_wide_corr_matrix(ret_tbl, c("x", "y"), min_obs = 12L),
+    regexp = "NA pairwise cell"
+  )
+})
+
+# ── STRAT_RETURNS_WIDE_CODES itself ─────────────────────────────────────────
+
+test_that("STRAT_RETURNS_WIDE_CODES has no duplicates and matches the 11-strategy #728 coverage", {
+  expect_equal(length(STRAT_RETURNS_WIDE_CODES), length(unique(STRAT_RETURNS_WIDE_CODES)))
+  expect_length(STRAT_RETURNS_WIDE_CODES, 11L)
+})


### PR DESCRIPTION
## Summary

Implements items 1, 2, and 4 of #728. Does **NOT** implement item 3
(rendering not-computed vs not-applicable) — that is visible dashboard
output requiring a Phase 0 prototype and human approval under
`.claude/rules/dashboard-output-first.md`. Refs #728 (this PR does not close
it).

### Item 1 — extend deflated-Sharpe / K_eff coverage (4/17 -> 11/17)

`strat_deflated_sharpe`'s `col_map` previously covered only Stock MAX,
Stock DRIF, Factor MAX, Factor DRIF. `R/plan_strategy_correlation.R` gains a
new `strat_returns_wide` target that `full_join`s (never `inner_join` — see
`.claude/rules/fail-loud-not-null.md`) every **monthly-frequency** strategy
with an accessible return series onto a common `ym` spine: the original 5
(`stk_max`, `stk_drif`, `fac_max`, `fac_drif`, `ltr` — LTR was already in
the family correlation matrix but never in the DSR `col_map`, an existing
inconsistency fixed here too) plus `xgb_drif`, `mom_prepeak`,
`mom_postpeak`, `mom_combined`, `value_hml`, `managed_futures`.

The remaining 6 of 17 strategies are **genuine, documented exclusions**, not
an oversight (see `STRAT_RETURNS_WIDE_CODES`'s comment,
`R/plan_strategy_correlation.R`):

| Strategy | Reason |
|---|---|
| CMR, OLMAR-1, TOM, Risk State, Avoid Worst | Daily-frequency return series (`ann_factor = 252`). Mixing daily and monthly series into one correlation matrix requires an aggregation step that risks the look-ahead bias described in #215 — the same reason `strat_returns_aligned` already excluded avoid_worst/risk_state. |
| PSO Optimal | Not an independent data source — it is `port_optimal_weights %*% c(stk_max, stk_drif, fac_max, fac_drif)`, a linear combination of four series already covered. Including a near-collinear combination alongside its own components adds no independent information and risks a near-singular correlation matrix in `hd_strat_keff_vertox()`'s Cholesky step. |

### Item 2 — leaderboard-wide K_eff, distinctly named

New targets `strat_corr_matrix_leaderboard` / `strat_keff_vertox_leaderboard`
compute the Vertox correlation-aware effective-strategy count across all 11
covered strategies (`hd_strat_keff_vertox`, seed 160, same as the existing
family target).

`k_eff_strat` was ambiguous about scope — #728's own finding. It is now two
distinctly-named columns:

- **`k_eff_family`** — the original 5-strategy family scope (informational
  only from this PR forward; no longer drives the published DSR).
- **`k_eff_leaderboard`** — the new 11-strategy leaderboard-wide scope; this
  is what `deflated_sharpe`/`dsr_pvalue`/`dsr_haircut_pct` are now computed
  against, and what `.detection_diag_row()`'s multiple-testing-corrected
  columns (`detection_min_n_years_mt`/`detection_underpowered_mt`, #726 item
  4) now read instead of the narrower family count.

S20 (`check_leaderboard_detection_power_values`) had its required-column
name, roxygen, and error messages updated `k_eff_strat` → `k_eff_leaderboard`
to match; its test file and snapshot were regenerated and re-verified green.

### Item 4 — S21 coverage-or-exemption gate

`check_leaderboard_deflated_sharpe_coverage()` (S21,
`R/plan_qa_gates.R`) follows the same shape as S19/S20: every
positive-Sharpe **Full Period** strategy must have a non-NA
`deflated_sharpe`/`dsr_pvalue`/`k_eff_leaderboard` verdict, or a written
reason in the new `DEFLATED_SHARPE_EXEMPTIONS` table. Per
`fail-loud-not-null.md`, the absence of a reason is what fails, not the NA
itself.

`DEFLATED_SHARPE_EXEMPTIONS` declares exactly the 6 strategies named above,
each with the same reasoning restated per-strategy.

**Scoping decision:** S21 covers only the `deflated_sharpe`/`dsr_pvalue`/
`k_eff_leaderboard` family — the columns items 1+2 directly fix — not
#728's full "rigour columns" list (`hac_sharpe`, `wf_corr`, `sharpe_ci_lo`/
`_hi`, `incremental_sharpe`, `ssr`). Each of those has a different coverage
story (e.g. `hac_sharpe` is populated only where `ltr_metrics`/`rsc_metrics`
carry it; `wf_corr` only where a tunable parameter grid exists) and would
need its own exemption audit. Flagged as follow-up work, not attempted here
— doing it honestly within this PR's time budget was not possible.

## What is observed vs predicted (mandatory disclosure)

**`tar_make()` was deliberately NOT run.** The main checkout owns the single
live `docs/_targets/` store; a concurrent build corrupted it once already
today (#730). Per the dispatch instructions, this means:

**Observed** (from `scripts/verify.sh`, full run, foreground):
- `docs/_targets.R` parses and passes `tar_validate()` structurally — the
  new targets and the extended `strat_deflated_sharpe` wire into the DAG
  with no naming/dependency errors.
- Root test suite: `total=709 failed=3` — matches the documented baseline
  exactly (`test-crypto-momentum.R`, `test-qa-summary-deps.R`,
  `test-stock-backtest.R`), 0 unexpected failures, 0 unexpected skips.
- Package test suite: `total=713 failed=1 skipped=15` — matches the
  documented baseline exactly, 0 unexpected failures/skips.
- New unit tests (`test-strategy-correlation-wide.R` — the
  `.full_join_return_spine()` and `.build_wide_corr_matrix()` helpers on
  synthetic data, including the NA-pairwise-overlap abort path;
  `test-leaderboard-deflated-sharpe-coverage.R` — S21 on synthetic
  fixtures) all pass, snapshots stable on a second run.

**Predicted, NOT observed** (would require a real `tar_make()`):
- The actual numeric value of `k_eff_leaderboard`. Mechanically it should
  be **≥** the old `k_eff_family` (4.847) — `hd_strat_keff_vertox`'s own
  documented axiom is "adding a new strategy weakly increases K_eff" — but
  the exact value depends on the real empirical correlation structure
  across 11 strategies, which this PR cannot compute without the live
  store.
- Whether `deflated_sharpe` gets **more conservative** for the 4 originally-
  covered strategies. `hd_deflated_sharpe()`'s haircut is monotonically
  increasing in `K_trials`, so a larger `k_eff_leaderboard` implies a lower
  (or equal) `deflated_sharpe` than the pre-#728 numbers for Stock/Factor
  MAX/DRIF — this is the expected, desired direction per #728's own
  argument, not a bug, but I cannot quote the magnitude.
- The actual `deflated_sharpe`/`dsr_pvalue` values for the 7 newly-covered
  strategies (LTR, XGB DRIF, Mom Pre-Peak, Mom Post-Peak, Mom 12-2, Value
  (HML), Managed Futures) — previously NA, now computed, but the concrete
  numbers are unknown until the pipeline rebuilds.
- **Whether S21 passes on the real store.** It is expected to fail until a
  fresh `tar_make()` picks up the widened `strat_deflated_sharpe` — sharing
  the same "the gate is correct, current data may not satisfy it yet"
  status as S19/S20 when they first shipped. If it fails, the error message
  will name the exact offending strategy/period.

No number above that is "predicted" is presented as "observed" anywhere
else in this PR body or in code comments.

## Test plan

- [x] `scripts/verify.sh` full run, foreground — PASS, baselines match exactly (quoted above)
- [x] `scripts/verify.sh --quick` — PASS (parse + `tar_validate()`), re-run after rebasing onto latest `origin/main`
- [x] New unit tests for `.full_join_return_spine()` / `.build_wide_corr_matrix()` (synthetic data, including the fail-loud NA-pairwise-overlap path)
- [x] New unit tests for S21 (`check_leaderboard_deflated_sharpe_coverage`), mirroring S19/S20's structure
- [x] S20 test file + snapshot updated for the `k_eff_strat` → `k_eff_leaderboard` rename, re-verified green
- [ ] Real pipeline rebuild (`tar_make()` in the main checkout) — NOT run here; will produce the actual before/after deflated-Sharpe numbers and determine whether S21 passes

Refs #728, #726, #727, #711, #160, #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
