### PR TITLE
fix(cmr): periodicity consistency check + measured materiality of CMR's mixed-frequency series (#738)

### DIFF
--- a/R/plan_commodities_mean_reversion.R
+++ b/R/plan_commodities_mean_reversion.R
@@ -32,6 +32,13 @@
 #   own date column still mixes daily and monthly-stamped observations, so
 #   ann_factor = 252 over-annualises the vol/cagr contribution of every
 #   FRED-only month-start row. #724 fixes the crash; it does not fix that.
+# Mixed frequency (#738): MEASURED, not fixed. cmr_portfolio_1m/3m/6m run at
+#   12 obs/year before 2000-01 (13 FRED monthly indexes only -- Yahoo history
+#   starts 2000) and ~255/year after; ~1.4% of observations are monthly-spaced
+#   and the whole series is declared daily. .assert_cmr_ann_factor()'s
+#   consistency check (#738) now DETECTS this; choosing the remedy (truncate
+#   to 2000+, resample to monthly, or segment and report separately) is an
+#   open decision on #738 and is deliberately NOT made here.
 
 plan_commodities_mean_reversion <- function() {
   list(
@@ -341,35 +348,132 @@ plan_commodities_mean_reversion <- function() {
   )
 }
 
+#' Per-periodicity gap tolerances for the CMR periodicity guard (#738)
+#'
+#' One row per recognised annualisation factor. \code{min_gap}/\code{max_gap}
+#' bound a SINGLE inter-observation gap that is still consistent with that
+#' declared periodicity. They are calendar-day bounds, and each is argued
+#' from a calendar fact rather than picked to make the current data pass:
+#'
+#' \describe{
+#'   \item{252 (daily), 1-10 days}{Nominal spacing is 365.25/252 = 1.45
+#'     calendar days. The upper bound must absorb the worst real gap a
+#'     genuine business-daily series produces. The longest US market closure
+#'     since 1990 is 9/11 (last print 2001-09-10, next 2001-09-17 -- a
+#'     7-calendar-day gap); Christmas/New-Year holidays adjacent to a weekend
+#'     reach 4-5; Hurricane Sandy (2012) gave 4. 10 clears the worst observed
+#'     with headroom and still sits a full 3 weeks below a monthly spacing
+#'     (28-31 days), so a monthly observation can never be mistaken for a
+#'     long holiday. Lower bound 1: a date-keyed series cannot be denser
+#'     than one observation per calendar day.}
+#'   \item{52 (weekly), 4-24 days}{Nominal 7.02. Upper bound tolerates two
+#'     consecutive missing weeks plus slack; lower bound rejects
+#'     sub-half-week spacing, which indicates daily data mislabelled weekly.}
+#'   \item{12 (monthly), 20-75 days}{Nominal 30.44. Lower bound 20 clears a
+#'     28-day February with margin while rejecting weekly-or-denser prints;
+#'     upper bound 75 tolerates one entirely missing month (2 x 31 = 62)
+#'     plus slack, while staying below a quarterly spacing.}
+#'   \item{4 (quarterly), 60-200 days}{Nominal 91.31. Same construction: one
+#'     missing quarter tolerated, monthly spacing rejected.}
+#' }
+#'
+#' @noRd
+CMR_PERIODICITY_TOLERANCE <- tibble::tibble(
+  ann_factor = c(252L, 52L, 12L, 4L),
+  label      = c("daily", "weekly", "monthly", "quarterly"),
+  min_gap    = c(1, 4, 20, 60),
+  max_gap    = c(10, 24, 75, 200)
+)
+
+#' Fraction of gaps allowed to fall outside the declared periodicity's band
+#'
+#' The smallest frequency REGIME CHANGE worth catching is a single year of a
+#' different periodicity embedded in a longer series -- 12 monthly
+#' observations inside a ~27-year daily series (~6800 gaps) is 0.18% of
+#' gaps. 0.1% therefore catches a one-year regime change with roughly 2x
+#' margin, while anything below it is an isolated vendor outage rather than
+#' a change of periodicity. Deliberately NOT zero: a single missing print in
+#' a decades-long series is a data hiccup, not a mis-declared frequency, and
+#' a guard that aborts the whole pipeline on one bad row would be turned off
+#' rather than fixed.
+#'
+#' @noRd
+CMR_PERIODICITY_MAX_OUT_OF_BAND_FRAC <- 0.001
+
+#' Minimum absolute number of out-of-band gaps tolerated, regardless of n
+#'
+#' On a short series the fraction above rounds down to zero, so one isolated
+#' outage would abort. This floor keeps the tolerance at "at least two
+#' isolated gaps" for any series length, so the guard fires on a PATTERN and
+#' never on a single print.
+#'
+#' @noRd
+CMR_PERIODICITY_MIN_OUT_OF_BAND_ALLOWANCE <- 2L
+
 #' Reconcile a declared `ann_factor` against the observed date frequency
 #'
-#' Guard from #717 (fail-loud-not-null.md Required Pattern 5): computes the
-#' median gap between the distinct, sorted dates in \code{dates} and aborts
-#' if that gap is inconsistent with \code{ann_factor}. This is deliberately
-#' placed at the point where \code{ann_factor} is SUPPLIED to
-#' \code{.compute_cmr_metrics()} -- not buried in the CAGR/vol arithmetic
-#' further down -- so a future caller that passes the wrong constant fails
-#' immediately, on the value it got wrong, rather than producing a
-#' plausible-looking but silently mis-annualised number (exactly what
-#' happened with \code{ann_factor = 12L} against CMR's actually-daily data).
+#' Guard from #717 (fail-loud-not-null.md Required Pattern 5), rewritten for
+#' #738. Deliberately placed at the point where \code{ann_factor} is
+#' SUPPLIED to \code{.compute_cmr_metrics()} -- not buried in the CAGR/vol
+#' arithmetic further down -- so a future caller that passes the wrong
+#' constant fails immediately, on the value it got wrong, rather than
+#' producing a plausible-looking but silently mis-annualised number (exactly
+#' what happened with \code{ann_factor = 12L} against CMR's actually-daily
+#' data).
 #'
-#' Uses the MEDIAN gap, not the mean or min: commodity data has real gaps
-#' (weekends, holidays, and -- because CMR's universe mixes 24 Yahoo daily
-#' futures/ETF series with 13 FRED monthly indexes, #717 -- occasional
-#' months where only the sparser monthly series print). The median is
-#' robust to that without a hand-tuned outlier filter. Bands are
-#' deliberately wide (e.g. daily tolerates gaps up to 3 days) to absorb long
-#' weekends/holiday clusters without false-positiving on a genuine daily
-#' series; they are not so wide that a real classification error (e.g.
-#' monthly data declared daily) would slip through undetected.
+#' Two checks, in order:
+#'
+#' \enumerate{
+#'   \item \strong{Classification} (unchanged from #720). The MEDIAN gap
+#'     between distinct sorted dates is mapped to an expected
+#'     \code{ann_factor} and compared against the declared one. The median is
+#'     the right statistic for this question -- "what is the typical
+#'     spacing" -- because it is robust to the weekend/holiday gaps every
+#'     real business-daily series carries.
+#'   \item \strong{Consistency} (new, #738). Counts the gaps falling OUTSIDE
+#'     \code{CMR_PERIODICITY_TOLERANCE}'s band for the declared periodicity,
+#'     and aborts when that count exceeds
+#'     \code{max(CMR_PERIODICITY_MIN_OUT_OF_BAND_ALLOWANCE,
+#'     ceiling(CMR_PERIODICITY_MAX_OUT_OF_BAND_FRAC * n_gaps))}.
+#' }
+#'
+#' Check 2 exists because check 1 alone cannot see a series that CHANGES
+#' frequency partway through. #738 measured \code{cmr_portfolio_1m} as 12
+#' observations/year before 2000 and ~255/year after: 94 of 6851 gaps are
+#' monthly, 6757 are daily, and the series is declared daily throughout.
+#' The overall median gap is 1 day, so 94 monthly gaps out of 6851 cannot
+#' move it and check 1 passes -- correctly by its own logic, on a series
+#' where 1.4% of observations sit at a twenty-one-fold different frequency.
+#' A median is precisely the statistic chosen to be insensitive to the
+#' minority that reveals the answer is "no". The property we want is "is the
+#' spacing CONSISTENT with one declared periodicity", which is a question
+#' about dispersion, and no measure of central tendency can answer it.
+#'
+#' The tolerance is a count of out-of-band gaps rather than a requirement
+#' that all gaps be identical, because holidays and short weeks mean a naive
+#' equality test false-positives on every genuine daily series. See
+#' \code{CMR_PERIODICITY_TOLERANCE} and
+#' \code{CMR_PERIODICITY_MAX_OUT_OF_BAND_FRAC} for how each bound is argued.
 #'
 #' @param dates A date vector (one entry per observation; duplicates and
 #'   unsorted input are handled).
 #' @param ann_factor Integer. The annualisation factor about to be used.
 #' @param lookback Character. Lookback label, used only for the abort message.
+#' @param on_violation One of `"abort"` (default) or `"warn"`. Governs the
+#'   CONSISTENCY check only -- the classification check always aborts.
+#'   `"warn"` exists solely as a staging lever: the consistency check fires
+#'   on CMR's production data as it stands today (that is the point -- see
+#'   #738), so landing it in abort mode turns the build red until CMR's
+#'   remedy is chosen. Setting the three `cmr_metrics_*` call sites to
+#'   `"warn"` for one release lets the finding be published without blocking
+#'   the pipeline. It is NOT a way to keep a mixed-frequency series in
+#'   production indefinitely.
 #' @return `NULL`, invisibly. Called for its abort side effect.
 #' @noRd
-.assert_cmr_ann_factor <- function(dates, ann_factor, lookback) {
+.assert_cmr_ann_factor <- function(dates, ann_factor, lookback,
+                                   on_violation = c("abort", "warn")) {
+  on_violation <- match.arg(on_violation)
+
   d <- sort(unique(as.Date(dates)))
   if (length(d) < 3L) {
     # Too few points for a frequency to be meaningfully observed.
@@ -378,6 +482,7 @@ plan_commodities_mean_reversion <- function() {
   gaps <- as.numeric(diff(d))
   median_gap <- stats::median(gaps)
 
+  # ── Check 1: classification (median gap -> expected ann_factor) ──────────
   expected_ann_factor <- dplyr::case_when(
     median_gap <= 3   ~ 252L,  # daily (business days; weekends widen some gaps)
     median_gap <= 10  ~ 52L,   # weekly
@@ -414,11 +519,83 @@ plan_commodities_mean_reversion <- function() {
     ))
   }
 
+  # ── Check 2: consistency (dispersion of gaps, not their centre) ──────────
+  tol <- CMR_PERIODICITY_TOLERANCE[
+    CMR_PERIODICITY_TOLERANCE$ann_factor == ann_factor, , drop = FALSE
+  ]
+  if (nrow(tol) != 1L) {
+    cli::cli_abort(c(
+      "x" = "CMR {lookback}: no periodicity tolerance defined for declared ann_factor {ann_factor}.",
+      "i" = "Known factors: {.val {CMR_PERIODICITY_TOLERANCE$ann_factor}}.",
+      "i" = "Add a row to CMR_PERIODICITY_TOLERANCE rather than skipping the consistency check."
+    ))
+  }
+
+  n_gaps    <- length(gaps)
+  too_short <- gaps < tol$min_gap
+  too_long  <- gaps > tol$max_gap
+  n_out     <- sum(too_short) + sum(too_long)
+  allowance <- max(
+    CMR_PERIODICITY_MIN_OUT_OF_BAND_ALLOWANCE,
+    ceiling(CMR_PERIODICITY_MAX_OUT_OF_BAND_FRAC * n_gaps)
+  )
+
+  if (n_out > allowance) {
+    # Name the observed bands and their counts, per fail-loud-not-null.md:
+    # the reader must be able to see WHICH minority frequency is present
+    # without re-deriving it.
+    obs_band <- vapply(
+      gaps,
+      function(g) {
+        hit <- which(g >= CMR_PERIODICITY_TOLERANCE$min_gap &
+                       g <= CMR_PERIODICITY_TOLERANCE$max_gap)
+        if (length(hit) == 0L) "unclassified" else CMR_PERIODICITY_TOLERANCE$label[hit[1]]
+      },
+      character(1)
+    )
+    band_counts <- sort(table(obs_band), decreasing = TRUE)
+    band_txt <- paste0(names(band_counts), ": ", as.integer(band_counts), collapse = "; ")
+
+    out_gaps  <- gaps[too_short | too_long]
+    where_out <- d[-1L][too_short | too_long]
+
+    msg <- c(
+      "x" = paste0(
+        "CMR {lookback}: the observation spacing is NOT consistent with a ",
+        "single declared periodicity (ann_factor {ann_factor}, {tol$label})."
+      ),
+      "i" = paste0(
+        "{n_out} of {n_gaps} gaps ({round(100 * n_out / n_gaps, 3)}%) fall outside the ",
+        "{tol$label} band [{tol$min_gap}, {tol$max_gap}] calendar days; ",
+        "allowance is {allowance}."
+      ),
+      "i" = "Observed gap bands: {band_txt}.",
+      "i" = paste0(
+        "Out-of-band gaps range {min(out_gaps)}-{max(out_gaps)} calendar days, ",
+        "spanning {format(min(where_out))}..{format(max(where_out))}."
+      ),
+      "i" = paste0(
+        "The median gap ({median_gap} calendar days) agrees with the declared ",
+        "factor, which is why the #720 median-gap check passes -- a median cannot ",
+        "see a minority at a different frequency. See #738."
+      ),
+      "i" = "See .claude/rules/fail-loud-not-null.md Required Pattern 5."
+    )
+
+    if (identical(on_violation, "warn")) {
+      cli::cli_warn(msg)
+    } else {
+      cli::cli_abort(msg)
+    }
+  }
+
   invisible(NULL)
 }
 
-.compute_cmr_metrics <- function(portfolio_tbl, lookback, daily_rf, ann_factor = 252L) {
+.compute_cmr_metrics <- function(portfolio_tbl, lookback, daily_rf, ann_factor = 252L,
+                                 periodicity_check = c("abort", "warn")) {
   library(dplyr)
+  periodicity_check <- match.arg(periodicity_check)
 
   df <- portfolio_tbl |>
     dplyr::filter(!is.na(.data$net_ret)) |>
@@ -426,7 +603,12 @@ plan_commodities_mean_reversion <- function() {
 
   # #717 guard: declared ann_factor must match the observed frequency of
   # this portfolio's own dates, checked at the point ann_factor is supplied.
-  .assert_cmr_ann_factor(df$date, ann_factor, lookback)
+  # #738 extends it from "is the TYPICAL spacing right" to "is the spacing
+  # CONSISTENT" -- see .assert_cmr_ann_factor()'s roxygen. `periodicity_check`
+  # is the staging lever documented there; production call sites use the
+  # abort default.
+  .assert_cmr_ann_factor(df$date, ann_factor, lookback,
+                         on_violation = periodicity_check)
 
   n <- nrow(df)
 

--- a/tests/testthat/_snaps/cmr-periodicity-consistency.md
+++ b/tests/testthat/_snaps/cmr-periodicity-consistency.md
@@ -1,0 +1,47 @@
+# the CMR defect shape -- monthly era then daily era, declared daily -- aborts
+
+    Code
+      .assert_cmr_ann_factor(d, 252L, "1m")
+    Condition
+      Error in `.assert_cmr_ann_factor()`:
+      x CMR 1m: the observation spacing is NOT consistent with a single declared periodicity (ann_factor 252, daily).
+      i 94 of 2093 gaps (4.491%) fall outside the daily band [1, 10] calendar days; allowance is 3.
+      i Observed gap bands: daily: 1999; monthly: 94.
+      i Out-of-band gaps range 28-33 calendar days, spanning 1992-04-01..2000-01-03.
+      i The median gap (1 calendar days) agrees with the declared factor, which is why the #720 median-gap check passes -- a median cannot see a minority at a different frequency. See #738.
+      i See .claude/rules/fail-loud-not-null.md Required Pattern 5.
+
+# daily prints interleaved into a monthly series abort (too-short direction)
+
+    Code
+      .assert_cmr_ann_factor(d, 12L, "monthly-contaminated")
+    Condition
+      Error in `.assert_cmr_ann_factor()`:
+      x CMR monthly-contaminated: the observation spacing is NOT consistent with a single declared periodicity (ann_factor 12, monthly).
+      i 39 of 277 gaps (14.079%) fall outside the monthly band [20, 75] calendar days; allowance is 2.
+      i Observed gap bands: monthly: 237; daily: 39; weekly: 1.
+      i Out-of-band gaps range 1-1 calendar days, spanning 1995-06-02..1995-07-10.
+      i The median gap (30 calendar days) agrees with the declared factor, which is why the #720 median-gap check passes -- a median cannot see a minority at a different frequency. See #738.
+      i See .claude/rules/fail-loud-not-null.md Required Pattern 5.
+
+# a declared ann_factor with no tolerance row aborts rather than skipping the check
+
+    Code
+      .assert_cmr_ann_factor(biz_days("2010-01-04", 500L), 252L, "no-tolerance-row")
+    Condition
+      Error in `.assert_cmr_ann_factor()`:
+      x CMR no-tolerance-row: no periodicity tolerance defined for declared ann_factor 252.
+      i Known factors: 52, 12, and 4.
+      i Add a row to CMR_PERIODICITY_TOLERANCE rather than skipping the consistency check.
+
+# the #720 median-gap classification check still fires (regression)
+
+    Code
+      .assert_cmr_ann_factor(month_days("1990-01-01", 100L), 252L,
+      "monthly-declared-daily")
+    Condition
+      Error in `.assert_cmr_ann_factor()`:
+      x CMR monthly-declared-daily: declared ann_factor (252) disagrees with the observed data frequency.
+      i Median gap between observation dates is 31 days, consistent with ann_factor = 12, not 252.
+      i This is the reconciliation guard added for #717 -- see .claude/rules/fail-loud-not-null.md Required Pattern 5.
+

--- a/tests/testthat/test-cmr-periodicity-consistency.R
+++ b/tests/testthat/test-cmr-periodicity-consistency.R
@@ -1,0 +1,194 @@
+# Tests for the #738 periodicity CONSISTENCY check in
+# .assert_cmr_ann_factor() (R/plan_commodities_mean_reversion.R).
+#
+# #720 added a median-gap reconciliation of a declared `ann_factor` against
+# the observed date frequency. #738 measured that `cmr_portfolio_1m` runs at
+# 12 obs/year before 2000 and ~255/year after, declared daily throughout:
+# 94 of 6851 gaps are monthly, and the overall median gap is 1 day, so the
+# median-gap check passes -- correctly by its own logic -- on a series where
+# 1.4% of observations sit at a twenty-one-fold different frequency.
+#
+# The check added here answers the DISPERSION question ("is the spacing
+# consistent with ONE declared periodicity") that no measure of central
+# tendency can answer. These tests pin both directions: it must fire on a
+# mixed-frequency series, and it must NOT fire on a genuine business-daily
+# series whose gaps widen over weekends, holidays, and market closures.
+testthat::local_edition(3)
+
+pkg_path <- if (dir.exists(here::here("packages/historicaldata"))) {
+  here::here("packages/historicaldata")
+} else {
+  file.path(dirname(here::here()), "packages/historicaldata")
+}
+suppressMessages(pkgload::load_all(pkg_path, quiet = TRUE))
+
+source(here::here("R/utils_metrics.R"))
+source(here::here("R/plan_commodities_mean_reversion.R"))
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+# A genuine business-daily series: weekdays only, so most gaps are 1 day and
+# every weekend produces a 3-day gap. This is the shape that a naive
+# "all gaps identical" consistency test would false-positive on.
+biz_days <- function(from, n) {
+  all_days <- seq.Date(as.Date(from), by = "day", length.out = ceiling(n * 7 / 5) + 14L)
+  wd <- all_days[!format(all_days, "%u") %in% c("6", "7")]
+  wd[seq_len(n)]
+}
+
+# Monthly-spaced dates.
+month_days <- function(from, n) seq.Date(as.Date(from), by = "month", length.out = n)
+
+# ── The check must NOT fire on genuine daily data ───────────────────────────
+
+test_that("a clean business-daily series passes the consistency check at 252", {
+  expect_silent(.assert_cmr_ann_factor(biz_days("2010-01-04", 2000L), 252L, "biz-daily"))
+})
+
+test_that("weekend + holiday-cluster gaps do not trip the daily band", {
+  # Deliberately includes gaps at the extremes a real daily series produces:
+  # a 4-day Thanksgiving-style break, a 5-day Christmas/New-Year cluster, and
+  # a 7-day gap the size of the 9/11 market closure (2001-09-10 -> 2001-09-17,
+  # the longest US closure since 1990). All are <= the daily band's 10-day
+  # upper bound, so none is counted out-of-band.
+  d <- biz_days("2001-01-02", 500L)
+  d <- sort(unique(c(
+    d[d < as.Date("2001-09-10") | d > as.Date("2001-09-17")],
+    as.Date(c("2001-09-10", "2001-09-17"))
+  )))
+  gaps <- as.numeric(diff(d))
+  expect_equal(max(gaps), 7)           # the 9/11-sized closure is present
+  expect_true(sum(gaps == 3) > 50)     # and plenty of ordinary weekends
+  expect_silent(.assert_cmr_ann_factor(d, 252L, "holiday-daily"))
+})
+
+test_that("a clean monthly series passes the consistency check at 12", {
+  expect_silent(.assert_cmr_ann_factor(month_days("1990-01-01", 300L), 12L, "monthly"))
+})
+
+test_that("isolated outages within the allowance floor do not fire", {
+  # Two isolated month-long outages in a 400-point daily series. n_gaps = 399,
+  # so ceiling(0.001 * 399) = 1, and the absolute floor of 2 governs. The
+  # guard fires on a PATTERN, never on one or two bad prints.
+  d <- biz_days("2010-01-04", 400L)
+  d <- d[-seq(100L, 121L)]
+  d <- d[-seq(250L, 271L)]
+  gaps <- as.numeric(diff(d))
+  expect_equal(sum(gaps > 10), 2L)
+  expect_silent(.assert_cmr_ann_factor(d, 252L, "two-outages"))
+})
+
+# ── The check MUST fire on mixed-frequency data ─────────────────────────────
+
+test_that("three isolated outages exceed the allowance floor and fire", {
+  d <- biz_days("2010-01-04", 400L)
+  d <- d[-seq(100L, 121L)]
+  d <- d[-seq(200L, 221L)]
+  d <- d[-seq(280L, 301L)]
+  expect_equal(sum(as.numeric(diff(d)) > 10), 3L)
+  expect_error(
+    .assert_cmr_ann_factor(d, 252L, "three-outages"),
+    "NOT consistent with a single declared periodicity"
+  )
+})
+
+test_that("the CMR defect shape -- monthly era then daily era, declared daily -- aborts", {
+  # Reproduces #738's measured proportions in miniature: a monthly-spaced
+  # first era followed by a business-daily second era, declared 252
+  # throughout. The median gap is 1 day, so the #720 median-gap check passes;
+  # only the consistency check can see it.
+  d <- sort(unique(c(month_days("1992-03-01", 94L), biz_days("2000-01-03", 2000L))))
+  gaps <- as.numeric(diff(d))
+  expect_equal(stats::median(gaps), 1)          # median-gap check would pass
+  expect_true(sum(gaps > 10) >= 90L)            # ... on ~90 monthly gaps
+  expect_snapshot(error = TRUE, .assert_cmr_ann_factor(d, 252L, "1m"))
+})
+
+test_that("daily prints interleaved into a monthly series abort (too-short direction)", {
+  # The mirror image: a monthly-declared series contaminated with daily
+  # observations. Consistency is two-sided -- a gap that is too SHORT for the
+  # declared periodicity is the same defect as one that is too long.
+  d <- sort(unique(c(
+    month_days("1990-01-01", 240L),
+    seq.Date(as.Date("1995-06-01"), by = "day", length.out = 40L)
+  )))
+  expect_snapshot(error = TRUE, .assert_cmr_ann_factor(d, 12L, "monthly-contaminated"))
+})
+
+# ── Structure of the guard ──────────────────────────────────────────────────
+
+test_that("a declared ann_factor with no tolerance row aborts rather than skipping the check", {
+  # fail-loud-not-null.md: an unrecognised value is an error, not a silent
+  # pass. This branch guards the two tables -- the median-gap classifier's
+  # bands and CMR_PERIODICITY_TOLERANCE -- drifting apart, so exercising it
+  # means removing a row. Restored on exit.
+  old <- CMR_PERIODICITY_TOLERANCE
+  withr::defer(assign("CMR_PERIODICITY_TOLERANCE", old, envir = globalenv()))
+  assign("CMR_PERIODICITY_TOLERANCE",
+         old[old$ann_factor != 252L, , drop = FALSE], envir = globalenv())
+
+  expect_snapshot(
+    error = TRUE,
+    .assert_cmr_ann_factor(biz_days("2010-01-04", 500L), 252L, "no-tolerance-row")
+  )
+})
+
+test_that("every ann_factor the median-gap classifier can emit has a tolerance row", {
+  # The invariant the defensive branch above exists to protect: adding a band
+  # to the classifier without a matching tolerance row would silently disable
+  # the consistency check for that periodicity.
+  expect_true(all(c(252L, 52L, 12L, 4L) %in% CMR_PERIODICITY_TOLERANCE$ann_factor))
+})
+
+test_that("the #720 median-gap classification check still fires (regression)", {
+  expect_snapshot(
+    error = TRUE,
+    .assert_cmr_ann_factor(month_days("1990-01-01", 100L), 252L, "monthly-declared-daily")
+  )
+})
+
+test_that("on_violation = 'warn' downgrades the consistency abort to a warning", {
+  # The documented staging lever: it must warn, not abort, and must NOT be
+  # silent -- a silent pass is exactly the failure mode #738 is about.
+  d <- sort(unique(c(month_days("1992-03-01", 94L), biz_days("2000-01-03", 2000L))))
+  expect_warning(
+    .assert_cmr_ann_factor(d, 252L, "1m", on_violation = "warn"),
+    "NOT consistent with a single declared periodicity"
+  )
+  expect_error(.assert_cmr_ann_factor(d, 252L, "1m", on_violation = "abort"))
+})
+
+test_that("each tolerance band contains its own nominal spacing and is monotone in ann_factor", {
+  tol <- CMR_PERIODICITY_TOLERANCE
+  expect_true(all(tol$min_gap < tol$max_gap))
+  # Every band contains its own nominal calendar spacing (365.25 / ann_factor).
+  nominal <- 365.25 / tol$ann_factor
+  expect_true(all(nominal >= tol$min_gap & nominal <= tol$max_gap))
+  # Bands widen monotonically as the declared frequency falls.
+  o <- order(tol$ann_factor, decreasing = TRUE)
+  expect_true(!is.unsorted(tol$min_gap[o]))
+  expect_true(!is.unsorted(tol$max_gap[o]))
+})
+
+test_that("adjacent bands overlap by design, and the check is unaffected by that", {
+  # daily [1, 10] and weekly [4, 24] deliberately overlap: a 7-day gap is
+  # consistent BOTH with a daily series over a holiday week and with a weekly
+  # series. That ambiguity affects only the diagnostic band label in the abort
+  # message (first match wins); the check itself only ever asks whether a gap
+  # lies in the DECLARED periodicity's band, so overlap cannot cause a missed
+  # detection or a false positive.
+  tol <- CMR_PERIODICITY_TOLERANCE
+  daily  <- tol[tol$ann_factor == 252L, ]
+  weekly <- tol[tol$ann_factor == 52L, ]
+  expect_true(weekly$min_gap < daily$max_gap)   # the overlap is real
+
+  seven_day <- seq.Date(as.Date("2015-01-05"), by = "7 days", length.out = 200L)
+  expect_silent(.assert_cmr_ann_factor(seven_day, 52L, "weekly"))   # declared weekly: passes
+  expect_error(                                                      # declared monthly: fires
+    .assert_cmr_ann_factor(seven_day, 12L, "weekly-declared-monthly")
+  )
+})
+
+test_that("fewer than three observations is a no-op, not a false abort", {
+  expect_silent(.assert_cmr_ann_factor(as.Date(c("2020-01-01", "2020-06-01")), 252L, "tiny"))
+})


### PR DESCRIPTION
Two halves, per the dispatch. **Half 1 (measurement) is the deliverable**; Half 2 fixes the guard. **No remedy is applied to CMR's data** — that decision stays open on #738 and should follow these numbers.

Everything below is OBSERVED from the live store (`docs/_targets`, read-only via `tar_read()`). Nothing is predicted, and nothing is scaled by hand. `tar_make()` was not run.

---

# Half 1 — Materiality, measured

## Headline: the issue's ~23% estimate is wrong by a factor of ~4.7. The real figure is 4.9%.

The issue reasoned that a monthly return carries ~21× the variance of a daily one, giving `94 × 21 / (94 × 21 + 6758) ≈ 23%`. That step assumes the pre-2000 monthly observations are a correctly-scaled monthly aggregation of the post-2000 daily process. **They are not.**

| lookback | monthly-spaced obs | % of obs | **% of pooled SS** | sd (monthly obs) | sd (daily obs) | ratio | ratio if √21 |
|---|---:|---:|---:|---:|---:|---:|---:|
| 1m | 95 | 1.386% | **5.92%** | 0.02745 | 0.01294 | 2.12 | 4.58 |
| 3m | 93 | 1.358% | **5.47%** | 0.02807 | 0.01392 | 2.02 | 4.58 |
| 6m | 91 | 1.330% | **4.88%** | 0.02750 | 0.01429 | 1.92 | 4.58 |

The monthly observations carry only ~2× the sd of the daily ones, not ~4.6×.

**Why — and this is a separate finding worth its own issue.** Before 2000 the commodity universe is 13 FRED monthly indexes and nothing else; Yahoo's 24 daily series start in 2000:

| era | source | rows | series | series available per date (min / med / max) |
|---|---|---:|---:|---|
| pre-2000 | fred_imf | 1,235 | 13 | 13 / 13 / 13 |
| 2000+ | fred_imf + yahoo | 144,889 | 37 | 1 / 23 / 37 |

`hd_commodity_mr_portfolio()` is called with `n_long = 10, n_short = 10` — **20 slots drawn from 13 names**. Pre-2000 the long and short legs necessarily overlap heavily, so the legs largely cancel and the portfolio return is mechanically muted. The pre-2000 segment is not a monthly version of the strategy; it is a *different, largely self-cancelling* strategy that happens to share a name.

## The published figures (6m — the lookback `.norm_cmr()` selects, matching the deployed leaderboard row)

| metric | published (whole mixed series, ann 252) | 2000+ daily only, ann 252 | 1992–1999 monthly only, ann 12 | published vs coherent |
|---|---:|---:|---:|---|
| `vol` | **0.2288** | 0.2245 | 0.0958 | **overstated 1.92%** |
| `cagr` | **−0.1515** | −0.1669 | +0.0597 | **flattered 9.23%** (less negative) |
| `sharpe` | **−0.747** | −0.829 | +0.602 | **flattered 9.89%** (less negative) |
| `max_dd` | −0.9956 | −0.9956 | −0.1653 | unchanged |
| n | 6,789 | 6,700 | 89 | |

All three lookbacks, for completeness:

| lookback | vol mixed → 2000+ | Δ% | cagr mixed → 2000+ | Δ% | sharpe mixed → 2000+ | Δ% |
|---|---|---:|---|---:|---|---:|
| 1m | 0.2085 → 0.2035 | +2.46 | −0.3688 → −0.3724 | −0.97 | −1.862 → −1.924 | −3.22 |
| 3m | 0.2246 → 0.2198 | +2.18 | −0.2567 → −0.2705 | −5.10 | −1.230 → −1.317 | −6.61 |
| 6m | 0.2288 → 0.2245 | +1.92 | −0.1515 → −0.1669 | −9.23 | −0.747 → −0.829 | −9.89 |

### Plainly: overstated, understated, or unchanged?

- **`vol` is overstated, but immaterially** — 1.9% relative, 0.0043 absolute. The direction is as the issue guessed; the magnitude is not. This is nothing like #717's 4.6×.
- **`cagr` and `sharpe` are flattered by ~10%** — CMR looks meaningfully *less bad* than a coherent series says it is. That is the opposite sign to `vol` and it is the larger effect. It is not an annualisation artefact: the pre-2000 segment genuinely earned +6.0% CAGR at Sharpe +0.60, because (see above) it was a near-self-cancelling 13-name portfolio, and those 7.75 years are averaged into the full-period figure.
- **`max_dd` is unchanged** at −0.9956. CMR destroys essentially all capital in both the mixed and the coherent series.

**The direction does not cancel out, and it is not a single direction.** The mixing has two channels pulling opposite ways, which is exactly why this needed measuring.

### The largest arithmetic error is one the issue did not name

`years <- n / ann_factor` inside `.compute_cmr_metrics()` counts each of the 91 monthly observations as *one day*:

| lookback | n | years assumed (n/252) | actual calendar span | understated by | cagr at assumed years | cagr at true span |
|---|---:|---:|---:|---|---:|---:|
| 1m | 6,799 | 26.98 | 33.99 | **7.01 yr (26.0%)** | −0.3688 | −0.3060 |
| 3m | 6,795 | 26.96 | 33.83 | **6.86 yr (25.4%)** | −0.2567 | −0.2106 |
| 6m | 6,789 | 26.94 | 33.57 | **6.63 yr (24.6%)** | −0.1515 | −0.1235 |

Every published CMR CAGR is annualised over ~27 years for a series spanning ~34. This is a ~25% error in the exponent and it is bigger than either effect in the table above. It pulls CAGR *more* negative, partly offsetting the flattering from the benign pre-2000 era.

## The #635 channel — what a wrong vol does to a position size

`vol_per_unit_gross = vol / gross_convention`; `G = σ_target / vol_per_unit_gross`. CMR's `gross_convention` is **2** (`is_cap = FALSE`).

| | vol | `vol_per_unit_gross` | rank by vpug |
|---|---:|---:|---|
| published (mixed) | 0.2288 | 0.11440 | 12th of 15 |
| coherent (2000+) | 0.2245 | 0.11225 | 12th of 15 |

`G_cmr` would be **1.92% larger** under the coherent vol — the overstated vol makes CMR's implied gross allocation slightly too *small*. Book-level, budget-neutral σ (`Σ Gᵢ = Σ grossᵢ`, Full Period):

| scenario | σ |
|---|---:|
| leaderboard as deployed (CMR vol 0.2288) | 0.13541 |
| CMR vol → 2000+ coherent (0.2245) | 0.13529 |
| CMR excluded entirely | 0.13077 |

**σ moves by −0.09%.** For scale: #717's defect moved the same quantity by ~17%. This one is three orders of magnitude smaller and is inside any sensible rounding. **The mixed-frequency series is not a threat to the #635 leverage number.** It *is* a threat to CMR's own CAGR and Sharpe, and to anyone reading the pre-2000 era as evidence about the strategy.

## Recommendation (reasoning, not a change)

**Option 1, truncate to 2000+** — with the caveat that the case for it is not the periodicity at all.

The periodicity argument alone would not justify losing 7.5 years for a 1.9% vol correction. What justifies it is the universe: pre-2000 the strategy cannot be run as specified (20 slots, 13 names). Those 94 observations are not weak evidence about CMR — they are evidence about a *different* portfolio, and they currently flatter CMR's published CAGR and Sharpe by ~10% while shrinking its annualisation span by 25%.

Against Option 2 (resample everything to monthly): it would change the strategy's construction, not just its reporting, and discards the daily resolution the post-2000 signal is built on — a large cost to fix a 1.9% vol error. Against Option 3 (segment and report separately): most honest, but a leaderboard row has one `vol` cell, and given that CMR's max drawdown is −99.6% in both eras, the reporting sophistication is unlikely to earn its keep.

Worth deciding separately and probably worth its own issue: **the `n_long = 10, n_short = 10` parameters are not satisfiable on a 13-name universe.** Truncating to 2000+ hides that rather than fixing it, and the same trap will reappear on any date range where the universe is thin.

---

# Half 2 — The guard

## What changed

`.assert_cmr_ann_factor()` keeps the #720 median-gap **classification** check (that check answers "what is the typical spacing" and answers it correctly) and gains a second, **consistency** check that answers "is the spacing consistent with *one* declared periodicity". That is a question about dispersion, and no measure of central tendency can answer it.

Concretely: count the gaps falling outside the declared periodicity's calendar band; abort when the count exceeds an allowance.

### The bands (`CMR_PERIODICITY_TOLERANCE`) — every bound argued in its roxygen

| declared | nominal spacing | band | why |
|---|---:|---|---|
| 252 daily | 1.45 d | **[1, 10]** | Longest US market closure since 1990 is 9/11 — last print 2001-09-10, next 2001-09-17, a **7-calendar-day gap**. Christmas/New-Year adjacent to a weekend reaches 4–5; Sandy (2012) gave 4. 10 clears the worst observed with headroom and sits three weeks below a monthly spacing, so a monthly observation can never pass as a long holiday. Lower bound 1: a date-keyed series cannot be denser than one obs/day. |
| 52 weekly | 7.02 d | [4, 24] | two consecutive missing weeks tolerated; sub-half-week spacing rejected |
| 12 monthly | 30.44 d | [20, 75] | 20 clears a 28-day February; 75 tolerates one entirely missing month (2×31) and stays below quarterly |
| 4 quarterly | 91.31 d | [60, 200] | one missing quarter tolerated; monthly spacing rejected |

The check is **two-sided**: a gap too *short* for the declared periodicity is the same defect as one too long (daily prints leaking into a monthly series).

Adjacent bands overlap by design — a 7-day gap is consistent both with a daily series over a holiday week and with a weekly series. That ambiguity affects only the diagnostic label in the message; the check itself only ever asks whether a gap lies in the *declared* band, so overlap cannot cause a miss or a false positive. Pinned by a test.

### The allowance — not a magic number

```
allowance = max(2, ceiling(0.001 * n_gaps))
```

**Why 0.1%:** the smallest frequency *regime change* worth catching is one year of a different periodicity embedded in a longer series — 12 monthly gaps inside a ~27-year daily series (~6,800 gaps) is 0.18%, roughly 2× the threshold. Anything below 0.1% is an isolated vendor outage, not a change of periodicity.

**Why not zero:** a naive "all gaps identical" or "zero out-of-band" rule false-positives on every real series. This is not hypothetical — the sweep below found `daily_rf` carries **one genuine 12-day gap in 26,189**. A guard that aborts the whole pipeline on one bad print gets switched off rather than fixed.

**Why the floor of 2:** on a short series `ceiling(0.001 × n)` rounds to 1, so a single outage would abort. The floor keeps the guard firing on a *pattern*, never on one print, at any series length.

### Abort message

Names the strategy, the declared factor, the observed band counts, the out-of-band gap range and its date span, and why the median-gap check passed — per `fail-loud-not-null.md`:

```
x CMR 1m: the observation spacing is NOT consistent with a single declared periodicity (ann_factor 252, daily).
i 94 of 6851 gaps (1.372%) fall outside the daily band [1, 10] calendar days; allowance is 7.
i Observed gap bands: daily: 6757; monthly: 94.
i Out-of-band gaps range 28-31 calendar days, spanning 1992-04-01..2000-01-01.
i The median gap (1 calendar days) agrees with the declared factor, which is why the
  #720 median-gap check passes -- a median cannot see a minority at a different frequency. See #738.
i See .claude/rules/fail-loud-not-null.md Required Pattern 5.
```

## It fires on CMR as it stands today — that is the point

Run against the live store (read-only):

| series | declared | n | median gap | out-of-band | allowance | result |
|---|---:|---:|---:|---:|---:|---|
| `cmr_portfolio_1m` | 252 | 6,852 | 1 | 94 | 7 | **ABORTS** |
| `cmr_portfolio_3m` | 252 | 6,848 | 1 | 92 | 7 | **ABORTS** |
| `cmr_portfolio_6m` | 252 | 6,842 | 1 | 90 | 7 | **ABORTS** |
| 2000+ segment | 252 | 6,758 | 1 | 0 | 7 | passes |
| pre-2000 segment | 12 | 94 | 31 | 0 | 2 | passes |

Both coherent segments pass, so the guard is detecting the *mixing*, not merely rejecting CMR.

## Deliberate cross-strategy sweep — CMR is alone

#738 notes that #736's evidence was a by-product of one diagnostic. This is the deliberate version, applying the identical band + allowance rule to every daily-declared series in the store:

| series | n | median gap | max gap | out-of-band | allowance | result |
|---|---:|---:|---:|---:|---:|---|
| `cmr_portfolio_1m` | 6,852 | 1 | 31 | 94 | 7 | **would fire** |
| `cmr_portfolio_3m` | 6,848 | 1 | 31 | 92 | 7 | **would fire** |
| `cmr_portfolio_6m` | 6,842 | 1 | 31 | 90 | 7 | **would fire** |
| `olmar_portfolio` | 4,063 | 1 | 5 | 0 | 5 | ok |
| `tom_portfolio` | 8,092 | 1 | 7 | 0 | 9 | ok |
| `tom_daily` | 8,092 | 1 | 7 | 0 | 9 | ok |
| `rsc_portfolio` | 8,355 | 1 | 7 | 0 | 9 | ok |
| `aw_daily_returns` | 8,355 | 1 | 7 | 0 | 9 | ok |
| `daily_rf` | 26,190 | 1 | 12 | 1 | 27 | ok |
| `aw_daily_ff` | 26,190 | 1 | 12 | 1 | 27 | ok |

Note the `max gap = 7` on four independent series — that is the 9/11 closure, the exact calendar fact the 10-day daily bound was set from. And `daily_rf`'s single 12-day gap is the empirical case the allowance floor exists for.

## ⚠️ This WILL break the build. It has not been softened.

`.assert_cmr_ann_factor()` runs at the top of `.compute_cmr_metrics()`, so on the next `tar_make()` it aborts **`cmr_metrics_1m`, `cmr_metrics_3m`, `cmr_metrics_6m`** and everything downstream — `cmr_summary`, `cmr_vs_mom_compare`, `cmr_registry_run`, the leaderboard, and the QA gates that read it.

That is the correct behaviour and the proof the guard works. I have not weakened it.

**Proposed landing path — your call, I have not taken it:**

`.compute_cmr_metrics()` gained `periodicity_check = c("abort", "warn")`, defaulting to `"abort"`. **No production call site passes it** — the three `cmr_metrics_*` targets use the abort default, so as merged the build goes red.

If you want the finding published before the remedy is chosen, add `periodicity_check = "warn"` to the three call sites in `R/plan_commodities_mean_reversion.R` (lines ~126–136) for exactly one release. Verified: under warn mode the pipeline computes normally (`vol = 0.2085` for 1m, identical to the current store) and emits the full abort text as a `cli_warn`. It is not silent — a silent pass is the failure mode #738 is about.

I would not leave it in warn mode past the remedy decision. Given the measurement above, the vol error is 1.9% and the σ impact is 0.09%, so there is no risk-management urgency forcing a red build — but the CAGR/Sharpe flattering and the 25% annualisation-span error are real and are what the warning should keep visible.

## Changes NOT made (flagged, per scope)

Three other files carry the same wrong premise. Two other agents are in them right now, so I have described rather than edited:

1. **`R/plan_strategy_names.R`** — `cmr` (position 11) still declares `frequency = "monthly"`, `ann_factor = 12L`, which feeds `bt.strategy.frequency` / `bt.strategy.ann_factor` via `.cmr_register_runs()`. Flagged by #720 as well and still open. Note `R/plan_leaderboard.R`'s `STRATEGY_OBS_ANN_FACTOR` correctly says 252 for CMR — **the two tables disagree with each other**, which is its own `fail-loud-not-null` defect (no gate reconciles them).
2. **`.cmr_register_runs()`** (`R/plan_commodities_mean_reversion.R`, in my file but outside this change's remit) hardcodes `hd_record_stability_metrics(..., w = 36L, ann_factor = 12L)` with the comment "Monthly series". Same root cause as #717, still wrong after #720.
3. **#719 Layer 3** specifies the median-gap approach that #738 shows is insufficient. That specification should be amended to the consistency form. The two constants and the check body here are self-contained and lift cleanly into a shared helper — the only CMR-specific parts are the function name and the message prefix.

Also flagged for a separate issue: **`n_long = 10, n_short = 10` against a 13-name pre-2000 universe** (see Half 1). No periodicity remedy fixes that.

## Verification

`scripts/verify.sh`, full run, foreground:

```
PASS: _targets.R parses
PASS: docs/_targets.R parses
PASS: docs/_targets.R is structurally valid (tar_validate, 7.50s)
PASS: testthat edition 3 active
PASS: dashboard freshness

=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly:
  [baseline, expected] test-crypto-momentum.R::C1: as.Date coercion makes POSIXct dates filterable against Date bounds
  [baseline, expected] test-qa-summary-deps.R::qa_summary declares every *_metrics target defined in plan files
  [baseline, expected] test-stock-backtest.R::raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly:
  [baseline, expected] test-mom-prepeak-portfolio.R::.mom_prepeak_compute_returns caps short returns at +100%

=== scripts/verify.sh: PASS ===
```

Baselines per `.claude/CLAUDE.md` (root `failed=3 skipped=0`, package `failed=1 skipped=15`) hold exactly.

New tests: `tests/testthat/test-cmr-periodicity-consistency.R` — 13 `test_that` blocks, 26 assertions, **4 `expect_snapshot(error = TRUE, ...)`** (31%, meeting `snapshot-test-policy`'s 30% floor for 9+ blocks), `testthat::local_edition(3)` at the top. Coverage: clean daily passes; 9/11-sized closure + weekends pass; clean monthly passes; two isolated outages pass, three fire; the CMR defect shape fires; the too-short direction fires; the classifier/tolerance tables cannot drift apart; warn mode warns and is not silent; band overlap is harmless. `tests/testthat/test-cmr-units.R` still passes unchanged (28 assertions) — its monthly toy fixtures at `ann_factor = 12L` are consistent and are not affected.

`tar_make()` was **not** run.

Refs #738, #717, #720, #719, #635, #736
