### PR TITLE
fix(cmr): size long/short legs by fixed fraction, not fixed headcount (#751 item C)

### DIFF
--- a/R/plan_commodities_mean_reversion.R
+++ b/R/plan_commodities_mean_reversion.R
@@ -58,13 +58,23 @@
 #   universe -- they keep printing monthly through the present (#751 finding
 #   3) and remain part of the post-cutoff cross-section. Whether they should
 #   be positions, conditioning data, or dropped post-cutoff is a SEPARATE,
-#   still-open decision on #751 -- this truncation does not resolve it, and
-#   in particular does NOT by itself make a 10-long/10-short (20-slot)
-#   portfolio constructible from tradeable names alone until the tradeable
-#   universe reaches 20: measured against the live store, only 6 tradeable
-#   (non-FRED/IMF) series exist as of mid-2000, and the count does not reach
-#   20 until 2006. Every month before then still fills some slots with
-#   IMF/FRED names even after this truncation.
+#   still-open decision on #751 -- this truncation does not resolve it.
+# Fixed-fraction sizing (#751 item C, decided 2026-08-25): the fixed
+#   n_long = n_short = 10L headcount is replaced by hd_commodity_mr_portfolio()'s
+#   own frac parameter (default 1/3, terciles) -- see that function's roxygen
+#   and .HD_CMR_DEFAULT_FRAC's roxygen (packages/historicaldata/R/
+#   commodities_mean_reversion.R) for the citation. The old fixed count was
+#   infeasible against the tradeable universe alone until 2006 (only 6
+#   tradeable series existed as of mid-2000, 16-17 through 2005 -- 20 slots
+#   could not be filled without reaching into the untradeable IMF/FRED
+#   names) and held ~10/24 = ~42% of the universe PER LEG (roughly 83% total)
+#   by 2015-2026 once 24 tradeable names existed -- the same parameter
+#   meaning two structurally different strategies at the two ends of the
+#   sample. A fixed fraction is feasible at every breadth automatically, with
+#   no cutoff to choose. Item D (rank-weighting the whole cross-section
+#   instead of a discrete long/short split) remains open -- see the #751
+#   comment thread for the recommendation on which is the better structural
+#   fit; this change implements C only.
 
 plan_commodities_mean_reversion <- function() {
   list(
@@ -103,7 +113,16 @@ plan_commodities_mean_reversion <- function() {
 
     # ── Portfolios: long-losers / short-winners ───────────────────────────
     # t+1 execution: signal at t -> trade executes at t+1 closing prices.
-    # 10 long + 10 short, equal weight within each leg.
+    # #751 items C/D (decided 2026-08-25): FIXED FRACTION per leg, not a
+    # fixed headcount. hd_commodity_mr_portfolio()'s own default (frac = 1/3,
+    # terciles) is used here rather than overridden -- see that function's
+    # roxygen and .HD_CMR_DEFAULT_FRAC's roxygen (packages/historicaldata/R/
+    # commodities_mean_reversion.R) for the Asness-Moskowitz-Pedersen /
+    # Miffre-Rallis citation and the tercile-vs-quintile reasoning. This
+    # replaces the previous n_long = n_short = 10L, which was infeasible
+    # against the tradeable universe alone until 2006 and held ~87% of the
+    # universe long-short by 2015-2026 -- see the file header above and #751
+    # for the full record.
     # 0.2% one-way transaction cost.
     # returns_tbl is cmr_tradeable_returns (#751 item 1), matching the
     # signal targets above -- both legs of the t -> t+1 join must be drawn
@@ -113,8 +132,6 @@ plan_commodities_mean_reversion <- function() {
       hd_commodity_mr_portfolio(
         signal_tbl  = cmr_signals_1m,
         returns_tbl = cmr_tradeable_returns,
-        n_long      = 10L,
-        n_short     = 10L,
         cost_bps    = 20
       )
     }),
@@ -123,8 +140,6 @@ plan_commodities_mean_reversion <- function() {
       hd_commodity_mr_portfolio(
         signal_tbl  = cmr_signals_3m,
         returns_tbl = cmr_tradeable_returns,
-        n_long      = 10L,
-        n_short     = 10L,
         cost_bps    = 20
       )
     }),
@@ -133,8 +148,6 @@ plan_commodities_mean_reversion <- function() {
       hd_commodity_mr_portfolio(
         signal_tbl  = cmr_signals_6m,
         returns_tbl = cmr_tradeable_returns,
-        n_long      = 10L,
-        n_short     = 10L,
         cost_bps    = 20
       )
     }),

--- a/packages/historicaldata/R/commodities_mean_reversion.R
+++ b/packages/historicaldata/R/commodities_mean_reversion.R
@@ -249,6 +249,75 @@ hd_commodity_mr_signal <- function(returns_tbl, lookback_months = 3L) {
 }
 
 
+#' Default fraction of the ranked cross-section held on each leg (#751 items C/D)
+#'
+#' Long-standing cross-sectional-sort convention is a FIXED FRACTION
+#' (quantile breakpoint) of the ranked universe, not a fixed headcount --
+#' Fama & French (1993) rank the whole equity universe into
+#' deciles/quintiles precisely because the universe's size varies by orders
+#' of magnitude over the sample. \code{hd_commodity_mr_portfolio()}
+#' previously held a fixed \code{n_long = n_short = 10}, which (#751) was
+#' infeasible against our own tradeable universe for its first six years
+#' (6-17 tradeable names 2000-2005, so 20 slots could not be filled from
+#' tradeable names alone) and held ~10/24 = ~42\% of the universe PER LEG
+#' (roughly 83\% total) by 2015-2026 (24 tradeable names) -- the same
+#' parameter meaning two structurally different strategies at the two ends
+#' of the sample.
+#'
+#' Two commodity-specific precedents exist at comparable breadth to ours (24
+#' tradeable names as of 2015-2026, per #751):
+#' \itemize{
+#'   \item Asness, Moskowitz & Pedersen (2013, "Value and Momentum
+#'     Everywhere", J. Finance) sort 27 commodity futures into TERCILES
+#'     (1/3 per leg).
+#'   \item Miffre & Rallis (2007, "Momentum Strategies in Commodity Futures
+#'     Markets", J. Banking & Finance) sort 31 commodity futures into
+#'     QUINTILES (1/5 per leg).
+#' }
+#' TERCILES is chosen as the default here: AMP's 27-future universe is
+#' within 3 names of our own 24-name tradeable universe -- the closer
+#' structural match of the two -- and a tercile (8 of 24 names per leg,
+#' currently) keeps meaningfully more cross-sectional discrimination than
+#' the old fixed count of 10 (~42\% per leg) without over-thinning the legs
+#' the way a quintile would in years where our tradeable universe is
+#' smaller (e.g. 2006-2007's 20 tradeable names -> a quintile gives 4 per
+#' leg, close to the \code{.HD_CMR_MIN_LEG_NAMES} floor below; a tercile
+#' gives 6). Quintiles remain a reasonable, better-precedented-by-breadth
+#' alternative (Miffre-Rallis' 31 futures is the larger universe) and can be
+#' requested via \code{frac = 1/5}.
+#'
+#' @noRd
+.HD_CMR_DEFAULT_FRAC <- 1 / 3
+
+#' Minimum number of names required on ONE side (long or short) for a
+#' cross-sectional quantile split to be treated as meaningful
+#'
+#' No formal minimum-breadth threshold for a commodity cross-sectional sort
+#' was found in the literature consulted for #751 item C -- Fama-French,
+#' Asness-Moskowitz-Pedersen, and Miffre-Rallis all state their quantile
+#' FRACTION but none states a floor on N before applying it. This constant
+#' is therefore a HOUSE RULE, not an adopted standard, documented as such
+#' rather than presented as literature-derived. It is framed the same way
+#' \code{.HD_MR_MIN_OBS_FLOOR} above is framed for the signal window: a leg
+#' of 1 name is not a diversified basket, it is that single name's own
+#' return relabelled as a "leg return" -- 2 is the smallest count for which
+#' a leg is actually more than one bet. Combined with \code{frac} this
+#' implies a minimum TOTAL ranked-name requirement of
+#' \code{ceiling(.HD_CMR_MIN_LEG_NAMES / frac)} (6 names, at the default
+#' tercile \code{frac}) before either leg is populated on a given date;
+#' below that, the date holds NO position (both legs empty, contributing
+#' \code{gross_ret = 0} for that date) rather than forcing a 1-name leg or
+#' risking an overlapping split -- see
+#' \code{\link{hd_commodity_mr_portfolio}}'s implementation. This is
+#' equivalent to capping the MAXIMUM held fraction implicitly (never more
+#' than \code{2 * frac} of the ranked universe is held, and never less than
+#' zero when breadth is too thin), which the fraction-vs-headcount
+#' literature above does support, even though it does not state a breadth
+#' floor as such.
+#'
+#' @noRd
+.HD_CMR_MIN_LEG_NAMES <- 2L
+
 #' Commodity Mean Reversion Portfolio
 #'
 #' Convert a mean-reversion signal tibble into monthly long/short portfolio
@@ -259,37 +328,58 @@ hd_commodity_mr_signal <- function(returns_tbl, lookback_months = 3L) {
 #' closing prices.  This is enforced by joining the signal at date \code{t}
 #' to the return realised at date \code{t+1} via \code{dplyr::lead()}.
 #'
+#' \strong{Fixed fraction, not fixed headcount (#751 items C/D):} each leg
+#' holds \code{floor(n_avail * frac)} names, where \code{n_avail} is the
+#' number of ranked names available on that date -- NOT a fixed count. See
+#' \code{.HD_CMR_DEFAULT_FRAC}'s roxygen for the tercile-vs-quintile
+#' citation and reasoning, and \code{.HD_CMR_MIN_LEG_NAMES}'s roxygen
+#' for the minimum-breadth floor below which a date holds no position.
+#' \code{floor()} together with \code{frac < 0.5} (enforced by input
+#' validation) guarantees \code{2 * n_leg <= 2 * frac * n_avail < n_avail},
+#' so the long and short legs can never overlap by construction; this is
+#' also verified explicitly at runtime (fail-loud-not-null.md) rather than
+#' trusted silently.
+#'
 #' @param signal_tbl Tibble returned by \code{\link{hd_commodity_mr_signal}},
 #'   with columns \code{date}, \code{series_id}, \code{mr_signal}.
 #' @param returns_tbl Tibble with columns \code{date}, \code{series_id},
 #'   \code{monthly_ret}.  Must overlap in date range with \code{signal_tbl}.
-#' @param n_long Integer. Number of top-ranked (biggest losers) commodities
-#'   to hold long (default 10).
-#' @param n_short Integer. Number of bottom-ranked (biggest winners) commodities
-#'   to sell short (default 10).
+#' @param frac Numeric fraction in \verb{(0, 0.5)}. Share of the ranked
+#'   cross-section held on EACH leg (long and short) -- \code{1/3} =
+#'   terciles (default), \code{1/5} = quintiles. Replaces the previous fixed
+#'   \code{n_long}/\code{n_short} headcount parameters (#751 items C/D): one
+#'   sizing mechanism, not two.
 #' @param cost_bps Numeric. One-way transaction cost in basis points
 #'   (default 20 = 0.2\%).  The same 0.2\% used in commodity momentum (#134).
 #'
-#' @return Tibble with one row per month and columns:
+#' @return Tibble with one row per date present in the signal/return join
+#'   and columns:
 #'   \describe{
-#'     \item{date}{Month-end date (the execution month, i.e. t+1).}
-#'     \item{gross_ret}{Gross portfolio return for the month.}
+#'     \item{date}{Execution date (t+1).}
+#'     \item{gross_ret}{Gross portfolio return for the date.}
 #'     \item{turnover}{One-way turnover fraction.}
 #'     \item{cost}{Transaction cost deducted (= turnover * cost_bps/10000).}
 #'     \item{net_ret}{Net return after transaction costs.}
-#'     \item{n_long}{Number of long positions held.}
-#'     \item{n_short}{Number of short positions held.}
+#'     \item{n_long}{Number of long positions actually held.}
+#'     \item{n_short}{Number of short positions actually held.}
+#'     \item{n_avail}{Number of ranked names available that date (breadth
+#'       diagnostic, #751 item C).}
+#'     \item{held_frac}{\code{(n_long + n_short) / n_avail}: the fraction of
+#'       that date's ranked universe actually held (breadth diagnostic,
+#'       #751 item C). 0 when \code{n_avail} is below the minimum-breadth
+#'       floor.}
 #'   }
-#'   Months where fewer than \code{n_long + n_short} commodities have valid
-#'   signals are silently included with actual position counts; months with
-#'   zero valid signals produce \code{gross_ret = 0}.
+#'   Dates below \code{.HD_CMR_MIN_LEG_NAMES}'s minimum-breadth floor
+#'   hold no position at all: \code{n_long = n_short = 0},
+#'   \code{gross_ret = 0}. Such dates are still returned as rows (not
+#'   dropped) so the return series stays date-complete for downstream
+#'   periodicity checks (#738).
 #'
 #' @family commodities_mr
 #' @export
 hd_commodity_mr_portfolio <- function(signal_tbl,
                                        returns_tbl,
-                                       n_long  = 10L,
-                                       n_short = 10L,
+                                       frac = .HD_CMR_DEFAULT_FRAC,
                                        cost_bps = 20) {
   if (!is.data.frame(signal_tbl)) {
     cli::cli_abort(c("x" = "{.arg signal_tbl} must be a data frame."))
@@ -297,11 +387,18 @@ hd_commodity_mr_portfolio <- function(signal_tbl,
   if (!is.data.frame(returns_tbl)) {
     cli::cli_abort(c("x" = "{.arg returns_tbl} must be a data frame."))
   }
-  n_long  <- as.integer(n_long)
-  n_short <- as.integer(n_short)
-  if (n_long < 1L || n_short < 1L) {
+  if (!is.numeric(frac) || length(frac) != 1L || is.na(frac) ||
+      frac <= 0 || frac >= 0.5) {
     cli::cli_abort(c(
-      "x" = "{.arg n_long} and {.arg n_short} must each be >= 1."
+      "x" = "{.arg frac} must be a single fraction in (0, 0.5), got {frac}.",
+      "i" = paste0(
+        "{.arg frac} is the share of the ranked cross-section held on EACH ",
+        "leg (long and short) -- 1/3 = terciles (default), 1/5 = quintiles."
+      ),
+      "i" = paste0(
+        "A value >= 0.5 would let the two legs overlap, or consume the ",
+        "entire ranked universe leaving nothing held out; see #751 items C/D."
+      )
     ))
   }
 
@@ -321,33 +418,86 @@ hd_commodity_mr_portfolio <- function(signal_tbl,
   combined <- signal_tbl |>
     dplyr::inner_join(ret_with_lead, by = c("date" = "signal_date", "series_id"))
 
-  # Rank within each signal date; assign long/short weights.
+  # Per-date breadth diagnostic (#751 item C), computed BEFORE the
+  # minimum-breadth floor is applied, so it is reported even for dates that
+  # end up holding no position at all.
+  breadth_by_date <- combined |>
+    dplyr::count(date, name = "n_avail")
+
+  min_total_names <- ceiling(.HD_CMR_MIN_LEG_NAMES / frac)
+
+  # Rank within each signal date; assign long/short weights by FRACTION of
+  # that date's own ranked breadth, not a fixed headcount (#751 items C/D).
   ranked <- combined |>
     dplyr::group_by(date) |>
     dplyr::mutate(
-      rk = dplyr::row_number(dplyr::desc(mr_signal)),  # rank 1 = highest signal = biggest loser
-      n_avail = dplyr::n()
+      rk      = dplyr::row_number(dplyr::desc(mr_signal)),  # rank 1 = highest signal = biggest loser
+      n_avail = dplyr::n(),
+      # Dates below the minimum-breadth floor hold no position (n_leg = 0)
+      # rather than a house-rule-forced 1-name leg or an overlapping split
+      # -- see .HD_CMR_MIN_LEG_NAMES's roxygen.
+      n_leg   = dplyr::if_else(
+        n_avail >= min_total_names,
+        as.integer(floor(n_avail * frac)),
+        0L
+      )
     ) |>
-    dplyr::filter(rk <= n_long | rk > (n_avail - n_short)) |>
+    dplyr::filter(n_leg > 0L, rk <= n_leg | rk > (n_avail - n_leg)) |>
     dplyr::mutate(
-      leg    = dplyr::if_else(rk <= n_long, "long", "short"),
-      n_leg  = dplyr::if_else(rk <= n_long, n_long, n_short),
-      weight = dplyr::if_else(leg == "long", 1 / n_long, -1 / n_short)
+      leg    = dplyr::if_else(rk <= n_leg, "long", "short"),
+      weight = dplyr::if_else(leg == "long", 1 / n_leg, -1 / n_leg)
     ) |>
     dplyr::ungroup()
 
-  # Monthly gross returns and position counts.
-  monthly <- ranked |>
+  # fail-loud-not-null.md: verify the no-overlap invariant explicitly rather
+  # than trusting the floor()/frac<0.5 arithmetic silently -- a future
+  # refactor that breaks it must abort loudly, not produce a
+  # plausible-looking but wrong portfolio.
+  overlap_dates <- ranked |>
+    dplyr::distinct(date, n_avail, n_leg) |>
+    dplyr::filter(2L * n_leg > n_avail)
+  if (nrow(overlap_dates) > 0L) {
+    cli::cli_abort(c(
+      "x" = paste0(
+        "CMR portfolio construction would OVERLAP the long/short legs on ",
+        "{nrow(overlap_dates)} date{?s}."
+      ),
+      "i" = paste0(
+        "2 * n_leg > n_avail should be impossible once {.arg frac} < 0.5 is ",
+        "enforced at input validation -- investigate the rank/n_leg ",
+        "arithmetic before trusting this portfolio."
+      ),
+      "i" = "First offending date: {format(overlap_dates$date[1])} (n_avail={overlap_dates$n_avail[1]}, n_leg={overlap_dates$n_leg[1]})."
+    ))
+  }
+
+  # Monthly gross returns and position counts, for dates that hold a
+  # position at all.
+  monthly_traded <- ranked |>
     dplyr::group_by(date) |>
     dplyr::summarise(
-      gross_ret = sum(weight * next_ret, na.rm = TRUE),
+      gross_ret   = sum(weight * next_ret, na.rm = TRUE),
       n_long_pos  = sum(leg == "long",  na.rm = TRUE),
       n_short_pos = sum(leg == "short", na.rm = TRUE),
       .groups = "drop"
     )
 
-  # Turnover: sum of absolute weight changes relative to prior month.
-  # Use series_id-level lag of weight within the ranked dataset.
+  # Every date the signal/return join produced (breadth_by_date) gets a row
+  # in the output, INCLUDING dates below the minimum-breadth floor -- those
+  # hold gross_ret = 0 / n_long = n_short = 0 (flat, no position), matching
+  # the pre-existing "zero valid signals -> gross_ret = 0" convention rather
+  # than silently vanishing from the return series (fail-loud-not-null.md:
+  # a dropped date is a dropped observation, not a neutral one).
+  monthly <- breadth_by_date |>
+    dplyr::left_join(monthly_traded, by = "date") |>
+    dplyr::mutate(
+      gross_ret   = dplyr::if_else(is.na(gross_ret), 0, gross_ret),
+      n_long_pos  = dplyr::if_else(is.na(n_long_pos), 0L, n_long_pos),
+      n_short_pos = dplyr::if_else(is.na(n_short_pos), 0L, n_short_pos)
+    )
+
+  # Turnover: sum of absolute weight changes relative to prior traded date.
+  # Use series_id-level lag of weight within the ranked (traded-only) dataset.
   weight_tbl <- ranked |>
     dplyr::select(date, series_id, weight) |>
     dplyr::arrange(series_id, date) |>
@@ -365,11 +515,12 @@ hd_commodity_mr_portfolio <- function(signal_tbl,
   monthly |>
     dplyr::left_join(turnover_tbl, by = "date") |>
     dplyr::mutate(
-      turnover = dplyr::if_else(is.na(turnover), 0, turnover),
-      cost     = turnover * cost_per_unit,
-      net_ret  = gross_ret - cost,
-      n_long   = n_long_pos,
-      n_short  = n_short_pos
+      turnover  = dplyr::if_else(is.na(turnover), 0, turnover),
+      cost      = turnover * cost_per_unit,
+      net_ret   = gross_ret - cost,
+      n_long    = n_long_pos,
+      n_short   = n_short_pos,
+      held_frac = dplyr::if_else(n_avail > 0L, (n_long + n_short) / n_avail, 0)
     ) |>
-    dplyr::select(date, gross_ret, turnover, cost, net_ret, n_long, n_short)
+    dplyr::select(date, gross_ret, turnover, cost, net_ret, n_long, n_short, n_avail, held_frac)
 }

--- a/packages/historicaldata/man/hd_commodity_mr_portfolio.Rd
+++ b/packages/historicaldata/man/hd_commodity_mr_portfolio.Rd
@@ -7,8 +7,7 @@
 hd_commodity_mr_portfolio(
   signal_tbl,
   returns_tbl,
-  n_long = 10L,
-  n_short = 10L,
+  frac = .HD_CMR_DEFAULT_FRAC,
   cost_bps = 20
 )
 }
@@ -19,29 +18,38 @@ with columns \code{date}, \code{series_id}, \code{mr_signal}.}
 \item{returns_tbl}{Tibble with columns \code{date}, \code{series_id},
 \code{monthly_ret}.  Must overlap in date range with \code{signal_tbl}.}
 
-\item{n_long}{Integer. Number of top-ranked (biggest losers) commodities
-to hold long (default 10).}
-
-\item{n_short}{Integer. Number of bottom-ranked (biggest winners) commodities
-to sell short (default 10).}
+\item{frac}{Numeric fraction in \verb{(0, 0.5)}. Share of the ranked
+cross-section held on EACH leg (long and short) -- \code{1/3} =
+terciles (default), \code{1/5} = quintiles. Replaces the previous fixed
+\code{n_long}/\code{n_short} headcount parameters (#751 items C/D): one
+sizing mechanism, not two.}
 
 \item{cost_bps}{Numeric. One-way transaction cost in basis points
 (default 20 = 0.2\\%).  The same 0.2\\% used in commodity momentum (#134).}
 }
 \value{
-Tibble with one row per month and columns:
+Tibble with one row per date present in the signal/return join
+and columns:
 \describe{
-\item{date}{Month-end date (the execution month, i.e. t+1).}
-\item{gross_ret}{Gross portfolio return for the month.}
+\item{date}{Execution date (t+1).}
+\item{gross_ret}{Gross portfolio return for the date.}
 \item{turnover}{One-way turnover fraction.}
 \item{cost}{Transaction cost deducted (= turnover * cost_bps/10000).}
 \item{net_ret}{Net return after transaction costs.}
-\item{n_long}{Number of long positions held.}
-\item{n_short}{Number of short positions held.}
+\item{n_long}{Number of long positions actually held.}
+\item{n_short}{Number of short positions actually held.}
+\item{n_avail}{Number of ranked names available that date (breadth
+diagnostic, #751 item C).}
+\item{held_frac}{\code{(n_long + n_short) / n_avail}: the fraction of
+that date's ranked universe actually held (breadth diagnostic,
+#751 item C). 0 when \code{n_avail} is below the minimum-breadth
+floor.}
 }
-Months where fewer than \code{n_long + n_short} commodities have valid
-signals are silently included with actual position counts; months with
-zero valid signals produce \code{gross_ret = 0}.
+Dates below \code{.HD_CMR_MIN_LEG_NAMES}'s minimum-breadth floor
+hold no position at all: \code{n_long = n_short = 0},
+\code{gross_ret = 0}. Such dates are still returned as rows (not
+dropped) so the return series stays date-complete for downstream
+periodicity checks (#738).
 }
 \description{
 Convert a mean-reversion signal tibble into monthly long/short portfolio
@@ -52,6 +60,18 @@ Execution discipline: the signal from month \code{t} (formed from returns
 through \code{t-1}) drives trades that are executed at month \code{t+1}
 closing prices.  This is enforced by joining the signal at date \code{t}
 to the return realised at date \code{t+1} via \code{dplyr::lead()}.
+
+\strong{Fixed fraction, not fixed headcount (#751 items C/D):} each leg
+holds \code{floor(n_avail * frac)} names, where \code{n_avail} is the
+number of ranked names available on that date -- NOT a fixed count. See
+\code{.HD_CMR_DEFAULT_FRAC}'s roxygen for the tercile-vs-quintile
+citation and reasoning, and \code{.HD_CMR_MIN_LEG_NAMES}'s roxygen
+for the minimum-breadth floor below which a date holds no position.
+\code{floor()} together with \code{frac < 0.5} (enforced by input
+validation) guarantees \code{2 * n_leg <= 2 * frac * n_avail < n_avail},
+so the long and short legs can never overlap by construction; this is
+also verified explicitly at runtime (fail-loud-not-null.md) rather than
+trusted silently.
 }
 \seealso{
 Other commodities_mr: 

--- a/packages/historicaldata/tests/testthat/test-commodities-mean-reversion.R
+++ b/packages/historicaldata/tests/testthat/test-commodities-mean-reversion.R
@@ -149,7 +149,7 @@ test_that("hd_commodity_mr_signal: sign matches expected reversal direction", {
 })
 
 
-test_that("hd_commodity_mr_portfolio: long weights sum to 1 per period", {
+test_that("hd_commodity_mr_portfolio: long/short weights sized by fraction, not headcount (#751 items C/D)", {
   set.seed(42)
   n_months <- 36
   n_assets <- 15
@@ -160,15 +160,17 @@ test_that("hd_commodity_mr_portfolio: long weights sum to 1 per period", {
     dplyr::mutate(monthly_ret = rnorm(dplyr::n(), 0, 0.04))
 
   sig  <- hd_commodity_mr_signal(tbl, lookback_months = 3L)
-  port <- hd_commodity_mr_portfolio(sig, tbl, n_long = 5L, n_short = 5L)
+  # Default frac = 1/3 (terciles): floor(15 * 1/3) = 5 per leg, matching the
+  # old n_long = n_short = 5L headcount exactly for this fixed-breadth
+  # fixture -- the two sizing mechanisms agree when breadth never changes.
+  port <- hd_commodity_mr_portfolio(sig, tbl)
 
-  # For every month: n_long weights sum = 1 / n_long * n_long = 1
-  # We verify via the weighted portfolio directly at the signal level.
-  # Because the function returns aggregate returns, we just check n_long/n_short.
   expect_true(all(port$n_long <= 5L),
-              info = "n_long positions never exceeds n_long parameter")
+              info = "n_long positions never exceeds floor(n_avail * frac)")
   expect_true(all(port$n_short <= 5L),
-              info = "n_short positions never exceeds n_short parameter")
+              info = "n_short positions never exceeds floor(n_avail * frac)")
+  # Breadth diagnostics (#751 item C / step toward item F) are reported.
+  expect_true(all(c("n_avail", "held_frac") %in% names(port)))
 })
 
 
@@ -180,7 +182,7 @@ test_that("hd_commodity_mr_portfolio: net_ret = gross_ret - cost", {
     dplyr::mutate(monthly_ret = rnorm(dplyr::n(), 0, 0.03))
 
   sig  <- hd_commodity_mr_signal(tbl, lookback_months = 3L)
-  port <- hd_commodity_mr_portfolio(sig, tbl, n_long = 3L, n_short = 3L, cost_bps = 20)
+  port <- hd_commodity_mr_portfolio(sig, tbl, cost_bps = 20)
 
   expect_equal(port$net_ret, port$gross_ret - port$cost, tolerance = 1e-12)
 })
@@ -194,9 +196,86 @@ test_that("hd_commodity_mr_portfolio: turnover is non-negative", {
     dplyr::mutate(monthly_ret = rnorm(dplyr::n(), 0, 0.05))
 
   sig  <- hd_commodity_mr_signal(tbl, lookback_months = 3L)
-  port <- hd_commodity_mr_portfolio(sig, tbl, n_long = 3L, n_short = 3L)
+  port <- hd_commodity_mr_portfolio(sig, tbl)
 
   expect_true(all(port$turnover >= 0))
+})
+
+
+test_that("hd_commodity_mr_portfolio: long/short legs never overlap across varying breadth (#751 items C/D)", {
+  # The exact concern #751 raised against fixed-count sizing: universe
+  # breadth changes dramatically over time (6 tradeable names in 2000, 24 by
+  # 2015). Sweep n_avail across a wide range at several fractions and verify
+  # the invariant hd_commodity_mr_portfolio() asserts internally (2 * n_leg
+  # <= n_avail) by checking its OBSERVABLE consequence: n_long + n_short
+  # never exceeds n_avail.
+  make_universe <- function(n_assets, n_months = 12L) {
+    dates <- seq.Date(as.Date("2010-01-31"), by = "month", length.out = n_months)
+    ids   <- paste0("U", seq_len(n_assets))
+    tidyr::expand_grid(date = dates, series_id = ids) |>
+      dplyr::mutate(monthly_ret = rnorm(dplyr::n(), 0, 0.03))
+  }
+
+  set.seed(99)
+  for (frac in c(1 / 3, 1 / 5)) {
+    for (n_assets in c(3L, 6L, 7L, 9L, 20L, 24L, 37L)) {
+      tbl  <- make_universe(n_assets)
+      sig  <- hd_commodity_mr_signal(tbl, lookback_months = 1L)
+      port <- hd_commodity_mr_portfolio(sig, tbl, frac = frac)
+      expect_true(
+        all(port$n_long + port$n_short <= n_assets),
+        info = paste("frac =", frac, "n_assets =", n_assets)
+      )
+    }
+  }
+})
+
+
+test_that("hd_commodity_mr_portfolio: below the minimum-breadth floor, no position is held (#751 item C)", {
+  # Hand-built signal/returns so breadth is exactly controlled: one date
+  # with only 4 ranked names (below the default tercile floor of
+  # ceiling(2 / (1/3)) = 6), one date with 9 (>= floor), one date with 24.
+  # Every series needs (signal date, next date) rows for the t+1 execution
+  # join.
+  build_cohort <- function(prefix, n, signal_date, next_date) {
+    ids <- paste0(prefix, seq_len(n))
+    dplyr::bind_rows(
+      tibble::tibble(date = signal_date, series_id = ids, monthly_ret = 0.01),
+      tibble::tibble(date = next_date,   series_id = ids, monthly_ret = 0.02)
+    )
+  }
+  returns_tbl <- dplyr::bind_rows(
+    build_cohort("L", 4L,  as.Date("2020-01-31"), as.Date("2020-02-29")),
+    build_cohort("M", 9L,  as.Date("2020-03-31"), as.Date("2020-04-30")),
+    build_cohort("H", 24L, as.Date("2020-05-31"), as.Date("2020-06-30"))
+  )
+  signal_tbl <- returns_tbl |>
+    dplyr::distinct(date, series_id) |>
+    dplyr::filter(date %in% as.Date(c("2020-01-31", "2020-03-31", "2020-05-31"))) |>
+    dplyr::mutate(mr_signal = stats::rnorm(dplyr::n()))
+
+  port <- hd_commodity_mr_portfolio(signal_tbl, returns_tbl, frac = 1 / 3)
+
+  low  <- port[port$date == as.Date("2020-01-31"), ]
+  mid  <- port[port$date == as.Date("2020-03-31"), ]
+  high <- port[port$date == as.Date("2020-05-31"), ]
+
+  # n_avail = 4 < min_total_names = ceiling(2 / (1/3)) = 6 -> no position.
+  expect_equal(low$n_long, 0L)
+  expect_equal(low$n_short, 0L)
+  expect_equal(low$gross_ret, 0)
+  expect_equal(low$held_frac, 0)
+  expect_equal(low$n_avail, 4L)
+
+  # n_avail = 9 >= 6 -> floor(9 / 3) = 3 per leg.
+  expect_equal(mid$n_long, 3L)
+  expect_equal(mid$n_short, 3L)
+  expect_equal(mid$n_avail, 9L)
+
+  # n_avail = 24 -> floor(24 / 3) = 8 per leg.
+  expect_equal(high$n_long, 8L)
+  expect_equal(high$n_short, 8L)
+  expect_equal(high$n_avail, 24L)
 })
 
 
@@ -261,11 +340,25 @@ test_that("hd_commodity_mr_signal: input validation — invalid lookback", {
 })
 
 
-test_that("hd_commodity_mr_portfolio: input validation — invalid n_long", {
+test_that("hd_commodity_mr_portfolio: input validation — invalid frac (#751 items C/D)", {
   sig <- tibble::tibble(date = Sys.Date(), series_id = "A", mr_signal = 0.1)
   ret <- tibble::tibble(date = Sys.Date(), series_id = "A", monthly_ret = 0.02)
+  # frac <= 0
   expect_error(
-    hd_commodity_mr_portfolio(sig, ret, n_long = 0L, n_short = 5L),
+    hd_commodity_mr_portfolio(sig, ret, frac = 0),
+    class = "rlang_error"
+  )
+  expect_error(
+    hd_commodity_mr_portfolio(sig, ret, frac = -0.1),
+    class = "rlang_error"
+  )
+  # frac >= 0.5 would let the legs overlap or exhaust the ranked universe.
+  expect_error(
+    hd_commodity_mr_portfolio(sig, ret, frac = 0.5),
+    class = "rlang_error"
+  )
+  expect_error(
+    hd_commodity_mr_portfolio(sig, ret, frac = 0.6),
     class = "rlang_error"
   )
 })


### PR DESCRIPTION
## Summary

Implements item **C** from #751: replace CMR's fixed `n_long = n_short = 10L`
headcount with a fixed **fraction** of the ranked cross-section per leg
(default `1/3`, terciles), per the Fama-French quantile-breakpoint
convention and the two closest commodity-specific precedents:

- Asness, Moskowitz & Pedersen (2013) rank **27** commodity futures into
  terciles — the closer breadth match to our own 24-name tradeable universe.
- Miffre & Rallis (2007) rank **31** commodity futures into quintiles.

Terciles is the default; quintiles remains available via `frac = 1/5`. See
`.HD_CMR_DEFAULT_FRAC`'s roxygen in
`packages/historicaldata/R/commodities_mean_reversion.R` for the full
reasoning.

## Why

The fixed headcount was infeasible against the tradeable universe alone
until 2006 (only 6–17 tradeable names existed 2000–2005) and held
~83–87% of the ranked universe long-short by 2015–2026 (24 tradeable
names) — the same parameter meaning two structurally different strategies
at the two ends of the sample. In the smallest-universe dates it was worse
than infeasible: it silently put **every** ranked name on the long leg
(`n_long >= n_avail` meant the short-leg filter condition was never
reached) — a `fail-loud-not-null.md` violation, not just a sizing problem.

## What changed

- `hd_commodity_mr_portfolio(signal_tbl, returns_tbl, frac = 1/3, cost_bps = 20)`
  — `n_long`/`n_short` removed entirely (one sizing mechanism, not two, per
  dispatch scope).
- `n_leg = floor(n_avail * frac)`, with `frac < 0.5` enforced at input
  validation, so `2 * n_leg < n_avail` always — the legs cannot overlap **by
  construction**. Also asserted explicitly at runtime
  (`fail-loud-not-null.md`: never trust an invariant silently).
- Dates with fewer than `ceiling(.HD_CMR_MIN_LEG_NAMES / frac)` = 6 ranked
  names hold **no position at all** (not a 1-name leg, not a forced
  overlap) — still returned as `gross_ret = 0` rows so the return series
  stays date-complete for the `#738` periodicity guard.
  **`.HD_CMR_MIN_LEG_NAMES` is an explicitly documented house rule** — no
  formal minimum-breadth threshold exists in the literature consulted
  (Fama-French / AMP / Miffre-Rallis all state a fraction, none states a
  floor on N).
- New output columns `n_avail`, `held_frac` — per-date breadth diagnostics,
  a step toward `#751` item F.
- `R/plan_commodities_mean_reversion.R`'s three `cmr_portfolio_*` targets no
  longer pass `n_long`/`n_short`; they use the function's own default.

## Measured impact (OBSERVED, direct function evaluation — see note below)

Per `#753`, a change under `packages/*/R/` does **not** invalidate the
targets that call it — `tar_read()` of `cmr_portfolio_*`/`cmr_metrics_*`
would return stale results computed by the OLD function. I evaluated
`hd_commodity_mr_portfolio()` directly (old vs new, side by side) on
`cmr_tradeable_returns` / `cmr_signals_*` / `daily_rf` read from the live
store:

| lookback | version         | sharpe | cagr    | vol    | max_dd  |
|----------|-----------------|-------:|--------:|-------:|--------:|
| 1m       | OLD (n=10/10)   | -0.434 | -0.0673 | 0.1988 | -0.8657 |
| 1m       | NEW (frac=1/3)  | -0.561 | -0.1349 | 0.2742 | -0.9782 |
| 3m       | OLD (n=10/10)   | -0.105 | -0.0046 | 0.2226 | -0.7221 |
| 3m       | NEW (frac=1/3)  | -0.298 | -0.0677 | 0.2906 | -0.8794 |
| 6m       | OLD (n=10/10)   |  0.074 |  0.0350 | 0.2239 | -0.7181 |
| 6m       | NEW (frac=1/3)  |  0.050 |  0.0333 | 0.2924 | -0.7889 |

**All three lookbacks get worse, not better.** CMR was already
indistinguishable from zero (sharpe 0.058, deflated sharpe -0.139 as of
`#755`); this makes it more negative on 1m/3m and roughly unchanged-to-worse
on 6m. Reporting this plainly per the dispatch note — a worse number here is
information, not a reason to pick a different fraction. Vol rises across
the board; holding a fraction of a currently-37-wide ranked universe (13
FRED/IMF + 24 tradeable — truncation removes dates, not series, `#751`
finding 3) generally means more names per leg than the old fixed 10 on most
of the sample, with apparently less of the diversification benefit the old
scheme happened to capture.

Breadth diagnostics observed directly: `n_avail` ranges 1–37 across the
post-truncation sample, `n_long` ranges 0–12, `held_frac` caps at exactly
0.667 (2/3, as designed for terciles) with a zero position at ~0.9% of
dates (below the minimum-breadth floor, concentrated in early
tradeable-era dates).

## Not in scope for this PR

- **Item B** (deduplicate ETF/futures twins) — untouched.
- **Item D** (rank-weighting the whole cross-section) — **not implemented**,
  per dispatch scope. Recommendation for the record: D may be the better
  structural fit — it is scale-free in `n_avail` and needs no fraction
  parameter at all, sidestepping the same fixed-vs-adaptive tension this PR
  resolves for C. Left as a separate, still-open decision.
- `#752`'s calendar lookback and `#755`'s tradeable-era truncation —
  unmodified.

## Verification

`scripts/verify.sh` run in the foreground (full mode): **PASS**. Root suite
matches the 3 documented baseline failures exactly (`#569`); package suite
matches the 1 documented baseline failure exactly, skip count 15 matches
the documented baseline (`#580`). New/updated tests in
`packages/historicaldata/tests/testthat/test-commodities-mean-reversion.R`
(no-overlap sweep across varying breadth, minimum-breadth-floor behaviour,
`frac` input validation) all pass.

Refs #751, #753.
