### PR TITLE
fix(cmr): truncate to the tradeable era on investability grounds (#751 item 1)

### DIFF
--- a/R/plan_commodities_mean_reversion.R
+++ b/R/plan_commodities_mean_reversion.R
@@ -37,27 +37,67 @@
 #   starts 2000) and ~255/year after; ~1.4% of observations are monthly-spaced
 #   and the whole series is declared daily. .assert_cmr_ann_factor()'s
 #   consistency check (#738) now DETECTS this; choosing the remedy (truncate
-#   to 2000+, resample to monthly, or segment and report separately) is an
-#   open decision on #738 and is deliberately NOT made here.
+#   to 2000+, resample to monthly, or segment and report separately) was an
+#   open decision on #738 -- item 1 below is the truncation half of that
+#   answer, decided on #751 (see next paragraph). The remaining half --
+#   resample vs segment vs leave as-is for the POST-cutoff mix of daily and
+#   monthly-printing names -- is still open (#751 finding 3).
+# Tradeable-era truncation (#751 item 1, decided 2026-08-24): CMR now drops
+#   every observation before the earliest TRADEABLE (non-FRED/IMF) date via
+#   cmr_tradeable_returns (below), replacing commodities_returns as the input
+#   to every signal/portfolio target in this file. This is an INVESTABILITY
+#   decision, not a frequency-repair one: the 13 pre-cutoff-only names are
+#   IMF Primary Commodity Price System indexes served via FRED
+#   (scripts/fetch_commodities.R) -- statistical price indexes, not
+#   securities, that cannot be bought or shorted. A backtest era in which
+#   every position is untradeable is not a track record, independent of any
+#   resampling. See .cmr_truncate_to_tradeable_era() below for the cutoff
+#   derivation (computed from the data every run, never a pasted date) and
+#   #751 for the full record.
+#   NOT done by this change: the 13 IMF/FRED series are NOT removed from the
+#   universe -- they keep printing monthly through the present (#751 finding
+#   3) and remain part of the post-cutoff cross-section. Whether they should
+#   be positions, conditioning data, or dropped post-cutoff is a SEPARATE,
+#   still-open decision on #751 -- this truncation does not resolve it, and
+#   in particular does NOT by itself make a 10-long/10-short (20-slot)
+#   portfolio constructible from tradeable names alone until the tradeable
+#   universe reaches 20: measured against the live store, only 6 tradeable
+#   (non-FRED/IMF) series exist as of mid-2000, and the count does not reach
+#   20 until 2006. Every month before then still fills some slots with
+#   IMF/FRED names even after this truncation.
 
 plan_commodities_mean_reversion <- function() {
   list(
 
+    # ── Tradeable universe (#751 item 1): truncate to the investable era ──
+    # commodities_returns (from plan_commodities_momentum.R) is NOT modified
+    # -- that target is shared with commodity momentum, which is out of
+    # scope for this decision. CMR gets its own truncated copy here. See the
+    # file header above and .cmr_truncate_to_tradeable_era()'s roxygen for
+    # the full rationale; this target does date filtering ONLY -- it does
+    # not remove any series from the universe.
+
+    targets::tar_target(cmr_tradeable_returns, {
+      .cmr_truncate_to_tradeable_era(commodities_returns)
+    }),
+
+
     # ── Signals: three lookback windows ──────────────────────────────────
-    # Re-uses commodities_returns from plan_commodities_momentum.R.
+    # Built on cmr_tradeable_returns (#751 item 1), not the raw
+    # commodities_returns -- see the target above.
     # Each signal: mr_signal = -(cumulative return over prior L months).
     # Higher signal -> bigger recent loser -> long candidate.
 
     targets::tar_target(cmr_signals_1m, {
-      hd_commodity_mr_signal(commodities_returns, lookback_months = 1L)
+      hd_commodity_mr_signal(cmr_tradeable_returns, lookback_months = 1L)
     }),
 
     targets::tar_target(cmr_signals_3m, {
-      hd_commodity_mr_signal(commodities_returns, lookback_months = 3L)
+      hd_commodity_mr_signal(cmr_tradeable_returns, lookback_months = 3L)
     }),
 
     targets::tar_target(cmr_signals_6m, {
-      hd_commodity_mr_signal(commodities_returns, lookback_months = 6L)
+      hd_commodity_mr_signal(cmr_tradeable_returns, lookback_months = 6L)
     }),
 
 
@@ -65,11 +105,14 @@ plan_commodities_mean_reversion <- function() {
     # t+1 execution: signal at t -> trade executes at t+1 closing prices.
     # 10 long + 10 short, equal weight within each leg.
     # 0.2% one-way transaction cost.
+    # returns_tbl is cmr_tradeable_returns (#751 item 1), matching the
+    # signal targets above -- both legs of the t -> t+1 join must be drawn
+    # from the same truncated universe.
 
     targets::tar_target(cmr_portfolio_1m, {
       hd_commodity_mr_portfolio(
         signal_tbl  = cmr_signals_1m,
-        returns_tbl = commodities_returns,
+        returns_tbl = cmr_tradeable_returns,
         n_long      = 10L,
         n_short     = 10L,
         cost_bps    = 20
@@ -79,7 +122,7 @@ plan_commodities_mean_reversion <- function() {
     targets::tar_target(cmr_portfolio_3m, {
       hd_commodity_mr_portfolio(
         signal_tbl  = cmr_signals_3m,
-        returns_tbl = commodities_returns,
+        returns_tbl = cmr_tradeable_returns,
         n_long      = 10L,
         n_short     = 10L,
         cost_bps    = 20
@@ -89,7 +132,7 @@ plan_commodities_mean_reversion <- function() {
     targets::tar_target(cmr_portfolio_6m, {
       hd_commodity_mr_portfolio(
         signal_tbl  = cmr_signals_6m,
-        returns_tbl = commodities_returns,
+        returns_tbl = cmr_tradeable_returns,
         n_long      = 10L,
         n_short     = 10L,
         cost_bps    = 20
@@ -223,6 +266,98 @@ plan_commodities_mean_reversion <- function() {
 
 # ── Internal helper ────────────────────────────────────────────────────────────
 # Not exported; called only within this plan's targets.
+
+#' Derive the CMR tradeable-era cutoff date (#751 item 1)
+#'
+#' The tradeable era begins at the EARLIEST date any tradeable (non-FRED/IMF,
+#' i.e. \code{source != "fred_imf"}) observation exists in the supplied
+#' returns tibble. Computed from the live data on every call -- never a
+#' pasted literal date -- per \code{.claude/rules/fail-loud-not-null.md}'s
+#' hand-entered-constant prohibition: the natural definition of "the
+#' tradeable era begins" is exactly this quantity, so it is derived rather
+#' than typed in, and the cutoff moves automatically if the fetch history
+#' changes.
+#'
+#' Series are classified programmatically by their \code{source} tag, not by
+#' a hand-typed list of tickers. \code{scripts/fetch_commodities.R} stamps
+#' every row \code{source = "fred_imf"} (the 13 IMF Primary Commodity Price
+#' System indexes) or \code{source = "yahoo"} (the tradeable futures/ETF
+#' series) at fetch time, and \code{calculate_commodity_returns()}
+#' (R/commodities_momentum.R) passes that column through unchanged -- it is
+#' never selected away. A hand-typed vector of the 13 IMF tickers would drift
+#' the moment the fetch universe changes; reading \code{source} does not.
+#'
+#' @param returns_tbl Tibble with columns \code{date} and \code{source}
+#'   (produced by \code{calculate_commodity_returns()} from
+#'   \code{commodities_raw}).
+#' @return A single \code{Date}: the earliest date with a tradeable
+#'   (non-FRED/IMF) observation.
+#' @noRd
+.cmr_tradeable_cutoff_date <- function(returns_tbl) {
+  if (!"source" %in% names(returns_tbl)) {
+    cli::cli_abort(c(
+      "x" = "{.arg returns_tbl} has no {.field source} column.",
+      "i" = paste0(
+        "Cannot distinguish tradeable (Yahoo futures/ETF) series from ",
+        "untradeable (FRED/IMF index) series without it."
+      ),
+      "i" = paste0(
+        "See #751 item 1 and scripts/fetch_commodities.R for the ",
+        "source-tagging contract that calculate_commodity_returns() relies on."
+      )
+    ))
+  }
+  tradeable_dates <- returns_tbl$date[returns_tbl$source != "fred_imf"]
+  if (length(tradeable_dates) == 0L) {
+    cli::cli_abort(c(
+      "x" = "No tradeable (non-FRED/IMF) commodity observations found in {.arg returns_tbl}.",
+      "i" = "Cannot derive the CMR tradeable-era cutoff -- see #751 item 1."
+    ))
+  }
+  min(tradeable_dates)
+}
+
+#' Truncate a commodities returns tibble to the tradeable era (#751 item 1)
+#'
+#' Decision (#751, 2026-08-24): exclude the pre-2000 era from CMR on
+#' INVESTABILITY grounds. The pre-cutoff-only names are IMF Primary
+#' Commodity Price System indexes served via FRED
+#' (\code{scripts/fetch_commodities.R}) -- statistical price indexes, not
+#' securities: they cannot be bought and cannot be shorted. A backtest era
+#' in which every position is untradeable is not a track record, and no
+#' amount of resampling changes that. This is explicitly the
+#' INVESTABILITY argument, not a frequency-merge-repair argument -- the
+#' mixed-frequency problem (#738) is separate and is NOT resolved by this
+#' truncation, because the 13 IMF/FRED series keep printing monthly through
+#' the present and remain part of the post-cutoff universe (#751 finding 3).
+#'
+#' This function ONLY truncates dates. It does NOT remove the FRED/IMF
+#' series from the universe -- they remain present (and rankable) after the
+#' cutoff. Whether they should be positions, conditioning data, or dropped
+#' post-cutoff is a SEPARATE, still-open decision on #751 and is not made
+#' here.
+#'
+#' @param returns_tbl Tibble with columns \code{date}, \code{source} (plus
+#'   whatever else \code{calculate_commodity_returns()} produces).
+#' @return \code{returns_tbl} filtered to \code{date >= cutoff}, where
+#'   \code{cutoff} is derived by \code{\link{.cmr_tradeable_cutoff_date}}.
+#' @noRd
+.cmr_truncate_to_tradeable_era <- function(returns_tbl) {
+  cutoff  <- .cmr_tradeable_cutoff_date(returns_tbl)
+  dropped <- sum(returns_tbl$date < cutoff)
+
+  cli::cli_inform(c(
+    "v" = paste0(
+      "CMR (#751 item 1): truncated to the tradeable era, {format(cutoff)} onward."
+    ),
+    "i" = paste0(
+      "Dropped {dropped} pre-cutoff observation{?s} (untradeable IMF/FRED-only era). ",
+      "FRED/IMF series that continue printing after the cutoff are NOT removed."
+    )
+  ))
+
+  returns_tbl |> dplyr::filter(.data$date >= cutoff)
+}
 
 #' Carry `daily_rf` forward across short non-trading gaps CMR's universe needs (#724)
 #'

--- a/tests/testthat/_snaps/cmr-tradeable-era.md
+++ b/tests/testthat/_snaps/cmr-tradeable-era.md
@@ -1,0 +1,19 @@
+# missing source column aborts with an informative error
+
+    Code
+      .cmr_tradeable_cutoff_date(bad_tbl)
+    Condition
+      Error in `.cmr_tradeable_cutoff_date()`:
+      x `returns_tbl` has no source column.
+      i Cannot distinguish tradeable (Yahoo futures/ETF) series from untradeable (FRED/IMF index) series without it.
+      i See #751 item 1 and scripts/fetch_commodities.R for the source-tagging contract that calculate_commodity_returns() relies on.
+
+# an all-FRED/IMF universe (no tradeable rows) aborts rather than returning NA/Inf
+
+    Code
+      .cmr_tradeable_cutoff_date(all_fred)
+    Condition
+      Error in `.cmr_tradeable_cutoff_date()`:
+      x No tradeable (non-FRED/IMF) commodity observations found in `returns_tbl`.
+      i Cannot derive the CMR tradeable-era cutoff -- see #751 item 1.
+

--- a/tests/testthat/test-cmr-tradeable-era.R
+++ b/tests/testthat/test-cmr-tradeable-era.R
@@ -1,0 +1,139 @@
+# Tests for the #751 item 1 tradeable-era truncation helpers
+# (.cmr_tradeable_cutoff_date() / .cmr_truncate_to_tradeable_era(),
+# R/plan_commodities_mean_reversion.R).
+#
+# Decision (#751, 2026-08-24): CMR excludes the pre-tradeable-era observations
+# on INVESTABILITY grounds -- the pre-cutoff-only names are IMF Primary
+# Commodity Price System indexes served via FRED, which are statistical price
+# indexes, not securities. These tests pin: (a) the cutoff is derived from the
+# data (earliest non-FRED/IMF date), never hardcoded; (b) truncation removes
+# dates, not series -- FRED/IMF rows on/after the cutoff survive; (c) the
+# fail-loud-not-null contract for a missing `source` column or an all-FRED
+# universe.
+testthat::local_edition(3)
+
+pkg_path <- if (dir.exists(here::here("packages/historicaldata"))) {
+  here::here("packages/historicaldata")
+} else {
+  file.path(dirname(here::here()), "packages/historicaldata")
+}
+suppressMessages(pkgload::load_all(pkg_path, quiet = TRUE))
+
+source(here::here("R/utils_metrics.R"))
+source(here::here("R/plan_commodities_mean_reversion.R"))
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+# A mixed universe: two FRED/IMF series starting well before any tradeable
+# series, plus two tradeable (Yahoo) series starting later, with the
+# tradeable series themselves staggered so the cutoff is not the same as
+# either series' own start date in isolation.
+mixed_universe <- function() {
+  # #751 finding 3: the FRED/IMF series do not stop at 2000 -- they keep
+  # printing monthly for decades after the tradeable era begins. length.out
+  # is chosen so both series extend well past the yahoo cutoff below.
+  fred_a <- tibble::tibble(
+    date = seq.Date(as.Date("1992-01-01"), by = "month", length.out = 300),
+    series_id = "POILWTIUSDM", source = "fred_imf", monthly_ret = 0.01
+  )
+  fred_b <- tibble::tibble(
+    date = seq.Date(as.Date("1992-06-01"), by = "month", length.out = 300),
+    series_id = "PCOPPUSDM", source = "fred_imf", monthly_ret = 0.01
+  )
+  yahoo_a <- tibble::tibble(
+    date = seq.Date(as.Date("2000-03-15"), by = "day", length.out = 200),
+    series_id = "CC=F", source = "yahoo", monthly_ret = 0.001
+  )
+  yahoo_b <- tibble::tibble(
+    date = seq.Date(as.Date("2000-08-30"), by = "day", length.out = 200),
+    series_id = "GC=F", source = "yahoo", monthly_ret = 0.001
+  )
+  dplyr::bind_rows(fred_a, fred_b, yahoo_a, yahoo_b)
+}
+
+# ── .cmr_tradeable_cutoff_date() ─────────────────────────────────────────────
+
+test_that("cutoff is the earliest TRADEABLE date, not the earliest date overall", {
+  tbl <- mixed_universe()
+  cutoff <- .cmr_tradeable_cutoff_date(tbl)
+  expect_equal(cutoff, as.Date("2000-03-15"))
+  # Sanity: the FRED series start much earlier, so a naive min(date) over the
+  # whole universe would have given the wrong (untradeable) answer.
+  expect_true(min(tbl$date) < cutoff)
+})
+
+test_that("cutoff ignores which series is earliest among FRED names -- only source matters", {
+  # Swap which FRED series starts first; the cutoff (driven entirely by the
+  # yahoo rows) must be unchanged.
+  tbl <- mixed_universe()
+  tbl$date[tbl$series_id == "PCOPPUSDM"][1] <- as.Date("1980-01-01")
+  cutoff <- .cmr_tradeable_cutoff_date(tbl)
+  expect_equal(cutoff, as.Date("2000-03-15"))
+})
+
+test_that("missing source column aborts with an informative error", {
+  bad_tbl <- tibble::tibble(date = Sys.Date(), series_id = "X", monthly_ret = 0.01)
+  expect_snapshot(error = TRUE, .cmr_tradeable_cutoff_date(bad_tbl))
+})
+
+test_that("an all-FRED/IMF universe (no tradeable rows) aborts rather than returning NA/Inf", {
+  all_fred <- tibble::tibble(
+    date = seq.Date(as.Date("1992-01-01"), by = "month", length.out = 12),
+    series_id = "POILWTIUSDM", source = "fred_imf", monthly_ret = 0.01
+  )
+  expect_snapshot(error = TRUE, .cmr_tradeable_cutoff_date(all_fred))
+})
+
+# ── .cmr_truncate_to_tradeable_era() ─────────────────────────────────────────
+
+test_that("truncation drops every pre-cutoff row of BOTH sources, keeps post-cutoff rows of BOTH sources", {
+  tbl <- mixed_universe()
+  out <- suppressMessages(.cmr_truncate_to_tradeable_era(tbl))
+
+  expect_true(all(out$date >= as.Date("2000-03-15")))
+  # FRED/IMF rows are not removed as a SERIES -- rows that fall on/after the
+  # cutoff survive.
+  expect_true(any(out$source == "fred_imf"))
+  expect_true(any(out$source == "yahoo"))
+  # Every pre-cutoff FRED row (the bulk of the universe) is gone.
+  expect_equal(sum(out$date < as.Date("2000-03-15")), 0L)
+})
+
+test_that("truncation does not remove any series id present on/after the cutoff", {
+  tbl <- mixed_universe()
+  out <- suppressMessages(.cmr_truncate_to_tradeable_era(tbl))
+  # Both FRED series print monthly well past the cutoff in this fixture, so
+  # neither series_id is dropped entirely -- only its early rows are.
+  expect_setequal(unique(out$series_id), unique(tbl$series_id))
+})
+
+test_that("truncation is a no-op when the tradeable era already covers the full universe", {
+  tbl <- tibble::tibble(
+    date = seq.Date(as.Date("2010-01-01"), by = "day", length.out = 30),
+    series_id = "CC=F", source = "yahoo", monthly_ret = 0.001
+  )
+  out <- suppressMessages(.cmr_truncate_to_tradeable_era(tbl))
+  expect_equal(nrow(out), nrow(tbl))
+  expect_equal(out$date, tbl$date)
+})
+
+test_that("truncation reports what it did via cli_inform (not silent)", {
+  tbl <- mixed_universe()
+  msgs <- testthat::capture_messages(.cmr_truncate_to_tradeable_era(tbl))
+  full <- paste(msgs, collapse = " ")
+  expect_match(full, "tradeable era")
+  expect_match(full, "2000-03-15")
+  expect_match(full, "Dropped \\d+ pre-cutoff observation")
+})
+
+test_that("truncated output feeds hd_commodity_mr_signal without introducing NAs from the boundary", {
+  # Integration-flavoured: the truncated tibble must still be a valid input
+  # to the exported CMR functions this file's targets actually call.
+  tbl <- mixed_universe()
+  out <- suppressMessages(.cmr_truncate_to_tradeable_era(tbl))
+  sig <- hd_commodity_mr_signal(out, lookback_months = 1L)
+  expect_false(any(is.na(sig$mr_signal)))
+  # Every signal date is on/after the cutoff -- no pre-cutoff leakage through
+  # the lookback window's lag.
+  expect_true(all(sig$date >= as.Date("2000-03-15")))
+})


### PR DESCRIPTION
## Summary

Implements the human decision recorded on #751 (2026-08-24, "Decisions taken"):
**exclude the pre-tradeable era from CMR, on investability grounds.**

The pre-cutoff-only names are IMF Primary Commodity Price System indexes served
via FRED (`scripts/fetch_commodities.R`) — statistical price indexes, not
securities. They cannot be bought and cannot be shorted. A backtest era in which
every position is untradeable is not a track record, and no amount of resampling
changes that. This is the investability argument, and it is explicitly **not** a
frequency-merge-repair argument — the mixed-frequency problem (#738) is separate
and is not resolved by this change.

## What changed

- New `cmr_tradeable_returns` target in `R/plan_commodities_mean_reversion.R`,
  built from the shared `commodities_returns` target (untouched —
  `plan_commodities_momentum.R` still uses the full, untruncated series).
- Two new internal helpers:
  - `.cmr_tradeable_cutoff_date()` — derives the cutoff as the **earliest date
    any non-FRED/IMF (`source != "fred_imf"`) observation exists**. Computed
    from the data every run; never a hardcoded literal date. Series are
    classified by the `source` column that `scripts/fetch_commodities.R`
    already stamps (`"fred_imf"` vs `"yahoo"`) and that
    `calculate_commodity_returns()` already passes through unchanged — no
    hand-typed ticker list.
  - `.cmr_truncate_to_tradeable_era()` — filters to `date >= cutoff` and
    `cli_inform`s what it dropped.
- `cmr_signals_1m/3m/6m` and `cmr_portfolio_1m/3m/6m` now consume
  `cmr_tradeable_returns` instead of the raw `commodities_returns`.
- File header comment updated to record the decision and its scope.

## What did NOT change

- **The FRED/IMF series are not removed from the universe.** They continue
  printing monthly past the cutoff (#751 finding 3) and remain part of the
  post-cutoff cross-section. What to do with them there — positions,
  conditioning data, or dropped — is a separate, still-open #751 decision.
- `n_long` / `n_short` (still 10/10).
- The #750 periodicity guard (`.assert_cmr_ann_factor`,
  `CMR_PERIODICITY_TOLERANCE`, the `periodicity_check = "warn"` staging lever).
- The #752 calendar-lookback logic (`hd_commodity_mr_signal`'s
  `slide_index_dbl` window).

## Measured before/after

**Method:** direct evaluation of the changed functions against the live
`data/raw/commodities.parquet`, using a single snapshot of the `daily_rf`
target read from the store (read-only) so both scenarios share one data
vintage. `tar_make()` was not run (main-checkout store lock; see verification
note below) — before and after both go through the identical
`.compute_cmr_metrics(..., periodicity_check = "warn", ann_factor = 252L)`
call the production targets use, differing only in whether
`commodities_returns` or `cmr_tradeable_returns` is the input. All numbers
below are **OBSERVED**.

| lookback | n_days before | n_days after | sharpe before | sharpe after | cagr before | cagr after | vol before | vol after | max_dd before | max_dd after |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1m | 6664 | 6624 | -0.438 | -0.439 | -0.0686 | -0.0683 | 0.2005 | 0.1988 | -0.8658 | -0.8658 |
| 3m | 6734 | 6640 | -0.029 | -0.132 | 0.0126 | -0.0105 | 0.2279 | 0.2220 | -0.7221 | -0.7221 |
| 6m | 6669 | 6575 | 0.140 | 0.058 | 0.0508 | 0.0315 | 0.2280 | 0.2232 | -0.7181 | -0.7181 |

Months-in-sample (unique calendar months present) drop from 358/410/407
(1m/3m/6m) to 319/317/314. The 1m lookback loses the fewest observations
because a ~30-day window around a single monthly FRED print mostly fails the
2-observation completeness floor already (`.HD_MR_MIN_OBS_FRACTION` /
`.HD_MR_MIN_OBS_FLOOR`) — most pre-cutoff monthly-only signal rows for the 1m
lookback were already `NA`-dropped before this change. The 3m and 6m windows
are wide enough to capture 3–6 monthly prints, so far more of the pre-cutoff
era survived into their portfolios before this fix.

**The predicted direction held**: #751's stated expectation was that "most of
[the measured CMR performance] does not survive" once the untradeable-era
mechanism is removed. 3m Sharpe goes from roughly flat (-0.029) to clearly
negative (-0.132); 6m Sharpe is cut by more than half (0.140 → 0.058) and CAGR
by more than a third (0.0508 → 0.0315). 1m is effectively unchanged, consistent
with it having already excluded most of the pre-cutoff era via the completeness
floor.

## The consequence this PR does not resolve

**10-long/10-short (20 slots) is still not constructible from tradeable names
alone until 2006.** Measured against the live store: only 6 tradeable
(non-FRED/IMF) series exist as of mid-2000; the count does not reach 20 until
2006. Every month before then still fills some slots with FRED/IMF names even
after this truncation — this PR removes the era where *zero* tradeable names
existed, not the era where *too few* exist. This is the strongest evidence for
the fixed-fraction / rank-weighting change (#751 options C/D) that comes next,
and is stated plainly here per the dispatch instructions rather than smoothed
over.

## Verification

`scripts/verify.sh` run in the foreground, full mode:

```
PASS: _targets.R parses
PASS: docs/_targets.R parses
PASS: docs/_targets.R is structurally valid (tar_validate, 7.14s)
PASS: testthat edition 3 active
PASS: dashboard freshness

=== root suite ===
SKIP count this run: 0
PASS: failures match the known baseline exactly (3, all documented in .claude/CLAUDE.md)

=== package suite ===
SKIP count this run: 15
PASS: failures match the known baseline exactly (1, documented)

=== scripts/verify.sh: PASS ===
```

No new failures, no new skips beyond the documented baselines.

**Not run:** `tar_make()` — the main checkout owns the single live store and
`scripts/build.sh` holds a lock; per project convention this PR does not
attempt to build it. The before/after numbers above were produced by direct
evaluation (see Method), not by reading stale/rebuilt targets, per #753 (a
`packages/*/R/` change wouldn't apply here anyway — this PR touches only root
`R/` and `tests/`, both of which `targets` does track as command dependencies,
but the store still wasn't rebuilt by this agent).

## Test plan

- [x] New `tests/testthat/test-cmr-tradeable-era.R` — 8 `test_that` blocks, 2
      `expect_snapshot(error = TRUE, ...)` blocks (missing `source` column;
      all-FRED-only universe), covering cutoff derivation, truncation
      behaviour (drops pre-cutoff rows of both sources, keeps FRED/IMF rows
      that fall on/after the cutoff, doesn't drop any series id), and an
      integration check that truncated output still flows cleanly into
      `hd_commodity_mr_signal()`.
- [x] `scripts/verify.sh` (full) — PASS, matches documented baselines exactly.

Refs #751.
