### PR TITLE
fix(build): stop lock refusal from deleting a live build's lock

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,6 +28,34 @@
 # script, which need no store -- see that script header comment for the
 # full three-check design).
 #
+# STEP 0.5 / build lock (#730): two overlapping tar_make() runs against ONE
+# store interleave writes to docs/_targets/meta/meta -- observed once,
+# producing a doubled/malformed meta line that made check_pipeline_errors.R
+# (Step 2) silently PASS on a truncated read while tar_make() itself had
+# printed "errored pipeline". Before Step 1 can start, this script now
+# acquires a best-effort lock (mkdir under the repo's .git dir, PID-stamped,
+# released via the trap-based cleanup below) and refuses to start a second
+# build while a live one holds it. See the "Step 0.5" block for the exact
+# stale-lock recovery behaviour.
+#
+# STEP 2b / cross-check (#730): Step 1's tar_make() log is now teed to a
+# temp file. Immediately after Step 2 (check_pipeline_errors.R) runs, this
+# script greps that log for the word "errored" -- if the log mentions it but
+# check_pipeline_errors.R reported clean, that disagreement is now a hard
+# failure (CROSSCHECK_STATUS) rather than something nothing looks for. This
+# is the check that would have caught #730's incident on its own, and it
+# also now gates Step 2.5 (metadata snapshot) and Step 4 (--render): a
+# snapshot or a publish from a store the cross-check distrusts is worse than
+# not producing one.
+#
+# NOT implemented here: #730's proposal 2 (asserting the tar_meta() row
+# count against docs/_targets_meta_snapshot.csv, #695 Check 3's committed
+# snapshot). That snapshot is written by THIS SAME script's Step 2.5, from
+# the same build it would be asked to validate -- using it as a pre-build
+# expectation needs the previous run's snapshot to be read and compared
+# before Step 1 overwrites the store, which is a genuine ordering question
+# deserving its own design, not a fold-in here. Left for a follow-up.
+#
 # STEP 2.5 / metadata snapshot (#695 Check 3 CI gap): immediately after a
 # clean Step 1 + Step 2, this script also writes
 # docs/_targets_meta_snapshot.csv via scripts/write_targets_meta_snapshot.R
@@ -93,21 +121,25 @@
 #      With --render: additionally, every page Step 4 rendered did so
 #      cleanly (see exit code 3 below for the alternative).
 #   1  the build RAN but reported a problem: one or more targets errored
-#      (per check_pipeline_errors.R), the metadata snapshot could not be
-#      written (per write_targets_meta_snapshot.R -- #695 Check 3 CI gap; see
-#      Step 2.5 above), a dead target reference or escalated staleness (per
+#      (per check_pipeline_errors.R), tar_make()'s own log disagreed with a
+#      clean check_pipeline_errors.R verdict (Step 2b cross-check, #730), the
+#      metadata snapshot could not be written (per
+#      write_targets_meta_snapshot.R -- #695 Check 3 CI gap; see Step 2.5
+#      above), a dead target reference or escalated staleness (per
 #      check_dashboard_freshness.R), and/or tar_make() itself exited
 #      non-zero (a crashed build still leaves a store worth inspecting, so
-#      Steps 2, 2.5, and 3 always run when Steps 1 + 2 permit -- see below --
-#      but a non-zero tar_make() exit is never silently treated as a pass
-#      even when the store it left behind happens to read clean). With
-#      --render: also covers the build being too dirty to render at all --
-#      Step 4 is skipped (not attempted) and says so; the render never even
-#      starts.
+#      Steps 2, 2b, 2.5, and 3 always run when Steps 1 + 2 permit -- see
+#      below -- but a non-zero tar_make() exit is never silently treated as
+#      a pass even when the store it left behind happens to read clean).
+#      With --render: also covers the build being too dirty to render at
+#      all -- Step 4 is skipped (not attempted) and says so; the render
+#      never even starts.
 #   2  the build did NOT run at all: wrong location (not the main checkout,
-#      or run from a linked worktree), the nix shell itself could not be
-#      entered (pre-flight check below), check_pipeline_errors.R could not
-#      read a store at all (no store / tar_meta() failed), or
+#      or run from a linked worktree), a build lock already held by a live
+#      PID (Step 0.5, #730 -- see its block for stale-lock recovery), the
+#      nix shell itself could not be entered (pre-flight check below),
+#      check_pipeline_errors.R could not read a store at all (no store,
+#      tar_meta() failed, or a truncated/malformed meta file -- #730), or
 #      check_dashboard_freshness.R --data-staleness could not run its checks
 #      at all. Also returned immediately, before anything runs, for an
 #      unrecognised command-line flag. This is NOT a pass -- never treat it
@@ -147,6 +179,28 @@ done
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# ---------------------------------------------------------------------------
+# #730: single unified cleanup trap for every temp resource this script
+# creates (build lock dir, tar_make() log, dashboard-freshness log). All
+# three variables are pre-declared empty here and populated later, at the
+# point each resource is actually created, so the trap (registered once,
+# below) is safe to fire at ANY point in the script -- including an early
+# exit before some of these vars are ever assigned -- without tripping
+# `set -u`. Declaring one trap here (instead of one per resource) also means
+# the build lock is guaranteed to be released on every exit path, not only
+# the one Step it happens to be textually near.
+# ---------------------------------------------------------------------------
+LOCKDIR=""
+TARMAKE_LOG=""
+DASHBOARD_LOG=""
+_cleanup() {
+  [[ -n "${LOCKDIR:-}" ]] && rm -rf "$LOCKDIR"
+  [[ -n "${TARMAKE_LOG:-}" ]] && rm -f "$TARMAKE_LOG"
+  [[ -n "${DASHBOARD_LOG:-}" ]] && rm -f "$DASHBOARD_LOG"
+  return 0
+}
+trap _cleanup EXIT
+
 # CRITICAL: cd into the repo this script belongs to -- see scripts/verify.sh's
 # header comment (#575) for why. `nix develop "$REPO_ROOT"` only selects
 # which flake provides the shell -- the command it runs INHERITS THE
@@ -182,6 +236,51 @@ if [[ "$GIT_DIR_ABS" == *"/.git/worktrees/"* ]]; then
   exit 2
 fi
 
+# ---------------------------------------------------------------------------
+# Step 0.5 (#730): concurrency guard. Nothing about `targets` itself locks
+# the store -- a second `tar_make()` starting against a store one is already
+# building will interleave writes to docs/_targets/meta/meta, which is
+# exactly the incident behind #730: two overlapping runs produced one
+# doubled, malformed meta line, and the checker built to catch an errored
+# pipeline instead reported PASS on a truncated read of that file. This is
+# a best-effort guard, not a distributed lock -- it protects against the
+# common case (a human, or a second script invocation, starting a second
+# scripts/build.sh while one is already running) via `mkdir`, which is
+# atomic w.r.t. EEXIST on a local filesystem, so at most one concurrent
+# invocation can create $LOCKDIR. The lock lives under $GIT_DIR_ABS (always
+# ".../.git" for the main checkout, confirmed not-a-worktree just above),
+# not under docs/_targets, because docs/_targets may not exist yet on a
+# first-ever build.
+# ---------------------------------------------------------------------------
+LOCKDIR="$GIT_DIR_ABS/build.lock.d"
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+  LOCK_PID="$(cat "$LOCKDIR/pid" 2>/dev/null || true)"
+  if [[ -n "$LOCK_PID" ]] && kill -0 "$LOCK_PID" 2>/dev/null; then
+    echo "!!! Refusing to start: another scripts/build.sh (PID $LOCK_PID) appears to be" >&2
+    echo "!!! running against this store already -- lock: $LOCKDIR" >&2
+    echo "!!! Two overlapping tar_make() runs against ONE store is exactly the incident" >&2
+    echo "!!! that corrupted docs/_targets/meta/meta and produced issue #730 (a checker" >&2
+    echo "!!! fail-open that then silently reported PASS on the truncated result)." >&2
+    echo "!!! If PID $LOCK_PID is definitely not running scripts/build.sh (e.g. a stale" >&2
+    echo "!!! lock left behind by a killed session), remove $LOCKDIR by hand and re-run." >&2
+    echo "!!! BUILD DID NOT RUN. This is NOT a pass.                                   !!!" >&2
+    exit 2
+  fi
+  echo "--- Step 0.5: stale build lock found (PID $LOCK_PID not running) -- removing and retrying ---"
+  rm -rf "$LOCKDIR"
+  if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "!!! Could not acquire build lock even after removing a stale one: $LOCKDIR !!!" >&2
+    echo "!!! BUILD DID NOT RUN. This is NOT a pass.                                   !!!" >&2
+    exit 2
+  fi
+fi
+# Written immediately after mkdir succeeds, before anything else, to
+# minimise (not eliminate) the window in which a second, near-simultaneous
+# invocation could read an empty pid file and mistake this lock for stale.
+echo "$$" > "$LOCKDIR/pid"
+echo "--- Step 0.5: build lock acquired (PID $$, $LOCKDIR) ---"
+echo ""
+
 echo "=== scripts/build.sh ==="
 echo "Repo root: $REPO_ROOT"
 echo ""
@@ -213,10 +312,18 @@ echo ""
 # unconditional, not gated on this step's exit code.
 # ---------------------------------------------------------------------------
 echo "--- Step 1: tar_make() (docs/_targets.R -> docs/_targets store) ---"
+# Tee to a temp file as well as stdout -- Step 2b (#730) greps this log for
+# tar_make()'s OWN verdict ("errored pipeline" / individual "... errored"
+# lines) as an independent cross-check against check_pipeline_errors.R's
+# tar_meta()-based verdict in Step 2. PIPESTATUS[0] (not plain $?) captures
+# the Rscript's own exit code, not tee's -- same pattern already used for
+# Step 3's DASHBOARD_LOG below.
+TARMAKE_LOG="$(mktemp)"
 set +e
 nix develop "$REPO_ROOT" --command Rscript -e \
-  'targets::tar_make(script = file.path("docs", "_targets.R"), store = file.path("docs", "_targets"))'
-TAR_MAKE_STATUS=$?
+  'targets::tar_make(script = file.path("docs", "_targets.R"), store = file.path("docs", "_targets"))' \
+  2>&1 | tee "$TARMAKE_LOG"
+TAR_MAKE_STATUS=${PIPESTATUS[0]}
 set -e
 echo "--- tar_make() exited $TAR_MAKE_STATUS ---"
 echo ""
@@ -236,12 +343,53 @@ echo "--- check_pipeline_errors.R exited $CHECK_STATUS ---"
 echo ""
 
 # ---------------------------------------------------------------------------
+# Step 2b (#730): cross-check tar_make()'s OWN verdict (Step 1's log)
+# against check_pipeline_errors.R's tar_meta()-based verdict (Step 2). This
+# is the check that would have caught #730 on its own: tar_make() printed
+# "errored pipeline" while check_pipeline_errors.R -- reading a truncated
+# view of a meta file corrupted by two overlapping runs -- printed
+# "PASS: no errored targets". Two independent sources of truth disagreeing
+# is the strongest signal available; nothing looked for it before.
+#
+# Deliberately matched on the word "errored" alone, not on tar_make()'s
+# exact bullet symbol (cli renders "✖"/"x" for cli::symbol$cross
+# depending on the calling terminal's UTF-8 capability, which nix develop
+# --command's non-interactive pipe here may or may not report as UTF-8-
+# capable) or on the specific phrase "errored pipeline" alone (which misses
+# the case where an individual target errors without the whole pipeline
+# verdict line surviving truncation). A clean tar_make() run's log does not
+# contain the substring "errored" under any known reporter output -- so
+# this is symbol/locale-agnostic and, per this script's stated design
+# constraint (a false PASS here is worse than a false FAIL), deliberately
+# the NOISIER of the two possible false-positive/false-negative trade-offs:
+# it will flag on any log line merely mentioning "errored" (e.g. a target's
+# own printed message quoting that word), not only the pipeline verdict.
+# ---------------------------------------------------------------------------
+CROSSCHECK_STATUS=0
+if [[ "$CHECK_STATUS" -eq 0 ]] && grep -qi 'errored' "$TARMAKE_LOG" 2>/dev/null; then
+  CROSSCHECK_STATUS=1
+  echo "--- Step 2b: CROSS-CHECK MISMATCH ---"
+  echo "!!! tar_make()'s own log (Step 1) mentions \"errored\", but"
+  echo "!!! check_pipeline_errors.R (Step 2) reported no errored targets. These two"
+  echo "!!! sources disagree -- treating this as a FAILURE rather than trusting"
+  echo "!!! check_pipeline_errors.R's clean verdict on its own (#730)."
+  echo "!!! Matching line(s) from the tar_make() log:"
+  grep -in 'errored' "$TARMAKE_LOG" 2>/dev/null | sed 's/^/!!!   /'
+  echo ""
+else
+  echo "--- Step 2b: cross-check clean (tar_make() log and check_pipeline_errors.R agree) ---"
+  echo ""
+fi
+
+# ---------------------------------------------------------------------------
 # Step 2.5: scripts/write_targets_meta_snapshot.R (#695 Check 3 CI gap). See
 # the header comment above for why this is gated on Step 1 + Step 2 only,
-# and why it never commits/pushes.
+# and why it never commits/pushes. Also gated on Step 2b (#730): a snapshot
+# taken while the cross-check disagrees would encode build times read from
+# the same meta file the cross-check just found reason to distrust.
 # ---------------------------------------------------------------------------
 SNAPSHOT_STATUS=0
-if [[ "$TAR_MAKE_STATUS" -eq 0 ]] && [[ "$CHECK_STATUS" -eq 0 ]]; then
+if [[ "$TAR_MAKE_STATUS" -eq 0 ]] && [[ "$CHECK_STATUS" -eq 0 ]] && [[ "$CROSSCHECK_STATUS" -eq 0 ]]; then
   echo "--- Step 2.5: scripts/write_targets_meta_snapshot.R (#695 Check 3 CI gap) ---"
   set +e
   nix develop "$REPO_ROOT" --command Rscript scripts/write_targets_meta_snapshot.R
@@ -250,8 +398,8 @@ if [[ "$TAR_MAKE_STATUS" -eq 0 ]] && [[ "$CHECK_STATUS" -eq 0 ]]; then
   echo "--- write_targets_meta_snapshot.R exited $SNAPSHOT_STATUS ---"
   echo ""
 else
-  echo "--- Step 2.5: skipping metadata snapshot write -- build not clean (tar_make() exit $TAR_MAKE_STATUS, check_pipeline_errors.R exit $CHECK_STATUS) ---"
-  echo "!!! A snapshot from a store with errored targets would encode wrong build times -- not writing one. !!!"
+  echo "--- Step 2.5: skipping metadata snapshot write -- build not clean (tar_make() exit $TAR_MAKE_STATUS, check_pipeline_errors.R exit $CHECK_STATUS, cross-check status $CROSSCHECK_STATUS) ---"
+  echo "!!! A snapshot from a store with errored targets -- or a store the cross-check found reason to distrust -- would encode wrong build times -- not writing one. !!!"
   echo ""
 fi
 
@@ -273,9 +421,10 @@ echo "--- Step 3: scripts/check_dashboard_freshness.R --data-staleness (#695) --
 # Tee to a temp file as well as stdout -- Step 4 (--render) needs to parse
 # this output for [STALE]/[DATA-STALE] page names without re-running the
 # check a second time. PIPESTATUS[0] (not plain $?) below captures the
-# Rscript's own exit code, not tee's.
+# Rscript's own exit code, not tee's. Cleanup is handled by the unified
+# _cleanup EXIT trap declared near the top of this script (#730) -- no
+# separate trap needed here.
 DASHBOARD_LOG="$(mktemp)"
-trap 'rm -f "$DASHBOARD_LOG"' EXIT
 set +e
 nix develop "$REPO_ROOT" --command Rscript scripts/check_dashboard_freshness.R --data-staleness 2>&1 | tee "$DASHBOARD_LOG"
 DASHBOARD_STATUS=${PIPESTATUS[0]}
@@ -292,6 +441,7 @@ echo ""
 echo "=== scripts/build.sh: summary ==="
 echo "tar_make() exit code:                              $TAR_MAKE_STATUS"
 echo "check_pipeline_errors.R exit code:                 $CHECK_STATUS"
+echo "cross-check status (tar_make() log vs Step 2, #730): $CROSSCHECK_STATUS"
 echo "write_targets_meta_snapshot.R exit code:           $SNAPSHOT_STATUS"
 echo "check_dashboard_freshness.R --data-staleness exit: $DASHBOARD_STATUS"
 echo ""
@@ -325,12 +475,13 @@ RENDER_STATUS=0
 RENDER_RAN=false
 if [[ "$RENDER" == "true" ]]; then
   echo "--- Step 4: --render (#695) ---"
-  if [[ "$TAR_MAKE_STATUS" -ne 0 ]] || [[ "$CHECK_STATUS" -ne 0 ]]; then
+  if [[ "$TAR_MAKE_STATUS" -ne 0 ]] || [[ "$CHECK_STATUS" -ne 0 ]] || [[ "$CROSSCHECK_STATUS" -ne 0 ]]; then
     echo "!!! Skipping --render: build was not clean (tar_make() exit $TAR_MAKE_STATUS,"
-    echo "!!! check_pipeline_errors.R exit $CHECK_STATUS). Rendering from a store with"
-    echo "!!! errored targets would publish wrong numbers into HTML that looks fine --"
-    echo "!!! strictly worse than not rendering at all. Fix the build, then re-run with"
-    echo "!!! --render."
+    echo "!!! check_pipeline_errors.R exit $CHECK_STATUS, cross-check status"
+    echo "!!! $CROSSCHECK_STATUS (#730)). Rendering from a store with errored targets --"
+    echo "!!! or one the cross-check found reason to distrust -- would publish wrong"
+    echo "!!! numbers into HTML that looks fine -- strictly worse than not rendering at"
+    echo "!!! all. Fix the build, then re-run with --render."
     echo ""
   else
     RENDER_RAN=true
@@ -408,10 +559,17 @@ if [[ "$RENDER" == "true" ]]; then
   fi
 fi
 
-if [[ "$TAR_MAKE_STATUS" -ne 0 ]] || [[ "$CHECK_STATUS" -ne 0 ]] || [[ "$SNAPSHOT_STATUS" -ne 0 ]] || [[ "$DASHBOARD_STATUS" -ne 0 ]]; then
+if [[ "$TAR_MAKE_STATUS" -ne 0 ]] || [[ "$CHECK_STATUS" -ne 0 ]] || [[ "$CROSSCHECK_STATUS" -ne 0 ]] || [[ "$SNAPSHOT_STATUS" -ne 0 ]] || [[ "$DASHBOARD_STATUS" -ne 0 ]]; then
   echo "=== scripts/build.sh: FAIL ==="
   if [[ "$CHECK_STATUS" -ne 0 ]]; then
     echo "One or more targets errored -- see the [ERROR] list above."
+  fi
+  if [[ "$CROSSCHECK_STATUS" -ne 0 ]]; then
+    echo "Step 2b cross-check (#730): tar_make()'s own log mentioned \"errored\" while"
+    echo "check_pipeline_errors.R reported no errored targets -- see the [Step 2b:"
+    echo "CROSS-CHECK MISMATCH] block above. Treat check_pipeline_errors.R's PASS as"
+    echo "untrustworthy here; investigate the meta file directly (tar_meta() /"
+    echo "docs/_targets/meta/meta) before relying on this build."
   fi
   if [[ "$SNAPSHOT_STATUS" -ne 0 ]]; then
     echo "write_targets_meta_snapshot.R failed to write docs/_targets_meta_snapshot.csv"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -252,28 +252,63 @@ fi
 # not under docs/_targets, because docs/_targets may not exist yet on a
 # first-ever build.
 # ---------------------------------------------------------------------------
-LOCKDIR="$GIT_DIR_ABS/build.lock.d"
-if ! mkdir "$LOCKDIR" 2>/dev/null; then
-  LOCK_PID="$(cat "$LOCKDIR/pid" 2>/dev/null || true)"
-  if [[ -n "$LOCK_PID" ]] && kill -0 "$LOCK_PID" 2>/dev/null; then
+
+# `kill -0 "$pid"` alone cannot tell EPERM ("process exists, not ours to
+# signal") apart from ESRCH ("no such process") -- both give a non-zero exit.
+# Treating that non-zero exit as "not running" (as this script used to)
+# means a live PID this user simply cannot signal -- e.g. PID 1 (launchd),
+# or any build owned by another user -- reads as dead and its lock gets
+# reclaimed out from under a build that is, in fact, still running. Where
+# the two failures disagree, the safe direction is to treat an
+# unsignallable PID as ALIVE: refusing to build is always safer than
+# building concurrently. Returns 0 (treat as alive) unless `kill -0`
+# reports ESRCH.
+_build_lock_pid_alive() {
+  local pid="$1" kill_err
+  if kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+  kill_err="$(kill -0 "$pid" 2>&1 1>/dev/null || true)"
+  [[ "$kill_err" == *"not permitted"* ]]
+}
+
+# The candidate lock path is resolved here, but $LOCKDIR (the variable the
+# EXIT trap above actually acts on) is deliberately NOT assigned until
+# ownership of the lock is actually claimed, below. Assigning $LOCKDIR this
+# early was the #730-class bug: a REFUSED invocation (another build already
+# holds the lock -- the `exit 2` a few lines down) would still populate
+# $LOCKDIR, so the trap on that invocation's own exit deleted the lock the
+# live build still held -- silently defeating the guard and inviting a
+# retry to race the live build for real.
+LOCK_PATH="$GIT_DIR_ABS/build.lock.d"
+if ! mkdir "$LOCK_PATH" 2>/dev/null; then
+  LOCK_PID="$(cat "$LOCK_PATH/pid" 2>/dev/null || true)"
+  if [[ -n "$LOCK_PID" ]] && _build_lock_pid_alive "$LOCK_PID"; then
     echo "!!! Refusing to start: another scripts/build.sh (PID $LOCK_PID) appears to be" >&2
-    echo "!!! running against this store already -- lock: $LOCKDIR" >&2
+    echo "!!! running against this store already -- lock: $LOCK_PATH" >&2
     echo "!!! Two overlapping tar_make() runs against ONE store is exactly the incident" >&2
     echo "!!! that corrupted docs/_targets/meta/meta and produced issue #730 (a checker" >&2
     echo "!!! fail-open that then silently reported PASS on the truncated result)." >&2
     echo "!!! If PID $LOCK_PID is definitely not running scripts/build.sh (e.g. a stale" >&2
-    echo "!!! lock left behind by a killed session), remove $LOCKDIR by hand and re-run." >&2
+    echo "!!! lock left behind by a killed session), remove $LOCK_PATH by hand and re-run." >&2
     echo "!!! BUILD DID NOT RUN. This is NOT a pass.                                   !!!" >&2
+    # $LOCKDIR is still "" here on purpose -- this invocation never claimed
+    # the lock, so the EXIT trap (which only rm -rf's a non-empty $LOCKDIR)
+    # must not touch it. See the comment above LOCK_PATH.
     exit 2
   fi
   echo "--- Step 0.5: stale build lock found (PID $LOCK_PID not running) -- removing and retrying ---"
-  rm -rf "$LOCKDIR"
-  if ! mkdir "$LOCKDIR" 2>/dev/null; then
-    echo "!!! Could not acquire build lock even after removing a stale one: $LOCKDIR !!!" >&2
+  rm -rf "$LOCK_PATH"
+  if ! mkdir "$LOCK_PATH" 2>/dev/null; then
+    echo "!!! Could not acquire build lock even after removing a stale one: $LOCK_PATH !!!" >&2
     echo "!!! BUILD DID NOT RUN. This is NOT a pass.                                   !!!" >&2
     exit 2
   fi
 fi
+# Ownership is claimed HERE -- only after `mkdir` has actually succeeded
+# (first try, or after reclaiming a stale lock above) -- which is the
+# earliest point at which the EXIT trap should be allowed to remove it.
+LOCKDIR="$LOCK_PATH"
 # Written immediately after mkdir succeeds, before anything else, to
 # minimise (not eliminate) the window in which a second, near-simultaneous
 # invocation could read an empty pid file and mistake this lock for stale.

--- a/scripts/check_pipeline_errors.R
+++ b/scripts/check_pipeline_errors.R
@@ -34,23 +34,91 @@
 # Exit codes:
 #   0  no errored targets
 #   1  one or more targets have a non-NA error in tar_meta()
-#   2  could not run the check at all (no store, tar_meta() failed, etc.) —
-#      this is NOT a pass, never treat it as one
+#   2  could not run the check at all (no store, tar_meta() failed, a
+#      truncated/malformed meta file, etc.) — this is NOT a pass, never
+#      treat it as one
+#
+# #730: tar_meta() reads the store's meta file with data.table::fread(),
+# which on a malformed line (e.g. two writers interleaving a record —
+# exactly what happens when two tar_make() runs race one store) does not
+# error. It emits a WARNING ("Stopped early on line N. Expected M fields
+# but found K.") and silently returns however many rows it managed to
+# parse before the bad line. Nothing about that return value distinguishes
+# "the pipeline genuinely has fewer targets" from "the read was truncated"
+# — both look like a data frame with fewer rows than expected, and the
+# `errored <- meta[!is.na(meta$error), ]` line below finds no error among
+# the rows it WAS given. The result, observed in #730: tar_make() printed
+# "errored pipeline", this script read a truncated 762-row view containing
+# neither the errored target nor several others, and printed
+# "PASS: no errored targets". A null-ish state (rows that failed to parse)
+# was indistinguishable from a legitimate absence (targets that didn't
+# error) — see .claude/rules/fail-loud-not-null.md. The withCallingHandlers()
+# below promotes any fread warning matching "Stopped early" or "fill=" (the
+# two data.table warning families for a truncated/ragged read) to a fatal
+# error, so a malformed meta file aborts with exit 2 ("could not run the
+# check at all") instead of silently passing on a partial view.
 
 suppressPackageStartupMessages({
   library(targets)
   library(here)
 })
 
-store_path <- here::here("docs", "_targets")
-
-if (!dir.exists(store_path)) {
-  message("!!! No targets store found at '", store_path, "' !!!")
-  message("!!! This script only READS an existing store -- run tar_make() first. !!!")
-  message("!!! VERIFICATION DID NOT RUN. This is NOT a pass.                      !!!")
-  quit(status = 2, save = "no")
+# .cpe_read_meta() (#730) -- reads tar_meta(fields = error, targets_only =
+# TRUE) from `store_path`, promoting a data.table::fread() truncation
+# warning to a fatal error rather than letting a partial parse pass
+# silently as a valid (if smaller) result. Errors (native tar_meta() errors,
+# or this promoted truncation error) are NOT caught here -- that is the
+# caller's job (.cpe_main(), below), the same split .cdf_main()/tar_meta()
+# uses in scripts/check_dashboard_freshness.R.
+#
+# The warning handler below deliberately RECORDS the match and calls
+# invokeRestart("muffleWarning") to let fread()'s C-level read finish
+# normally, and only raises stop() AFTER withCallingHandlers() returns --
+# NOT from inside the handler itself. Raising stop() from inside a warning
+# handler unwinds the R call stack via a longjmp through fread()'s C code
+# before its own internal cleanup runs, which empirically (while writing
+# this file's tests) produced a real, intermittent knock-on failure on the
+# NEXT fread() call in the same R session ("Previous fread() session was
+# not cleaned up properly" followed by "Couldn't open file ... No such
+# file or directory" building an unrelated store moments later). Recording
+# then raising afterward avoids interrupting fread() mid-read altogether.
+# Pattern-matched on the two data.table warning families that indicate a
+# short/ragged read ("Stopped early on line N..." and the "fill=TRUE"
+# suggestion fread appends to the same class of warning) -- never on the
+# row count, since a short count alone cannot be told apart from a
+# legitimately smaller pipeline.
+.cpe_read_meta <- function(store_path) {
+  truncation_warning <- NULL
+  meta <- withCallingHandlers(
+    targets::tar_meta(store = store_path, fields = error, targets_only = TRUE),
+    warning = function(w) {
+      msg <- conditionMessage(w)
+      if (grepl("Stopped early|fill=", msg)) {
+        truncation_warning <<- msg
+        invokeRestart("muffleWarning")
+      }
+    }
+  )
+  if (!is.null(truncation_warning)) {
+    stop(
+      "tar_meta() emitted a data.table::fread() truncation warning while ",
+      "reading the store's meta file -- the rows fread() DID manage to ",
+      "parse are an INCOMPLETE view of the store, not a complete one with ",
+      "fewer targets (#730). Treating this as fatal rather than silently ",
+      "passing on a partial read. Original warning: ", truncation_warning,
+      call. = FALSE
+    )
+  }
+  meta
 }
 
+# .cpe_main() -- orchestrates the check against `store_path`, printing the
+# same report this script has always printed, and RETURNING (not
+# quit()-ing) an exit-status integer, so it is testable without
+# terminating the R session (mirrors .cdf_main() in
+# scripts/check_dashboard_freshness.R). The Rscript entry point at the
+# bottom of this file calls quit(status = ...) using this return value.
+#
 # NOT `complete_only = TRUE` (#693). tar_meta()'s own source
 # (targets::tar_meta, confirmed against the installed package version in
 # this nix shell) does:
@@ -71,32 +139,53 @@ if (!dir.exists(store_path)) {
 # `targets_only = FALSE` also returns metadata rows for functions and
 # other global objects, not just targets -- without it, the count would
 # never have meant "targets" even after fixing complete_only.
-meta <- tryCatch(
-  targets::tar_meta(store = store_path, fields = error, targets_only = TRUE),
-  error = function(e) {
-    message("!!! tar_meta() failed: ", conditionMessage(e), " !!!")
-    NULL
+.cpe_main <- function(store_path = here::here("docs", "_targets")) {
+  if (!dir.exists(store_path)) {
+    message("!!! No targets store found at '", store_path, "' !!!")
+    message("!!! This script only READS an existing store -- run tar_make() first. !!!")
+    message("!!! VERIFICATION DID NOT RUN. This is NOT a pass.                      !!!")
+    return(2L)
   }
-)
 
-if (is.null(meta)) {
-  message("!!! VERIFICATION DID NOT RUN. This is NOT a pass. !!!")
-  quit(status = 2, save = "no")
+  meta <- tryCatch(
+    .cpe_read_meta(store_path),
+    error = function(e) {
+      message("!!! tar_meta() failed: ", conditionMessage(e), " !!!")
+      NULL
+    }
+  )
+
+  if (is.null(meta)) {
+    message("!!! VERIFICATION DID NOT RUN. This is NOT a pass. !!!")
+    return(2L)
+  }
+
+  errored <- meta[!is.na(meta$error), , drop = FALSE]
+
+  cat(sprintf("Store: %s\n", store_path))
+  cat(sprintf("Targets inspected: %d\n", nrow(meta)))
+  cat(sprintf("Targets errored:   %d\n", nrow(errored)))
+
+  if (nrow(errored) == 0) {
+    cat("PASS: no errored targets\n")
+    return(0L)
+  }
+
+  cat(sprintf("FAIL: %d errored target(s):\n", nrow(errored)))
+  for (i in seq_len(nrow(errored))) {
+    cat(sprintf("  [ERROR] %s -- %s\n", errored$name[i], errored$error[i]))
+  }
+  return(1L)
 }
 
-errored <- meta[!is.na(meta$error), , drop = FALSE]
-
-cat(sprintf("Store: %s\n", store_path))
-cat(sprintf("Targets inspected: %d\n", nrow(meta)))
-cat(sprintf("Targets errored:   %d\n", nrow(errored)))
-
-if (nrow(errored) == 0) {
-  cat("PASS: no errored targets\n")
-  quit(status = 0, save = "no")
+# Only run when this file is the Rscript entry point (sys.nframe() == 0),
+# never when source()'d for its functions -- same pattern (and same
+# empirical basis) as scripts/check_dashboard_freshness.R:
+# `Rscript file.R` gives sys.nframe() == 0 at top level; `source("file.R")`
+# gives sys.nframe() > 0 (source() itself adds a frame).
+# tests/testthat/test-check-pipeline-errors.R source()s this file and must
+# NOT trigger a live run against the real store.
+if (sys.nframe() == 0) {
+  status <- .cpe_main()
+  quit(status = status, save = "no")
 }
-
-cat(sprintf("FAIL: %d errored target(s):\n", nrow(errored)))
-for (i in seq_len(nrow(errored))) {
-  cat(sprintf("  [ERROR] %s -- %s\n", errored$name[i], errored$error[i]))
-}
-quit(status = 1, save = "no")

--- a/tests/test_build_lock.sh
+++ b/tests/test_build_lock.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# tests/test_build_lock.sh -- regression tests for scripts/build.sh's Step 0.5
+# concurrency lock (#730, and the two bugs fixed on top of it).
+#
+# Bug A (the headline bug): the trap-visible $LOCKDIR used to be assigned to
+# the lock's path BEFORE `mkdir` was attempted, so a REFUSED invocation (one
+# that detects a live build already holds the lock and exits 2) still had
+# $LOCKDIR populated -- and the EXIT trap unconditionally rm -rf's a non-empty
+# $LOCKDIR. A refused invocation therefore deleted the lock the live build
+# still held, silently defeating the guard: retrying after the refusal would
+# then race the live build for real, which is exactly the corruption #730's
+# lock exists to prevent.
+#
+# Bug B: the liveness check (`kill -0 "$LOCK_PID" 2>/dev/null`) cannot
+# distinguish EPERM ("process exists, not ours to signal") from ESRCH ("no
+# such process") -- both give a non-zero exit, both used to read as "not
+# running". A live-but-unsignallable PID (e.g. PID 1 / launchd, or any lock
+# left by another user) was therefore treated as dead and its lock silently
+# reclaimed.
+#
+# These tests exercise the REAL scripts/build.sh, copied verbatim into a
+# throwaway scratch git repo (never the real repo, never the real
+# docs/_targets store -- see .claude/CLAUDE.md "Verifying a change" and the
+# `destructive-ops-guard` rule). The scratch repo has no flake.nix, so
+# `nix develop` fails immediately at the pre-flight check that runs right
+# after Step 0.5 -- deterministic and near-instant, unlike a real build,
+# which is exactly what lets these tests run in well under a second each
+# instead of a 10+ minute cold nix build. What is stubbed: everything from
+# the nix pre-flight onward (Steps 1-4: tar_make(), check_pipeline_errors.R,
+# the metadata snapshot, --render). Nothing about Step 0.5 itself -- lock
+# path resolution, mkdir, the liveness check, the EXIT trap -- is stubbed;
+# it is the actual code in scripts/build.sh, unmodified, run as a subprocess.
+#
+# Usage: bash tests/test_build_lock.sh
+# Exit code: 0 if all tests pass, 1 if any test fails.
+
+set -uo pipefail  # deliberately NOT -e: test bodies check exit codes by hand
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_SH="$REPO_ROOT/scripts/build.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "  PASS: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "  FAIL: $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+assert_eq() {
+  local actual="$1" expected="$2" msg="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$msg (got $actual)"
+  else
+    fail "$msg (expected $expected, got $actual)"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" msg="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$msg"
+  else
+    fail "$msg (did not find: $needle)"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" msg="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    pass "$msg"
+  else
+    fail "$msg (unexpectedly found: $needle)"
+  fi
+}
+
+# Sets up a throwaway git repo with a minimal `_targets.R` (so build.sh's
+# "is this a valid checkout" check passes) and its own copy of the real
+# scripts/build.sh (so REPO_ROOT inside that subprocess resolves to the
+# scratch repo, never to $REPO_ROOT). No flake.nix is created on purpose --
+# see file header. Prints the scratch dir path on stdout.
+setup_scratch_repo() {
+  local dir
+  dir="$(mktemp -d)"
+  git init -q "$dir"
+  touch "$dir/_targets.R"
+  mkdir -p "$dir/scripts"
+  cp "$BUILD_SH" "$dir/scripts/build.sh"
+  chmod +x "$dir/scripts/build.sh"
+  echo "$dir"
+}
+
+echo "=== tests/test_build_lock.sh ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test 1 (regression test for Bug A): a refused invocation must NOT delete
+# the lock the live build still holds. This is the test that must FAIL
+# against the pre-fix code and PASS against the fix -- see the manual
+# before/after run in the PR description for the demonstration.
+# ---------------------------------------------------------------------------
+echo "--- Test 1: lock survives a refusal ---"
+scratch="$(setup_scratch_repo)"
+lockdir="$scratch/.git/build.lock.d"
+mkdir -p "$lockdir"
+
+# A genuinely live, same-user, long-running process to act as the lock owner.
+sleep 300 &
+live_pid=$!
+echo "$live_pid" > "$lockdir/pid"
+
+out="$("$scratch/scripts/build.sh" 2>&1)"
+status=$?
+
+kill "$live_pid" 2>/dev/null
+wait "$live_pid" 2>/dev/null
+
+assert_eq "$status" 2 "refused invocation exits 2"
+assert_contains "$out" "Refusing to start" "refusal message printed"
+if [[ -d "$lockdir" ]]; then
+  pass "lock directory still exists after the refused invocation exited"
+else
+  fail "lock directory was deleted by the refused invocation -- THE BUG"
+fi
+rm -rf "$scratch"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test 2: a genuinely stale lock (dead PID) is still reclaimed and the build
+# proceeds -- must not regress while fixing Test 1.
+# ---------------------------------------------------------------------------
+echo "--- Test 2: stale lock is reclaimed ---"
+scratch="$(setup_scratch_repo)"
+lockdir="$scratch/.git/build.lock.d"
+mkdir -p "$lockdir"
+
+# A PID guaranteed to be dead: spawn a no-op subshell and wait for it to
+# exit and be reaped, so `kill -0` on it reports ESRCH.
+( : ) &
+dead_pid=$!
+wait "$dead_pid" 2>/dev/null
+echo "$dead_pid" > "$lockdir/pid"
+
+out="$("$scratch/scripts/build.sh" 2>&1)"
+status=$?
+
+assert_contains "$out" "stale build lock found" "stale-lock message printed"
+assert_not_contains "$out" "Refusing to start" "did not refuse on a dead PID"
+assert_contains "$out" "Step 0.5: build lock acquired" "lock re-acquired after reclaim"
+# The scratch repo has no flake.nix, so the run fails at the nix pre-flight
+# step that immediately follows Step 0.5 -- see file header. Exit 2 here
+# reflects that stub, not a Step 0.5 refusal (already asserted above).
+assert_eq "$status" 2 "run proceeds past Step 0.5, then fails at the (stubbed) nix pre-flight"
+rm -rf "$scratch"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test 3: a run that acquires its own lock releases it on exit (the EXIT
+# trap still works correctly after the Bug A fix -- LOCKDIR IS populated
+# once ownership is actually claimed).
+# ---------------------------------------------------------------------------
+echo "--- Test 3: own lock is released on exit ---"
+scratch="$(setup_scratch_repo)"
+lockdir="$scratch/.git/build.lock.d"
+
+out="$("$scratch/scripts/build.sh" 2>&1)"
+status=$?
+
+assert_contains "$out" "Step 0.5: build lock acquired" "lock acquired (no pre-existing lock)"
+if [[ -d "$lockdir" ]]; then
+  fail "lock directory was NOT released after the run exited"
+else
+  pass "lock directory released after the run exited"
+fi
+rm -rf "$scratch"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test 4 (regression test for Bug B): a PID that exists but cannot be
+# signalled (EPERM) must be treated as ALIVE, not reclaimed. PID 1 (launchd
+# on macOS, init on Linux) is always running and never signallable by an
+# unprivileged user.
+# ---------------------------------------------------------------------------
+echo "--- Test 4: EPERM (PID 1) is treated as alive, not reclaimed ---"
+scratch="$(setup_scratch_repo)"
+lockdir="$scratch/.git/build.lock.d"
+mkdir -p "$lockdir"
+echo "1" > "$lockdir/pid"
+
+out="$("$scratch/scripts/build.sh" 2>&1)"
+status=$?
+
+assert_eq "$status" 2 "refused invocation exits 2"
+assert_contains "$out" "Refusing to start" "refusal message printed for PID 1"
+assert_not_contains "$out" "stale build lock found" "PID 1 not treated as stale"
+if [[ -d "$lockdir" ]]; then
+  pass "lock directory (owned by PID 1) still exists"
+else
+  fail "lock directory was deleted -- PID 1 was wrongly treated as dead"
+fi
+rm -rf "$scratch"
+echo ""
+
+echo "=== Summary: $PASS_COUNT passed, $FAIL_COUNT failed ==="
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/tests/testthat/_snaps/check-pipeline-errors.md
+++ b/tests/testthat/_snaps/check-pipeline-errors.md
@@ -1,0 +1,16 @@
+# key .cpe_* function signatures are stable
+
+    Code
+      args(.cpe_read_meta)
+    Output
+      function (store_path) 
+      NULL
+
+---
+
+    Code
+      args(.cpe_main)
+    Output
+      function (store_path = here::here("docs", "_targets")) 
+      NULL
+

--- a/tests/testthat/test-check-pipeline-errors.R
+++ b/tests/testthat/test-check-pipeline-errors.R
@@ -1,0 +1,189 @@
+testthat::local_edition(3)
+source(here::here("scripts", "check_pipeline_errors.R"))
+
+# Regression tests for scripts/check_pipeline_errors.R (#680, #730).
+#
+# scripts/check_pipeline_errors.R defines its logic as `.cpe_*` functions and
+# only RUNS the check (calling quit()) when it is the Rscript entry point
+# (sys.nframe() == 0 at its own top level -- see that file's final block).
+# source()'ing it here (sys.nframe() > 0) loads the functions without
+# triggering a live run against the real repo's docs/_targets store, exactly
+# the pattern test-dashboard-freshness.R uses for check_dashboard_freshness.R.
+#
+# These tests build REAL, throwaway targets stores under withr::local_tempdir()
+# -- never the real docs/_targets store (see .claude/CLAUDE.md and the
+# worktree-location rule: a worktree must not build or touch the main
+# checkout's store).
+#
+# #730 regression -- the empirical finding that shaped .make_toy_store()'s
+# default size: the real incident's meta file (~772 targets) triggered
+# data.table::fread()'s "Stopped early" warning when two tar_make() runs
+# interleaved a write to it. A SMALL corrupted store does NOT reliably
+# reproduce that warning -- confirmed empirically while writing this test
+# (8, 60, and 150-target stores all silently absorbed an identical
+# double-the-line-onto-itself corruption with ZERO warning, via
+# data.table::fread()'s `fill = TRUE` -- which targets::tar_meta() always
+# passes -- padding/merging the ragged row instead of stopping). Only at
+# ~300 targets does fread's warning reliably fire:
+# "Stopped early on line 153. Expected 18 fields but found 35." -- the exact
+# field counts (18 expected, 35 found) reported in #730 itself, which is
+# strong independent confirmation this corruption method matches the real
+# incident (two writers interleaving one target's record). Tests that need
+# the warning to fire use n_targets = 300L for this reason; tests that don't
+# (clean PASS / FAIL paths) use a small store to stay fast.
+
+.make_toy_store <- function(dir, n_targets = 5L, with_error_target = TRUE) {
+  script_path <- file.path(dir, "_targets.R")
+  store_path <- file.path(dir, "_targets")
+  defs <- sprintf("targets::tar_target(t%d, %d + 1)", seq_len(n_targets), seq_len(n_targets))
+  if (with_error_target) {
+    defs <- c(defs, 'targets::tar_target(bad, stop("deliberate test error"))')
+  }
+  writeLines(c(
+    'targets::tar_option_set(error = "continue")', # matches docs/_targets.R's real setting
+    "list(",
+    paste0("  ", defs, collapse = ",\n"),
+    ")"
+  ), script_path)
+  targets::tar_make(
+    script = script_path, store = store_path,
+    callr_function = NULL, reporter = "silent"
+  )
+  store_path
+}
+
+# Corrupts one line roughly in the MIDDLE of the meta file by duplicating it
+# onto itself -- mimics two writers interleaving a record for the SAME
+# target, exactly as #730 describes ("the leaderboard record written twice,
+# concatenated"). A middle line matters: corrupting the LAST line does not
+# reproduce the warning (confirmed empirically), only a line fread reaches
+# mid-file, after it has already locked in an expected column count from
+# earlier rows.
+.corrupt_meta_middle_line <- function(store_path) {
+  meta_path <- file.path(store_path, "meta", "meta")
+  lines <- readLines(meta_path)
+  mid_idx <- as.integer(floor(length(lines) / 2))
+  stopifnot(mid_idx > 1L, mid_idx < length(lines))
+  lines[mid_idx] <- paste0(lines[mid_idx], lines[mid_idx])
+  writeLines(lines, meta_path)
+  invisible(meta_path)
+}
+
+# ── .cpe_main() -- store-existence / clean / errored paths ─────────────────
+
+test_that(".cpe_main returns 2 and reports when no store directory exists", {
+  dir <- withr::local_tempdir()
+  missing_store <- file.path(dir, "does_not_exist")
+  status <- NA_integer_
+  msgs <- character(0)
+  withCallingHandlers(
+    status <- .cpe_main(store_path = missing_store),
+    message = function(m) {
+      msgs <<- c(msgs, conditionMessage(m))
+      invokeRestart("muffleMessage")
+    }
+  )
+  expect_equal(status, 2L)
+  expect_true(any(grepl("No targets store found", msgs)))
+  expect_true(any(grepl("VERIFICATION DID NOT RUN", msgs)))
+})
+
+test_that(".cpe_main returns 0 and reports PASS on a clean store with no errored targets", {
+  dir <- withr::local_tempdir()
+  store <- .make_toy_store(dir, n_targets = 5L, with_error_target = FALSE)
+  status <- NA_integer_
+  out <- utils::capture.output(status <- .cpe_main(store_path = store))
+  expect_equal(status, 0L)
+  txt <- paste(out, collapse = "\n")
+  expect_match(txt, "Targets inspected: 5")
+  expect_match(txt, "Targets errored:   0")
+  expect_match(txt, "PASS: no errored targets")
+})
+
+test_that(".cpe_main returns 1 and reports the errored target's name and message", {
+  dir <- withr::local_tempdir()
+  store <- .make_toy_store(dir, n_targets = 5L, with_error_target = TRUE)
+  status <- NA_integer_
+  out <- utils::capture.output(status <- .cpe_main(store_path = store))
+  expect_equal(status, 1L)
+  txt <- paste(out, collapse = "\n")
+  expect_match(txt, "Targets inspected: 6")
+  expect_match(txt, "FAIL: 1 errored target")
+  expect_match(txt, "\\[ERROR\\] bad -- deliberate test error")
+})
+
+# ── #730: the corrupted-meta-file regression this issue is actually about ──
+
+test_that(".cpe_read_meta() does NOT misfire on a large but uncorrupted store", {
+  dir <- withr::local_tempdir()
+  store <- .make_toy_store(dir, n_targets = 300L, with_error_target = FALSE)
+  meta <- expect_no_warning(.cpe_read_meta(store))
+  expect_equal(nrow(meta), 300L)
+})
+
+test_that(".cpe_read_meta() promotes a data.table::fread truncation warning to a fatal error naming #730 (#730)", {
+  dir <- withr::local_tempdir()
+  store <- .make_toy_store(dir, n_targets = 300L, with_error_target = FALSE)
+  .corrupt_meta_middle_line(store)
+  # A single call captured once, not re-invoked per assertion: calling
+  # .cpe_read_meta()/tar_meta() twice in a row against the same store inside
+  # one test hit an unrelated data.table::fread() internal-session error
+  # ("Couldn't open file ... No such file or directory", confirmed empirically
+  # while writing this test) -- an artefact of repeated fread() calls, not a
+  # #730 concern. One call + one captured condition avoids it.
+  cond <- tryCatch(.cpe_read_meta(store), error = function(e) e)
+  expect_s3_class(cond, "error")
+  msg <- conditionMessage(cond)
+  expect_match(msg, "truncation warning")
+  expect_match(msg, "#730")
+  expect_match(msg, "INCOMPLETE view")
+})
+
+test_that("BEFORE this fix's mechanism, a corrupted meta file silently returns a truncated frame with no signal at all (documents the exact bug #730 reports)", {
+  # This test calls targets::tar_meta() directly -- NOT .cpe_read_meta() --
+  # to document the underlying fail-open behaviour #730 is about: fread()'s
+  # warning is silently discardable, and the truncated row count alone
+  # cannot be told apart from "the pipeline genuinely has fewer targets"
+  # (.claude/rules/fail-loud-not-null.md). This is why #730 proposal 1
+  # cannot be "check the row count" -- it must intercept the WARNING itself.
+  dir <- withr::local_tempdir()
+  store <- .make_toy_store(dir, n_targets = 300L, with_error_target = FALSE)
+  .corrupt_meta_middle_line(store)
+  raw <- suppressWarnings(
+    targets::tar_meta(store = store, fields = error, targets_only = TRUE)
+  )
+  expect_lt(nrow(raw), 300L) # truncated -- the read silently lost rows
+  expect_true(all(is.na(raw$error))) # and reports zero errors among what it DID read
+})
+
+test_that(".cpe_main() returns 2 -- NOT a false PASS -- when the meta file is corrupted by two interleaved writers (#730)", {
+  # The end-to-end regression: BEFORE this fix, this exact scenario made the
+  # top-level script print \"PASS: no errored targets\" on a truncated read
+  # (see #730's incident table). AFTER, .cpe_main() must return 2
+  # (\"could not run the check at all\") and say why -- never 0.
+  dir <- withr::local_tempdir()
+  store <- .make_toy_store(dir, n_targets = 300L, with_error_target = FALSE)
+  .corrupt_meta_middle_line(store)
+  status <- NA_integer_
+  msgs <- character(0)
+  withCallingHandlers(
+    utils::capture.output(status <- .cpe_main(store_path = store)),
+    message = function(m) {
+      msgs <<- c(msgs, conditionMessage(m))
+      invokeRestart("muffleMessage")
+    }
+  )
+  expect_equal(status, 2L)
+  expect_false(identical(status, 0L)) # the exact false-PASS #730 reports must not recur
+  all_msgs <- paste(msgs, collapse = "\n")
+  expect_match(all_msgs, "tar_meta\\(\\) failed")
+  expect_match(all_msgs, "#730")
+  expect_match(all_msgs, "VERIFICATION DID NOT RUN")
+})
+
+# ── Function signature stability (catches API drift, snapshot-test-policy.md) ──
+
+test_that("key .cpe_* function signatures are stable", {
+  expect_snapshot(args(.cpe_read_meta))
+  expect_snapshot(args(.cpe_main))
+})


### PR DESCRIPTION
## Summary

Builds on top of #737 (`fix/pipeline-error-checker-fail-open`), rebased onto current `main`. This branch **includes** #737's commit plus one more commit fixing two bugs in the Step 0.5 concurrency lock that #737 itself introduced (proposal 4 of #730).

Recommend merging this PR **instead of** #737, since it is #737 plus the lock fix, already rebased onto current `main`. If #737 is merged first, this becomes a 1-commit follow-up PR against the same base — either order is fine, but this branch should not be merged as an *additional*, separate diff on top of an already-merged #737 without first re-rebasing.

- Fixes a lock-refusal path that deleted the lock a *live* build still held, defeating the guard entirely (a retry after refusal could then race the live build for real — the exact corruption #730 exists to prevent).
- Fixes an EPERM/ESRCH conflation in the lock's liveness check that let a live-but-unsignallable PID (e.g. PID 1) be wrongly reclaimed as stale.
- Adds `tests/test_build_lock.sh`, 4 scenarios / 13 assertions, run against the real `scripts/build.sh` in a throwaway scratch repo (never the real store).

## Bug A — refusal deletes the live build's lock

`LOCKDIR` — the variable the script's unconditional `EXIT` trap acts on (`[[ -n "${LOCKDIR:-}" ]] && rm -rf "$LOCKDIR"`) — was assigned to the lock's path **before** `mkdir` was attempted:

```bash
LOCKDIR="$GIT_DIR_ABS/build.lock.d"
if ! mkdir "$LOCKDIR" 2>/dev/null; then
  ...
  exit 2   # refused -- but $LOCKDIR is already populated
```

A refused invocation (another build genuinely holds the lock) still exits through the same trap, which then deletes the lock the *other*, still-running build owns.

Reproduced directly against the pre-fix script: planted a live PID as lock owner, ran `scripts/build.sh`, got correctly refused (exit 2, "Refusing to start: another scripts/build.sh (PID …)"), then `ls $GIT_DIR/build.lock.d` → gone. Confirmed this is worse than no lock: it stops the second build and then removes the evidence that would stop a third.

**Fix:** split the candidate path (`LOCK_PATH`) from the trap-visible ownership variable (`LOCKDIR`). `LOCKDIR` is populated only *after* `mkdir` has actually succeeded — first try, or after reclaiming a genuinely stale lock — never on the refusal path.

## Bug B — EPERM read as "not running"

```bash
if [[ -n "$LOCK_PID" ]] && kill -0 "$LOCK_PID" 2>/dev/null; then
```

`kill -0`'s exit status alone cannot distinguish EPERM ("process exists, I can't signal it") from ESRCH ("no such process") — both are non-zero. Verified on this machine:

```
$ kill -0 1
kill: (1) - Operation not permitted     # exit 1
$ kill -0 999999
kill: (999999) - No such process        # exit 1
```

PID 1 (launchd/init) is always running and never signallable by an unprivileged user, yet the old code treated it as dead: planting PID 1 as lock owner made `build.sh` print `stale build lock found (PID 1 not running) -- removing and retrying` and reclaim it.

**Fix:** a small helper (`_build_lock_pid_alive`) inspects `kill -0`'s stderr text and treats an EPERM PID as **alive** — the safer of the two possible wrong answers, since refusing to build is always safer than building concurrently. In a single-user context this is a narrow edge case (lock owner is normally the invoking user), but it's a fail-open in a safety mechanism, the exact class #730 addresses.

Where the two bugs could disagree in behaviour, I kept refusal as the default: an unsignallable PID is now *never* silently reclaimed.

## Tests

`tests/test_build_lock.sh` — 4 scenarios, 13 assertions, run against the **real** `scripts/build.sh`, copied verbatim into a throwaway scratch git repo (its own `.git`, its own `_targets.R`, no `flake.nix`). No `flake.nix` means `nix develop`'s pre-flight check — which runs immediately after Step 0.5 — fails fast and deterministically, so each scenario runs in well under a second instead of requiring a real (10+ minute cold) build. What's stubbed: everything from the nix pre-flight onward (`tar_make()`, `check_pipeline_errors.R`, the metadata snapshot, `--render`). Nothing about Step 0.5 itself is stubbed — the actual lock-path resolution, `mkdir`, liveness check, and `EXIT` trap run as written.

1. **Lock survives a refusal** (regression test for Bug A) — plant a genuinely live, same-user `sleep 300 &` PID as lock owner; run `build.sh`; assert exit 2 **and** the lock directory still exists afterwards.
2. **Stale lock is reclaimed** — dead PID owner (spawned-then-reaped); assert the build proceeds past Step 0.5 (no regression).
3. **Own lock released on exit** — no pre-existing lock; assert the lock is gone after the run exits.
4. **EPERM treated as alive** (regression test for Bug B) — PID 1 as owner; assert refusal, not reclamation.

Ran all 4 against **both** versions to confirm these are genuine regression tests, not just green-by-construction:

- **Against the fix:** 13/13 assertions pass.
- **Against the pre-fix script** (same test file, `BUILD_SH` pointed at `git show HEAD:scripts/build.sh` before this commit): 9/13 pass, 4 fail — exactly the ones targeting the two bugs (Test 1's "lock directory still exists" assertion; Test 4's three EPERM assertions). Tests 2 and 3 are unaffected either way, confirming the fix is scoped to the two targeted bugs and doesn't touch the reclaim/release paths.

## Verification

`scripts/verify.sh`, full run, foreground, well under the 10-minute timeout. Result: `=== scripts/verify.sh: PASS ===`. Root suite: 0 skips, 3/3 known baseline failures matched exactly (issue #569). Package suite: 15/15 expected skips (4 `{alphavantager}` absent + 11 `HD_TEST_LIVE`-gated), 1/1 known baseline failure matched exactly. No regressions.

`bash -n scripts/build.sh` and `bash -n tests/test_build_lock.sh` — both clean.

Did **not** run `tar_make()` against the real store at `docs/_targets` — all lock-logic testing used the throwaway scratch repo described above.

## Test plan

- [x] `bash -n scripts/build.sh`
- [x] `bash -n tests/test_build_lock.sh`
- [x] `bash tests/test_build_lock.sh` — 13/13 pass against the fix
- [x] Same test file against pre-fix `scripts/build.sh` — 4/13 fail (the targeted bugs), confirming genuine regression coverage
- [x] `scripts/verify.sh` (full, foreground) — PASS, baselines match exactly
