### PR TITLE
fix(cmr): calendar-based lookback window for hd_commodity_mr_signal() (#751 item E)

### DIFF
--- a/packages/historicaldata/R/commodities_mean_reversion.R
+++ b/packages/historicaldata/R/commodities_mean_reversion.R
@@ -14,50 +14,149 @@
 #   is daily-dominated (ann_factor=252), not monthly (ann_factor=12) despite
 #   this file's "monthly"/lookback_months naming throughout -- see
 #   R/plan_commodities_mean_reversion.R's file header for the source
-#   evidence. `lookback_months` here counts unique dates in the merged
-#   universe (one row per date), not calendar months; cosmetic-only fix,
-#   left un-renamed per #720's note (shared with commodities_momentum.R).
+#   evidence. The `monthly_ret`/`lookback_months` naming is left un-renamed
+#   per #720's note (shared with commodities_momentum.R); `monthly_ret` holds
+#   a per-observation return whose actual period is daily for 96% of the
+#   merged universe's rows (Yahoo futures/ETF series) and monthly for the
+#   rest (FRED/IMF indexes) -- the name is a historical label, not a
+#   guarantee about the row's cadence.
+# #751: `lookback_months` was PREVIOUSLY a row-count window (the `lb`-th
+#   previous ROW, regardless of its date) -- correctly "cosmetic-only" per
+#   #720 only for a single-frequency series, but WRONG for this mixed-cadence
+#   universe: `lookback_months = 3` gave a FRED monthly series a genuine
+#   3-month window and a Yahoo daily series a 3-*trading-day* window, and
+#   both were then ranked in the same cross-sectional sort. A 3-month return
+#   has ~sqrt(21) times the dispersion of a 3-day return, so the monthly
+#   names occupied the extreme ranks near-mechanically whenever they printed.
+#   Verified still live through 2026-03-01 (13 IMF series still print
+#   monthly), not just a pre-2000 artifact. hd_commodity_mr_signal() now
+#   uses a CALENDAR window (elapsed days), so `lookback_months = 3` means the
+#   same economic horizon for every series regardless of how often it prints
+#   -- see that function's roxygen for the window/floor design.
 # Universe re-uses commodities_returns from plan_commodities_momentum.R.
 
 
+#' Average Gregorian calendar month length, in days (365.2425 / 12)
+#'
+#' Used to convert \code{lookback_months} into a fixed number of CALENDAR
+#' DAYS for \code{\link{hd_commodity_mr_signal}}'s sliding window, rather
+#' than using \code{lubridate::months()} period arithmetic directly.
+#' \code{months()} subtraction produces \code{NA} whenever the anchor date
+#' has no equivalent day N months prior (e.g. day 31 minus 3 months, when
+#' the target month has fewer than 31 days) -- see
+#' \code{strategy_mom_prepeak.R}'s \code{lubridate::`%m-%`} workaround for
+#' the same underlying gotcha. A fixed-day window sidesteps this entirely:
+#' \code{date - lubridate::days(n)} is always defined. 30.436875 (=
+#' 365.2425 / 12) is the standard Gregorian mean month length; using it
+#' rather than a round number (30) keeps a 12-month window close to 365
+#' days rather than drifting short by ~4 days a year.
+#'
+#' @noRd
+.HD_MR_MEAN_DAYS_PER_MONTH <- 365.2425 / 12
+
+#' Minimum window-fill fraction required for a calendar window to be treated
+#' as complete
+#'
+#' A calendar window can span the right number of days while containing
+#' almost no observations, if it happens to cross a data gap (a stale/thin
+#' patch of a series, or -- for this mixed-cadence universe -- a series that
+#' is far sparser than a typical window expects). \code{slider}'s own
+#' \code{.complete = TRUE} only checks that the window's start boundary
+#' falls inside the series' observed date RANGE; it does not check how many
+#' observations actually fall inside the window.
+#'
+#' This fraction is applied against \code{window_days / median_gap_days} --
+#' the observation count a window of this length would contain if the
+#' series kept up its own typical (median) spacing. 0.5 tolerates normal
+#' weekend/holiday sparsity in a daily series and the +/-1 rounding a
+#' ~30.44-day-average month produces against real (non-uniform) monthly
+#' print dates, while still rejecting a window degraded by an outage/gap
+#' materially larger than the series' own norm. It is deliberately not
+#' closer to 1: a strict 90-100% fill would reject completely ordinary daily
+#' windows that happen to contain an extra holiday cluster.
+#'
+#' @noRd
+.HD_MR_MIN_OBS_FRACTION <- 0.5
+
+#' Absolute floor on observations inside a calendar window, regardless of
+#' cadence
+#'
+#' A "cumulative return over a lookback window" is a product over multiple
+#' observations; a window containing only the observation at \code{t} itself
+#' is not a lookback return at all, it is that single observation's own
+#' return relabelled as a longer-horizon one. 2 is the smallest count for
+#' which the product spans more than one observation. This floor matters
+#' when a series' own cadence cannot be estimated (fewer than 2 dated
+#' observations) or is so sparse that \code{.HD_MR_MIN_OBS_FRACTION} of the
+#' cadence-implied count would round below it.
+#'
+#' @noRd
+.HD_MR_MIN_OBS_FLOOR <- 2L
+
 #' Commodity Mean Reversion Signal
 #'
-#' Compute a monthly mean-reversion signal for a commodity universe.
+#' Compute a mean-reversion signal for a commodity universe over a fixed
+#' CALENDAR window (elapsed days), not a fixed number of rows.
 #' The signal is the *negative* of the lookback-period return: commodities
 #' that have fallen the most receive the highest (most positive) signal,
 #' while those that have risen the most receive the lowest (most negative)
 #' signal.
 #'
-#' Look-ahead safety: the signal at month \code{t} is constructed from
-#' cumulative returns over months \code{(t - lookback_months)} through
-#' \code{(t - 1)}.  The one-period lag is enforced via
-#' \code{dplyr::lag(cumret)} before the negation, so no return at or after
-#' month \code{t} ever enters signal formation.
+#' Look-ahead safety: the signal at date \code{t} is constructed from
+#' cumulative returns over the \code{lookback_months} calendar months
+#' immediately preceding \code{t}, ending at \code{t - 1}'s observation. The
+#' one-period lag is enforced via \code{dplyr::lag(cumret)} before the
+#' negation, so no return at or after date \code{t} ever enters signal
+#' formation.
 #'
-#' @param returns_tbl Tibble with columns \code{date} (Date, month-end),
-#'   \code{series_id} (character), and \code{monthly_ret} (numeric monthly
-#'   return).  Produced by \code{calculate_commodity_returns()}.
-#' @param lookback_months Integer. Number of months used to compute the
-#'   mean-reversion signal (default 3).  Typical values: 1, 3, 6.
+#' @param returns_tbl Tibble with columns \code{date} (Date), \code{series_id}
+#'   (character), and \code{monthly_ret} (numeric per-observation return;
+#'   despite the name, this is a DAILY return for series that print daily --
+#'   see the file header note). Produced by \code{calculate_commodity_returns()}.
+#' @param lookback_months Integer. Number of CALENDAR months the
+#'   mean-reversion window spans (default 3), applied uniformly regardless
+#'   of how often the underlying series is actually observed. Typical
+#'   values: 1, 3, 6.
 #'
 #' @return Tibble with columns:
 #'   \describe{
-#'     \item{date}{Month-end date.}
+#'     \item{date}{Observation date.}
 #'     \item{series_id}{Commodity identifier.}
 #'     \item{mr_signal}{Mean-reversion signal = negative of cumulative
-#'       return over the prior \code{lookback_months} months. Higher values
-#'       (bigger recent losers) rank first for the long leg.}
+#'       return over the prior \code{lookback_months} calendar months.
+#'       Higher values (bigger recent losers) rank first for the long leg.}
 #'   }
-#'   Rows with \code{NA} signals (insufficient history) are dropped.
+#'   Rows with \code{NA} signals (insufficient history, or too few actual
+#'   observations inside an otherwise-complete window) are dropped.
 #'
 #' @details
-#' The cumulative return over a rolling window is computed as
-#' \eqn{\prod_{i=1}^{L}(1 + r_{t-i}) - 1}, where \eqn{L} is
-#' \code{lookback_months}.  This product is formed using
-#' \code{slider::slide_dbl} with \code{.complete = TRUE} so partial windows
-#' produce \code{NA}.  The result is then lagged by one period to guarantee
-#' look-ahead safety, and the signal is the negation of the lagged cumulative
-#' return.
+#' \strong{Window (#751):} the cumulative return is computed over a window
+#' spanning \code{round(lookback_months * 365.2425 / 12)} CALENDAR DAYS
+#' ending at \code{t} (inclusive), via \code{slider::slide_index_dbl()} keyed
+#' on \code{date} rather than row position. This means
+#' \code{lookback_months = 3} spans the same ~91-day economic horizon for
+#' every series in the universe, whether it is observed daily (~63
+#' observations in that window) or monthly (~3 observations). Previously the
+#' window was \code{lookback_months} PREVIOUS ROWS regardless of their
+#' dates, which silently gave a daily series a 3-*trading-day* window under
+#' the same argument that gave a monthly series a genuine 3-month window
+#' (#751) -- see the file header for the full defect history.
+#'
+#' \strong{Completeness (fail-loud-not-null.md):} a window counts as complete
+#' only if BOTH (a) its start boundary falls within the series' own observed
+#' date range (\code{slider}'s \code{.complete = TRUE}), AND (b) it actually
+#' contains at least \code{max(.HD_MR_MIN_OBS_FLOOR,
+#' ceiling(.HD_MR_MIN_OBS_FRACTION * expected_obs))} observations, where
+#' \code{expected_obs} is \code{window_days / median_gap_days} for that
+#' series' own median inter-observation gap. Condition (a) alone would
+#' accept a window that nominally spans the right number of days but
+#' crosses a data outage and contains almost no real observations -- see
+#' \code{.HD_MR_MIN_OBS_FRACTION}'s roxygen for why a per-series relative
+#' floor is used rather than one fixed count (a fixed count could not serve
+#' both a ~63-observation daily window and a ~3-observation monthly one).
+#' Windows failing either condition produce \code{NA}, which propagates
+#' through the one-period lag and causes that row to be dropped from the
+#' returned tibble, exactly as an insufficient-history \code{NA} always has.
 #'
 #' @family commodities_mr
 #' @export
@@ -82,19 +181,64 @@ hd_commodity_mr_signal <- function(returns_tbl, lookback_months = 3L) {
   }
   lookback_months <- as.integer(lookback_months)
 
+  # #751: fixed CALENDAR days, not a row count and not lubridate::months()
+  # period arithmetic -- see .HD_MR_MEAN_DAYS_PER_MONTH's roxygen for why.
+  window_days <- .HD_MR_MEAN_DAYS_PER_MONTH * lookback_months
+
   returns_tbl |>
     dplyr::arrange(series_id, date) |>
     dplyr::group_by(series_id) |>
     dplyr::mutate(
-      # Cumulative return over the lookback window ending at t (inclusive of t).
-      # .complete = TRUE ensures NA for partial windows.
-      cumret_raw = slider::slide_dbl(
-        monthly_ret,
+      # This series' own typical observation cadence (median calendar-day
+      # gap between its consecutive dates). Mirrors the "median gap defines
+      # periodicity" logic in .assert_cmr_ann_factor()
+      # (R/plan_commodities_mean_reversion.R), applied per-series here
+      # rather than to the whole merged universe. NA when fewer than 2
+      # dated observations exist for this series.
+      .median_gap_days = {
+        d <- sort(unique(date))
+        if (length(d) < 2L) NA_real_ else stats::median(as.numeric(diff(d)))
+      },
+      # Observation count a `window_days`-wide window would hold if this
+      # series kept up its own median cadence. 0 (not NA) when the cadence
+      # is unknown/degenerate, so the fraction-of-expected floor collapses
+      # to .HD_MR_MIN_OBS_FLOOR below rather than propagating NA into the
+      # comparison.
+      .expected_obs = dplyr::if_else(
+        is.na(.median_gap_days) | .median_gap_days <= 0,
+        0,
+        window_days / .median_gap_days
+      ),
+      # Minimum observations required inside the window for it to count as
+      # complete -- see .HD_MR_MIN_OBS_FRACTION / .HD_MR_MIN_OBS_FLOOR.
+      .min_obs = pmax(
+        .HD_MR_MIN_OBS_FLOOR,
+        ceiling(.HD_MR_MIN_OBS_FRACTION * .expected_obs)
+      ),
+      # Cumulative return over the CALENDAR window ending at t (inclusive).
+      # Keyed on `date` (slide_index_dbl), not row position (slide_dbl) --
+      # this is the #751 fix. .complete = TRUE requires the window's start
+      # boundary to fall within this series' own observed date range.
+      cumret_raw = slider::slide_index_dbl(
+        monthly_ret, date,
         .f = function(r) prod(1 + r) - 1,
-        .before = lookback_months - 1L,
+        .before = lubridate::days(round(window_days)),
         .after  = 0L,
         .complete = TRUE
       ),
+      # How many observations actually fell inside that same window --
+      # .complete = TRUE alone cannot see a window that spans the right
+      # number of days but crosses a data gap and contains almost none.
+      .n_obs_window = slider::slide_index_dbl(
+        monthly_ret, date,
+        .f = function(r) as.double(length(r)),
+        .before = lubridate::days(round(window_days)),
+        .after  = 0L,
+        .complete = TRUE
+      ),
+      # Enforce the fill-fraction floor: too few actual observations ->
+      # treat the window as incomplete (NA), same as slider's own guard.
+      cumret_raw = dplyr::if_else(.n_obs_window < .min_obs, NA_real_, cumret_raw),
       # Lag by 1: cumret at position t becomes the lookback return through t-1.
       # Signal = negation so recent losers have high (positive) signal.
       mr_signal = -dplyr::lag(cumret_raw, n = 1L)

--- a/packages/historicaldata/man/hd_commodity_mr_signal.Rd
+++ b/packages/historicaldata/man/hd_commodity_mr_signal.Rd
@@ -7,45 +7,71 @@
 hd_commodity_mr_signal(returns_tbl, lookback_months = 3L)
 }
 \arguments{
-\item{returns_tbl}{Tibble with columns \code{date} (Date, month-end),
-\code{series_id} (character), and \code{monthly_ret} (numeric monthly
-return).  Produced by \code{calculate_commodity_returns()}.}
+\item{returns_tbl}{Tibble with columns \code{date} (Date), \code{series_id}
+(character), and \code{monthly_ret} (numeric per-observation return;
+despite the name, this is a DAILY return for series that print daily --
+see the file header note). Produced by \code{calculate_commodity_returns()}.}
 
-\item{lookback_months}{Integer. Number of months used to compute the
-mean-reversion signal (default 3).  Typical values: 1, 3, 6.}
+\item{lookback_months}{Integer. Number of CALENDAR months the
+mean-reversion window spans (default 3), applied uniformly regardless
+of how often the underlying series is actually observed. Typical
+values: 1, 3, 6.}
 }
 \value{
 Tibble with columns:
 \describe{
-\item{date}{Month-end date.}
+\item{date}{Observation date.}
 \item{series_id}{Commodity identifier.}
 \item{mr_signal}{Mean-reversion signal = negative of cumulative
-return over the prior \code{lookback_months} months. Higher values
-(bigger recent losers) rank first for the long leg.}
+return over the prior \code{lookback_months} calendar months.
+Higher values (bigger recent losers) rank first for the long leg.}
 }
-Rows with \code{NA} signals (insufficient history) are dropped.
+Rows with \code{NA} signals (insufficient history, or too few actual
+observations inside an otherwise-complete window) are dropped.
 }
 \description{
-Compute a monthly mean-reversion signal for a commodity universe.
+Compute a mean-reversion signal for a commodity universe over a fixed
+CALENDAR window (elapsed days), not a fixed number of rows.
 The signal is the \emph{negative} of the lookback-period return: commodities
 that have fallen the most receive the highest (most positive) signal,
 while those that have risen the most receive the lowest (most negative)
 signal.
 }
 \details{
-Look-ahead safety: the signal at month \code{t} is constructed from
-cumulative returns over months \code{(t - lookback_months)} through
-\code{(t - 1)}.  The one-period lag is enforced via
-\code{dplyr::lag(cumret)} before the negation, so no return at or after
-month \code{t} ever enters signal formation.
+Look-ahead safety: the signal at date \code{t} is constructed from
+cumulative returns over the \code{lookback_months} calendar months
+immediately preceding \code{t}, ending at \code{t - 1}'s observation. The
+one-period lag is enforced via \code{dplyr::lag(cumret)} before the
+negation, so no return at or after date \code{t} ever enters signal
+formation.
 
-The cumulative return over a rolling window is computed as
-\eqn{\prod_{i=1}^{L}(1 + r_{t-i}) - 1}, where \eqn{L} is
-\code{lookback_months}.  This product is formed using
-\code{slider::slide_dbl} with \code{.complete = TRUE} so partial windows
-produce \code{NA}.  The result is then lagged by one period to guarantee
-look-ahead safety, and the signal is the negation of the lagged cumulative
-return.
+\strong{Window (#751):} the cumulative return is computed over a window
+spanning \code{round(lookback_months * 365.2425 / 12)} CALENDAR DAYS
+ending at \code{t} (inclusive), via \code{slider::slide_index_dbl()} keyed
+on \code{date} rather than row position. This means
+\code{lookback_months = 3} spans the same ~91-day economic horizon for
+every series in the universe, whether it is observed daily (~63
+observations in that window) or monthly (~3 observations). Previously the
+window was \code{lookback_months} PREVIOUS ROWS regardless of their
+dates, which silently gave a daily series a 3-\emph{trading-day} window under
+the same argument that gave a monthly series a genuine 3-month window
+(#751) -- see the file header for the full defect history.
+
+\strong{Completeness (fail-loud-not-null.md):} a window counts as complete
+only if BOTH (a) its start boundary falls within the series' own observed
+date range (\code{slider}'s \code{.complete = TRUE}), AND (b) it actually
+contains at least \code{max(.HD_MR_MIN_OBS_FLOOR,
+ceiling(.HD_MR_MIN_OBS_FRACTION * expected_obs))} observations, where
+\code{expected_obs} is \code{window_days / median_gap_days} for that
+series' own median inter-observation gap. Condition (a) alone would
+accept a window that nominally spans the right number of days but
+crosses a data outage and contains almost no real observations -- see
+\code{.HD_MR_MIN_OBS_FRACTION}'s roxygen for why a per-series relative
+floor is used rather than one fixed count (a fixed count could not serve
+both a ~63-observation daily window and a ~3-observation monthly one).
+Windows failing either condition produce \code{NA}, which propagates
+through the one-period lag and causes that row to be dropped from the
+returned tibble, exactly as an insufficient-history \code{NA} always has.
 }
 \seealso{
 Other commodities_mr: 

--- a/packages/historicaldata/tests/testthat/test-commodities-mean-reversion.R
+++ b/packages/historicaldata/tests/testthat/test-commodities-mean-reversion.R
@@ -1,25 +1,110 @@
-test_that("hd_commodity_mr_signal: look-ahead guard — signal at t uses only returns <= t-1", {
-  # Synthetic series: 24 months, one commodity
-  # months 1-12: return 0.05 (rising), months 13-24: return -0.05 (falling)
-  dates <- seq.Date(as.Date("2010-01-31"), by = "month", length.out = 24)
-  rets  <- c(rep(0.05, 12), rep(-0.05, 12))
+test_that("hd_commodity_mr_signal: signal at t is unaffected by any return at/after t (look-ahead guard)", {
+  # #751: the window is now CALENDAR-based (slide_index_dbl keyed on date),
+  # not row-count-based, so a row-index hand-computation of the "expected"
+  # signal (the previous version of this test) no longer describes the
+  # function's own window boundaries. Test the PROPERTY instead: perturbing
+  # every return at/after a cutoff date must not change any signal computed
+  # for a date strictly before that cutoff, regardless of the internal
+  # window implementation.
+  set.seed(1)
+  dates <- seq.Date(as.Date("2010-01-01"), by = "month", length.out = 24)
+  rets  <- rnorm(24, 0, 0.03)
   tbl   <- tibble::tibble(date = dates, series_id = "A", monthly_ret = rets)
+
+  sig_base <- hd_commodity_mr_signal(tbl, lookback_months = 3L)
+
+  cutoff <- dates[15]
+  tbl_perturbed <- tbl
+  perturb_idx <- tbl_perturbed$date >= cutoff
+  # Gross perturbation (+1000%): any leak into cumret_raw's product would be
+  # numerically unmistakable.
+  tbl_perturbed$monthly_ret[perturb_idx] <- tbl_perturbed$monthly_ret[perturb_idx] + 10
+
+  sig_perturbed <- hd_commodity_mr_signal(tbl_perturbed, lookback_months = 3L)
+
+  base_before      <- sig_base[sig_base$date < cutoff, ]
+  perturbed_before <- sig_perturbed[sig_perturbed$date < cutoff, ]
+
+  # Same set of dates carry a signal either way -- the perturbation must not
+  # change which pre-cutoff windows are treated as complete.
+  expect_equal(base_before$date, perturbed_before$date)
+  expect_equal(base_before$mr_signal, perturbed_before$mr_signal, tolerance = 1e-10)
+})
+
+
+test_that("hd_commodity_mr_signal: same lookback_months spans a genuinely different observation count for a daily vs a monthly series (#751 fix)", {
+  # This is the defect #751 reports: under the OLD row-count window, both
+  # series below would have used exactly 3 rows regardless of their actual
+  # dates. Under the calendar-based window, the daily series' window spans
+  # ~63 trading-day observations while the monthly series' window spans ~3
+  # -- the same ~91-day economic horizon for both.
+  d_daily <- seq.Date(as.Date("2020-01-01"), as.Date("2020-12-31"), by = "day")
+  d_daily <- d_daily[!weekdays(d_daily) %in% c("Saturday", "Sunday")]
+  daily <- tibble::tibble(
+    date = d_daily, series_id = "DAILY",
+    monthly_ret = rep(0.001, length(d_daily))
+  )
+
+  d_monthly <- seq.Date(as.Date("2020-01-01"), as.Date("2020-12-01"), by = "month")
+  monthly <- tibble::tibble(
+    date = d_monthly, series_id = "MONTHLY",
+    monthly_ret = rep(0.03, length(d_monthly))
+  )
+
+  combined <- dplyr::bind_rows(daily, monthly)
+  sig <- hd_commodity_mr_signal(combined, lookback_months = 3L)
+
+  # Both series carry a constant per-observation return, so the magnitude of
+  # the cumulative return directly reveals how many observations the window
+  # actually captured: |signal| = (1 + r)^n - 1.
+  daily_sig   <- sig$mr_signal[sig$series_id == "DAILY"]
+  monthly_sig <- sig$mr_signal[sig$series_id == "MONTHLY"]
+
+  # Both series carry a POSITIVE constant return, so cumret = (1+r)^n - 1 > 0
+  # and mr_signal = -cumret < 0 for every valid row; |signal| = cumret, so
+  # n = log(1 + |signal|) / log(1 + r).
+  n_daily_implied   <- log(1 + min(abs(daily_sig))) / log(1.001)
+  n_monthly_implied <- log(1 + min(abs(monthly_sig))) / log(1.03)
+
+  # Daily window: ~63 trading days in a ~91-day span (weekends excluded).
+  # Monthly window: ~3 month-start prints in the same span. A wide interval
+  # is used because slide_index_dbl's window boundary interacts with real
+  # weekday/month-length irregularity -- the point being tested is the ORDER
+  # OF MAGNITUDE difference (roughly 20x), not an exact count.
+  expect_true(n_daily_implied > 40, info = paste("n_daily_implied =", n_daily_implied))
+  expect_true(n_monthly_implied >= 2 && n_monthly_implied <= 5,
+              info = paste("n_monthly_implied =", n_monthly_implied))
+  # Under the OLD row-count window both would have been exactly 3.
+  expect_true(n_daily_implied > 3 * n_monthly_implied)
+})
+
+
+test_that("hd_commodity_mr_signal: a data gap inside an otherwise-complete window is excluded, not silently accepted (fail-loud-not-null)", {
+  # Dense daily block, a 70-day gap, then a dense daily block again. Right
+  # after the gap resumes, slider's .complete = TRUE alone would accept the
+  # window (its start boundary is still within the series' overall date
+  # range), but the window actually contains far fewer observations than
+  # this series' own median cadence predicts. The .HD_MR_MIN_OBS_FRACTION
+  # floor must reject it.
+  block1 <- seq.Date(as.Date("2010-01-01"), as.Date("2010-04-10"), by = "day")
+  block2_start <- as.Date("2010-04-10") + 70
+  block2 <- seq.Date(block2_start, by = "day", length.out = 80)
+  dates  <- c(block1, block2)
+  tbl <- tibble::tibble(date = dates, series_id = "S", monthly_ret = rep(0.001, length(dates)))
 
   sig <- hd_commodity_mr_signal(tbl, lookback_months = 3L)
 
-  # For any row with signal date d, the signal must equal
-  # -(prod(1 + r[d-3:d-1]) - 1), NOT using return at d itself.
-  # We verify by constructing the expected signal manually.
-  for (i in seq_len(nrow(sig))) {
-    d      <- sig$date[i]
-    d_idx  <- which(tbl$date == d)
-    # Signal window: indices (d_idx-3) to (d_idx-1) relative to tbl
-    lb_idx <- (d_idx - 3):(d_idx - 1)
-    if (any(lb_idx < 1)) next  # skip if window not fully populated
-    expected_signal <- -(prod(1 + tbl$monthly_ret[lb_idx]) - 1)
-    expect_equal(sig$mr_signal[i], expected_signal, tolerance = 1e-10,
-                 info = paste("date =", d))
-  }
+  # The first date of block2 still carries a signal (it reflects the dense
+  # block1 window computed the day before the gap).
+  expect_true(block2_start %in% sig$date)
+  # The date immediately after that is excluded: its window (looking back
+  # ~91 days from block2_start) crosses the 70-day gap and contains far
+  # fewer observations than a dense daily window normally would.
+  expect_false((block2_start + 1) %in% sig$date)
+  # Signal resumes once enough dense post-gap data has accumulated to
+  # refill the window past the floor (measured directly against this
+  # implementation: 2010-08-04, 46 days after block2 starts).
+  expect_true(as.Date("2010-08-04") %in% sig$date)
 })
 
 


### PR DESCRIPTION
## Summary

Item **E** from #751: makes `hd_commodity_mr_signal()`'s `lookback_months`
argument a **calendar window** (elapsed days), not a row-count window.

Under the previous row-count window, `lookback_months = 3` gave a FRED/IMF
monthly series a genuine 3-month window and a Yahoo daily series a
3-*trading-day* window, and both were then ranked in the same
cross-sectional sort. A 3-month return has ~sqrt(21) times the dispersion
of a 3-day return, so the monthly names occupied the extreme ranks
near-mechanically whenever they printed -- filling both the long and short
buckets. This is verified still live through 2026-03-01 (13 IMF series
still print monthly), not only a pre-2000 artifact.

The file's own header comment previously called this "cosmetic-only" per
#720. That classification was wrong for this mixed-cadence universe and is
corrected in this PR.

## What changed

- `hd_commodity_mr_signal()` (`packages/historicaldata/R/commodities_mean_reversion.R`)
  now computes the cumulative lookback return with `slider::slide_index_dbl()`
  keyed on `date`, with `.before = lubridate::days(round(lookback_months * 365.2425/12))`
  -- a fixed calendar-day window, so `lookback_months = 3` spans the same
  ~91-day economic horizon for every series regardless of how often it
  prints.
- `lubridate::days()` (fixed days) is used rather than `months()` period
  arithmetic, because `months()` subtraction produces `NA` at day-31
  anchors with no equivalent day N months prior (the same gotcha
  `strategy_mom_prepeak.R`'s `%m-%` workaround exists for).
- **Completeness floor (fail-loud-not-null.md):** `slider`'s own
  `.complete = TRUE` only checks that a window's start boundary falls
  inside a series' observed date range -- it does not check how many
  observations actually landed inside the window. A window can span the
  right number of days while crossing a data gap and containing almost no
  real observations. Added a per-series minimum-observation floor:
  `max(.HD_MR_MIN_OBS_FLOOR = 2, ceiling(.HD_MR_MIN_OBS_FRACTION = 0.5 *
  window_days / series' own median gap))`. Windows failing this floor
  produce `NA`, same as an insufficient-history window always has. See the
  new `.HD_MR_MEAN_DAYS_PER_MONTH` / `.HD_MR_MIN_OBS_FRACTION` /
  `.HD_MR_MIN_OBS_FLOOR` roxygen blocks for the full reasoning behind each
  constant.
- File header and function roxygen updated to describe the new semantics
  and correct the "cosmetic-only" mischaracterization; the `monthly_ret`
  column is **not** renamed (see "What I deliberately did not do" below).
- 3 new tests replace the old row-count-based look-ahead test (which
  hand-computed expected signals from row indices -- a description of the
  *old* implementation, not a property of the function) and add explicit
  coverage for the fix and the new floor:
  1. Look-ahead guard rewritten as a **property test**: perturbing every
     return at/after a cutoff date must not change any signal computed for
     a date strictly before the cutoff -- true regardless of internal
     window implementation.
  2. Directly demonstrates the #751 defect and its fix: a daily series and
     a monthly series with the same `lookback_months = 3` now capture
     ~63 vs ~3 observations respectively (previously both would have been
     exactly 3).
  3. Directly demonstrates the new completeness floor: a dense daily
     series with an internal 70-day gap has its post-gap window correctly
     excluded (not silently accepted as complete) until enough dense data
     has re-accumulated.

## What I deliberately did not do (per dispatch scope)

- **Did not touch universe composition** -- no series dropped, no ETF/futures
  dedup, `n_long`/`n_short` unchanged. Those are separate open decisions on
  #751.
- **Did not truncate to 2000+.** Also a separate #751 decision.
- **Did not touch the #738 periodicity guard** (`.assert_cmr_ann_factor()`,
  staged at `periodicity_check = "warn"` per #750) -- untouched, still
  fires on the same underlying mixed-frequency condition (see measurement
  below). This PR does not resolve #738.
- **Did not rename `monthly_ret`.** It is misleadingly named (holds a daily
  return for 96% of rows), but renaming ripples through every caller in
  this file and the plan file, which would fold an unrelated mechanical
  change into this one and violate "one change per verification run." Fixed
  the misleading comment/roxygen instead; renaming is left as a follow-up if
  wanted.

## Verification

**OBSERVED** (all commands run this session):

1. `scripts/verify.sh` (full run, foreground) -- **PASS**.
   - Root suite: `total=755 failed=3 skipped=0` -- matches the documented
     baseline exactly (3 known failures: `test-crypto-momentum.R`,
     `test-qa-summary-deps.R`, `test-stock-backtest.R`). Total count differs
     from the `.claude/CLAUDE.md`-documented 739 due to unrelated commits
     since that baseline was written; the failure *signatures* match
     exactly, which is what `scripts/verify.sh` actually checks.
   - Package suite: `total=715 failed=1 skipped=15` -- matches the
     documented baseline exactly (1 known failure:
     `test-mom-prepeak-portfolio.R`; skip count 15 = 4 `{alphavantager}`-absent
     + 11 `HD_TEST_LIVE`-gated).
   - `parse("_targets.R")`, `docs/_targets.R` parse + `tar_validate`,
     testthat edition 3 active, dashboard freshness -- all PASS.

2. `packages/historicaldata/tests/testthat/test-commodities-mean-reversion.R`
   in isolation -- 23/23 assertions pass.

3. **Before/after live-store comparison** (read-only `tar_read()` against
   `docs/_targets`, **no** `tar_make()` run; new function evaluated directly
   against the same `commodities_returns`/`daily_rf` the live store already
   has):

   | lookback | sharpe before | sharpe after | cagr before | cagr after | vol before | vol after | max_dd before | max_dd after |
   |---|---|---|---|---|---|---|---|---|
   | 1m | -1.86  | -0.438 | -0.369 | -0.0686 | 0.208 | 0.200 | -1.000 | -0.866 |
   | 3m | -1.23  | -0.029 | -0.257 |  0.0126 | 0.225 | 0.228 | -1.000 | -0.722 |
   | 6m | -0.747 |  0.14  | -0.152 |  0.0508 | 0.229 | 0.228 | -0.996 | -0.718 |

   Sharpe moves from deeply negative to roughly flat/slightly positive
   across all three lookbacks. This is consistent with #751's own
   prediction ("most of it does not [survive]") -- reported plainly, not
   softened. The `.compute_cmr_metrics()` call used `periodicity_check =
   "warn"`, matching the current staged production config (#750); the #738
   periodicity warning still fires (39-93 of ~6700-6800 gaps out of band per
   lookback) since this PR does not touch that guard.

**PREDICTED, not run** (explicitly out of scope -- `scripts/build.sh` holds
a lock and `tar_make()` was not run): that a full `tar_make()` on this
branch reproduces the "after" figures above through the real pipeline. The
live-store read above exercises the identical code path
(`hd_commodity_mr_signal` -> `hd_commodity_mr_portfolio` ->
`.compute_cmr_metrics`) against the same live data, so this is expected but
not directly observed via `tar_make()` itself.

## Refs

Refs #751, #738, #750, #720, #717
