### PR TITLE
fix(608): derive Sortino risk-free rate from stk_rf instead of hardcoded 2%/yr

### DIFF
--- a/R/plan_backtest.R
+++ b/R/plan_backtest.R
@@ -68,6 +68,67 @@
   sharpe_ratio_rf(df$ret, df$rf_ret, periods_per_year = ann_factor)$sharpe
 }
 
+#' Rf-adjusted Sortino ratio for a dated monthly return vector (#608)
+#'
+#' Replaces the hardcoded 2%/yr `rf_annual` constant this file's Sortino
+#' computation used until #608 with the real Fama-French monthly
+#' risk-free series (`stk_rf`), joined via the canonical
+#' `.join_rf_series()` (R/utils_metrics.R) -- the same three-case
+#' (leading/trailing/interior) coverage policy `.ltr_join_rf()`
+#' (R/plan_ltr_momentum.R) and `.mom_prepeak_join_rf()`
+#' (R/plan_mom_prepeak.R) already use. `.bt_sharpe_rf()` above predates
+#' `.join_rf_series()`'s extraction and implements the same policy
+#' locally; this new helper uses the shared implementation directly
+#' rather than adding a third local copy.
+#'
+#' The Sortino formula itself is unchanged from the pre-#608 version
+#' except for the risk-free input: numerator is the annualised mean
+#' EXCESS return (`mean(ret) * ann_factor - mean(rf_ret) * ann_factor`,
+#' i.e. the real per-period rf averaged over the same window, instead of
+#' a flat 2%/yr); downside deviation is still `sd()` of raw negative
+#' returns (not excess returns), matching the original definition. As a
+#' side effect of routing through `.join_rf_series()`, a trailing month
+#' with no risk-free rate published yet (Fama-French publication lag) is
+#' now dropped from Sortino exactly as it already was from Sharpe via
+#' `.bt_sharpe_rf()`, rather than silently included with an implicit
+#' zero-ish rf.
+#'
+#' @param dates Date vector, position-aligned with `rets`.
+#' @param rets Numeric vector of monthly returns.
+#' @param stk_rf Tibble with columns `ym`, `rf_ret` (R/plan_stock_backtest.R).
+#' @param ann_factor Integer. Annualisation factor (12 for monthly).
+#' @return Numeric scalar Sortino (may be NA_real_ when fewer than 2
+#'   observations remain after coverage handling, or no downside
+#'   observations exist, or downside deviation is zero/non-finite).
+#' @noRd
+.bt_sortino_rf <- function(dates, rets, stk_rf, ann_factor = 12L) {
+  df <- tibble::tibble(date = as.Date(dates), ret = rets) |>
+    dplyr::filter(!is.na(.data$ret)) |>
+    dplyr::mutate(ym = format(.data$date, "%Y-%m"))
+
+  if (nrow(df) < 2L) return(NA_real_)
+
+  df <- .join_rf_series(
+    df = df, rf = stk_rf, key = "ym",
+    label = ".bt_sortino_rf", rf_label = "stk_rf",
+    rf_source = "R/plan_stock_backtest.R",
+    df_label = "bt returns", strategy_label = "Defense First / SPY",
+    period_noun = "month"
+  )
+
+  if (nrow(df) < 2L) return(NA_real_)
+
+  down <- df$ret[df$ret < 0]
+  if (length(down) == 0L) return(NA_real_)
+
+  ann_ret <- mean(df$ret) * ann_factor
+  ann_rf  <- mean(df$rf_ret) * ann_factor
+  downside_dev <- stats::sd(down) * sqrt(ann_factor)
+  if (!is.finite(downside_dev) || downside_dev <= 0) return(NA_real_)
+
+  (ann_ret - ann_rf) / downside_dev
+}
+
 plan_backtest <- function() {
   list(
     # ── Parameters ────────────────────────────────────────────────
@@ -244,10 +305,6 @@ plan_backtest <- function() {
       port <- bt_expanding$actual_return
       bench <- bt_expanding$benchmark_return
       n <- length(port)
-      # rf_annual retained ONLY for sortino, which is out of #677's scope
-      # (issue #677's inventory covers sharpe formulas only) -- sortino
-      # stays on the old arithmetic-mean + hardcoded-rf basis by design.
-      rf_annual <- 0.02  # approximate risk-free rate
 
       compute_metrics <- function(rets, label, rdts) {
         n <- length(rets)
@@ -258,9 +315,9 @@ plan_backtest <- function() {
         # #677: canonical rf-adjusted geometric Sharpe (R/utils_metrics.R),
         # replacing the arithmetic-mean numerator + hardcoded 2%/yr rf_annual.
         sharpe <- .bt_sharpe_rf(rdts, rets, stk_rf, ann_factor = 12L)
-        # Sortino: downside deviation (unchanged -- out of #677 scope)
-        down <- rets[rets < 0]
-        sortino <- if (length(down) > 0) (mean(rets) * 12 - rf_annual) / (sd(down) * sqrt(12)) else NA
+        # #608: real Fama-French monthly risk-free series (stk_rf), replacing
+        # the hardcoded 2%/yr rf_annual constant used here until now.
+        sortino <- .bt_sortino_rf(rdts, rets, stk_rf, ann_factor = 12L)
         # Max drawdown
         cum_series <- cumprod(1 + rets)
         peak <- cummax(cum_series)

--- a/tests/testthat/_snaps/bt-sortino-rf.md
+++ b/tests/testthat/_snaps/bt-sortino-rf.md
@@ -1,0 +1,20 @@
+# .bt_sortino_rf aborts on an INTERIOR gap (not a publication lag)
+
+    Code
+      .bt_sortino_rf(dts, r, rf, ann_factor = 12L)
+    Condition
+      Error in `.join_rf_series()`:
+      x 1 month inside stk_rf's own span have no risk-free rate (Defense First / SPY).
+      i Missing month: "2020-10".
+      i stk_rf spans 2020-01..2021-12, so this is a HOLE in the series, not a publication lag.
+      i Investigate the FF3 source (R/plan_stock_backtest.R) before trusting any Defense First / SPY Sharpe figure.
+
+# .bt_sortino_rf aborts when stk_rf lacks required columns
+
+    Code
+      .bt_sortino_rf(dts, r, bad_rf, ann_factor = 12L)
+    Condition
+      Error in `.join_rf_series()`:
+      x .bt_sortino_rf(): stk_rf is missing 1 required column: rf_ret.
+      i Expected a tibble with ym and rf_ret (R/plan_stock_backtest.R).
+

--- a/tests/testthat/test-bt-sortino-rf.R
+++ b/tests/testthat/test-bt-sortino-rf.R
@@ -1,0 +1,95 @@
+# Tests for .bt_sortino_rf() in R/plan_backtest.R (#608)
+#
+# plan_backtest.R's bt_metrics_is target previously used
+# (mean(rets) * 12 - rf_annual) / (sd(down) * sqrt(12)) with rf_annual
+# hardcoded at 2%/yr, regardless of era. .bt_sortino_rf() replaces the
+# constant with the real Fama-French monthly rf (stk_rf target), joined
+# via the canonical .join_rf_series() (R/utils_metrics.R) -- the same
+# helper .ltr_join_rf()/.mom_prepeak_join_rf() use, and the same
+# leading/trailing/interior coverage policy .bt_sharpe_rf() (above it in
+# this file) implements locally.
+testthat::local_edition(3)
+
+source(here::here("R/utils_metrics.R"))
+source(here::here("R/plan_backtest.R"))
+
+make_dates <- function(n) seq.Date(as.Date("2020-01-01"), by = "month", length.out = n)
+
+make_stk_rf <- function(n, rf_ret = 0.0016) {
+  tibble::tibble(ym = format(make_dates(n), "%Y-%m"), rf_ret = rep(rf_ret, n))
+}
+
+test_that(".bt_sortino_rf matches a hand-computed rf-adjusted Sortino", {
+  set.seed(21)
+  r   <- rnorm(36, mean = 0.008, sd = 0.05)
+  dts <- make_dates(36)
+  rf  <- make_stk_rf(36, rf_ret = 0.001)
+
+  result <- .bt_sortino_rf(dts, r, rf, ann_factor = 12L)
+
+  down <- r[r < 0]
+  expected <- (mean(r) * 12 - mean(rf$rf_ret) * 12) / (sd(down) * sqrt(12))
+
+  expect_equal(result, expected)
+})
+
+test_that(".bt_sortino_rf differs from the old hardcoded-2pct formula when the real rf differs from 2%/yr", {
+  set.seed(22)
+  r   <- rnorm(36, mean = 0.01, sd = 0.06)
+  dts <- make_dates(36)
+  # Real monthly rf implying ~6%/yr -- deliberately far from the old 2% constant
+  rf  <- make_stk_rf(36, rf_ret = 0.005)
+
+  new_sortino <- .bt_sortino_rf(dts, r, rf, ann_factor = 12L)
+
+  # Old (pre-#608) formula: hardcoded 2%/yr rf_annual, applied identically
+  # regardless of era.
+  down <- r[r < 0]
+  old_sortino <- (mean(r) * 12 - 0.02) / (sd(down) * sqrt(12))
+
+  expect_false(isTRUE(all.equal(new_sortino, old_sortino)))
+})
+
+test_that(".bt_sortino_rf returns NA_real_ when there are no downside months", {
+  dts <- make_dates(12)
+  r   <- rep(0.01, 12)  # always positive -- no downside deviation to compute
+  rf  <- make_stk_rf(12)
+
+  expect_equal(.bt_sortino_rf(dts, r, rf, ann_factor = 12L), NA_real_)
+})
+
+test_that(".bt_sortino_rf returns NA_real_ with fewer than 2 observations", {
+  dts <- make_dates(1)
+  r   <- 0.01
+  rf  <- make_stk_rf(1)
+
+  expect_equal(.bt_sortino_rf(dts, r, rf, ann_factor = 12L), NA_real_)
+})
+
+test_that(".bt_sortino_rf trims a trailing uncovered month and warns (Fama-French publication lag)", {
+  # Two distinct negative values so downside deviation is non-zero (a
+  # constant downside series would give sd(down) == 0 -> NA_real_ by design).
+  r   <- rep(c(0.02, -0.01, -0.03, 0.015), 6)
+  dts <- make_dates(24)
+  rf  <- make_stk_rf(24)[1:20, ]  # rf ends 4 months before returns
+
+  expect_warning(result <- .bt_sortino_rf(dts, r, rf, ann_factor = 12L), regexp = "Dropped")
+  expect_true(is.finite(result))
+})
+
+test_that(".bt_sortino_rf aborts on an INTERIOR gap (not a publication lag)", {
+  r   <- rep(c(0.02, -0.01, -0.03, 0.015), 6)
+  dts <- make_dates(24)
+  rf  <- make_stk_rf(24)
+  rf  <- rf[-10, ]
+
+  expect_snapshot(error = TRUE, .bt_sortino_rf(dts, r, rf, ann_factor = 12L))
+})
+
+test_that(".bt_sortino_rf aborts when stk_rf lacks required columns", {
+  r      <- rep(c(0.01, -0.005), 6)
+  dts    <- make_dates(12)
+  bad_rf <- tibble::tibble(ym = format(make_dates(12), "%Y-%m"))
+
+  expect_snapshot(error = TRUE, .bt_sortino_rf(dts, r, bad_rf, ann_factor = 12L))
+})


### PR DESCRIPTION
## Problem

`R/plan_backtest.R` computed the Sortino ratio for the `bt_metrics_is` target
with `rf_annual <- 0.02` — a flat 2%/yr risk-free rate applied uniformly
across the whole sample, regardless of era. #677 had already migrated this
file's **Sharpe** computations (`bt_metrics_is`, `bt_comparison`,
`bt_replication_metrics`, `bt_oos_vs_is`) onto the real Fama-French monthly
risk-free series (`stk_rf`) via `.bt_sharpe_rf()`, but explicitly left
Sortino on the hardcoded basis as out of #677's scope. This constant was the
only remaining `# approximate` value in the R sources (per #608).

## Fix

Add `.bt_sortino_rf()`, mirroring `.bt_sharpe_rf()` immediately above it:
joins `dates`/`rets` to `stk_rf` via the canonical `.join_rf_series()`
(`R/utils_metrics.R`) — the same shared helper `.ltr_join_rf()`
(`R/plan_ltr_momentum.R`) and `.mom_prepeak_join_rf()`
(`R/plan_mom_prepeak.R`) already use, with its established
leading/trailing/interior risk-free coverage policy:

- **Interior gap** (a hole inside `stk_rf`'s own span) → aborts loudly.
- **Trailing gap** (Fama-French publication lag) → trims + `cli_warn`s,
  naming the dropped months.

`.bt_sharpe_rf()` itself is untouched — it predates `.join_rf_series()`'s
extraction and implements the same policy locally; I did not want to risk
its existing snapshot-tested behaviour for an unrelated fix.

The Sortino **formula** is otherwise unchanged from the pre-fix version:
numerator is still the annualised mean excess return
(`mean(ret) - mean(rf_ret)`, annualised), denominator is still `sd()` of raw
negative returns (downside relative to zero, not relative to rf), annualised
by `sqrt(ann_factor)`. Only the risk-free input changed — from a scalar
constant to the real per-period series, averaged over the same window the
Sharpe computation already uses.

One behavioural side effect: because `.bt_sortino_rf()` now routes through
the same trailing-gap trimming as `.bt_sharpe_rf()`, a month with no risk-free
rate published yet is dropped from Sortino exactly as it already was from
Sharpe, rather than being silently included with an implicit rf of 0.

## Verified — before/after (live store, read-only + predicted)

Read `bt_expanding`, `bt_metrics_is`, and `stk_rf` **read-only** from the live
store (`docs/_targets`) to get the observed "before" figures, then called the
new `.bt_sortino_rf()` directly against that same live data to predict the
"after" figures (I did not run `tar_make()` — `scripts/build.sh`'s lock is
respected; the observed live-store numbers below are exact, the "predicted"
numbers are computed by direct function evaluation against that live data,
not by rebuilding the target).

Real average monthly rf over the `bt_expanding` window (`2008-05`..`2019-12`,
140/140 months matched, no gaps) annualises to **~0.52%/yr**, vs the old
hardcoded **2%/yr** — a ~1.48pp overstatement, consistent with most of this
window falling in the post-financial-crisis ZIRP era.

| strategy | sortino (before, observed) | sortino (after, predicted) | sharpe (unaffected) |
|---|---|---|---|
| Defense First | 0.73 | **1.10** | 0.47 (unchanged — already real-rf via #677) |
| SPY (buy & hold) | 0.70 | **0.82** | 0.62 (unchanged — already real-rf via #677) |

Both Sortino figures move **up**, because the real rf for this specific
window is *lower* than the old flat 2% assumption — the opposite direction
from what a reader might guess if they only remembered "2023–2024 rf was
understated by the 2% constant" from #608's table; this backtest's window
ends in 2019 and never reaches that era.

**Zero-crossing check:** neither Sharpe nor Sortino crosses zero for either
strategy, before or after. Sharpe is untouched by this commit. This file's
targets (`bt_metrics_is`, `bt_comparison`, `bt_replication_metrics`,
`bt_oos_vs_is`) do not feed the published leaderboard (see the file-header
NOTE, `R/plan_backtest.R:9-13` — standalone `docs/macro-defense-rotation.qmd`
vignette), so `hd_detection_power()`'s Sharpe-sign-dependent treatment is not
implicated by this PR.

## Testing

New `tests/testthat/test-bt-sortino-rf.R` (8 tests, mirroring the existing
`test-bt-sharpe-rf.R` pattern):

- Matches a hand-computed rf-adjusted Sortino exactly.
- Differs from the old hardcoded-2%/yr formula when the real rf differs.
- Returns `NA_real_` with no downside months, or fewer than 2 observations.
- Trims a trailing Fama-French-publication-lag gap and warns (`cli_warn`).
- Aborts on an interior gap and on a malformed `stk_rf` (both
  `expect_snapshot(error = TRUE, ...)` per `snapshot-test-policy.md`).

`scripts/verify.sh` (full run, foreground): **PASS**. Root suite
`total=730 failed=3 skipped=0` — matches the documented 3-failure baseline
exactly (no new failures; my 8 new tests are the delta from the prior root
total). Package suite `total=713 failed=1 skipped=15` — matches the
documented baseline exactly, untouched by this change.

`parse("_targets.R")` and `parse("R/plan_backtest.R")`: both succeed.

I did **not** run `tar_make()` — the main checkout owns the single live
store and `scripts/build.sh` holds a lock; the before/after table above uses
the live store read-only plus direct function evaluation, not a rebuild.
Please build this branch against the real store to confirm the actual
after-figures before merging.

## Scope note

Per dispatch instructions, I did not touch `R/plan_strategy_names.R`,
`R/plan_leaderboard.R`, `R/plan_qa_gates.R`, or
`R/plan_commodities_mean_reversion.R` — no change to any of those was needed
for this fix; `R/plan_backtest.R` is entirely self-contained (its targets
don't feed the leaderboard, and it already had its own private `stk_rf`-based
Sharpe helper from #677 to mirror).

Refs #608
