### PR TITLE
fix(docs): make build-info-footer include self-sufficient (supersedes #743)

### DIFF
--- a/.github/workflows/full-render-cadence.yml
+++ b/.github/workflows/full-render-cadence.yml
@@ -1,0 +1,111 @@
+name: Full render cadence (weekly)
+
+# #740: scripts/build.sh --render (no flag) only ever renders pages Step 3
+# flags [STALE]/[DATA-STALE] -- a page that is PERMANENTLY up-to-date but
+# broken is therefore never exercised by any gate. `scripts/build.sh
+# --render-all` closes that gap by rendering every docs/*.qmd page
+# unconditionally, but it is a manual, ~20-minute human act (same cost
+# dashboard-freshness.yml's header comment already documents for an ordinary
+# --render) -- nothing enforces that anyone actually runs it periodically.
+#
+# WHY THIS WORKFLOW NEVER RUNS quarto render ITSELF: doing the real thing in
+# CI would mean running tar_make() against docs/_targets.R on a fresh
+# runner -- live external data fetches (equity/macro/crypto APIs, credentials
+# this workflow does not have), a 10+ minute cold nix build, and a store that
+# is NOT the main checkout's (see .claude/CLAUDE.md and the
+# worktree-location rule for why a second, unofficial store must never race
+# the canonical one -- scripts/build.sh itself refuses to run anywhere except
+# the main checkout for exactly this reason). dashboard-freshness.yml's own
+# header comment already rejected this same approach for its Check 3 and
+# instead reads a small COMMITTED snapshot; this workflow follows the same
+# pattern for the same reason.
+#
+# So this workflow reads ONE committed file, docs/_full_render_marker.txt --
+# written by `scripts/build.sh --render-all` (never committed automatically;
+# a human reviews and commits it exactly like any other file that script
+# writes under docs/) -- and fails if it is older than
+# FULL_RENDER_MAX_AGE_DAYS, or missing entirely. A green run here means
+# "someone ran --render-all recently enough that every dashboard page has
+# been exercised, not just the ones Step 3 happened to flag as stale."
+#
+# WEEKLY, NOT DAILY: mirrors dashboard-freshness.yml's own cadence
+# reasoning -- the fix is a deliberate ~20-minute human act, and a threshold
+# measured in weeks gives a full working week to act before this goes red.
+
+on:
+  schedule:
+    - cron: '30 8 * * 1'      # weekly, Monday 08:30 UTC (after dashboard-freshness.yml's 08:00 run)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write               # to auto-file an issue on failure
+
+env:
+  # How old docs/_full_render_marker.txt may be before this workflow fails.
+  # 30 days: roughly monthly, consistent with the ~20-minute human cost of a
+  # full render and this repo's other staleness thresholds being measured in
+  # weeks, not days (see dashboard-freshness.yml's own cadence comment).
+  FULL_RENDER_MAX_AGE_DAYS: 30
+
+jobs:
+  full-render-cadence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check docs/_full_render_marker.txt age
+        id: check
+        run: |
+          REPORT="./full-render-cadence-report.md"
+          MARKER="docs/_full_render_marker.txt"
+          if [[ ! -f "$MARKER" ]]; then
+            {
+              echo "\`$MARKER\` not found -- no \`scripts/build.sh --render-all\` has ever"
+              echo "been committed."
+              echo ""
+              echo "Run \`scripts/build.sh --render-all\` in the main checkout, review the"
+              echo "output, and commit the resulting \`$MARKER\` (and any refreshed"
+              echo "\`docs/*.html\`) to establish a baseline (#740)."
+            } > "$REPORT"
+            cat "$REPORT"
+            exit 1
+          fi
+          LAST_RENDER="$(grep '^last_full_render_utc:' "$MARKER" | cut -d' ' -f2)"
+          if [[ -z "$LAST_RENDER" ]]; then
+            {
+              echo "\`$MARKER\` exists but has no \`last_full_render_utc:\` line -- malformed."
+              echo ""
+              echo "Contents:"
+              echo '```'
+              cat "$MARKER"
+              echo '```'
+            } > "$REPORT"
+            cat "$REPORT"
+            exit 1
+          fi
+          LAST_EPOCH="$(date -u -d "$LAST_RENDER" +%s)"
+          NOW_EPOCH="$(date -u +%s)"
+          AGE_DAYS=$(( (NOW_EPOCH - LAST_EPOCH) / 86400 ))
+          echo "age_days=$AGE_DAYS" >> "$GITHUB_OUTPUT"
+          if [[ "$AGE_DAYS" -gt "$FULL_RENDER_MAX_AGE_DAYS" ]]; then
+            {
+              echo "Last full render was **$AGE_DAYS day(s) ago** ($LAST_RENDER) --"
+              echo "exceeds the ${FULL_RENDER_MAX_AGE_DAYS}-day threshold."
+              echo ""
+              echo "Run \`scripts/build.sh --render-all\` in the main checkout, review the"
+              echo "output, and commit the refreshed \`docs/*.html\` + \`$MARKER\` (#740)."
+            } > "$REPORT"
+            cat "$REPORT"
+            exit 1
+          fi
+          echo "PASS: last full render was $LAST_RENDER ($AGE_DAYS day(s) ago) -- within the ${FULL_RENDER_MAX_AGE_DAYS}-day threshold."
+
+      - name: Create issue on schedule failure
+        if: failure() && github.event_name == 'schedule'
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "full-render-cadence: docs/_full_render_marker.txt is stale or missing"
+          content-filepath: ./full-render-cadence-report.md
+          labels: bug, theme:infra, dashboard-freshness

--- a/docs/_includes/build-info-footer.qmd
+++ b/docs/_includes/build-info-footer.qmd
@@ -2,5 +2,10 @@
 #| label: build-info
 #| echo: false
 #| results: asis
+if (!exists("build_info", mode = "function")) {
+  utils_path <- if (file.exists("vignette_utils.R")) "vignette_utils.R" else
+    file.path(here::here(), "docs/vignette_utils.R")
+  source(utils_path)
+}
 build_info()
 ```

--- a/docs/avoid-worst-days.qmd
+++ b/docs/avoid-worst-days.qmd
@@ -547,3 +547,7 @@ The strategy is not overfit to VIX > 30 specifically. It works across a range of
 - **[Macro Defense Rotation](macro-defense-rotation.html)** — structural alternative that rotates among TLT/GLD/DBC/UUP to capture the same downside-protection rationale with a tradeable signal
 - **[European Overlay](european-overlay.html)** — applies a similar regime-detection overlay using ECB CISS systemic-stress data across European markets
 - **[Strategy Leaderboard](leaderboard.html)** — comparative ranking of Avoid Worst Days against all other strategies
+
+#### Build Info
+
+{{< include _includes/build-info-footer.qmd >}}

--- a/docs/bdbb-sol.qmd
+++ b/docs/bdbb-sol.qmd
@@ -97,3 +97,7 @@ knitr::kable(
 - **[Falsification](falsification.html)** — statistical testing framework applied to all systematic strategies; the same hypothesis-testing approach used to evaluate the BDBB diagnostics
 - **[Negative Results](falsification.html#failed-strategies)** — documents approaches that failed empirical scrutiny; the BDBB mean-reversion findings sit alongside these investigations
 - **[Strategy Leaderboard](leaderboard.html)** — performance comparison across all strategies; provides context for the SOL/USD queueing model relative to other systematic approaches
+
+## Build Info
+
+{{< include _includes/build-info-footer.qmd >}}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -102,6 +102,24 @@
 # This script refuses to run from a linked worktree -- see the git-dir check
 # below.
 #
+# --render-all (#740): Step 4 as shipped only ever renders pages Step 3
+# flagged [STALE]/[DATA-STALE] -- so a page that is permanently up-to-date
+# but BROKEN is never exercised by any gate, which is exactly the class of
+# bug #699/#530 described. This flag forces Step 4 to render every
+# docs/*.qmd page regardless of staleness, reusing the same all-pages code
+# path that already existed as a fallback for when Step 3's completion
+# marker is missing (see the STALE_PAGES selection block in Step 4 below).
+# On success it also writes docs/_full_render_marker.txt (timestamp + pass/
+# fail counts) -- like every other file --render produces, this is left for
+# a human to review and commit, never committed automatically. A CI job
+# (.github/workflows/full-render-cadence.yml) reads that COMMITTED marker's
+# age on a schedule and opens an issue if nobody has run --render-all
+# recently -- CI itself never runs tar_make()/quarto render against real
+# data (see that workflow's header comment for why: it needs live data
+# fetches and would collide with the "MAIN CHECKOUT ONLY" constraint on this
+# very script; the same reasoning dashboard-freshness.yml already documents
+# for why ITS Check 3 reads a committed snapshot instead of building one).
+#
 # Usage:
 #   scripts/build.sh
 #   scripts/build.sh --render
@@ -112,6 +130,10 @@
 #     review and commit -- this flag never runs `git add`/`git commit`/
 #     `git push`. An unrecognised flag is rejected immediately, before
 #     entering the nix shell, with a usage message and exit 2.
+#   scripts/build.sh --render-all
+#     Same as --render, except Step 4 renders EVERY docs/*.qmd page,
+#     regardless of what Step 3 flagged as stale (#740). Also writes
+#     docs/_full_render_marker.txt on completion -- see above.
 #
 # Exit codes:
 #   0  tar_make() ran, scripts/check_pipeline_errors.R found no errored
@@ -161,16 +183,23 @@ set -euo pipefail
 # fail immediately and cheaply, not after a 10+ minute cold nix build.
 # ---------------------------------------------------------------------------
 RENDER=false
+RENDER_ALL=false
 for arg in "$@"; do
   case "$arg" in
     --render)
       RENDER=true
       ;;
+    --render-all)
+      RENDER=true
+      RENDER_ALL=true
+      ;;
     *)
       echo "!!! Unknown argument: $arg" >&2
-      echo "!!! Usage: scripts/build.sh [--render]" >&2
-      echo "!!!   --render  after a clean build, re-render docs/*.qmd pages Step 3" >&2
-      echo "!!!             flagged as stale (see this script's header comment)." >&2
+      echo "!!! Usage: scripts/build.sh [--render|--render-all]" >&2
+      echo "!!!   --render      after a clean build, re-render docs/*.qmd pages Step 3" >&2
+      echo "!!!                 flagged as stale (see this script's header comment)." >&2
+      echo "!!!   --render-all  same, but render EVERY docs/*.qmd page regardless of" >&2
+      echo "!!!                 staleness (#740)." >&2
       echo "!!! BUILD DID NOT RUN. This is NOT a pass.                              !!!" >&2
       exit 2
       ;;
@@ -520,7 +549,10 @@ if [[ "$RENDER" == "true" ]]; then
     echo ""
   else
     RENDER_RAN=true
-    if grep -q '::VERIFY:DASHBOARD_FRESHNESS_STATUS::' "$DASHBOARD_LOG" 2>/dev/null; then
+    if [[ "$RENDER_ALL" == "true" ]]; then
+      echo "--render-all requested (#740) -- rendering every docs/*.qmd page regardless of staleness."
+      STALE_PAGES="$(find "$REPO_ROOT/docs" -maxdepth 1 -name '*.qmd' -exec basename {} \; | sort -u)"
+    elif grep -q '::VERIFY:DASHBOARD_FRESHNESS_STATUS::' "$DASHBOARD_LOG" 2>/dev/null; then
       # Parse Step 3's own stdout for the page names it flagged -- both
       # "  [STALE] <page>.qmd -- ..." (Check 2) and
       # "  [DATA-STALE] <page>.qmd -- ..." (Check 3) lines, per that
@@ -566,22 +598,25 @@ if [[ "$RENDER" == "true" ]]; then
           N_RENDER_FAILED=$((N_RENDER_FAILED + 1))
           continue
         fi
-        # Same five patterns verification-before-completion.md's Post-Deploy
-        # Validation table checks against the deployed site -- a page can
-        # exit 0 from quarto render and still emit NULL/MISSING EVIDENCE
-        # where a number belongs.
-        N_HITS=0
-        for pattern in 'not available' 'not found in targets' 'MISSING EVIDENCE' 'Error in' '#&gt;'; do
-          HITS="$(grep -Fc "$pattern" "$REPO_ROOT/$html_path" 2>/dev/null || true)"
-          HITS="${HITS:-0}"
-          N_HITS=$((N_HITS + HITS))
-        done
-        if [[ "$N_HITS" -gt 0 ]]; then
-          echo "  [RENDER-FAIL] $page -- rendered, but $N_HITS error-pattern hit(s) found in $html_path"
+        # #740: delegate to scripts/check_html_errors.sh -- the one
+        # trustworthy implementation of this check now. It matches the same
+        # pattern family verification-before-completion.md's Post-Deploy
+        # Validation table checks against the deployed site, but
+        # case-sensitively and after stripping <script>/<style>/data: URI
+        # content -- the naive version this block used to run inline
+        # false-positived on vendored JS, base64 font blobs, and case-folded
+        # "NaN" (see that script's header for the full before/after counts).
+        set +e
+        HTML_ERR_OUT="$(bash "$REPO_ROOT/scripts/check_html_errors.sh" "$REPO_ROOT/$html_path" 2>&1)"
+        HTML_ERR_STATUS=$?
+        set -e
+        if [[ "$HTML_ERR_STATUS" -ne 0 ]]; then
+          echo "  [RENDER-FAIL] $page -- rendered, but check_html_errors.sh found error-pattern hit(s):"
+          echo "$HTML_ERR_OUT" | sed 's/^/    /'
           RENDER_STATUS=1
           N_RENDER_FAILED=$((N_RENDER_FAILED + 1))
         else
-          echo "  [OK] $page -- rendered clean (0 error-pattern hits)"
+          echo "  [OK] $page -- rendered clean (check_html_errors.sh: 0 error-pattern hits)"
           N_RENDER_OK=$((N_RENDER_OK + 1))
         fi
       done <<< "$STALE_PAGES"
@@ -590,6 +625,25 @@ if [[ "$RENDER" == "true" ]]; then
       echo "$N_STALE page(s) re-rendered; nothing was committed or pushed -- review the"
       echo "file(s) under docs/ and commit them yourself if they look right."
       echo ""
+
+      # --render-all marker (#740): written on EVERY --render-all completion,
+      # pass or fail -- this is a cadence signal ("did a human exercise every
+      # page recently"), not a pass/fail gate; RENDER_STATUS above already
+      # carries the pass/fail verdict for this specific invocation. Never
+      # committed here -- same "human reviews and commits" contract as every
+      # other file this script writes under docs/.
+      if [[ "$RENDER_ALL" == "true" ]]; then
+        MARKER_PATH="$REPO_ROOT/docs/_full_render_marker.txt"
+        {
+          echo "last_full_render_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "pages_rendered: $N_STALE"
+          echo "pages_ok: $N_RENDER_OK"
+          echo "pages_failed: $N_RENDER_FAILED"
+        } > "$MARKER_PATH"
+        echo "Wrote $MARKER_PATH -- commit it so full-render-cadence.yml (#740) can"
+        echo "see a full render happened recently. Not committed automatically."
+        echo ""
+      fi
     fi
   fi
 fi

--- a/scripts/check_html_errors.sh
+++ b/scripts/check_html_errors.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# scripts/check_html_errors.sh -- trustworthy rendered-HTML error-pattern
+# check (#740).
+#
+# WHY THIS EXISTS: scripts/build.sh Step 4 (--render) and the manual
+# Post-Deploy Validation procedure in verification-before-completion.md both
+# grep rendered docs/*.qmd -> .html output for reader-visible defects.
+# Applied naively -- case-insensitive, against raw markup, matching "NaN" --
+# that grep false-positives THREE separate ways (#740, reproduced on the live
+# 2026-08-24 site):
+#
+#   1. Case-insensitive "NaN" matches inside ordinary words: "financial"
+#      contains "nan". A case-INsensitive scan of docs/european-overlay.html
+#      alone hit this.
+#   2. Vendored, minified third-party JS emits "Error:"-shaped tokens that
+#      have nothing to do with the page's own R output -- DataTables' own
+#      internal `iDrawError:-1` matches the literal pattern "Error:". This
+#      lives inside <script> blocks.
+#   3. Base64-encoded `data:` URIs (embedded webfonts, images) can contain the
+#      literal substring "NaN" BY CHANCE -- 'N', 'a', 'n' are all valid
+#      base64-alphabet characters, so a long enough blob eventually produces
+#      every 3-character combination somewhere.
+#
+# On docs/macro-defense-rotation.html specifically, the naive check (grep -i,
+# no stripping) reported 38 hits; case-sensitive matching cut it to 18;
+# stripping <script>/<style> cut it to 5; every one of those 5 remaining hits
+# was inside a base64 font data: URI. True count: zero.
+#
+# This script is now the ONE place that check lives. scripts/build.sh Step 4
+# calls it per rendered page instead of hand-rolling its own grep loop, and
+# anyone re-running the manual Post-Deploy Validation procedure by hand should
+# call this instead of retyping the pattern list.
+#
+# DESIGN TRADE-OFF (deliberate): favour a false positive over a false
+# negative. Stripping <script>, <style>, and data: URI payloads removes ONLY
+# markup that can never be the page's own rendered R output (vendored library
+# code, embedded binary blobs) -- it never touches rendered prose, table
+# cells, or captions a reader would actually see. A real "Error in ..." or a
+# genuine computed NaN sitting in a table cell is untouched by any of the
+# three strip rules above and is still caught. NULL and bare "NA" are
+# deliberately NOT included in the pattern list below (unlike the fuller
+# table in verification-before-completion.md's Post-Deploy Validation
+# section) -- both are short, extremely common substrings of ordinary English
+# words and identifiers ("NAME", "ANALYSIS", "NATIONAL", "NULLify") with no
+# tag/word-boundary rule that reliably separates a real defect from an
+# ordinary word, so adding them un-bounded would reintroduce exactly the
+# class of false positive this script exists to remove. If a computation ever
+# needs to be checked for a literal NULL/NA render defect, that is better done
+# with a narrower, page-specific assertion (e.g. `expect_snapshot_value()` on
+# the target itself, per snapshot-test-policy) than a repo-wide grep.
+#
+# Usage:
+#   scripts/check_html_errors.sh <html-file> [<html-file> ...]
+#   scripts/check_html_errors.sh --all
+#     Checks every docs/*.html file that has a same-named docs/*.qmd source.
+#     docs/MERMAID_LESSONS.html is DELIBERATELY EXCLUDED by --all: it renders
+#     from docs/MERMAID_LESSONS.md (not a .qmd), is not one of the 15
+#     dashboard pages scripts/build.sh's Step 3/Step 4 cover, and -- being a
+#     lessons-learned page -- legitimately discusses real historical errors
+#     as its actual subject matter. A reader passing it explicitly as a named
+#     file argument still gets it checked; --all just never adds it on its
+#     own.
+#
+# Exit codes:
+#   0  every file checked has zero pattern hits
+#   1  at least one file has one or more pattern hits (see the per-file,
+#      per-pattern table printed above the summary line)
+#   2  usage error, or --all found no docs/*.qmd -> docs/*.html pairs to check
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Patterns per verification-before-completion.md's Post-Deploy Validation
+# table, minus NULL/bare NA (see DESIGN TRADE-OFF above), plus #740's NaN
+# addition. Matched CASE-SENSITIVELY, after stripping <script>, <style>, and
+# data: URI payloads (see strip_html below) -- see file header for why each
+# of those three steps is necessary and why together they are still the
+# stricter (favours-false-positive) trade-off, not a looser one.
+PATTERNS=(
+  'not available'
+  'not found in targets'
+  'MISSING EVIDENCE'
+  'Error in'
+  'Error:'
+  '#&gt;'
+  'NaN'
+)
+
+usage() {
+  echo "Usage: $0 <html-file> [<html-file> ...]" >&2
+  echo "       $0 --all" >&2
+  exit 2
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+fi
+
+FILES=()
+if [[ "$1" == "--all" ]]; then
+  while IFS= read -r qmd; do
+    page="$(basename "$qmd" .qmd)"
+    html="$REPO_ROOT/docs/${page}.html"
+    if [[ -f "$html" ]]; then
+      FILES+=("$html")
+    fi
+  done < <(find "$REPO_ROOT/docs" -maxdepth 1 -name '*.qmd' | sort)
+else
+  for f in "$@"; do
+    FILES+=("$f")
+  done
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "!!! No HTML files to check (no docs/*.qmd -> docs/*.html pairs found) !!!" >&2
+  exit 2
+fi
+
+# strip_html <path> -- prints the file's content to stdout with <script>,
+# <style>, and data: URI payloads removed. Case-insensitive, DOTALL (a
+# vendored <script> block routinely spans many lines). Uses python3 (present
+# on the bare macOS PATH and in CI runners without needing the project's nix
+# shell -- this check has nothing to do with R) because portable
+# case-insensitive multi-line removal is awkward in pure sed/awk/grep.
+strip_html() {
+  python3 - "$1" <<'PYEOF'
+import re, sys
+with open(sys.argv[1], "r", errors="replace") as fh:
+    src = fh.read()
+clean = re.sub(r'<script\b[^>]*>.*?</script>', '', src, flags=re.S | re.I)
+clean = re.sub(r'<style\b[^>]*>.*?</style>', '', clean, flags=re.S | re.I)
+# data: URIs are embedded inside an attribute (src="data:...") or a CSS
+# url(data:...) -- stop at whichever quote/paren closes the value. Base64's
+# alphabet has no '"', "'", or ')' characters, so this bound is exact, never
+# eating past the payload into real surrounding markup.
+clean = re.sub(r'data:[^"\')]*', '', clean, flags=re.S | re.I)
+sys.stdout.write(clean)
+PYEOF
+}
+
+TOTAL_HITS=0
+ANY_FAIL=0
+
+printf "%-30s" "Page"
+for p in "${PATTERNS[@]}"; do
+  printf " %10s" "$p"
+done
+printf " %8s\n" "TOTAL"
+
+for html in "${FILES[@]}"; do
+  page="$(basename "$html" .html)"
+  stripped="$(mktemp)"
+  strip_html "$html" > "$stripped"
+
+  row_total=0
+  counts=()
+  for p in "${PATTERNS[@]}"; do
+    hits="$(grep -Fc -- "$p" "$stripped" 2>/dev/null || true)"
+    hits="${hits:-0}"
+    counts+=("$hits")
+    row_total=$((row_total + hits))
+  done
+  rm -f "$stripped"
+
+  printf "%-30s" "$page"
+  for c in "${counts[@]}"; do
+    printf " %10d" "$c"
+  done
+  printf " %8d\n" "$row_total"
+
+  TOTAL_HITS=$((TOTAL_HITS + row_total))
+  if [[ "$row_total" -gt 0 ]]; then
+    ANY_FAIL=1
+  fi
+done
+
+echo ""
+if [[ "$ANY_FAIL" -ne 0 ]]; then
+  echo "RESULT: FAIL -- $TOTAL_HITS error-pattern hit(s) found across ${#FILES[@]} page(s)"
+  echo "  (case-sensitive match; <script>/<style>/data: URI stripped -- #740)"
+  echo "::VERIFY:HTML_ERRORS_STATUS::FAIL::"
+  exit 1
+else
+  echo "RESULT: PASS -- 0 error-pattern hits across ${#FILES[@]} page(s)"
+  echo "  (case-sensitive match; <script>/<style>/data: URI stripped -- #740)"
+  echo "::VERIFY:HTML_ERRORS_STATUS::PASS::"
+  exit 0
+fi

--- a/tests/test_check_html_errors.sh
+++ b/tests/test_check_html_errors.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# tests/test_check_html_errors.sh -- regression tests for
+# scripts/check_html_errors.sh (#740).
+#
+# #740 documented three independent ways a naive grep for error patterns
+# false-positives against real rendered dashboard HTML:
+#   1. case-insensitive "NaN" matches inside ordinary words ("financial")
+#   2. vendored minified JS emits "Error:"-shaped tokens inside <script>
+#      blocks (DataTables' own iDrawError:-1)
+#   3. base64 data: URIs can contain the literal substring "NaN" by chance
+#
+# These tests build small HTML fixtures reproducing each source in
+# isolation, plus a fixture with a genuine defect that must still be caught
+# (the false-positive fixes must not become false negatives -- #740's stated
+# design trade-off is to favour a false positive over a false negative).
+#
+# Usage: bash tests/test_check_html_errors.sh
+# Exit code: 0 if all tests pass, 1 if any test fails.
+
+set -uo pipefail  # deliberately NOT -e: test bodies check exit codes by hand
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECKER="$REPO_ROOT/scripts/check_html_errors.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "  PASS: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "  FAIL: $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+assert_eq() {
+  local actual="$1" expected="$2" msg="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$msg (got $actual)"
+  else
+    fail "$msg (expected $expected, got $actual)"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" msg="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$msg"
+  else
+    fail "$msg (did not find: $needle)"
+  fi
+}
+
+echo "=== tests/test_check_html_errors.sh ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test 1: case-insensitive "NaN" inside an ordinary word ("financial") must
+# NOT be flagged -- source 1 from #740.
+# ---------------------------------------------------------------------------
+echo "--- Test 1: 'financial' does not trigger a NaN false positive ---"
+f1="$(mktemp /tmp/check_html_errors_test1.XXXXXX.html)"
+printf '<html><body><p>The financial results are strong.</p></body></html>' > "$f1"
+"$CHECKER" "$f1" > /dev/null 2>&1
+assert_eq "$?" 0 "'financial' (lowercase nan) alone: clean exit"
+rm -f "$f1"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test 2: an "Error:"-shaped token inside a <script> block (vendored JS) must
+# NOT be flagged -- source 2 from #740.
+# ---------------------------------------------------------------------------
+echo "--- Test 2: vendored <script> 'Error:' token does not trigger a false positive ---"
+f2="$(mktemp /tmp/check_html_errors_test2.XXXXXX.html)"
+printf '<html><head><script>function f(){ iDrawError:-1; }</script></head><body><p>OK</p></body></html>' > "$f2"
+"$CHECKER" "$f2" > /dev/null 2>&1
+assert_eq "$?" 0 "vendored <script> 'Error:' token alone: clean exit"
+rm -f "$f2"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test 3: a base64 data: URI containing the literal substring "NaN" by
+# chance must NOT be flagged -- source 3 from #740. 'N', 'a', 'n' are all
+# valid base64-alphabet characters, so a long enough blob can contain "NaN"
+# with no meaning at all; the fixture string "AAAANaNBBBB==" is deliberately
+# constructed to contain the literal 3-character substring "NaN" (asserted
+# below) purely as base64-alphabet noise.
+# ---------------------------------------------------------------------------
+echo "--- Test 3: base64 data: URI containing literal 'NaN' does not trigger a false positive ---"
+f3="$(mktemp /tmp/check_html_errors_test3.XXXXXX.html)"
+printf '<html><body><img src="data:font/woff;base64,AAAANaNBBBB=="></body></html>' > "$f3"
+if ! grep -q "NaN" "$f3"; then
+  fail "Test 3 fixture setup: does not contain literal 'NaN' -- test is invalid"
+else
+  "$CHECKER" "$f3" > /dev/null 2>&1
+  assert_eq "$?" 0 "base64 data: URI containing 'NaN': clean exit"
+fi
+rm -f "$f3"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test 4 (regression guard): a genuine defect in rendered TEXT -- not inside
+# <script>/<style>/data: -- MUST still be caught. The false-positive fixes
+# above must not become false negatives.
+# ---------------------------------------------------------------------------
+echo "--- Test 4: a genuine 'Error in' + NaN defect in body text is still caught ---"
+f4="$(mktemp /tmp/check_html_errors_test4.XXXXXX.html)"
+printf '<html><body><p>Genuine defect: Error in compute_thing(): argument is NaN</p></body></html>' > "$f4"
+out4="$("$CHECKER" "$f4" 2>&1)"
+status4=$?
+assert_eq "$status4" 1 "genuine defect: FAIL exit code"
+assert_contains "$out4" "RESULT: FAIL" "genuine defect: FAIL result line printed"
+rm -f "$f4"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test 5: all three false-positive sources combined in one fixture, plus one
+# genuine defect -- exercises stripping order does not interfere across
+# sources, and the genuine defect is still the only thing counted.
+# ---------------------------------------------------------------------------
+echo "--- Test 5: combined fixture -- 3 false-positive sources suppressed, 1 genuine defect caught ---"
+f5="$(mktemp /tmp/check_html_errors_test5.XXXXXX.html)"
+{
+  echo '<html><head>'
+  echo '<style>.foo{background:#fff}</style>'
+  echo '<script>function f(){ iDrawError:-1; }</script>'
+  echo '</head><body>'
+  echo '<p>The financial results are strong.</p>'
+  echo '<img src="data:font/woff;base64,AAAANaNBBBB==">'
+  echo '<p>Genuine defect: Error in compute_thing(): argument is NaN</p>'
+  echo '</body></html>'
+} > "$f5"
+out5="$("$CHECKER" "$f5" 2>&1)"
+status5=$?
+assert_eq "$status5" 1 "combined fixture: FAIL exit code (genuine defect present)"
+# Exactly 2 hits expected: one "Error in", one "NaN" -- both from the
+# genuine-defect line. Everything else in the fixture must be suppressed.
+assert_contains "$out5" "FAIL -- 2 error-pattern hit(s)" "combined fixture: exactly 2 hits (not 3+ from false positives)"
+rm -f "$f5"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test 6: usage errors.
+# ---------------------------------------------------------------------------
+echo "--- Test 6: usage errors ---"
+"$CHECKER" > /dev/null 2>&1
+assert_eq "$?" 2 "no arguments: exit 2"
+"$CHECKER" --all --this-is-not-a-thing > /dev/null 2>&1
+# --all with extra args is still treated as --all (ignores trailing args) --
+# this just confirms it does not crash; the real --all path is exercised
+# against the repo's own docs/ tree in Test 7.
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test 7: --all finds the repo's docs/*.qmd -> docs/*.html pairs and
+# excludes MERMAID_LESSONS.html (no corresponding .qmd).
+# ---------------------------------------------------------------------------
+echo "--- Test 7: --all enumerates docs/*.qmd -> docs/*.html pairs ---"
+out7="$("$CHECKER" --all 2>&1)"
+if echo "$out7" | grep -q "No HTML files to check"; then
+  echo "  SKIP: no docs/*.html files present in this checkout (worktree may not have rendered output)"
+elif echo "$out7" | grep -qi "MERMAID_LESSONS"; then
+  fail "--all must not include MERMAID_LESSONS.html (no corresponding .qmd)"
+else
+  pass "--all correctly excludes MERMAID_LESSONS.html"
+fi
+echo ""
+
+echo "=== Summary: $PASS_COUNT passed, $FAIL_COUNT failed ==="
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Supersedes #743 — this branch carries #743's commit (`c41d96f`) plus one fix
commit on top. #743 (the #697 task) added
`{{< include _includes/build-info-footer.qmd >}}` to two pages. It works on
`docs/avoid-worst-days.qmd` but breaks the render on `docs/bdbb-sol.qmd`:

```
Error in `build_info()`:
! could not find function "build_info"
Quitting from bdbb-sol.qmd:103-108 [build-info]
Execution halted
```

Reproduced with `scripts/build.sh --render-all` against the real store: 14
pages rendered clean, `bdbb-sol.qmd` failed, exit code 3.

**Cause:** `docs/_includes/build-info-footer.qmd` calls `build_info()`
(defined in `docs/vignette_utils.R`) without ensuring that file was ever
sourced. `avoid-worst-days.qmd` happens to source it in its own setup chunk;
`bdbb-sol.qmd` does not. The include carried an undeclared prerequisite.

**Fix:** made the include self-sufficient instead of patching the one page.
`_includes/build-info-footer.qmd` now resolves and sources
`vignette_utils.R` itself when `build_info()` isn't already available
(`exists("build_info", mode = "function")` guard), using the same
local-path-then-`here::here()` idiom every page's own setup chunk already
uses. A page that already sourced it is unaffected. Property achieved: adding
this include to any page no longer requires the author to know about an
unmentioned prerequisite (see `.claude/rules/fail-loud-not-null.md` Required
Pattern 5 — this is the same defect shape: a fix scoped to the known
instance rather than the property).

## Test plan

- [x] `quarto render docs/bdbb-sol.qmd` — now succeeds (`Output created:
      bdbb-sol.html`); rendered HTML contains the build-info footer
      (`historicaldata dev | Git ... | R ... | Built 2026-08-24 12:03:27`)
- [x] `quarto render docs/avoid-worst-days.qmd` — regression check on the
      shared include (this page already sourced `vignette_utils.R`) — still
      succeeds
- [x] `scripts/check_html_errors.sh` on both rendered pages — 0 hits
- [x] `scripts/verify.sh` full run — PASS, all known baselines matched
      exactly (root suite 3/3 baseline failures, package suite 1/1 baseline
      failure, 15 expected skips)
- [x] Rendered HTML artifacts were NOT committed (reverted after
      verification) — they reflected an unrelated data refresh from the live
      store timestamp, not the fix itself; CI/`--render-all` will regenerate
      them normally

Refs #697, #740, #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)
