### PR TITLE
fix(strategy-names): add missing olmar row; derive STRATEGY_OBS_ANN_FACTOR (#629)

### DIFF
--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -78,18 +78,27 @@
 # the pipeline if a leaderboard strategy has no row here -- so a strategy
 # added later without updating this table fails loudly instead of silently
 # returning NA forever for the new diagnostic below.
-STRATEGY_OBS_ANN_FACTOR <- tibble::tibble(
-  strategy = c(
-    "Factor MAX", "Factor DRIF", "Stock MAX", "Stock DRIF", "XGB DRIF",
-    "LTR", "CMR", "Mom Pre-Peak", "Mom Post-Peak", "Mom 12-2",
-    "Value (HML)", "Managed Futures", "PSO Optimal",
-    "OLMAR-1", "TOM", "Risk State", "Avoid Worst"
-  ),
-  obs_ann_factor = c(
-    12, 12, 12, 12, 12,
-    12, 252, 12, 12, 12,
-    12, 12, 12,
-    252, 252, 252, 252
+#
+# ── Derived from strategy_names, not hand-duplicated (#629) ────────────────
+# `strategy` (== strategy_names$short_name) and `obs_ann_factor` (==
+# strategy_names$ann_factor) used to be a SECOND, hand-maintained copy of
+# data that already lives in R/plan_strategy_names.R's strategy_names --
+# and the two silently disagreed: OLMAR-1 was declared here but absent from
+# strategy_names entirely (#629). They are now derived from
+# hd_strategy_names_tbl() (the plain, non-target constructor behind the
+# strategy_names tar_target -- callable at source() time, see that file) so
+# the two structurally cannot drift again. Only `obs_ann_factor_source` --
+# the human-readable provenance citation, verified against each strategy's
+# own calc_metrics()/compute_*() call -- remains hand-maintained here, keyed
+# by code_name, because that citation text is not part of strategy_names'
+# schema. `.build_strategy_obs_ann_factor()` aborts loudly (fail-loud-not-
+# null.md) if a strategy_names row has no matching citation, or vice versa.
+.strategy_obs_ann_factor_source <- tibble::tibble(
+  code_name = c(
+    "fac_max", "drif", "stk_max", "stk_drif", "xgb_drif",
+    "ltr", "cmr", "mom_prepeak", "mom_postpeak", "mom_combined",
+    "ev_ebit", "mf_tsm", "pso_optimal",
+    "olmar", "tom", "rsc", "avoid_worst"
   ),
   obs_ann_factor_source = c(
     "R/plan_factormax.R (ann_vol <- sd(...) * sqrt(12))",
@@ -110,6 +119,52 @@ STRATEGY_OBS_ANN_FACTOR <- tibble::tibble(
     "R/plan_risk_state.R calc_metrics(periods_per_year = 252L default); calc_metrics() now returns n_obs (#726 item 3), renamed to `months` by .norm_rsc() below -- previously this row's `months` was always NA because rsc_metrics had no months/n_days column at all",
     "R/plan_avoid_worst.R (ann_factor = 252L throughout, e.g. .aw_sharpe_rf_full())"
   )
+)
+
+#' Build STRATEGY_OBS_ANN_FACTOR from strategy_names + its provenance table
+#'
+#' Exposed as a function (rather than inlined at source() time) so tests can
+#' exercise the mismatch-abort path directly (#629) without needing a real
+#' drift between the two tables.
+#'
+#' @param strategy_names_tbl Output of `hd_strategy_names_tbl()`
+#'   (R/plan_strategy_names.R) -- must have `code_name`, `short_name`,
+#'   `ann_factor` columns.
+#' @param source_tbl `.strategy_obs_ann_factor_source` -- must have
+#'   `code_name`, `obs_ann_factor_source` columns.
+#' @return Tibble with `strategy`, `obs_ann_factor`, `obs_ann_factor_source`.
+#' @noRd
+.build_strategy_obs_ann_factor <- function(strategy_names_tbl, source_tbl) {
+  joined <- strategy_names_tbl |>
+    dplyr::transmute(
+      code_name,
+      strategy = short_name,
+      obs_ann_factor = ann_factor
+    ) |>
+    dplyr::left_join(source_tbl, by = "code_name")
+
+  missing <- joined$strategy[is.na(joined$obs_ann_factor_source)]
+  if (length(missing) > 0L) {
+    cli::cli_abort(c(
+      "x" = paste0(
+        length(missing), " strategy/strategies in strategy_names have no ",
+        "obs_ann_factor_source citation:"
+      ),
+      setNames(sprintf("  %s", missing), rep("i", length(missing))),
+      "i" = paste0(
+        "Add a row to .strategy_obs_ann_factor_source (R/plan_leaderboard.R) ",
+        "keyed by code_name, citing the strategy's calc_metrics()/",
+        "compute_*() annualisation source."
+      )
+    ))
+  }
+
+  dplyr::select(joined, strategy, obs_ann_factor, obs_ann_factor_source)
+}
+
+STRATEGY_OBS_ANN_FACTOR <- .build_strategy_obs_ann_factor(
+  hd_strategy_names_tbl(),
+  .strategy_obs_ann_factor_source
 )
 
 plan_leaderboard <- function() {

--- a/R/plan_strategy_names.R
+++ b/R/plan_strategy_names.R
@@ -4,165 +4,213 @@
 # All downstream plans (falsification vignette, leaderboard, etc.)
 # should filter this target rather than defining their own name tables.
 #
-# Current count: 16 strategies (rows 1-11 original; rows 12-14 mom_prepeak
+# Current count: 17 strategies (rows 1-11 original; rows 12-14 mom_prepeak
 # siblings added in #365 PR 2/4; row 15 ev_ebit added in #426;
-# row 16 mf_tsm added in #427).
+# row 16 mf_tsm added in #427; row 17 olmar added in #629).
 
 plan_strategy_names <- function() {
   list(
-    targets::tar_target(strategy_names, {
-      tibble::tibble(
-        code_name = c(
-          "avoid_worst", "drif", "fac_max", "rsc", "ltr", "tom",
-          "stk_max", "stk_drif", "xgb_drif", "pso_optimal",
-          "cmr",
-          # ── #365: pre-peak / post-peak 12-2 momentum decomposition ──
-          "mom_prepeak", "mom_postpeak", "mom_combined",
-          # ── #426: EV/EBIT fundamental value sleeve (HML proxy v0) ──
-          "ev_ebit",
-          # ── #427: cross-asset TS-momentum / managed futures (MOP 2012 v0) ──
-          "mf_tsm"
-        ),
-        short_name = c(
-          "Avoid Worst", "Factor DRIF", "Factor MAX", "Risk State", "LTR", "TOM",
-          "Stock MAX", "Stock DRIF", "XGB DRIF", "PSO Optimal",
-          "CMR",
-          "Mom Pre-Peak", "Mom Post-Peak", "Mom 12-2",
-          "Value (HML)",
-          "Managed Futures"
-        ),
-        long_name = c(
-          "Avoid Worst Days (VIX Protection)",
-          "Factor DRIF (Factor Rotation)",
-          "Factor MAX (Factor Momentum)",
-          "Risk State (VIX Overlay)",
-          "LTR (Cross-Sectional Momentum)",
-          "Turn-of-the-Month (TOM Overlay)",
-          "Stock MAX (Daily Return Sorting)",
-          "Stock DRIF (Elastic Net Stock Selection)",
-          "XGB DRIF (XGBoost Stock Selection)",
-          "PSO Optimal (Portfolio Optimisation)",
-          "Commodities Mean Reversion",
-          "Pre-Peak 12-2 Momentum (Büsing 2022)",
-          "Post-Peak 12-2 Momentum (Büsing 2022)",
-          "Standard 12-2 Momentum (Büsing baseline)",
-          "EV/EBIT Value Sleeve (HML+RMW Proxy, v0)",
-          "Cross-Asset TS-Momentum (MOP 2012, ETF Proxies, v0)"
-        ),
-        asset_class = c(
-          "overlay", "factor", "factor", "overlay", "equity", "overlay",
-          "equity", "equity", "equity", "combined",
-          "commodities",
-          "equity", "equity", "equity",
-          "factor",
-          "multi_asset"
-        ),
-        frequency = c(
-          "daily", "monthly", "monthly", "daily", "monthly", "daily",
-          "monthly", "monthly", "monthly", "monthly",
-          # #717: cmr (position 11) is daily, not monthly -- the 37-series
-          # universe is 96% Yahoo daily futures/ETF rows (see #717/#720).
-          "daily",
-          "monthly", "monthly", "monthly",
-          "monthly",
-          "monthly"
-        ),
-        ann_factor = c(252L, 12L, 12L, 252L, 12L, 252L, 12L, 12L, 12L, 12L, 252L,
-                       12L, 12L, 12L, 12L, 12L),
-        vignette_url = c(
-          "avoid-worst-days.html", "drif.html", "factor-max.html",
-          "leaderboard.html", "leaderboard.html", "turn-of-month.html",
-          "stock-backtest.html", "stock-backtest.html",
-          "stock-backtest.html", "leaderboard.html",
-          "commodities-mean-reversion.html",
-          "momentum-prepeak.html", "momentum-prepeak.html", "momentum-prepeak.html",
-          "leaderboard.html",
-          "leaderboard.html"
-        ),
-        # ── #346 strategy registry keywords (rough first-pass; refine after a full tar_make) ──
-        # Order matches code_name above (1 avoid_worst .. 11 cmr, 12-14 mom_prepeak siblings,
-        # 15 ev_ebit added in #426, 16 mf_tsm added in #427).
-        time_horizon_days_avg = c(
-          1L,  21L, 21L, 1L,  252L, 1L,
-          21L, 21L, 21L, 90L,
-          21L,
-          21L, 21L, 21L,
-          252L,
-          252L
-        ),
-        trades_per_year_avg = c(
-          12,  12,  12,  12,  12,  12,
-          12,  12,  12,   4,
-          12,
-          12, 12, 12,
-          12,
-          12
-        ),
-        liquidity_tier = factor(
-          c("high", "high", "high", "high", "med", "high",
-            "med",  "med",  "med",  "high",
-            "med",
-            "med", "med", "med",
-            "high",
-            "high"),
-          levels = c("high", "med", "low")
-        ),
-        turnover_pct_per_period_avg = c(
-          50, 30, 30, 50, 20, 10,
-          100, 100, 100, 10,
-          100,
-          100, 100, 100,
-          20,
-          25
-        ),
-        directionality = factor(
-          c("overlay",    "long_only",  "long_only",  "overlay",    "long_short", "overlay",
-            "long_short", "long_short", "long_short", "long_only",
-            "long_short",
-            "long_short", "long_short", "long_short",
-            "long_only",
-            "long_short"),
-          levels = c("long_only", "long_short", "market_neutral", "overlay")
-        ),
-        # Tags as JSON-encoded character vectors so duckplyr can pick them
-        # up as VARCHAR and a future hd_strategy_tags() helper can parse.
-        tags = c(
-          '["vix","market_timing","overlay"]',
-          '["factor_rotation","elastic_net","monthly"]',
-          '["factor_rotation","monthly"]',
-          '["vix","market_timing","overlay"]',
-          '["momentum","cross_sectional","monthly"]',
-          '["calendar","seasonal","overlay"]',
-          '["momentum","cross_sectional","stock_level"]',
-          '["elastic_net","ml","stock_level"]',
-          '["xgboost","ml","stock_level","monotonic"]',
-          '["portfolio","pso","optimisation","combined"]',
-          '["mean_reversion","commodities"]',
-          '["momentum","cross_sectional","decomposition","prepeak"]',
-          '["momentum","cross_sectional","decomposition","postpeak"]',
-          '["momentum","cross_sectional","baseline"]',
-          '["value","fundamental","factor","monthly","quality"]',
-          '["managed_futures","time_series_momentum","cross_asset","monthly","trend"]'
-        ),
-        research_paper_doi = c(
-          NA_character_,                  # 1 avoid_worst (folk wisdom; no single paper)
-          "10.2139/ssrn.5520615",         # 2 drif (Cakici et al. 2024 — placeholder)
-          "10.2139/ssrn.5520615",         # 3 fac_max
-          NA_character_,                  # 4 rsc (VIX overlay variant)
-          "10.1016/0304-405X(93)90023-5", # 5 ltr (Jegadeesh & Titman 1993 placeholder)
-          NA_character_,                  # 6 tom (TradeQuantix newsletter — no DOI)
-          "10.2139/ssrn.5520615",         # 7 stk_max (Cakici family at stock level)
-          "10.2139/ssrn.5520615",         # 8 stk_drif
-          NA_character_,                  # 9 xgb_drif (no paper)
-          NA_character_,                  # 10 pso_optimal (PSO is engineering)
-          NA_character_,                  # 11 cmr (internal — #134/#138)
-          "10.2139/ssrn.4298538",         # 12 mom_prepeak (Büsing, Mohrschladt & Siedhoff 2022)
-          "10.2139/ssrn.4298538",         # 13 mom_postpeak
-          "10.2139/ssrn.4298538",         # 14 mom_combined (baseline)
-          "10.1111/j.1540-6261.1993.tb04741.x", # 15 ev_ebit (Fama & French 1993 three-factor model)
-          "10.1111/jofi.12131"                   # 16 mf_tsm (Moskowitz, Ooi & Pedersen 2012)
-        )
-      )
-    })
+    targets::tar_target(strategy_names, hd_strategy_names_tbl())
+  )
+}
+
+#' Plain (non-target) constructor for the strategy_names tibble (#629)
+#'
+#' Extracted out of the `strategy_names` tar_target so this single source
+#' of truth is callable WITHOUT tar_make()/tar_read(). Sourcing this file
+#' is enough -- e.g. R/plan_leaderboard.R derives STRATEGY_OBS_ANN_FACTOR's
+#' `strategy`/`obs_ann_factor` columns by calling this function directly
+#' at source() time, instead of hand-maintaining a second, drift-prone copy
+#' of the same data (see the STRATEGY_OBS_ANN_FACTOR comment in
+#' R/plan_leaderboard.R and issue #629 for the two-lists-disagreeing defect
+#' this closes). Any new code that needs the full strategy roster outside
+#' the targets pipeline (tests, other plan files) should call this function
+#' rather than duplicating the tibble.
+#' @noRd
+hd_strategy_names_tbl <- function() {
+  tibble::tibble(
+    code_name = c(
+      "avoid_worst", "drif", "fac_max", "rsc", "ltr", "tom",
+      "stk_max", "stk_drif", "xgb_drif", "pso_optimal",
+      "cmr",
+      # ── #365: pre-peak / post-peak 12-2 momentum decomposition ──
+      "mom_prepeak", "mom_postpeak", "mom_combined",
+      # ── #426: EV/EBIT fundamental value sleeve (HML proxy v0) ──
+      "ev_ebit",
+      # ── #427: cross-asset TS-momentum / managed futures (MOP 2012 v0) ──
+      "mf_tsm",
+      # ── #629: OLMAR-1 online moving-average reversion (Li & Hoi 2012) --
+      # was already ranked on the leaderboard (R/plan_leaderboard.R
+      # STRATEGY_OBS_ANN_FACTOR) but missing from this declared list --
+      # appended at the end (not inserted mid-vector) to avoid corrupting
+      # the alignment of any existing row.
+      "olmar"
+    ),
+    short_name = c(
+      "Avoid Worst", "Factor DRIF", "Factor MAX", "Risk State", "LTR", "TOM",
+      "Stock MAX", "Stock DRIF", "XGB DRIF", "PSO Optimal",
+      "CMR",
+      "Mom Pre-Peak", "Mom Post-Peak", "Mom 12-2",
+      "Value (HML)",
+      "Managed Futures",
+      # Must exactly match STRATEGY_OBS_ANN_FACTOR's "OLMAR-1" display key
+      # (R/plan_leaderboard.R) -- that is the join key the two now share.
+      "OLMAR-1"
+    ),
+    long_name = c(
+      "Avoid Worst Days (VIX Protection)",
+      "Factor DRIF (Factor Rotation)",
+      "Factor MAX (Factor Momentum)",
+      "Risk State (VIX Overlay)",
+      "LTR (Cross-Sectional Momentum)",
+      "Turn-of-the-Month (TOM Overlay)",
+      "Stock MAX (Daily Return Sorting)",
+      "Stock DRIF (Elastic Net Stock Selection)",
+      "XGB DRIF (XGBoost Stock Selection)",
+      "PSO Optimal (Portfolio Optimisation)",
+      "Commodities Mean Reversion",
+      "Pre-Peak 12-2 Momentum (Büsing 2022)",
+      "Post-Peak 12-2 Momentum (Büsing 2022)",
+      "Standard 12-2 Momentum (Büsing baseline)",
+      "EV/EBIT Value Sleeve (HML+RMW Proxy, v0)",
+      "Cross-Asset TS-Momentum (MOP 2012, ETF Proxies, v0)",
+      "OLMAR-1 (Online Moving Average Reversion, Li & Hoi 2012)"
+    ),
+    asset_class = c(
+      "overlay", "factor", "factor", "overlay", "equity", "overlay",
+      "equity", "equity", "equity", "combined",
+      "commodities",
+      "equity", "equity", "equity",
+      "factor",
+      "multi_asset",
+      "equity"
+    ),
+    frequency = c(
+      "daily", "monthly", "monthly", "daily", "monthly", "daily",
+      "monthly", "monthly", "monthly", "monthly",
+      # #717: cmr (position 11) is daily, not monthly -- the 37-series
+      # universe is 96% Yahoo daily futures/ETF rows (see #717/#720).
+      "daily",
+      "monthly", "monthly", "monthly",
+      "monthly",
+      "monthly",
+      # #629: OLMAR-1 rebalances daily (R/plan_olmar.R weights formed at
+      # close of day t, realised on t+1 -- see this file's own comment).
+      "daily"
+    ),
+    ann_factor = c(252L, 12L, 12L, 252L, 12L, 252L, 12L, 12L, 12L, 12L, 252L,
+                   12L, 12L, 12L, 12L, 12L,
+                   252L),
+    vignette_url = c(
+      "avoid-worst-days.html", "drif.html", "factor-max.html",
+      "leaderboard.html", "leaderboard.html", "turn-of-month.html",
+      "stock-backtest.html", "stock-backtest.html",
+      "stock-backtest.html", "leaderboard.html",
+      "commodities-mean-reversion.html",
+      "momentum-prepeak.html", "momentum-prepeak.html", "momentum-prepeak.html",
+      "leaderboard.html",
+      "leaderboard.html",
+      # No dedicated vignette (plan_olmar.R explicitly defers it) --
+      # only appears on the leaderboard, same as PSO Optimal.
+      "leaderboard.html"
+    ),
+    # ── #346 strategy registry keywords (rough first-pass; refine after a full tar_make) ──
+    # Order matches code_name above (1 avoid_worst .. 11 cmr, 12-14 mom_prepeak siblings,
+    # 15 ev_ebit added in #426, 16 mf_tsm added in #427, 17 olmar added in #629).
+    time_horizon_days_avg = c(
+      1L,  21L, 21L, 1L,  252L, 1L,
+      21L, 21L, 21L, 90L,
+      21L,
+      21L, 21L, 21L,
+      252L,
+      252L,
+      # OLMAR-1's SMA window (R/plan_olmar.R olmar_params$window = 25L).
+      25L
+    ),
+    trades_per_year_avg = c(
+      12,  12,  12,  12,  12,  12,
+      12,  12,  12,   4,
+      12,
+      12, 12, 12,
+      12,
+      12,
+      # Same convention as the other daily strategies above (avoid_worst,
+      # rsc, tom, cmr) -- rebalance-evaluation frequency, not literal count.
+      12
+    ),
+    liquidity_tier = factor(
+      c("high", "high", "high", "high", "med", "high",
+        "med",  "med",  "med",  "high",
+        "med",
+        "med", "med", "med",
+        "high",
+        "high",
+        # 30-ticker large-cap + broad-ETF universe (R/plan_olmar.R
+        # olmar_params$tickers) -- highly liquid, same tier as Stock MAX.
+        "high"),
+      levels = c("high", "med", "low")
+    ),
+    turnover_pct_per_period_avg = c(
+      50, 30, 30, 50, 20, 10,
+      100, 100, 100, 10,
+      100,
+      100, 100, 100,
+      20,
+      25,
+      # Daily online mean-reversion rebalance -- same turnover tier as CMR.
+      100
+    ),
+    directionality = factor(
+      c("overlay",    "long_only",  "long_only",  "overlay",    "long_short", "overlay",
+        "long_short", "long_short", "long_short", "long_only",
+        "long_short",
+        "long_short", "long_short", "long_short",
+        "long_only",
+        "long_short",
+        # Tilt fraction around equal weight (R/plan_olmar.R
+        # olmar_params$leverage = 0.2) -- no shorting evidence in the code.
+        "long_only"),
+      levels = c("long_only", "long_short", "market_neutral", "overlay")
+    ),
+    # Tags as JSON-encoded character vectors so duckplyr can pick them
+    # up as VARCHAR and a future hd_strategy_tags() helper can parse.
+    tags = c(
+      '["vix","market_timing","overlay"]',
+      '["factor_rotation","elastic_net","monthly"]',
+      '["factor_rotation","monthly"]',
+      '["vix","market_timing","overlay"]',
+      '["momentum","cross_sectional","monthly"]',
+      '["calendar","seasonal","overlay"]',
+      '["momentum","cross_sectional","stock_level"]',
+      '["elastic_net","ml","stock_level"]',
+      '["xgboost","ml","stock_level","monotonic"]',
+      '["portfolio","pso","optimisation","combined"]',
+      '["mean_reversion","commodities"]',
+      '["momentum","cross_sectional","decomposition","prepeak"]',
+      '["momentum","cross_sectional","decomposition","postpeak"]',
+      '["momentum","cross_sectional","baseline"]',
+      '["value","fundamental","factor","monthly","quality"]',
+      '["managed_futures","time_series_momentum","cross_asset","monthly","trend"]',
+      '["mean_reversion","online_portfolio_selection","equity_basket","daily"]'
+    ),
+    research_paper_doi = c(
+      NA_character_,                  # 1 avoid_worst (folk wisdom; no single paper)
+      "10.2139/ssrn.5520615",         # 2 drif (Cakici et al. 2024 — placeholder)
+      "10.2139/ssrn.5520615",         # 3 fac_max
+      NA_character_,                  # 4 rsc (VIX overlay variant)
+      "10.1016/0304-405X(93)90023-5", # 5 ltr (Jegadeesh & Titman 1993 placeholder)
+      NA_character_,                  # 6 tom (TradeQuantix newsletter — no DOI)
+      "10.2139/ssrn.5520615",         # 7 stk_max (Cakici family at stock level)
+      "10.2139/ssrn.5520615",         # 8 stk_drif
+      NA_character_,                  # 9 xgb_drif (no paper)
+      NA_character_,                  # 10 pso_optimal (PSO is engineering)
+      NA_character_,                  # 11 cmr (internal — #134/#138)
+      "10.2139/ssrn.4298538",         # 12 mom_prepeak (Büsing, Mohrschladt & Siedhoff 2022)
+      "10.2139/ssrn.4298538",         # 13 mom_postpeak
+      "10.2139/ssrn.4298538",         # 14 mom_combined (baseline)
+      "10.1111/j.1540-6261.1993.tb04741.x", # 15 ev_ebit (Fama & French 1993 three-factor model)
+      "10.1111/jofi.12131",                  # 16 mf_tsm (Moskowitz, Ooi & Pedersen 2012)
+      NA_character_                   # 17 olmar (Li & Hoi 2012, ICML -- arXiv:1206.4626, no verified formal DOI at this commit)
+    )
   )
 }

--- a/tests/testthat/_snaps/strategy-names.md
+++ b/tests/testthat/_snaps/strategy-names.md
@@ -1,0 +1,34 @@
+# full strategy_names tuple table is stable (parallel-vector alignment snapshot)
+
+    Code
+      print(tuple_tbl, width = 200)
+    Output
+            code_name      short_name                                                long_name frequency ann_factor
+      1   avoid_worst     Avoid Worst                        Avoid Worst Days (VIX Protection)     daily        252
+      2          drif     Factor DRIF                            Factor DRIF (Factor Rotation)   monthly         12
+      3       fac_max      Factor MAX                             Factor MAX (Factor Momentum)   monthly         12
+      4           rsc      Risk State                                 Risk State (VIX Overlay)     daily        252
+      5           ltr             LTR                           LTR (Cross-Sectional Momentum)   monthly         12
+      6           tom             TOM                          Turn-of-the-Month (TOM Overlay)     daily        252
+      7       stk_max       Stock MAX                         Stock MAX (Daily Return Sorting)   monthly         12
+      8      stk_drif      Stock DRIF                 Stock DRIF (Elastic Net Stock Selection)   monthly         12
+      9      xgb_drif        XGB DRIF                       XGB DRIF (XGBoost Stock Selection)   monthly         12
+      10  pso_optimal     PSO Optimal                     PSO Optimal (Portfolio Optimisation)   monthly         12
+      11          cmr             CMR                               Commodities Mean Reversion     daily        252
+      12  mom_prepeak    Mom Pre-Peak                     Pre-Peak 12-2 Momentum (Büsing 2022)   monthly         12
+      13 mom_postpeak   Mom Post-Peak                    Post-Peak 12-2 Momentum (Büsing 2022)   monthly         12
+      14 mom_combined        Mom 12-2                 Standard 12-2 Momentum (Büsing baseline)   monthly         12
+      15      ev_ebit     Value (HML)                 EV/EBIT Value Sleeve (HML+RMW Proxy, v0)   monthly         12
+      16       mf_tsm Managed Futures      Cross-Asset TS-Momentum (MOP 2012, ETF Proxies, v0)   monthly         12
+      17        olmar         OLMAR-1 OLMAR-1 (Online Moving Average Reversion, Li & Hoi 2012)     daily        252
+
+# .build_strategy_obs_ann_factor() aborts loudly when a strategy has no source citation
+
+    Code
+      .build_strategy_obs_ann_factor(strategy_names_tbl, incomplete_source)
+    Condition
+      Error in `.build_strategy_obs_ann_factor()`:
+      x 1 strategy/strategies in strategy_names have no obs_ann_factor_source citation:
+      i  OLMAR-1
+      i Add a row to .strategy_obs_ann_factor_source (R/plan_leaderboard.R) keyed by code_name, citing the strategy's calc_metrics()/compute_*() annualisation source.
+

--- a/tests/testthat/test-leaderboard-detection-power-coverage.R
+++ b/tests/testthat/test-leaderboard-detection-power-coverage.R
@@ -12,6 +12,10 @@ testthat::local_edition(3)
 # target silently produces NA for a new strategy forever. This gate catches
 # that gap at pipeline time instead.
 
+# plan_strategy_names.R must be sourced first -- STRATEGY_OBS_ANN_FACTOR is
+# now DERIVED from its hd_strategy_names_tbl() constructor (#629), not a
+# second hand-maintained copy.
+source(here::here("R/plan_strategy_names.R"))
 source(here::here("R/plan_leaderboard.R"))
 source(here::here("R/plan_qa_gates.R"))
 

--- a/tests/testthat/test-strategy-names.R
+++ b/tests/testthat/test-strategy-names.R
@@ -1,0 +1,96 @@
+testthat::local_edition(3)
+# Tests for hd_strategy_names_tbl() (R/plan_strategy_names.R) -- the plain,
+# non-target constructor behind the `strategy_names` tar_target -- and for
+# .build_strategy_obs_ann_factor() (R/plan_leaderboard.R), which derives
+# STRATEGY_OBS_ANN_FACTOR from it instead of hand-duplicating the same data
+# (#629: OLMAR-1 was ranked on the leaderboard but absent from
+# strategy_names -- a single-source-of-truth violation between the two
+# hand-maintained lists).
+
+source(here::here("R/plan_strategy_names.R"))
+source(here::here("R/plan_leaderboard.R"))
+
+# ── Parallel-vector integrity ────────────────────────────────────────────
+# strategy_names.R is a set of hand-aligned parallel vectors with inline
+# comments between elements -- a misaligned edit silently corrupts a
+# DIFFERENT strategy's declaration with no obvious symptom (see the
+# strategy-name-consistency rule + prior #629 dispatch notes). These tests
+# evaluate the actual constructed tibble rather than eyeballing the diff.
+
+strategy_names_tbl <- hd_strategy_names_tbl()
+
+test_that("hd_strategy_names_tbl() has 17 strategies with all vectors equal length", {
+  expect_equal(nrow(strategy_names_tbl), 17L)
+  # Every column must be length 17 -- tibble::tibble() would already error
+  # on unequal lengths at construction time, but assert explicitly so a
+  # future refactor that swaps tibble::tibble() for something more lenient
+  # (e.g. data.frame(stringsAsFactors=...)) cannot silently recycle a
+  # shorter vector.
+  lengths <- vapply(strategy_names_tbl, length, integer(1))
+  expect_true(all(lengths == 17L))
+})
+
+test_that("hd_strategy_names_tbl() has no duplicate code_name or short_name", {
+  expect_equal(nrow(strategy_names_tbl), dplyr::n_distinct(strategy_names_tbl$code_name))
+  expect_equal(nrow(strategy_names_tbl), dplyr::n_distinct(strategy_names_tbl$short_name))
+})
+
+test_that("olmar row (#629) is present with the expected declared values", {
+  olmar_row <- dplyr::filter(strategy_names_tbl, code_name == "olmar")
+  expect_equal(nrow(olmar_row), 1L)
+  expect_equal(olmar_row$short_name, "OLMAR-1")
+  expect_equal(olmar_row$frequency, "daily")
+  expect_equal(olmar_row$ann_factor, 252L)
+  expect_equal(olmar_row$asset_class, "equity")
+  expect_equal(as.character(olmar_row$directionality), "long_only")
+})
+
+# OBSERVED (not predicted): full parallel-vector table for the PR record,
+# every position's (code, short, long, frequency, ann_factor) tuple.
+test_that("full strategy_names tuple table is stable (parallel-vector alignment snapshot)", {
+  tuple_tbl <- strategy_names_tbl |>
+    dplyr::select(code_name, short_name, long_name, frequency, ann_factor) |>
+    as.data.frame()
+  expect_snapshot(print(tuple_tbl, width = 200))
+})
+
+# ── STRATEGY_OBS_ANN_FACTOR derivation (#629) ────────────────────────────
+
+test_that("STRATEGY_OBS_ANN_FACTOR covers exactly the same strategies as strategy_names", {
+  expect_setequal(STRATEGY_OBS_ANN_FACTOR$strategy, strategy_names_tbl$short_name)
+  expect_equal(nrow(STRATEGY_OBS_ANN_FACTOR), nrow(strategy_names_tbl))
+})
+
+test_that("STRATEGY_OBS_ANN_FACTOR$obs_ann_factor agrees with strategy_names$ann_factor for every strategy", {
+  merged <- dplyr::inner_join(
+    STRATEGY_OBS_ANN_FACTOR,
+    dplyr::select(strategy_names_tbl, short_name, ann_factor),
+    by = c("strategy" = "short_name")
+  )
+  expect_equal(nrow(merged), nrow(STRATEGY_OBS_ANN_FACTOR))
+  expect_equal(merged$obs_ann_factor, merged$ann_factor)
+})
+
+test_that("STRATEGY_OBS_ANN_FACTOR includes OLMAR-1 at ann_factor 252 (#629 regression)", {
+  olmar_obs <- dplyr::filter(STRATEGY_OBS_ANN_FACTOR, strategy == "OLMAR-1")
+  expect_equal(nrow(olmar_obs), 1L)
+  expect_equal(olmar_obs$obs_ann_factor, 252)
+})
+
+test_that(".build_strategy_obs_ann_factor() aborts loudly when a strategy has no source citation", {
+  incomplete_source <- dplyr::filter(.strategy_obs_ann_factor_source, code_name != "olmar")
+  expect_error(
+    .build_strategy_obs_ann_factor(strategy_names_tbl, incomplete_source),
+    regexp = "OLMAR-1"
+  )
+  expect_snapshot(
+    error = TRUE,
+    .build_strategy_obs_ann_factor(strategy_names_tbl, incomplete_source)
+  )
+})
+
+test_that(".build_strategy_obs_ann_factor() succeeds and drops code_name from the output", {
+  built <- .build_strategy_obs_ann_factor(strategy_names_tbl, .strategy_obs_ann_factor_source)
+  expect_setequal(names(built), c("strategy", "obs_ann_factor", "obs_ann_factor_source"))
+  expect_equal(nrow(built), nrow(strategy_names_tbl))
+})


### PR DESCRIPTION
## Problem

`R/plan_strategy_names.R`'s `strategy_names` target — the declared single source of truth for strategy naming — had 16 entries and no `olmar` row. `R/plan_leaderboard.R`'s `STRATEGY_OBS_ANN_FACTOR` (a second, hand-maintained list used for the detection-power diagnostic) had 17 entries including `"OLMAR-1"`, the leaderboard's highest-Sharpe strategy (0.780). Any join keyed on `strategy_names$code_name` silently dropped OLMAR.

## Fix

1. **Added the missing `olmar` row** to `strategy_names` (appended at position 17, not inserted mid-vector, to avoid corrupting the alignment of any existing row). Values sourced from `R/plan_olmar.R`: `frequency = "daily"`, `ann_factor = 252L` (verified against `STRATEGY_OBS_ANN_FACTOR`'s pre-existing OLMAR-1 citation), `time_horizon_days_avg = 25L` (the SMA window), `liquidity_tier = "high"` (large-cap + broad-ETF basket), `directionality = "long_only"` (tilt around equal weight, no shorting evidence in the code).

2. **Derived `STRATEGY_OBS_ANN_FACTOR` from `strategy_names`** rather than continuing to hand-maintain it — this is the actual fix for the drift, not just a one-off patch. `R/plan_strategy_names.R` now exposes `hd_strategy_names_tbl()`, a plain (non-target) constructor callable at `source()` time without `tar_make()`/`tar_read()`. `R/plan_leaderboard.R`'s `.build_strategy_obs_ann_factor()` joins `hd_strategy_names_tbl()`'s `short_name`/`ann_factor` against a hand-maintained `obs_ann_factor_source` provenance table (keyed by `code_name`, since citation text isn't part of `strategy_names`' schema), and `cli::cli_abort()`s if a strategy/citation pair ever goes out of sync again. The two tables can no longer silently drift — no separate QA gate needed since agreement is now enforced structurally at construction time.

3. **New test file** `tests/testthat/test-strategy-names.R`: parallel-vector length/alignment checks (observed by evaluating the tibble, not eyeballed from the diff — see the printed table below), OLMAR row value assertions, set-equality + value-equality between `STRATEGY_OBS_ANN_FACTOR` and `strategy_names`, and `expect_snapshot(error = TRUE, ...)` coverage for the new `cli_abort` path per `snapshot-test-policy`.

## Parallel-vector integrity — OBSERVED

```
   code_name      short_name                                                long_name frequency ann_factor
1   avoid_worst     Avoid Worst                        Avoid Worst Days (VIX Protection)     daily        252
2          drif     Factor DRIF                            Factor DRIF (Factor Rotation)   monthly         12
3       fac_max      Factor MAX                             Factor MAX (Factor Momentum)   monthly         12
4           rsc      Risk State                                 Risk State (VIX Overlay)     daily        252
5           ltr             LTR                           LTR (Cross-Sectional Momentum)   monthly         12
6           tom             TOM                          Turn-of-the-Month (TOM Overlay)     daily        252
7       stk_max       Stock MAX                         Stock MAX (Daily Return Sorting)   monthly         12
8      stk_drif      Stock DRIF                 Stock DRIF (Elastic Net Stock Selection)   monthly         12
9      xgb_drif        XGB DRIF                       XGB DRIF (XGBoost Stock Selection)   monthly         12
10  pso_optimal     PSO Optimal                     PSO Optimal (Portfolio Optimisation)   monthly         12
11          cmr             CMR                               Commodities Mean Reversion     daily        252
12  mom_prepeak    Mom Pre-Peak                     Pre-Peak 12-2 Momentum (Büsing 2022)   monthly         12
13 mom_postpeak   Mom Post-Peak                    Post-Peak 12-2 Momentum (Büsing 2022)   monthly         12
14 mom_combined        Mom 12-2                 Standard 12-2 Momentum (Büsing baseline)   monthly         12
15      ev_ebit     Value (HML)                 EV/EBIT Value Sleeve (HML+RMW Proxy, v0)   monthly         12
16       mf_tsm Managed Futures      Cross-Asset TS-Momentum (MOP 2012, ETF Proxies, v0)   monthly         12
17        olmar         OLMAR-1 OLMAR-1 (Online Moving Average Reversion, Li & Hoi 2012)     daily        252
```

All 17 vectors evaluated at length 17; no duplicate `code_name`/`short_name`; `STRATEGY_OBS_ANN_FACTOR$obs_ann_factor` agrees with `strategy_names$ann_factor` for all 17 strategies including the new OLMAR-1 row (252).

## Not attempted

`research_paper_doi` for `olmar` is `NA_character_` (Li & Hoi 2012, ICML — arXiv:1206.4626 preprint, no verified formal DOI found in the codebase or elsewhere at this commit) — consistent with the existing convention for `tom`/`xgb_drif`/`pso_optimal`/etc., which use `NA_character_` rather than a guessed citation.

## Verification

`scripts/verify.sh` full run, foreground:
- Root suite: 732 tests, 3 failures — **matches the known baseline exactly** (`test-crypto-momentum.R::C1`, `test-qa-summary-deps.R`, `test-stock-backtest.R` — all pre-existing, documented in `.claude/CLAUDE.md`).
- Package suite: 713 tests, 1 failure, 15 skips — **matches the known baseline exactly**.
- All 9 new tests in `test-strategy-names.R` pass (21 assertions).
- All 7 existing tests in `test-leaderboard-detection-power-coverage.R` still pass after adding the required `plan_strategy_names.R` `source()` call (new source-order dependency, since `STRATEGY_OBS_ANN_FACTOR` construction now calls `hd_strategy_names_tbl()`).

Per dispatch instructions, `tar_make()` was **not** run — the main checkout owns the live `_targets` store and `scripts/build.sh` holds a lock. All numbers above are observed from `scripts/verify.sh` and direct `Rscript` evaluation of the tibble, not predicted.

Refs #629
