### PR TITLE
fix(cmr): stage periodicity_check = "warn" at production call sites

### DIFF
--- a/R/plan_commodities_mean_reversion.R
+++ b/R/plan_commodities_mean_reversion.R
@@ -32,6 +32,13 @@
 #   own date column still mixes daily and monthly-stamped observations, so
 #   ann_factor = 252 over-annualises the vol/cagr contribution of every
 #   FRED-only month-start row. #724 fixes the crash; it does not fix that.
+# Mixed frequency (#738): MEASURED, not fixed. cmr_portfolio_1m/3m/6m run at
+#   12 obs/year before 2000-01 (13 FRED monthly indexes only -- Yahoo history
+#   starts 2000) and ~255/year after; ~1.4% of observations are monthly-spaced
+#   and the whole series is declared daily. .assert_cmr_ann_factor()'s
+#   consistency check (#738) now DETECTS this; choosing the remedy (truncate
+#   to 2000+, resample to monthly, or segment and report separately) is an
+#   open decision on #738 and is deliberately NOT made here.
 
 plan_commodities_mean_reversion <- function() {
   list(
@@ -341,35 +348,132 @@ plan_commodities_mean_reversion <- function() {
   )
 }
 
+#' Per-periodicity gap tolerances for the CMR periodicity guard (#738)
+#'
+#' One row per recognised annualisation factor. \code{min_gap}/\code{max_gap}
+#' bound a SINGLE inter-observation gap that is still consistent with that
+#' declared periodicity. They are calendar-day bounds, and each is argued
+#' from a calendar fact rather than picked to make the current data pass:
+#'
+#' \describe{
+#'   \item{252 (daily), 1-10 days}{Nominal spacing is 365.25/252 = 1.45
+#'     calendar days. The upper bound must absorb the worst real gap a
+#'     genuine business-daily series produces. The longest US market closure
+#'     since 1990 is 9/11 (last print 2001-09-10, next 2001-09-17 -- a
+#'     7-calendar-day gap); Christmas/New-Year holidays adjacent to a weekend
+#'     reach 4-5; Hurricane Sandy (2012) gave 4. 10 clears the worst observed
+#'     with headroom and still sits a full 3 weeks below a monthly spacing
+#'     (28-31 days), so a monthly observation can never be mistaken for a
+#'     long holiday. Lower bound 1: a date-keyed series cannot be denser
+#'     than one observation per calendar day.}
+#'   \item{52 (weekly), 4-24 days}{Nominal 7.02. Upper bound tolerates two
+#'     consecutive missing weeks plus slack; lower bound rejects
+#'     sub-half-week spacing, which indicates daily data mislabelled weekly.}
+#'   \item{12 (monthly), 20-75 days}{Nominal 30.44. Lower bound 20 clears a
+#'     28-day February with margin while rejecting weekly-or-denser prints;
+#'     upper bound 75 tolerates one entirely missing month (2 x 31 = 62)
+#'     plus slack, while staying below a quarterly spacing.}
+#'   \item{4 (quarterly), 60-200 days}{Nominal 91.31. Same construction: one
+#'     missing quarter tolerated, monthly spacing rejected.}
+#' }
+#'
+#' @noRd
+CMR_PERIODICITY_TOLERANCE <- tibble::tibble(
+  ann_factor = c(252L, 52L, 12L, 4L),
+  label      = c("daily", "weekly", "monthly", "quarterly"),
+  min_gap    = c(1, 4, 20, 60),
+  max_gap    = c(10, 24, 75, 200)
+)
+
+#' Fraction of gaps allowed to fall outside the declared periodicity's band
+#'
+#' The smallest frequency REGIME CHANGE worth catching is a single year of a
+#' different periodicity embedded in a longer series -- 12 monthly
+#' observations inside a ~27-year daily series (~6800 gaps) is 0.18% of
+#' gaps. 0.1% therefore catches a one-year regime change with roughly 2x
+#' margin, while anything below it is an isolated vendor outage rather than
+#' a change of periodicity. Deliberately NOT zero: a single missing print in
+#' a decades-long series is a data hiccup, not a mis-declared frequency, and
+#' a guard that aborts the whole pipeline on one bad row would be turned off
+#' rather than fixed.
+#'
+#' @noRd
+CMR_PERIODICITY_MAX_OUT_OF_BAND_FRAC <- 0.001
+
+#' Minimum absolute number of out-of-band gaps tolerated, regardless of n
+#'
+#' On a short series the fraction above rounds down to zero, so one isolated
+#' outage would abort. This floor keeps the tolerance at "at least two
+#' isolated gaps" for any series length, so the guard fires on a PATTERN and
+#' never on a single print.
+#'
+#' @noRd
+CMR_PERIODICITY_MIN_OUT_OF_BAND_ALLOWANCE <- 2L
+
 #' Reconcile a declared `ann_factor` against the observed date frequency
 #'
-#' Guard from #717 (fail-loud-not-null.md Required Pattern 5): computes the
-#' median gap between the distinct, sorted dates in \code{dates} and aborts
-#' if that gap is inconsistent with \code{ann_factor}. This is deliberately
-#' placed at the point where \code{ann_factor} is SUPPLIED to
-#' \code{.compute_cmr_metrics()} -- not buried in the CAGR/vol arithmetic
-#' further down -- so a future caller that passes the wrong constant fails
-#' immediately, on the value it got wrong, rather than producing a
-#' plausible-looking but silently mis-annualised number (exactly what
-#' happened with \code{ann_factor = 12L} against CMR's actually-daily data).
+#' Guard from #717 (fail-loud-not-null.md Required Pattern 5), rewritten for
+#' #738. Deliberately placed at the point where \code{ann_factor} is
+#' SUPPLIED to \code{.compute_cmr_metrics()} -- not buried in the CAGR/vol
+#' arithmetic further down -- so a future caller that passes the wrong
+#' constant fails immediately, on the value it got wrong, rather than
+#' producing a plausible-looking but silently mis-annualised number (exactly
+#' what happened with \code{ann_factor = 12L} against CMR's actually-daily
+#' data).
 #'
-#' Uses the MEDIAN gap, not the mean or min: commodity data has real gaps
-#' (weekends, holidays, and -- because CMR's universe mixes 24 Yahoo daily
-#' futures/ETF series with 13 FRED monthly indexes, #717 -- occasional
-#' months where only the sparser monthly series print). The median is
-#' robust to that without a hand-tuned outlier filter. Bands are
-#' deliberately wide (e.g. daily tolerates gaps up to 3 days) to absorb long
-#' weekends/holiday clusters without false-positiving on a genuine daily
-#' series; they are not so wide that a real classification error (e.g.
-#' monthly data declared daily) would slip through undetected.
+#' Two checks, in order:
+#'
+#' \enumerate{
+#'   \item \strong{Classification} (unchanged from #720). The MEDIAN gap
+#'     between distinct sorted dates is mapped to an expected
+#'     \code{ann_factor} and compared against the declared one. The median is
+#'     the right statistic for this question -- "what is the typical
+#'     spacing" -- because it is robust to the weekend/holiday gaps every
+#'     real business-daily series carries.
+#'   \item \strong{Consistency} (new, #738). Counts the gaps falling OUTSIDE
+#'     \code{CMR_PERIODICITY_TOLERANCE}'s band for the declared periodicity,
+#'     and aborts when that count exceeds
+#'     \code{max(CMR_PERIODICITY_MIN_OUT_OF_BAND_ALLOWANCE,
+#'     ceiling(CMR_PERIODICITY_MAX_OUT_OF_BAND_FRAC * n_gaps))}.
+#' }
+#'
+#' Check 2 exists because check 1 alone cannot see a series that CHANGES
+#' frequency partway through. #738 measured \code{cmr_portfolio_1m} as 12
+#' observations/year before 2000 and ~255/year after: 94 of 6851 gaps are
+#' monthly, 6757 are daily, and the series is declared daily throughout.
+#' The overall median gap is 1 day, so 94 monthly gaps out of 6851 cannot
+#' move it and check 1 passes -- correctly by its own logic, on a series
+#' where 1.4% of observations sit at a twenty-one-fold different frequency.
+#' A median is precisely the statistic chosen to be insensitive to the
+#' minority that reveals the answer is "no". The property we want is "is the
+#' spacing CONSISTENT with one declared periodicity", which is a question
+#' about dispersion, and no measure of central tendency can answer it.
+#'
+#' The tolerance is a count of out-of-band gaps rather than a requirement
+#' that all gaps be identical, because holidays and short weeks mean a naive
+#' equality test false-positives on every genuine daily series. See
+#' \code{CMR_PERIODICITY_TOLERANCE} and
+#' \code{CMR_PERIODICITY_MAX_OUT_OF_BAND_FRAC} for how each bound is argued.
 #'
 #' @param dates A date vector (one entry per observation; duplicates and
 #'   unsorted input are handled).
 #' @param ann_factor Integer. The annualisation factor about to be used.
 #' @param lookback Character. Lookback label, used only for the abort message.
+#' @param on_violation One of `"abort"` (default) or `"warn"`. Governs the
+#'   CONSISTENCY check only -- the classification check always aborts.
+#'   `"warn"` exists solely as a staging lever: the consistency check fires
+#'   on CMR's production data as it stands today (that is the point -- see
+#'   #738), so landing it in abort mode turns the build red until CMR's
+#'   remedy is chosen. Setting the three `cmr_metrics_*` call sites to
+#'   `"warn"` for one release lets the finding be published without blocking
+#'   the pipeline. It is NOT a way to keep a mixed-frequency series in
+#'   production indefinitely.
 #' @return `NULL`, invisibly. Called for its abort side effect.
 #' @noRd
-.assert_cmr_ann_factor <- function(dates, ann_factor, lookback) {
+.assert_cmr_ann_factor <- function(dates, ann_factor, lookback,
+                                   on_violation = c("abort", "warn")) {
+  on_violation <- match.arg(on_violation)
+
   d <- sort(unique(as.Date(dates)))
   if (length(d) < 3L) {
     # Too few points for a frequency to be meaningfully observed.
@@ -378,6 +482,7 @@ plan_commodities_mean_reversion <- function() {
   gaps <- as.numeric(diff(d))
   median_gap <- stats::median(gaps)
 
+  # ── Check 1: classification (median gap -> expected ann_factor) ──────────
   expected_ann_factor <- dplyr::case_when(
     median_gap <= 3   ~ 252L,  # daily (business days; weekends widen some gaps)
     median_gap <= 10  ~ 52L,   # weekly
@@ -414,11 +519,83 @@ plan_commodities_mean_reversion <- function() {
     ))
   }
 
+  # ── Check 2: consistency (dispersion of gaps, not their centre) ──────────
+  tol <- CMR_PERIODICITY_TOLERANCE[
+    CMR_PERIODICITY_TOLERANCE$ann_factor == ann_factor, , drop = FALSE
+  ]
+  if (nrow(tol) != 1L) {
+    cli::cli_abort(c(
+      "x" = "CMR {lookback}: no periodicity tolerance defined for declared ann_factor {ann_factor}.",
+      "i" = "Known factors: {.val {CMR_PERIODICITY_TOLERANCE$ann_factor}}.",
+      "i" = "Add a row to CMR_PERIODICITY_TOLERANCE rather than skipping the consistency check."
+    ))
+  }
+
+  n_gaps    <- length(gaps)
+  too_short <- gaps < tol$min_gap
+  too_long  <- gaps > tol$max_gap
+  n_out     <- sum(too_short) + sum(too_long)
+  allowance <- max(
+    CMR_PERIODICITY_MIN_OUT_OF_BAND_ALLOWANCE,
+    ceiling(CMR_PERIODICITY_MAX_OUT_OF_BAND_FRAC * n_gaps)
+  )
+
+  if (n_out > allowance) {
+    # Name the observed bands and their counts, per fail-loud-not-null.md:
+    # the reader must be able to see WHICH minority frequency is present
+    # without re-deriving it.
+    obs_band <- vapply(
+      gaps,
+      function(g) {
+        hit <- which(g >= CMR_PERIODICITY_TOLERANCE$min_gap &
+                       g <= CMR_PERIODICITY_TOLERANCE$max_gap)
+        if (length(hit) == 0L) "unclassified" else CMR_PERIODICITY_TOLERANCE$label[hit[1]]
+      },
+      character(1)
+    )
+    band_counts <- sort(table(obs_band), decreasing = TRUE)
+    band_txt <- paste0(names(band_counts), ": ", as.integer(band_counts), collapse = "; ")
+
+    out_gaps  <- gaps[too_short | too_long]
+    where_out <- d[-1L][too_short | too_long]
+
+    msg <- c(
+      "x" = paste0(
+        "CMR {lookback}: the observation spacing is NOT consistent with a ",
+        "single declared periodicity (ann_factor {ann_factor}, {tol$label})."
+      ),
+      "i" = paste0(
+        "{n_out} of {n_gaps} gaps ({round(100 * n_out / n_gaps, 3)}%) fall outside the ",
+        "{tol$label} band [{tol$min_gap}, {tol$max_gap}] calendar days; ",
+        "allowance is {allowance}."
+      ),
+      "i" = "Observed gap bands: {band_txt}.",
+      "i" = paste0(
+        "Out-of-band gaps range {min(out_gaps)}-{max(out_gaps)} calendar days, ",
+        "spanning {format(min(where_out))}..{format(max(where_out))}."
+      ),
+      "i" = paste0(
+        "The median gap ({median_gap} calendar days) agrees with the declared ",
+        "factor, which is why the #720 median-gap check passes -- a median cannot ",
+        "see a minority at a different frequency. See #738."
+      ),
+      "i" = "See .claude/rules/fail-loud-not-null.md Required Pattern 5."
+    )
+
+    if (identical(on_violation, "warn")) {
+      cli::cli_warn(msg)
+    } else {
+      cli::cli_abort(msg)
+    }
+  }
+
   invisible(NULL)
 }
 
-.compute_cmr_metrics <- function(portfolio_tbl, lookback, daily_rf, ann_factor = 252L) {
+.compute_cmr_metrics <- function(portfolio_tbl, lookback, daily_rf, ann_factor = 252L,
+                                 periodicity_check = c("abort", "warn")) {
   library(dplyr)
+  periodicity_check <- match.arg(periodicity_check)
 
   df <- portfolio_tbl |>
     dplyr::filter(!is.na(.data$net_ret)) |>
@@ -426,7 +603,12 @@ plan_commodities_mean_reversion <- function() {
 
   # #717 guard: declared ann_factor must match the observed frequency of
   # this portfolio's own dates, checked at the point ann_factor is supplied.
-  .assert_cmr_ann_factor(df$date, ann_factor, lookback)
+  # #738 extends it from "is the TYPICAL spacing right" to "is the spacing
+  # CONSISTENT" -- see .assert_cmr_ann_factor()'s roxygen. `periodicity_check`
+  # is the staging lever documented there; production call sites use the
+  # abort default.
+  .assert_cmr_ann_factor(df$date, ann_factor, lookback,
+                         on_violation = periodicity_check)
 
   n <- nrow(df)
 

--- a/R/plan_commodities_mean_reversion.R
+++ b/R/plan_commodities_mean_reversion.R
@@ -122,17 +122,36 @@ plan_commodities_mean_reversion <- function() {
 
     # ── Performance metrics per lookback ──────────────────────────────────
     # Sharpe, MDD, max DD duration (hd_dd_duration from risk_metrics.R).
+    #
+    # periodicity_check = "warn" (TEMPORARY STAGING, #738): the #738
+    # consistency check fires on CMR's real production data (94/92/90
+    # out-of-band gaps against an allowance of 7 -- see the frequency note at
+    # the top of this file), so its documented default of "abort" would turn
+    # every `tar_make()` red until the mixed-frequency remedy (truncate to
+    # 2000+, resample to monthly, or segment and report separately) is chosen
+    # on #738. "warn" is the staging lever `.assert_cmr_ann_factor()`
+    # documents for exactly this situation: it publishes the finding loudly
+    # in every build log without blocking the pipeline. This is NOT a
+    # decision that the mixed frequency is acceptable -- it is a decision to
+    # keep `main` green while that separate decision is still open.
+    # Ends when: the #738 remedy lands and CMR's dates are no longer mixed
+    # frequency. At that point the guard passes on its own with the
+    # documented "abort" default, and this argument should be DELETED at all
+    # three call sites below, not left in place or flipped back manually.
 
     targets::tar_target(cmr_metrics_1m, {
-      .compute_cmr_metrics(cmr_portfolio_1m, lookback = "1m", daily_rf = daily_rf, ann_factor = 252L)
+      .compute_cmr_metrics(cmr_portfolio_1m, lookback = "1m", daily_rf = daily_rf, ann_factor = 252L,
+                           periodicity_check = "warn")
     }),
 
     targets::tar_target(cmr_metrics_3m, {
-      .compute_cmr_metrics(cmr_portfolio_3m, lookback = "3m", daily_rf = daily_rf, ann_factor = 252L)
+      .compute_cmr_metrics(cmr_portfolio_3m, lookback = "3m", daily_rf = daily_rf, ann_factor = 252L,
+                           periodicity_check = "warn")
     }),
 
     targets::tar_target(cmr_metrics_6m, {
-      .compute_cmr_metrics(cmr_portfolio_6m, lookback = "6m", daily_rf = daily_rf, ann_factor = 252L)
+      .compute_cmr_metrics(cmr_portfolio_6m, lookback = "6m", daily_rf = daily_rf, ann_factor = 252L,
+                           periodicity_check = "warn")
     }),
 
 

--- a/tests/testthat/_snaps/cmr-periodicity-consistency.md
+++ b/tests/testthat/_snaps/cmr-periodicity-consistency.md
@@ -1,0 +1,47 @@
+# the CMR defect shape -- monthly era then daily era, declared daily -- aborts
+
+    Code
+      .assert_cmr_ann_factor(d, 252L, "1m")
+    Condition
+      Error in `.assert_cmr_ann_factor()`:
+      x CMR 1m: the observation spacing is NOT consistent with a single declared periodicity (ann_factor 252, daily).
+      i 94 of 2093 gaps (4.491%) fall outside the daily band [1, 10] calendar days; allowance is 3.
+      i Observed gap bands: daily: 1999; monthly: 94.
+      i Out-of-band gaps range 28-33 calendar days, spanning 1992-04-01..2000-01-03.
+      i The median gap (1 calendar days) agrees with the declared factor, which is why the #720 median-gap check passes -- a median cannot see a minority at a different frequency. See #738.
+      i See .claude/rules/fail-loud-not-null.md Required Pattern 5.
+
+# daily prints interleaved into a monthly series abort (too-short direction)
+
+    Code
+      .assert_cmr_ann_factor(d, 12L, "monthly-contaminated")
+    Condition
+      Error in `.assert_cmr_ann_factor()`:
+      x CMR monthly-contaminated: the observation spacing is NOT consistent with a single declared periodicity (ann_factor 12, monthly).
+      i 39 of 277 gaps (14.079%) fall outside the monthly band [20, 75] calendar days; allowance is 2.
+      i Observed gap bands: monthly: 237; daily: 39; weekly: 1.
+      i Out-of-band gaps range 1-1 calendar days, spanning 1995-06-02..1995-07-10.
+      i The median gap (30 calendar days) agrees with the declared factor, which is why the #720 median-gap check passes -- a median cannot see a minority at a different frequency. See #738.
+      i See .claude/rules/fail-loud-not-null.md Required Pattern 5.
+
+# a declared ann_factor with no tolerance row aborts rather than skipping the check
+
+    Code
+      .assert_cmr_ann_factor(biz_days("2010-01-04", 500L), 252L, "no-tolerance-row")
+    Condition
+      Error in `.assert_cmr_ann_factor()`:
+      x CMR no-tolerance-row: no periodicity tolerance defined for declared ann_factor 252.
+      i Known factors: 52, 12, and 4.
+      i Add a row to CMR_PERIODICITY_TOLERANCE rather than skipping the consistency check.
+
+# the #720 median-gap classification check still fires (regression)
+
+    Code
+      .assert_cmr_ann_factor(month_days("1990-01-01", 100L), 252L,
+      "monthly-declared-daily")
+    Condition
+      Error in `.assert_cmr_ann_factor()`:
+      x CMR monthly-declared-daily: declared ann_factor (252) disagrees with the observed data frequency.
+      i Median gap between observation dates is 31 days, consistent with ann_factor = 12, not 252.
+      i This is the reconciliation guard added for #717 -- see .claude/rules/fail-loud-not-null.md Required Pattern 5.
+

--- a/tests/testthat/test-cmr-periodicity-consistency.R
+++ b/tests/testthat/test-cmr-periodicity-consistency.R
@@ -158,6 +158,73 @@ test_that("on_violation = 'warn' downgrades the consistency abort to a warning",
   expect_error(.assert_cmr_ann_factor(d, 252L, "1m", on_violation = "abort"))
 })
 
+# ── .compute_cmr_metrics()'s periodicity_check staging lever (#738) ────────
+# The two tests above exercise .assert_cmr_ann_factor() directly. The three
+# production call sites (cmr_metrics_1m/3m/6m, R/plan_commodities_mean_reversion.R)
+# don't call that helper themselves -- they pass periodicity_check through to
+# .compute_cmr_metrics(), which forwards it as on_violation. These tests
+# close that gap: they drive the guard through the ACTUAL parameter the
+# staged call sites use, so a future refactor that breaks the forwarding
+# (e.g. .compute_cmr_metrics() stops passing periodicity_check through, or
+# starts swallowing it) fails here rather than only in production output.
+
+test_that(".compute_cmr_metrics defaults periodicity_check to 'abort' -- never inherited by omission", {
+  # A caller that forgets the argument must get the STRICT behaviour. The
+  # lenient 'warn' path is opt-in only at the three staged call sites; every
+  # other/future call site is silently protected by this default.
+  d <- sort(unique(c(month_days("1992-03-01", 94L), biz_days("2000-01-03", 2000L))))
+  set.seed(738)
+  portfolio <- tibble::tibble(date = d, net_ret = stats::rnorm(length(d), 0, 0.01))
+  # daily_rf aligned 1:1 on date with the portfolio: no rf-join gap of its
+  # own, so only the periodicity guard is under test.
+  daily_rf <- tibble::tibble(date = d, rf_ret = rep(0.00005, length(d)))
+
+  expect_error(
+    .compute_cmr_metrics(portfolio, lookback = "1m", daily_rf = daily_rf, ann_factor = 252L),
+    "NOT consistent with a single declared periodicity"
+  )
+})
+
+test_that(".compute_cmr_metrics(periodicity_check = 'warn') warns with the full diagnostic and still computes finite metrics", {
+  # The staging lever actually wired at cmr_metrics_1m/3m/6m. A staging flag
+  # that silently did nothing -- proceeded without warning, or aborted
+  # anyway, or returned the NA-row short-circuit instead of real metrics --
+  # would be exactly the class of defect fail-loud-not-null.md exists to
+  # catch, just inverted (silent success instead of silent failure).
+  d <- sort(unique(c(month_days("1992-03-01", 94L), biz_days("2000-01-03", 2000L))))
+  set.seed(738)
+  portfolio <- tibble::tibble(date = d, net_ret = stats::rnorm(length(d), 0, 0.01))
+  daily_rf <- tibble::tibble(date = d, rf_ret = rep(0.00005, length(d)))
+
+  w <- testthat::capture_warnings(
+    metrics <- .compute_cmr_metrics(
+      portfolio,
+      lookback = "1m", daily_rf = daily_rf, ann_factor = 252L,
+      periodicity_check = "warn"
+    )
+  )
+
+  # Full diagnostic, not a truncated summary: the strategy/lookback label,
+  # the declared factor, the out-of-band count/allowance, and the observed
+  # band breakdown all round-trip into the warning text a reader sees.
+  full_warning <- paste(w, collapse = " ")
+  expect_match(full_warning, "CMR 1m")
+  expect_match(full_warning, "ann_factor 252")
+  expect_match(full_warning, "NOT consistent with a single declared periodicity")
+  expect_match(full_warning, "\\d+ of \\d+ gaps")
+  expect_match(full_warning, "fall outside the")
+  expect_match(full_warning, "allowance is \\d+")
+  expect_match(full_warning, "Observed gap bands:")
+
+  # Not the n < 12 NA-row short-circuit, and not a silently-abandoned
+  # computation -- real, finite metrics from real data.
+  expect_equal(metrics$lookback, "1m")
+  expect_gt(metrics$n_days, 12L)
+  expect_true(is.finite(metrics$sharpe))
+  expect_true(is.finite(metrics$cagr))
+  expect_true(is.finite(metrics$vol))
+})
+
 test_that("each tolerance band contains its own nominal spacing and is monotone in ann_factor", {
   tol <- CMR_PERIODICITY_TOLERANCE
   expect_true(all(tol$min_gap < tol$max_gap))

--- a/tests/testthat/test-cmr-periodicity-consistency.R
+++ b/tests/testthat/test-cmr-periodicity-consistency.R
@@ -1,0 +1,194 @@
+# Tests for the #738 periodicity CONSISTENCY check in
+# .assert_cmr_ann_factor() (R/plan_commodities_mean_reversion.R).
+#
+# #720 added a median-gap reconciliation of a declared `ann_factor` against
+# the observed date frequency. #738 measured that `cmr_portfolio_1m` runs at
+# 12 obs/year before 2000 and ~255/year after, declared daily throughout:
+# 94 of 6851 gaps are monthly, and the overall median gap is 1 day, so the
+# median-gap check passes -- correctly by its own logic -- on a series where
+# 1.4% of observations sit at a twenty-one-fold different frequency.
+#
+# The check added here answers the DISPERSION question ("is the spacing
+# consistent with ONE declared periodicity") that no measure of central
+# tendency can answer. These tests pin both directions: it must fire on a
+# mixed-frequency series, and it must NOT fire on a genuine business-daily
+# series whose gaps widen over weekends, holidays, and market closures.
+testthat::local_edition(3)
+
+pkg_path <- if (dir.exists(here::here("packages/historicaldata"))) {
+  here::here("packages/historicaldata")
+} else {
+  file.path(dirname(here::here()), "packages/historicaldata")
+}
+suppressMessages(pkgload::load_all(pkg_path, quiet = TRUE))
+
+source(here::here("R/utils_metrics.R"))
+source(here::here("R/plan_commodities_mean_reversion.R"))
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+# A genuine business-daily series: weekdays only, so most gaps are 1 day and
+# every weekend produces a 3-day gap. This is the shape that a naive
+# "all gaps identical" consistency test would false-positive on.
+biz_days <- function(from, n) {
+  all_days <- seq.Date(as.Date(from), by = "day", length.out = ceiling(n * 7 / 5) + 14L)
+  wd <- all_days[!format(all_days, "%u") %in% c("6", "7")]
+  wd[seq_len(n)]
+}
+
+# Monthly-spaced dates.
+month_days <- function(from, n) seq.Date(as.Date(from), by = "month", length.out = n)
+
+# ── The check must NOT fire on genuine daily data ───────────────────────────
+
+test_that("a clean business-daily series passes the consistency check at 252", {
+  expect_silent(.assert_cmr_ann_factor(biz_days("2010-01-04", 2000L), 252L, "biz-daily"))
+})
+
+test_that("weekend + holiday-cluster gaps do not trip the daily band", {
+  # Deliberately includes gaps at the extremes a real daily series produces:
+  # a 4-day Thanksgiving-style break, a 5-day Christmas/New-Year cluster, and
+  # a 7-day gap the size of the 9/11 market closure (2001-09-10 -> 2001-09-17,
+  # the longest US closure since 1990). All are <= the daily band's 10-day
+  # upper bound, so none is counted out-of-band.
+  d <- biz_days("2001-01-02", 500L)
+  d <- sort(unique(c(
+    d[d < as.Date("2001-09-10") | d > as.Date("2001-09-17")],
+    as.Date(c("2001-09-10", "2001-09-17"))
+  )))
+  gaps <- as.numeric(diff(d))
+  expect_equal(max(gaps), 7)           # the 9/11-sized closure is present
+  expect_true(sum(gaps == 3) > 50)     # and plenty of ordinary weekends
+  expect_silent(.assert_cmr_ann_factor(d, 252L, "holiday-daily"))
+})
+
+test_that("a clean monthly series passes the consistency check at 12", {
+  expect_silent(.assert_cmr_ann_factor(month_days("1990-01-01", 300L), 12L, "monthly"))
+})
+
+test_that("isolated outages within the allowance floor do not fire", {
+  # Two isolated month-long outages in a 400-point daily series. n_gaps = 399,
+  # so ceiling(0.001 * 399) = 1, and the absolute floor of 2 governs. The
+  # guard fires on a PATTERN, never on one or two bad prints.
+  d <- biz_days("2010-01-04", 400L)
+  d <- d[-seq(100L, 121L)]
+  d <- d[-seq(250L, 271L)]
+  gaps <- as.numeric(diff(d))
+  expect_equal(sum(gaps > 10), 2L)
+  expect_silent(.assert_cmr_ann_factor(d, 252L, "two-outages"))
+})
+
+# ── The check MUST fire on mixed-frequency data ─────────────────────────────
+
+test_that("three isolated outages exceed the allowance floor and fire", {
+  d <- biz_days("2010-01-04", 400L)
+  d <- d[-seq(100L, 121L)]
+  d <- d[-seq(200L, 221L)]
+  d <- d[-seq(280L, 301L)]
+  expect_equal(sum(as.numeric(diff(d)) > 10), 3L)
+  expect_error(
+    .assert_cmr_ann_factor(d, 252L, "three-outages"),
+    "NOT consistent with a single declared periodicity"
+  )
+})
+
+test_that("the CMR defect shape -- monthly era then daily era, declared daily -- aborts", {
+  # Reproduces #738's measured proportions in miniature: a monthly-spaced
+  # first era followed by a business-daily second era, declared 252
+  # throughout. The median gap is 1 day, so the #720 median-gap check passes;
+  # only the consistency check can see it.
+  d <- sort(unique(c(month_days("1992-03-01", 94L), biz_days("2000-01-03", 2000L))))
+  gaps <- as.numeric(diff(d))
+  expect_equal(stats::median(gaps), 1)          # median-gap check would pass
+  expect_true(sum(gaps > 10) >= 90L)            # ... on ~90 monthly gaps
+  expect_snapshot(error = TRUE, .assert_cmr_ann_factor(d, 252L, "1m"))
+})
+
+test_that("daily prints interleaved into a monthly series abort (too-short direction)", {
+  # The mirror image: a monthly-declared series contaminated with daily
+  # observations. Consistency is two-sided -- a gap that is too SHORT for the
+  # declared periodicity is the same defect as one that is too long.
+  d <- sort(unique(c(
+    month_days("1990-01-01", 240L),
+    seq.Date(as.Date("1995-06-01"), by = "day", length.out = 40L)
+  )))
+  expect_snapshot(error = TRUE, .assert_cmr_ann_factor(d, 12L, "monthly-contaminated"))
+})
+
+# ── Structure of the guard ──────────────────────────────────────────────────
+
+test_that("a declared ann_factor with no tolerance row aborts rather than skipping the check", {
+  # fail-loud-not-null.md: an unrecognised value is an error, not a silent
+  # pass. This branch guards the two tables -- the median-gap classifier's
+  # bands and CMR_PERIODICITY_TOLERANCE -- drifting apart, so exercising it
+  # means removing a row. Restored on exit.
+  old <- CMR_PERIODICITY_TOLERANCE
+  withr::defer(assign("CMR_PERIODICITY_TOLERANCE", old, envir = globalenv()))
+  assign("CMR_PERIODICITY_TOLERANCE",
+         old[old$ann_factor != 252L, , drop = FALSE], envir = globalenv())
+
+  expect_snapshot(
+    error = TRUE,
+    .assert_cmr_ann_factor(biz_days("2010-01-04", 500L), 252L, "no-tolerance-row")
+  )
+})
+
+test_that("every ann_factor the median-gap classifier can emit has a tolerance row", {
+  # The invariant the defensive branch above exists to protect: adding a band
+  # to the classifier without a matching tolerance row would silently disable
+  # the consistency check for that periodicity.
+  expect_true(all(c(252L, 52L, 12L, 4L) %in% CMR_PERIODICITY_TOLERANCE$ann_factor))
+})
+
+test_that("the #720 median-gap classification check still fires (regression)", {
+  expect_snapshot(
+    error = TRUE,
+    .assert_cmr_ann_factor(month_days("1990-01-01", 100L), 252L, "monthly-declared-daily")
+  )
+})
+
+test_that("on_violation = 'warn' downgrades the consistency abort to a warning", {
+  # The documented staging lever: it must warn, not abort, and must NOT be
+  # silent -- a silent pass is exactly the failure mode #738 is about.
+  d <- sort(unique(c(month_days("1992-03-01", 94L), biz_days("2000-01-03", 2000L))))
+  expect_warning(
+    .assert_cmr_ann_factor(d, 252L, "1m", on_violation = "warn"),
+    "NOT consistent with a single declared periodicity"
+  )
+  expect_error(.assert_cmr_ann_factor(d, 252L, "1m", on_violation = "abort"))
+})
+
+test_that("each tolerance band contains its own nominal spacing and is monotone in ann_factor", {
+  tol <- CMR_PERIODICITY_TOLERANCE
+  expect_true(all(tol$min_gap < tol$max_gap))
+  # Every band contains its own nominal calendar spacing (365.25 / ann_factor).
+  nominal <- 365.25 / tol$ann_factor
+  expect_true(all(nominal >= tol$min_gap & nominal <= tol$max_gap))
+  # Bands widen monotonically as the declared frequency falls.
+  o <- order(tol$ann_factor, decreasing = TRUE)
+  expect_true(!is.unsorted(tol$min_gap[o]))
+  expect_true(!is.unsorted(tol$max_gap[o]))
+})
+
+test_that("adjacent bands overlap by design, and the check is unaffected by that", {
+  # daily [1, 10] and weekly [4, 24] deliberately overlap: a 7-day gap is
+  # consistent BOTH with a daily series over a holiday week and with a weekly
+  # series. That ambiguity affects only the diagnostic band label in the abort
+  # message (first match wins); the check itself only ever asks whether a gap
+  # lies in the DECLARED periodicity's band, so overlap cannot cause a missed
+  # detection or a false positive.
+  tol <- CMR_PERIODICITY_TOLERANCE
+  daily  <- tol[tol$ann_factor == 252L, ]
+  weekly <- tol[tol$ann_factor == 52L, ]
+  expect_true(weekly$min_gap < daily$max_gap)   # the overlap is real
+
+  seven_day <- seq.Date(as.Date("2015-01-05"), by = "7 days", length.out = 200L)
+  expect_silent(.assert_cmr_ann_factor(seven_day, 52L, "weekly"))   # declared weekly: passes
+  expect_error(                                                      # declared monthly: fires
+    .assert_cmr_ann_factor(seven_day, 12L, "weekly-declared-monthly")
+  )
+})
+
+test_that("fewer than three observations is a no-op, not a false abort", {
+  expect_silent(.assert_cmr_ann_factor(as.Date(c("2020-01-01", "2020-06-01")), 252L, "tiny"))
+})


### PR DESCRIPTION
## Summary

Supersedes #748 (carries #748's commit `236e945` plus this one). #748 added
the #738 dispersion-based periodicity **consistency** check to
`.assert_cmr_ann_factor()` and gave `.compute_cmr_metrics()` a
`periodicity_check = c("abort", "warn")` staging lever -- but wired it
nowhere. The guard is correct and fires on CMR's real production data (it
genuinely is monthly before 2000 and daily after), so as #748 stood, the
next `tar_make()` would abort `cmr_metrics_1m/3m/6m` and take `main` red.

This PR stages the lever as decided: the three production call sites now
pass `periodicity_check = "warn"` explicitly, so the build stays green while
the finding is loud in every build log. It does **not** decide the
mixed-frequency remedy (truncate to 2000+, resample to monthly, or segment)
-- that stays open on #738.

- `cmr_metrics_1m/3m/6m` (`R/plan_commodities_mean_reversion.R`) each pass
  `periodicity_check = "warn"`, with a comment naming #738 and stating what
  ends the staging: the #738 remedy landing, after which the guard passes on
  its own under the "abort" default and this argument should be **deleted**,
  not flipped back.
- `.compute_cmr_metrics()`'s own default stays `"abort"` -- a call site that
  forgets the argument gets the strict behaviour, never the lenient one by
  omission. Only the three staged call sites opt down.
- New tests in `tests/testthat/test-cmr-periodicity-consistency.R` drive the
  guard through `.compute_cmr_metrics()`'s actual `periodicity_check`
  parameter (the existing tests only exercised `.assert_cmr_ann_factor()`
  directly):
  - one confirms the default still aborts end-to-end through
    `.compute_cmr_metrics()`, not just through the lower-level helper;
  - the other confirms `"warn"` emits the **full** diagnostic (strategy
    label, declared factor, out-of-band count/allowance, observed gap
    bands) and still returns finite `sharpe`/`cagr`/`vol` -- ruling out
    both a silently-abandoned computation and the `n < 12` NA-row
    short-circuit swallowing the case.

## Verification

**OBSERVED** (all commands actually run this session, not predicted):

1. `scripts/verify.sh` (full run) -- **PASS**.
   - Root suite: `total=739 failed=3 skipped=0` -- matches the documented
     baseline exactly (same 3 known failures: `test-crypto-momentum.R`,
     `test-qa-summary-deps.R`, `test-stock-backtest.R`). No new failures.
   - Package suite (`packages/historicaldata/`): `total=713 failed=1
     skipped=15` -- matches the documented baseline exactly (1 known
     failure: `test-mom-prepeak-portfolio.R`; skip count 15 = 4
     `{alphavantager}`-absent + 11 `HD_TEST_LIVE`-gated, per
     `.claude/CLAUDE.md`).
   - `parse("_targets.R")`, `docs/_targets.R` parse + `tar_validate`,
     testthat edition 3 active, dashboard freshness -- all PASS.

2. `tests/testthat/test-cmr-periodicity-consistency.R` run in isolation --
   39/39 expectations pass, 0 failures, 0 stray warnings (the new tests use
   `expect_warning`/`capture_warnings`, which absorb the warning rather than
   letting it surface as a test-run warning).

3. Live-store demonstration (read-only `tar_read()` against
   `docs/_targets`, **no** `tar_make()` run):
   - `cmr_portfolio_1m`: 6852 rows; `daily_rf`: 26190 rows.
   - **Default (`"abort"`) path** on the live `cmr_portfolio_1m` raises:
     ```
     x CMR 1m: the observation spacing is NOT consistent with a single
       declared periodicity (ann_factor 252, daily).
     i 94 of 6851 gaps (1.372%) fall outside the daily band [1, 10] calendar
       days; allowance is 7.
     i Observed gap bands: daily: 6757; monthly: 94.
     i Out-of-band gaps range 28-31 calendar days, spanning
       1992-04-01..2000-01-01.
     i The median gap (1 calendar days) agrees with the declared factor,
       which is why the #720 median-gap check passes -- a median cannot see
       a minority at a different frequency. See #738.
     i See .claude/rules/fail-loud-not-null.md Required Pattern 5.
     ```
   - **Staged (`"warn"`) path** on the same data: emits the identical
     diagnostic text above as a `warning()`, not an error (plus one
     unrelated, pre-existing warning from the Fama-French publication-lag
     trim in `.cmr_join_rf` -- present regardless of this change), and
     still computes:
     | lookback | n_days | sharpe | cagr | vol | max_dd |
     |---|---|---|---|---|---|
     | 1m | 6799 | -1.86 | -0.369 | 0.208 | -1.000 |
     | 3m | 6795 | -1.23 | -0.257 | 0.225 | -1.000 |
     | 6m | 6789 | -0.747 | -0.152 | 0.229 | -0.996 |
     All `sharpe`/`cagr`/`vol` values are finite (`is.finite() == TRUE`).

**PREDICTED, not run** (explicitly out of scope for this dispatch --
`scripts/build.sh` holds a lock and `tar_make()` was not run):
- That a full `tar_make()` on this branch completes with `cmr_metrics_1m/3m/6m`
  green rather than erroring. The live-store read above exercises the same
  code path with the same live data and the same `periodicity_check =
  "warn"` argument, so this is expected but not directly observed via
  `tar_make()` itself -- please confirm on your own build.

## Refs

Refs #738, #748
