### PR TITLE
fix(pipeline): close check_pipeline_errors.R fail-open on a truncated meta read

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,6 +28,34 @@
 # script, which need no store -- see that script header comment for the
 # full three-check design).
 #
+# STEP 0.5 / build lock (#730): two overlapping tar_make() runs against ONE
+# store interleave writes to docs/_targets/meta/meta -- observed once,
+# producing a doubled/malformed meta line that made check_pipeline_errors.R
+# (Step 2) silently PASS on a truncated read while tar_make() itself had
+# printed "errored pipeline". Before Step 1 can start, this script now
+# acquires a best-effort lock (mkdir under the repo's .git dir, PID-stamped,
+# released via the trap-based cleanup below) and refuses to start a second
+# build while a live one holds it. See the "Step 0.5" block for the exact
+# stale-lock recovery behaviour.
+#
+# STEP 2b / cross-check (#730): Step 1's tar_make() log is now teed to a
+# temp file. Immediately after Step 2 (check_pipeline_errors.R) runs, this
+# script greps that log for the word "errored" -- if the log mentions it but
+# check_pipeline_errors.R reported clean, that disagreement is now a hard
+# failure (CROSSCHECK_STATUS) rather than something nothing looks for. This
+# is the check that would have caught #730's incident on its own, and it
+# also now gates Step 2.5 (metadata snapshot) and Step 4 (--render): a
+# snapshot or a publish from a store the cross-check distrusts is worse than
+# not producing one.
+#
+# NOT implemented here: #730's proposal 2 (asserting the tar_meta() row
+# count against docs/_targets_meta_snapshot.csv, #695 Check 3's committed
+# snapshot). That snapshot is written by THIS SAME script's Step 2.5, from
+# the same build it would be asked to validate -- using it as a pre-build
+# expectation needs the previous run's snapshot to be read and compared
+# before Step 1 overwrites the store, which is a genuine ordering question
+# deserving its own design, not a fold-in here. Left for a follow-up.
+#
 # STEP 2.5 / metadata snapshot (#695 Check 3 CI gap): immediately after a
 # clean Step 1 + Step 2, this script also writes
 # docs/_targets_meta_snapshot.csv via scripts/write_targets_meta_snapshot.R
@@ -93,21 +121,25 @@
 #      With --render: additionally, every page Step 4 rendered did so
 #      cleanly (see exit code 3 below for the alternative).
 #   1  the build RAN but reported a problem: one or more targets errored
-#      (per check_pipeline_errors.R), the metadata snapshot could not be
-#      written (per write_targets_meta_snapshot.R -- #695 Check 3 CI gap; see
-#      Step 2.5 above), a dead target reference or escalated staleness (per
+#      (per check_pipeline_errors.R), tar_make()'s own log disagreed with a
+#      clean check_pipeline_errors.R verdict (Step 2b cross-check, #730), the
+#      metadata snapshot could not be written (per
+#      write_targets_meta_snapshot.R -- #695 Check 3 CI gap; see Step 2.5
+#      above), a dead target reference or escalated staleness (per
 #      check_dashboard_freshness.R), and/or tar_make() itself exited
 #      non-zero (a crashed build still leaves a store worth inspecting, so
-#      Steps 2, 2.5, and 3 always run when Steps 1 + 2 permit -- see below --
-#      but a non-zero tar_make() exit is never silently treated as a pass
-#      even when the store it left behind happens to read clean). With
-#      --render: also covers the build being too dirty to render at all --
-#      Step 4 is skipped (not attempted) and says so; the render never even
-#      starts.
+#      Steps 2, 2b, 2.5, and 3 always run when Steps 1 + 2 permit -- see
+#      below -- but a non-zero tar_make() exit is never silently treated as
+#      a pass even when the store it left behind happens to read clean).
+#      With --render: also covers the build being too dirty to render at
+#      all -- Step 4 is skipped (not attempted) and says so; the render
+#      never even starts.
 #   2  the build did NOT run at all: wrong location (not the main checkout,
-#      or run from a linked worktree), the nix shell itself could not be
-#      entered (pre-flight check below), check_pipeline_errors.R could not
-#      read a store at all (no store / tar_meta() failed), or
+#      or run from a linked worktree), a build lock already held by a live
+#      PID (Step 0.5, #730 -- see its block for stale-lock recovery), the
+#      nix shell itself could not be entered (pre-flight check below),
+#      check_pipeline_errors.R could not read a store at all (no store,
+#      tar_meta() failed, or a truncated/malformed meta file -- #730), or
 #      check_dashboard_freshness.R --data-staleness could not run its checks
 #      at all. Also returned immediately, before anything runs, for an
 #      unrecognised command-line flag. This is NOT a pass -- never treat it
@@ -147,6 +179,28 @@ done
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# ---------------------------------------------------------------------------
+# #730: single unified cleanup trap for every temp resource this script
+# creates (build lock dir, tar_make() log, dashboard-freshness log). All
+# three variables are pre-declared empty here and populated later, at the
+# point each resource is actually created, so the trap (registered once,
+# below) is safe to fire at ANY point in the script -- including an early
+# exit before some of these vars are ever assigned -- without tripping
+# `set -u`. Declaring one trap here (instead of one per resource) also means
+# the build lock is guaranteed to be released on every exit path, not only
+# the one Step it happens to be textually near.
+# ---------------------------------------------------------------------------
+LOCKDIR=""
+TARMAKE_LOG=""
+DASHBOARD_LOG=""
+_cleanup() {
+  [[ -n "${LOCKDIR:-}" ]] && rm -rf "$LOCKDIR"
+  [[ -n "${TARMAKE_LOG:-}" ]] && rm -f "$TARMAKE_LOG"
+  [[ -n "${DASHBOARD_LOG:-}" ]] && rm -f "$DASHBOARD_LOG"
+  return 0
+}
+trap _cleanup EXIT
+
 # CRITICAL: cd into the repo this script belongs to -- see scripts/verify.sh's
 # header comment (#575) for why. `nix develop "$REPO_ROOT"` only selects
 # which flake provides the shell -- the command it runs INHERITS THE
@@ -182,6 +236,51 @@ if [[ "$GIT_DIR_ABS" == *"/.git/worktrees/"* ]]; then
   exit 2
 fi
 
+# ---------------------------------------------------------------------------
+# Step 0.5 (#730): concurrency guard. Nothing about `targets` itself locks
+# the store -- a second `tar_make()` starting against a store one is already
+# building will interleave writes to docs/_targets/meta/meta, which is
+# exactly the incident behind #730: two overlapping runs produced one
+# doubled, malformed meta line, and the checker built to catch an errored
+# pipeline instead reported PASS on a truncated read of that file. This is
+# a best-effort guard, not a distributed lock -- it protects against the
+# common case (a human, or a second script invocation, starting a second
+# scripts/build.sh while one is already running) via `mkdir`, which is
+# atomic w.r.t. EEXIST on a local filesystem, so at most one concurrent
+# invocation can create $LOCKDIR. The lock lives under $GIT_DIR_ABS (always
+# ".../.git" for the main checkout, confirmed not-a-worktree just above),
+# not under docs/_targets, because docs/_targets may not exist yet on a
+# first-ever build.
+# ---------------------------------------------------------------------------
+LOCKDIR="$GIT_DIR_ABS/build.lock.d"
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+  LOCK_PID="$(cat "$LOCKDIR/pid" 2>/dev/null || true)"
+  if [[ -n "$LOCK_PID" ]] && kill -0 "$LOCK_PID" 2>/dev/null; then
+    echo "!!! Refusing to start: another scripts/build.sh (PID $LOCK_PID) appears to be" >&2
+    echo "!!! running against this store already -- lock: $LOCKDIR" >&2
+    echo "!!! Two overlapping tar_make() runs against ONE store is exactly the incident" >&2
+    echo "!!! that corrupted docs/_targets/meta/meta and produced issue #730 (a checker" >&2
+    echo "!!! fail-open that then silently reported PASS on the truncated result)." >&2
+    echo "!!! If PID $LOCK_PID is definitely not running scripts/build.sh (e.g. a stale" >&2
+    echo "!!! lock left behind by a killed session), remove $LOCKDIR by hand and re-run." >&2
+    echo "!!! BUILD DID NOT RUN. This is NOT a pass.                                   !!!" >&2
+    exit 2
+  fi
+  echo "--- Step 0.5: stale build lock found (PID $LOCK_PID not running) -- removing and retrying ---"
+  rm -rf "$LOCKDIR"
+  if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "!!! Could not acquire build lock even after removing a stale one: $LOCKDIR !!!" >&2
+    echo "!!! BUILD DID NOT RUN. This is NOT a pass.                                   !!!" >&2
+    exit 2
+  fi
+fi
+# Written immediately after mkdir succeeds, before anything else, to
+# minimise (not eliminate) the window in which a second, near-simultaneous
+# invocation could read an empty pid file and mistake this lock for stale.
+echo "$$" > "$LOCKDIR/pid"
+echo "--- Step 0.5: build lock acquired (PID $$, $LOCKDIR) ---"
+echo ""
+
 echo "=== scripts/build.sh ==="
 echo "Repo root: $REPO_ROOT"
 echo ""
@@ -213,10 +312,18 @@ echo ""
 # unconditional, not gated on this step's exit code.
 # ---------------------------------------------------------------------------
 echo "--- Step 1: tar_make() (docs/_targets.R -> docs/_targets store) ---"
+# Tee to a temp file as well as stdout -- Step 2b (#730) greps this log for
+# tar_make()'s OWN verdict ("errored pipeline" / individual "... errored"
+# lines) as an independent cross-check against check_pipeline_errors.R's
+# tar_meta()-based verdict in Step 2. PIPESTATUS[0] (not plain $?) captures
+# the Rscript's own exit code, not tee's -- same pattern already used for
+# Step 3's DASHBOARD_LOG below.
+TARMAKE_LOG="$(mktemp)"
 set +e
 nix develop "$REPO_ROOT" --command Rscript -e \
-  'targets::tar_make(script = file.path("docs", "_targets.R"), store = file.path("docs", "_targets"))'
-TAR_MAKE_STATUS=$?
+  'targets::tar_make(script = file.path("docs", "_targets.R"), store = file.path("docs", "_targets"))' \
+  2>&1 | tee "$TARMAKE_LOG"
+TAR_MAKE_STATUS=${PIPESTATUS[0]}
 set -e
 echo "--- tar_make() exited $TAR_MAKE_STATUS ---"
 echo ""
@@ -236,12 +343,53 @@ echo "--- check_pipeline_errors.R exited $CHECK_STATUS ---"
 echo ""
 
 # ---------------------------------------------------------------------------
+# Step 2b (#730): cross-check tar_make()'s OWN verdict (Step 1's log)
+# against check_pipeline_errors.R's tar_meta()-based verdict (Step 2). This
+# is the check that would have caught #730 on its own: tar_make() printed
+# "errored pipeline" while check_pipeline_errors.R -- reading a truncated
+# view of a meta file corrupted by two overlapping runs -- printed
+# "PASS: no errored targets". Two independent sources of truth disagreeing
+# is the strongest signal available; nothing looked for it before.
+#
+# Deliberately matched on the word "errored" alone, not on tar_make()'s
+# exact bullet symbol (cli renders "✖"/"x" for cli::symbol$cross
+# depending on the calling terminal's UTF-8 capability, which nix develop
+# --command's non-interactive pipe here may or may not report as UTF-8-
+# capable) or on the specific phrase "errored pipeline" alone (which misses
+# the case where an individual target errors without the whole pipeline
+# verdict line surviving truncation). A clean tar_make() run's log does not
+# contain the substring "errored" under any known reporter output -- so
+# this is symbol/locale-agnostic and, per this script's stated design
+# constraint (a false PASS here is worse than a false FAIL), deliberately
+# the NOISIER of the two possible false-positive/false-negative trade-offs:
+# it will flag on any log line merely mentioning "errored" (e.g. a target's
+# own printed message quoting that word), not only the pipeline verdict.
+# ---------------------------------------------------------------------------
+CROSSCHECK_STATUS=0
+if [[ "$CHECK_STATUS" -eq 0 ]] && grep -qi 'errored' "$TARMAKE_LOG" 2>/dev/null; then
+  CROSSCHECK_STATUS=1
+  echo "--- Step 2b: CROSS-CHECK MISMATCH ---"
+  echo "!!! tar_make()'s own log (Step 1) mentions \"errored\", but"
+  echo "!!! check_pipeline_errors.R (Step 2) reported no errored targets. These two"
+  echo "!!! sources disagree -- treating this as a FAILURE rather than trusting"
+  echo "!!! check_pipeline_errors.R's clean verdict on its own (#730)."
+  echo "!!! Matching line(s) from the tar_make() log:"
+  grep -in 'errored' "$TARMAKE_LOG" 2>/dev/null | sed 's/^/!!!   /'
+  echo ""
+else
+  echo "--- Step 2b: cross-check clean (tar_make() log and check_pipeline_errors.R agree) ---"
+  echo ""
+fi
+
+# ---------------------------------------------------------------------------
 # Step 2.5: scripts/write_targets_meta_snapshot.R (#695 Check 3 CI gap). See
 # the header comment above for why this is gated on Step 1 + Step 2 only,
-# and why it never commits/pushes.
+# and why it never commits/pushes. Also gated on Step 2b (#730): a snapshot
+# taken while the cross-check disagrees would encode build times read from
+# the same meta file the cross-check just found reason to distrust.
 # ---------------------------------------------------------------------------
 SNAPSHOT_STATUS=0
-if [[ "$TAR_MAKE_STATUS" -eq 0 ]] && [[ "$CHECK_STATUS" -eq 0 ]]; then
+if [[ "$TAR_MAKE_STATUS" -eq 0 ]] && [[ "$CHECK_STATUS" -eq 0 ]] && [[ "$CROSSCHECK_STATUS" -eq 0 ]]; then
   echo "--- Step 2.5: scripts/write_targets_meta_snapshot.R (#695 Check 3 CI gap) ---"
   set +e
   nix develop "$REPO_ROOT" --command Rscript scripts/write_targets_meta_snapshot.R
@@ -250,8 +398,8 @@ if [[ "$TAR_MAKE_STATUS" -eq 0 ]] && [[ "$CHECK_STATUS" -eq 0 ]]; then
   echo "--- write_targets_meta_snapshot.R exited $SNAPSHOT_STATUS ---"
   echo ""
 else
-  echo "--- Step 2.5: skipping metadata snapshot write -- build not clean (tar_make() exit $TAR_MAKE_STATUS, check_pipeline_errors.R exit $CHECK_STATUS) ---"
-  echo "!!! A snapshot from a store with errored targets would encode wrong build times -- not writing one. !!!"
+  echo "--- Step 2.5: skipping metadata snapshot write -- build not clean (tar_make() exit $TAR_MAKE_STATUS, check_pipeline_errors.R exit $CHECK_STATUS, cross-check status $CROSSCHECK_STATUS) ---"
+  echo "!!! A snapshot from a store with errored targets -- or a store the cross-check found reason to distrust -- would encode wrong build times -- not writing one. !!!"
   echo ""
 fi
 
@@ -273,9 +421,10 @@ echo "--- Step 3: scripts/check_dashboard_freshness.R --data-staleness (#695) --
 # Tee to a temp file as well as stdout -- Step 4 (--render) needs to parse
 # this output for [STALE]/[DATA-STALE] page names without re-running the
 # check a second time. PIPESTATUS[0] (not plain $?) below captures the
-# Rscript's own exit code, not tee's.
+# Rscript's own exit code, not tee's. Cleanup is handled by the unified
+# _cleanup EXIT trap declared near the top of this script (#730) -- no
+# separate trap needed here.
 DASHBOARD_LOG="$(mktemp)"
-trap 'rm -f "$DASHBOARD_LOG"' EXIT
 set +e
 nix develop "$REPO_ROOT" --command Rscript scripts/check_dashboard_freshness.R --data-staleness 2>&1 | tee "$DASHBOARD_LOG"
 DASHBOARD_STATUS=${PIPESTATUS[0]}
@@ -292,6 +441,7 @@ echo ""
 echo "=== scripts/build.sh: summary ==="
 echo "tar_make() exit code:                              $TAR_MAKE_STATUS"
 echo "check_pipeline_errors.R exit code:                 $CHECK_STATUS"
+echo "cross-check status (tar_make() log vs Step 2, #730): $CROSSCHECK_STATUS"
 echo "write_targets_meta_snapshot.R exit code:           $SNAPSHOT_STATUS"
 echo "check_dashboard_freshness.R --data-staleness exit: $DASHBOARD_STATUS"
 echo ""
@@ -325,12 +475,13 @@ RENDER_STATUS=0
 RENDER_RAN=false
 if [[ "$RENDER" == "true" ]]; then
   echo "--- Step 4: --render (#695) ---"
-  if [[ "$TAR_MAKE_STATUS" -ne 0 ]] || [[ "$CHECK_STATUS" -ne 0 ]]; then
+  if [[ "$TAR_MAKE_STATUS" -ne 0 ]] || [[ "$CHECK_STATUS" -ne 0 ]] || [[ "$CROSSCHECK_STATUS" -ne 0 ]]; then
     echo "!!! Skipping --render: build was not clean (tar_make() exit $TAR_MAKE_STATUS,"
-    echo "!!! check_pipeline_errors.R exit $CHECK_STATUS). Rendering from a store with"
-    echo "!!! errored targets would publish wrong numbers into HTML that looks fine --"
-    echo "!!! strictly worse than not rendering at all. Fix the build, then re-run with"
-    echo "!!! --render."
+    echo "!!! check_pipeline_errors.R exit $CHECK_STATUS, cross-check status"
+    echo "!!! $CROSSCHECK_STATUS (#730)). Rendering from a store with errored targets --"
+    echo "!!! or one the cross-check found reason to distrust -- would publish wrong"
+    echo "!!! numbers into HTML that looks fine -- strictly worse than not rendering at"
+    echo "!!! all. Fix the build, then re-run with --render."
     echo ""
   else
     RENDER_RAN=true
@@ -408,10 +559,17 @@ if [[ "$RENDER" == "true" ]]; then
   fi
 fi
 
-if [[ "$TAR_MAKE_STATUS" -ne 0 ]] || [[ "$CHECK_STATUS" -ne 0 ]] || [[ "$SNAPSHOT_STATUS" -ne 0 ]] || [[ "$DASHBOARD_STATUS" -ne 0 ]]; then
+if [[ "$TAR_MAKE_STATUS" -ne 0 ]] || [[ "$CHECK_STATUS" -ne 0 ]] || [[ "$CROSSCHECK_STATUS" -ne 0 ]] || [[ "$SNAPSHOT_STATUS" -ne 0 ]] || [[ "$DASHBOARD_STATUS" -ne 0 ]]; then
   echo "=== scripts/build.sh: FAIL ==="
   if [[ "$CHECK_STATUS" -ne 0 ]]; then
     echo "One or more targets errored -- see the [ERROR] list above."
+  fi
+  if [[ "$CROSSCHECK_STATUS" -ne 0 ]]; then
+    echo "Step 2b cross-check (#730): tar_make()'s own log mentioned \"errored\" while"
+    echo "check_pipeline_errors.R reported no errored targets -- see the [Step 2b:"
+    echo "CROSS-CHECK MISMATCH] block above. Treat check_pipeline_errors.R's PASS as"
+    echo "untrustworthy here; investigate the meta file directly (tar_meta() /"
+    echo "docs/_targets/meta/meta) before relying on this build."
   fi
   if [[ "$SNAPSHOT_STATUS" -ne 0 ]]; then
     echo "write_targets_meta_snapshot.R failed to write docs/_targets_meta_snapshot.csv"

--- a/scripts/check_pipeline_errors.R
+++ b/scripts/check_pipeline_errors.R
@@ -34,23 +34,91 @@
 # Exit codes:
 #   0  no errored targets
 #   1  one or more targets have a non-NA error in tar_meta()
-#   2  could not run the check at all (no store, tar_meta() failed, etc.) —
-#      this is NOT a pass, never treat it as one
+#   2  could not run the check at all (no store, tar_meta() failed, a
+#      truncated/malformed meta file, etc.) — this is NOT a pass, never
+#      treat it as one
+#
+# #730: tar_meta() reads the store's meta file with data.table::fread(),
+# which on a malformed line (e.g. two writers interleaving a record —
+# exactly what happens when two tar_make() runs race one store) does not
+# error. It emits a WARNING ("Stopped early on line N. Expected M fields
+# but found K.") and silently returns however many rows it managed to
+# parse before the bad line. Nothing about that return value distinguishes
+# "the pipeline genuinely has fewer targets" from "the read was truncated"
+# — both look like a data frame with fewer rows than expected, and the
+# `errored <- meta[!is.na(meta$error), ]` line below finds no error among
+# the rows it WAS given. The result, observed in #730: tar_make() printed
+# "errored pipeline", this script read a truncated 762-row view containing
+# neither the errored target nor several others, and printed
+# "PASS: no errored targets". A null-ish state (rows that failed to parse)
+# was indistinguishable from a legitimate absence (targets that didn't
+# error) — see .claude/rules/fail-loud-not-null.md. The withCallingHandlers()
+# below promotes any fread warning matching "Stopped early" or "fill=" (the
+# two data.table warning families for a truncated/ragged read) to a fatal
+# error, so a malformed meta file aborts with exit 2 ("could not run the
+# check at all") instead of silently passing on a partial view.
 
 suppressPackageStartupMessages({
   library(targets)
   library(here)
 })
 
-store_path <- here::here("docs", "_targets")
-
-if (!dir.exists(store_path)) {
-  message("!!! No targets store found at '", store_path, "' !!!")
-  message("!!! This script only READS an existing store -- run tar_make() first. !!!")
-  message("!!! VERIFICATION DID NOT RUN. This is NOT a pass.                      !!!")
-  quit(status = 2, save = "no")
+# .cpe_read_meta() (#730) -- reads tar_meta(fields = error, targets_only =
+# TRUE) from `store_path`, promoting a data.table::fread() truncation
+# warning to a fatal error rather than letting a partial parse pass
+# silently as a valid (if smaller) result. Errors (native tar_meta() errors,
+# or this promoted truncation error) are NOT caught here -- that is the
+# caller's job (.cpe_main(), below), the same split .cdf_main()/tar_meta()
+# uses in scripts/check_dashboard_freshness.R.
+#
+# The warning handler below deliberately RECORDS the match and calls
+# invokeRestart("muffleWarning") to let fread()'s C-level read finish
+# normally, and only raises stop() AFTER withCallingHandlers() returns --
+# NOT from inside the handler itself. Raising stop() from inside a warning
+# handler unwinds the R call stack via a longjmp through fread()'s C code
+# before its own internal cleanup runs, which empirically (while writing
+# this file's tests) produced a real, intermittent knock-on failure on the
+# NEXT fread() call in the same R session ("Previous fread() session was
+# not cleaned up properly" followed by "Couldn't open file ... No such
+# file or directory" building an unrelated store moments later). Recording
+# then raising afterward avoids interrupting fread() mid-read altogether.
+# Pattern-matched on the two data.table warning families that indicate a
+# short/ragged read ("Stopped early on line N..." and the "fill=TRUE"
+# suggestion fread appends to the same class of warning) -- never on the
+# row count, since a short count alone cannot be told apart from a
+# legitimately smaller pipeline.
+.cpe_read_meta <- function(store_path) {
+  truncation_warning <- NULL
+  meta <- withCallingHandlers(
+    targets::tar_meta(store = store_path, fields = error, targets_only = TRUE),
+    warning = function(w) {
+      msg <- conditionMessage(w)
+      if (grepl("Stopped early|fill=", msg)) {
+        truncation_warning <<- msg
+        invokeRestart("muffleWarning")
+      }
+    }
+  )
+  if (!is.null(truncation_warning)) {
+    stop(
+      "tar_meta() emitted a data.table::fread() truncation warning while ",
+      "reading the store's meta file -- the rows fread() DID manage to ",
+      "parse are an INCOMPLETE view of the store, not a complete one with ",
+      "fewer targets (#730). Treating this as fatal rather than silently ",
+      "passing on a partial read. Original warning: ", truncation_warning,
+      call. = FALSE
+    )
+  }
+  meta
 }
 
+# .cpe_main() -- orchestrates the check against `store_path`, printing the
+# same report this script has always printed, and RETURNING (not
+# quit()-ing) an exit-status integer, so it is testable without
+# terminating the R session (mirrors .cdf_main() in
+# scripts/check_dashboard_freshness.R). The Rscript entry point at the
+# bottom of this file calls quit(status = ...) using this return value.
+#
 # NOT `complete_only = TRUE` (#693). tar_meta()'s own source
 # (targets::tar_meta, confirmed against the installed package version in
 # this nix shell) does:
@@ -71,32 +139,53 @@ if (!dir.exists(store_path)) {
 # `targets_only = FALSE` also returns metadata rows for functions and
 # other global objects, not just targets -- without it, the count would
 # never have meant "targets" even after fixing complete_only.
-meta <- tryCatch(
-  targets::tar_meta(store = store_path, fields = error, targets_only = TRUE),
-  error = function(e) {
-    message("!!! tar_meta() failed: ", conditionMessage(e), " !!!")
-    NULL
+.cpe_main <- function(store_path = here::here("docs", "_targets")) {
+  if (!dir.exists(store_path)) {
+    message("!!! No targets store found at '", store_path, "' !!!")
+    message("!!! This script only READS an existing store -- run tar_make() first. !!!")
+    message("!!! VERIFICATION DID NOT RUN. This is NOT a pass.                      !!!")
+    return(2L)
   }
-)
 
-if (is.null(meta)) {
-  message("!!! VERIFICATION DID NOT RUN. This is NOT a pass. !!!")
-  quit(status = 2, save = "no")
+  meta <- tryCatch(
+    .cpe_read_meta(store_path),
+    error = function(e) {
+      message("!!! tar_meta() failed: ", conditionMessage(e), " !!!")
+      NULL
+    }
+  )
+
+  if (is.null(meta)) {
+    message("!!! VERIFICATION DID NOT RUN. This is NOT a pass. !!!")
+    return(2L)
+  }
+
+  errored <- meta[!is.na(meta$error), , drop = FALSE]
+
+  cat(sprintf("Store: %s\n", store_path))
+  cat(sprintf("Targets inspected: %d\n", nrow(meta)))
+  cat(sprintf("Targets errored:   %d\n", nrow(errored)))
+
+  if (nrow(errored) == 0) {
+    cat("PASS: no errored targets\n")
+    return(0L)
+  }
+
+  cat(sprintf("FAIL: %d errored target(s):\n", nrow(errored)))
+  for (i in seq_len(nrow(errored))) {
+    cat(sprintf("  [ERROR] %s -- %s\n", errored$name[i], errored$error[i]))
+  }
+  return(1L)
 }
 
-errored <- meta[!is.na(meta$error), , drop = FALSE]
-
-cat(sprintf("Store: %s\n", store_path))
-cat(sprintf("Targets inspected: %d\n", nrow(meta)))
-cat(sprintf("Targets errored:   %d\n", nrow(errored)))
-
-if (nrow(errored) == 0) {
-  cat("PASS: no errored targets\n")
-  quit(status = 0, save = "no")
+# Only run when this file is the Rscript entry point (sys.nframe() == 0),
+# never when source()'d for its functions -- same pattern (and same
+# empirical basis) as scripts/check_dashboard_freshness.R:
+# `Rscript file.R` gives sys.nframe() == 0 at top level; `source("file.R")`
+# gives sys.nframe() > 0 (source() itself adds a frame).
+# tests/testthat/test-check-pipeline-errors.R source()s this file and must
+# NOT trigger a live run against the real store.
+if (sys.nframe() == 0) {
+  status <- .cpe_main()
+  quit(status = status, save = "no")
 }
-
-cat(sprintf("FAIL: %d errored target(s):\n", nrow(errored)))
-for (i in seq_len(nrow(errored))) {
-  cat(sprintf("  [ERROR] %s -- %s\n", errored$name[i], errored$error[i]))
-}
-quit(status = 1, save = "no")

--- a/tests/testthat/_snaps/check-pipeline-errors.md
+++ b/tests/testthat/_snaps/check-pipeline-errors.md
@@ -1,0 +1,16 @@
+# key .cpe_* function signatures are stable
+
+    Code
+      args(.cpe_read_meta)
+    Output
+      function (store_path) 
+      NULL
+
+---
+
+    Code
+      args(.cpe_main)
+    Output
+      function (store_path = here::here("docs", "_targets")) 
+      NULL
+

--- a/tests/testthat/test-check-pipeline-errors.R
+++ b/tests/testthat/test-check-pipeline-errors.R
@@ -1,0 +1,189 @@
+testthat::local_edition(3)
+source(here::here("scripts", "check_pipeline_errors.R"))
+
+# Regression tests for scripts/check_pipeline_errors.R (#680, #730).
+#
+# scripts/check_pipeline_errors.R defines its logic as `.cpe_*` functions and
+# only RUNS the check (calling quit()) when it is the Rscript entry point
+# (sys.nframe() == 0 at its own top level -- see that file's final block).
+# source()'ing it here (sys.nframe() > 0) loads the functions without
+# triggering a live run against the real repo's docs/_targets store, exactly
+# the pattern test-dashboard-freshness.R uses for check_dashboard_freshness.R.
+#
+# These tests build REAL, throwaway targets stores under withr::local_tempdir()
+# -- never the real docs/_targets store (see .claude/CLAUDE.md and the
+# worktree-location rule: a worktree must not build or touch the main
+# checkout's store).
+#
+# #730 regression -- the empirical finding that shaped .make_toy_store()'s
+# default size: the real incident's meta file (~772 targets) triggered
+# data.table::fread()'s "Stopped early" warning when two tar_make() runs
+# interleaved a write to it. A SMALL corrupted store does NOT reliably
+# reproduce that warning -- confirmed empirically while writing this test
+# (8, 60, and 150-target stores all silently absorbed an identical
+# double-the-line-onto-itself corruption with ZERO warning, via
+# data.table::fread()'s `fill = TRUE` -- which targets::tar_meta() always
+# passes -- padding/merging the ragged row instead of stopping). Only at
+# ~300 targets does fread's warning reliably fire:
+# "Stopped early on line 153. Expected 18 fields but found 35." -- the exact
+# field counts (18 expected, 35 found) reported in #730 itself, which is
+# strong independent confirmation this corruption method matches the real
+# incident (two writers interleaving one target's record). Tests that need
+# the warning to fire use n_targets = 300L for this reason; tests that don't
+# (clean PASS / FAIL paths) use a small store to stay fast.
+
+.make_toy_store <- function(dir, n_targets = 5L, with_error_target = TRUE) {
+  script_path <- file.path(dir, "_targets.R")
+  store_path <- file.path(dir, "_targets")
+  defs <- sprintf("targets::tar_target(t%d, %d + 1)", seq_len(n_targets), seq_len(n_targets))
+  if (with_error_target) {
+    defs <- c(defs, 'targets::tar_target(bad, stop("deliberate test error"))')
+  }
+  writeLines(c(
+    'targets::tar_option_set(error = "continue")', # matches docs/_targets.R's real setting
+    "list(",
+    paste0("  ", defs, collapse = ",\n"),
+    ")"
+  ), script_path)
+  targets::tar_make(
+    script = script_path, store = store_path,
+    callr_function = NULL, reporter = "silent"
+  )
+  store_path
+}
+
+# Corrupts one line roughly in the MIDDLE of the meta file by duplicating it
+# onto itself -- mimics two writers interleaving a record for the SAME
+# target, exactly as #730 describes ("the leaderboard record written twice,
+# concatenated"). A middle line matters: corrupting the LAST line does not
+# reproduce the warning (confirmed empirically), only a line fread reaches
+# mid-file, after it has already locked in an expected column count from
+# earlier rows.
+.corrupt_meta_middle_line <- function(store_path) {
+  meta_path <- file.path(store_path, "meta", "meta")
+  lines <- readLines(meta_path)
+  mid_idx <- as.integer(floor(length(lines) / 2))
+  stopifnot(mid_idx > 1L, mid_idx < length(lines))
+  lines[mid_idx] <- paste0(lines[mid_idx], lines[mid_idx])
+  writeLines(lines, meta_path)
+  invisible(meta_path)
+}
+
+# ── .cpe_main() -- store-existence / clean / errored paths ─────────────────
+
+test_that(".cpe_main returns 2 and reports when no store directory exists", {
+  dir <- withr::local_tempdir()
+  missing_store <- file.path(dir, "does_not_exist")
+  status <- NA_integer_
+  msgs <- character(0)
+  withCallingHandlers(
+    status <- .cpe_main(store_path = missing_store),
+    message = function(m) {
+      msgs <<- c(msgs, conditionMessage(m))
+      invokeRestart("muffleMessage")
+    }
+  )
+  expect_equal(status, 2L)
+  expect_true(any(grepl("No targets store found", msgs)))
+  expect_true(any(grepl("VERIFICATION DID NOT RUN", msgs)))
+})
+
+test_that(".cpe_main returns 0 and reports PASS on a clean store with no errored targets", {
+  dir <- withr::local_tempdir()
+  store <- .make_toy_store(dir, n_targets = 5L, with_error_target = FALSE)
+  status <- NA_integer_
+  out <- utils::capture.output(status <- .cpe_main(store_path = store))
+  expect_equal(status, 0L)
+  txt <- paste(out, collapse = "\n")
+  expect_match(txt, "Targets inspected: 5")
+  expect_match(txt, "Targets errored:   0")
+  expect_match(txt, "PASS: no errored targets")
+})
+
+test_that(".cpe_main returns 1 and reports the errored target's name and message", {
+  dir <- withr::local_tempdir()
+  store <- .make_toy_store(dir, n_targets = 5L, with_error_target = TRUE)
+  status <- NA_integer_
+  out <- utils::capture.output(status <- .cpe_main(store_path = store))
+  expect_equal(status, 1L)
+  txt <- paste(out, collapse = "\n")
+  expect_match(txt, "Targets inspected: 6")
+  expect_match(txt, "FAIL: 1 errored target")
+  expect_match(txt, "\\[ERROR\\] bad -- deliberate test error")
+})
+
+# ── #730: the corrupted-meta-file regression this issue is actually about ──
+
+test_that(".cpe_read_meta() does NOT misfire on a large but uncorrupted store", {
+  dir <- withr::local_tempdir()
+  store <- .make_toy_store(dir, n_targets = 300L, with_error_target = FALSE)
+  meta <- expect_no_warning(.cpe_read_meta(store))
+  expect_equal(nrow(meta), 300L)
+})
+
+test_that(".cpe_read_meta() promotes a data.table::fread truncation warning to a fatal error naming #730 (#730)", {
+  dir <- withr::local_tempdir()
+  store <- .make_toy_store(dir, n_targets = 300L, with_error_target = FALSE)
+  .corrupt_meta_middle_line(store)
+  # A single call captured once, not re-invoked per assertion: calling
+  # .cpe_read_meta()/tar_meta() twice in a row against the same store inside
+  # one test hit an unrelated data.table::fread() internal-session error
+  # ("Couldn't open file ... No such file or directory", confirmed empirically
+  # while writing this test) -- an artefact of repeated fread() calls, not a
+  # #730 concern. One call + one captured condition avoids it.
+  cond <- tryCatch(.cpe_read_meta(store), error = function(e) e)
+  expect_s3_class(cond, "error")
+  msg <- conditionMessage(cond)
+  expect_match(msg, "truncation warning")
+  expect_match(msg, "#730")
+  expect_match(msg, "INCOMPLETE view")
+})
+
+test_that("BEFORE this fix's mechanism, a corrupted meta file silently returns a truncated frame with no signal at all (documents the exact bug #730 reports)", {
+  # This test calls targets::tar_meta() directly -- NOT .cpe_read_meta() --
+  # to document the underlying fail-open behaviour #730 is about: fread()'s
+  # warning is silently discardable, and the truncated row count alone
+  # cannot be told apart from "the pipeline genuinely has fewer targets"
+  # (.claude/rules/fail-loud-not-null.md). This is why #730 proposal 1
+  # cannot be "check the row count" -- it must intercept the WARNING itself.
+  dir <- withr::local_tempdir()
+  store <- .make_toy_store(dir, n_targets = 300L, with_error_target = FALSE)
+  .corrupt_meta_middle_line(store)
+  raw <- suppressWarnings(
+    targets::tar_meta(store = store, fields = error, targets_only = TRUE)
+  )
+  expect_lt(nrow(raw), 300L) # truncated -- the read silently lost rows
+  expect_true(all(is.na(raw$error))) # and reports zero errors among what it DID read
+})
+
+test_that(".cpe_main() returns 2 -- NOT a false PASS -- when the meta file is corrupted by two interleaved writers (#730)", {
+  # The end-to-end regression: BEFORE this fix, this exact scenario made the
+  # top-level script print \"PASS: no errored targets\" on a truncated read
+  # (see #730's incident table). AFTER, .cpe_main() must return 2
+  # (\"could not run the check at all\") and say why -- never 0.
+  dir <- withr::local_tempdir()
+  store <- .make_toy_store(dir, n_targets = 300L, with_error_target = FALSE)
+  .corrupt_meta_middle_line(store)
+  status <- NA_integer_
+  msgs <- character(0)
+  withCallingHandlers(
+    utils::capture.output(status <- .cpe_main(store_path = store)),
+    message = function(m) {
+      msgs <<- c(msgs, conditionMessage(m))
+      invokeRestart("muffleMessage")
+    }
+  )
+  expect_equal(status, 2L)
+  expect_false(identical(status, 0L)) # the exact false-PASS #730 reports must not recur
+  all_msgs <- paste(msgs, collapse = "\n")
+  expect_match(all_msgs, "tar_meta\\(\\) failed")
+  expect_match(all_msgs, "#730")
+  expect_match(all_msgs, "VERIFICATION DID NOT RUN")
+})
+
+# ── Function signature stability (catches API drift, snapshot-test-policy.md) ──
+
+test_that("key .cpe_* function signatures are stable", {
+  expect_snapshot(args(.cpe_read_meta))
+  expect_snapshot(args(.cpe_main))
+})


### PR DESCRIPTION
## Summary

Refs #730. `scripts/check_pipeline_errors.R` exists to catch `tar_make()` exiting 0 while targets errored (`error = "continue"`). It had a fail-open of its own: when the store's meta file is unreadable (e.g. two overlapping `tar_make()` runs interleaving a write), `data.table::fread()` emits a **warning**, not an error, and silently returns a truncated read — indistinguishable from a legitimately smaller pipeline. Observed once: `tar_make()` printed `errored pipeline`; the checker read a truncated 762-row view and printed `PASS: no errored targets`.

Implements #730 proposals **1, 3, and 4**. Proposal 2 is **not** implemented — see `scripts/build.sh`'s header comment for why (the snapshot it would validate against is written by this same script's own Step 2.5, from the same build; using it as a pre-build expectation needs its own design, not a fold-in here).

- **Proposal 1** (`scripts/check_pipeline_errors.R`): refactored into `.cpe_read_meta()` / `.cpe_main()` so the logic is testable without a real store, mirroring `check_dashboard_freshness.R`'s `.cdf_*` / `sys.nframe() == 0` pattern. `.cpe_read_meta()` now promotes any `data.table::fread` truncation warning (`"Stopped early"` / `"fill="`) to a fatal error naming #730, so a malformed meta file aborts (exit 2) instead of passing on a partial read.
- **Proposal 3** (`scripts/build.sh`): Step 1 (`tar_make()`) now tees its log. New **Step 2b** greps that log for the word "errored" and fails the build if the log mentions it while `check_pipeline_errors.R` reports clean — the check that would have caught #730's incident on its own. Gates Step 2.5 (metadata snapshot) and Step 4 (`--render`) too.
- **Proposal 4** (`scripts/build.sh`): new **Step 0.5** concurrency guard — a PID-stamped, `mkdir`-atomic lock under `$GIT_DIR_ABS` refuses a second `build.sh` while a live one holds it, and reclaims a stale lock (dead PID) automatically.

### Design note (per the design constraint in the dispatch)

A false PASS here is worse than a false FAIL. Where a choice existed, I chose the noisier behaviour:
- The Step 2b cross-check matches on the bare word **"errored"**, not the exact bullet symbol or phrase (`cli` renders `✖`/`x` for `cli::symbol$cross` depending on the caller's UTF-8 capability, and matching only `"errored pipeline"` would miss an individual-target error line that doesn't survive to the final verdict). This will also flag a log line that merely *mentions* "errored" in unrelated text — accepted as the safer failure mode.
- `.cpe_read_meta()`'s warning-promotion pattern (`"Stopped early|fill="`) is on the warning *text*, never on the row count, since a short count alone can't be told apart from a legitimately smaller pipeline (`.claude/rules/fail-loud-not-null.md`).

### An implementation wrinkle worth flagging

While writing the regression test I found `.cpe_read_meta()`'s original design — raising `stop()` from *inside* the `warning=` handler — reliably produced a **second, unrelated** failure on the *next* `fread()` call in the same R session (`data.table` leaves its C-level read in a bad state when interrupted mid-call via a longjmp). Fixed by recording the match and muffling the warning so `fread()` finishes normally, then raising the error *after* `withCallingHandlers()` returns. Documented in the function's header comment.

## Verification

`scripts/verify.sh` — full run, foreground, exit 0:

```
::VERIFY:ROOT_SUMMARY:: total=717 failed=3 skipped=0
PASS: failures match the known baseline exactly (3 pre-existing failures, issue #569)
::VERIFY:PKG_SUMMARY:: total=713 failed=1 skipped=15
PASS: failures match the known baseline exactly (1 pre-existing failure, issue #569)
=== scripts/verify.sh: PASS ===
```

**Before/after against a real, deliberately-corrupted store** (a throwaway 300-target toy store under `/private/tmp`, never the real `docs/_targets` store — corrupted by duplicating one meta line onto itself, exactly matching #730's own field counts: 18 expected, 35 found):

BEFORE (pre-fix script, same corrupted store):
```
Warning message:
In data.table::fread(...) :
  Stopped early on line 153. Expected 18 fields but found 35. ...
Store: .../toy_store_730/_targets
Targets inspected: 146
Targets errored:   0
PASS: no errored targets
===ORIGINAL SCRIPT EXIT CODE: 0===
```

AFTER (this PR, same corrupted store):
```
!!! tar_meta() failed: tar_meta() emitted a data.table::fread() truncation warning
while reading the store's meta file -- the rows fread() DID manage to parse are an
INCOMPLETE view of the store, not a complete one with fewer targets (#730). ...
!!! VERIFICATION DID NOT RUN. This is NOT a pass. !!!

===FIXED SCRIPT .cpe_main() STATUS: 2 ===
```

Also confirmed empirically while building the test: a **small** corrupted store (8/60/150 targets) silently absorbs the identical corruption with **zero** `fread` warning at all — `data.table::fread`'s `fill = TRUE` (which `targets::tar_meta()` always passes) only reliably triggers the "Stopped early" warning at larger scale. `tests/testthat/test-check-pipeline-errors.R` documents this and uses a 300-target store for the tests that depend on the warning firing.

`tests/testthat/test-check-pipeline-errors.R` — 26/26 passing, run three times to rule out the flakiness described above:
```
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 26 ]
```

**Step 2b cross-check logic**, verified standalone against 4 scenarios (clean/clean, errored-log+clean-checker [the #730 scenario], errored-log+checker-already-caught-it, clean-log+checker-exit-2):
```
clean log, check clean -> CROSSCHECK_STATUS=0
errored-pipeline log, check clean (THE #730 SCENARIO) -> CROSSCHECK_STATUS=1
errored log, but check ALREADY caught it (status=1) -> CROSSCHECK_STATUS=0
clean log, check already flagged exit 2 -> CROSSCHECK_STATUS=0
```

**Step 0.5 lockfile**, verified standalone (the exact logic copy-matched from `build.sh`, run against a throwaway lock dir — `build.sh` itself legitimately refuses to run outside the main checkout, so it can't be exercised end-to-end from this worktree):
```
=== Test 1: second invocation refuses while a LIVE PID holds the lock ===
acquire_lock() exit status: 2 (expect 2 -- refused)

=== Test 2: stale lock (dead PID) does NOT block -- lock is reclaimed ===
acquire_lock() exit status: 0 (expect 0 -- reclaimed)
pid file now contains: 93626 (expect this script's own PID: 93626)

=== Test 3: mkdir atomicity -- two near-simultaneous acquires, only one wins ===
child A exit: 0
child B exit: 2
```

`bash -n scripts/build.sh` — clean.

No changes to `docs/_targets` (real store never touched — every store built by this PR's tests/verification is a throwaway under `withr::local_tempdir()` or `/private/tmp`).

## Test plan

- [x] `scripts/verify.sh` full run — PASS, baselines unchanged
- [x] `tests/testthat/test-check-pipeline-errors.R` — 26/26, stable across 3 runs
- [x] Before/after transcript against a real corrupted store
- [x] Step 2b cross-check logic verified standalone (4 scenarios)
- [x] Step 0.5 lockfile verified standalone (live-PID refusal, stale-PID reclaim, mkdir atomicity)
- [x] `bash -n scripts/build.sh`
- [x] Real `docs/_targets` store never touched

Refs #730.
