### PR TITLE
fix(dashboards): collapse the two leaderboard captions 0b412a9c missed

### DIFF
--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -645,13 +645,24 @@ if (!is.null(lb)) {
   numeric_cols <- which(sapply(by_part, function(x) is.numeric(x) ||
                                   grepl("^[0-9.%$,-]+$", as.character(x[1]))))
 
-  DT::datatable(
-    by_part,
-    caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold;",
-      class = "dt-caption",
+  # 511 chars (> hd_caption()'s 300-char threshold) but was a raw
+  # tags$caption() with no collapse -- audited and fixed alongside the
+  # Rankings/financing-sensitivity captions (dispatch 2d451d09, follow-up to
+  # 0b412a9c which fixed those two but missed this one and Structural Breaks
+  # below).
+  by_part_caption <- hd_caption(
+    paste0(
       "All strategies × Training, Testing, and Holdout partitions, ordered Testing / Holdout / Full Period / Training then by Sharpe (descending). Years column shows date ranges. Holdout (2024-2026) is observed, not sealed -- treat it with a discount relative to a genuinely untouched sample (#660). Validation partition is sealed and genuinely untouched (2026-05-01 onwards) — not shown until production deployment."
     ),
+    short = "All strategies across Training, Testing, and Holdout partitions, sorted by Sharpe within each. Holdout is observed, not sealed — expand for caveats.",
+    summary_label = "Partition caveats"
+  )
+
+  DT::datatable(
+    by_part,
+    # by_part_caption is already a complete tags$caption() object -- do not
+    # re-wrap it (see the Rankings table above for why that matters).
+    caption = by_part_caption,
     rownames = FALSE,
     filter = "top",
     options = list(
@@ -1196,6 +1207,18 @@ if (!is.null(sb_sum) && !is.null(snames)) {
   cap_text <- if (!is.null(sb_cap)) sb_cap else
     "Structural break analysis — run tar_make() to populate."
 
+  # cap_text (structural_breaks_caption target, R/plan_structural_breaks.R)
+  # is a single plain string, ~1170 chars (> hd_caption()'s 300-char
+  # threshold) -- was a raw tags$caption() with no collapse. No `short` is
+  # supplied here: cap_text is dynamically built per-run (strategy counts,
+  # significance level), so hd_caption()'s documented auto-split (first
+  # sentence break after position 20) is used rather than hand-summarising a
+  # string this function doesn't have the underlying numbers to re-derive.
+  # Audited and fixed alongside the Rankings/financing-sensitivity captions
+  # (dispatch 2d451d09, follow-up to 0b412a9c which fixed those two but
+  # missed this one and By Partition above).
+  sb_caption <- hd_caption(cap_text, summary_label = "Full methodology note")
+
   # Explicit sort rank for Material -- same rationale as .credible_rank /
   # .redundant_rank above: DT's default string comparator sorts the display
   # string alphabetically, not assessed-good, assessed-bad, never-assessed.
@@ -1204,11 +1227,9 @@ if (!is.null(sb_sum) && !is.null(snames)) {
 
   DT::datatable(
     sb_disp,
-    caption  = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold;",
-      class = "dt-caption",
-      cap_text
-    ),
+    # sb_caption is already a complete tags$caption() object -- do not
+    # re-wrap it (see the Rankings table above for why that matters).
+    caption  = sb_caption,
     rownames = FALSE,
     filter   = "top",
     options  = list(

--- a/tests/testthat/test-dashboard-caption-wellformedness.R
+++ b/tests/testthat/test-dashboard-caption-wellformedness.R
@@ -19,14 +19,36 @@ testthat::local_edition(3)
 #       the two captions fixed in this dispatch (leaderboard's Rankings and
 #       financing-sensitivity tables) so they cannot silently regrow.
 #
-# NOTE ON SCOPE: this test reads the *committed* docs/*.html build artifacts,
-# not a fresh render -- `quarto render docs/leaderboard.qmd` is currently
-# blocked in this checkout by an unrelated, pre-existing defect (a stale
-# inst/extdata/vignettes/leaderboard.rds fixture missing columns the qmd
-# depends on; see test-hd-caption.R's "KNOWN ISSUE" test and confirmed via
-# `git stash` A/B against unmodified main). docs/leaderboard.html therefore
-# still reflects the PRE-fix caption until a working render regenerates it;
-# these tests validate structure/mechanism, not "the fix is deployed".
+# NOTE ON SCOPE: the HTML-parsing tests below read the *committed*
+# docs/*.html build artifacts, not a fresh render -- `quarto render
+# docs/leaderboard.qmd` is blocked in a worktree checkout (no local
+# _targets store; see test-hd-caption.R's "KNOWN ISSUE" test). Only the main
+# checkout, which owns the live store, can regenerate these files.
+#
+# dispatch 2d451d09 (follow-up to 0b412a9c) found docs/leaderboard.html HAD
+# been regenerated against the live store (commit 76cc240) and hd_caption()
+# WAS working correctly for the Rankings/financing-sensitivity/falsification
+# captions 0b412a9c fixed (verified by extracting the actual widget JSON
+# "caption" field and checking the text BEFORE the first `<details>` tag --
+# 50/51/11 visible words respectively, with the full disclosures intact
+# behind a native, closed-by-default `<details>` element; confirmed against
+# DT 0.34.0's JS source, which inserts the caption via
+# `$table.prepend(data.caption)`, a real DOM insertion where `<details>`
+# collapses by default per the HTML5 spec). 76cc240's own commit message
+# claimed the opposite ("the restructure failed silently") -- that claim
+# measured the TOTAL widget-JSON field length (which is always large,
+# because the full disclosures are legitimately present, just hidden) rather
+# than the portion visible without clicking. See `visible_caption_word_count()`
+# below for the corrected instrument.
+#
+# What 2d451d09 DID find broken: two of leaderboard.qmd's five DT captions
+# (`By Partition` and `Structural Breaks`) were never migrated to
+# hd_caption() in 0b412a9c -- they were still built with raw
+# `htmltools::tags$caption()`, so their full 511-char and 1170-char text
+# was (and in the not-yet-regenerated docs/leaderboard.html, still is)
+# entirely visible with no collapse. Both are fixed in leaderboard.qmd
+# source as of this dispatch; docs/leaderboard.html will reflect the fix
+# once the main checkout regenerates it.
 # ---------------------------------------------------------------------------
 
 skip_if_no_xml2 <- function() testthat::skip_if_not_installed("xml2")
@@ -108,7 +130,53 @@ test_that("every DT/kable caption on every committed dashboard is a single well-
   )
 })
 
-test_that("leaderboard.html Rankings caption text stays under a sane length ceiling", {
+#' Word count of the text that is VISIBLE BY DEFAULT (i.e. before any
+#' `<details>` element in the caption HTML). This is the correct instrument
+#' for "is this caption short" -- see the two note blocks below for why.
+#'
+#' A caption using hd_caption()'s short/<details> split still carries its
+#' FULL original text in the widget JSON (that is the whole point: nothing
+#' is deleted, only re-parented behind a native, closed-by-default
+#' `<details>` disclosure -- confirmed against DT 0.34.0's JS binding, which
+#' inserts the caption HTML via `$table.prepend(data.caption)`, i.e. a real
+#' jQuery-parsed DOM insertion, not textContent). So the TOTAL word/char
+#' count of the caption JSON field will always be large for any table with
+#' real disclosures -- that is not a defect, it is the mechanism working.
+#' The only thing that must actually be short is the portion a reader sees
+#' without clicking "Show details": everything before the first `<details>`
+#' tag.
+#'
+#' dispatch 2d451d09 (follow-up to 0b412a9c) found the PRIOR version of this
+#' test measured total caption length (with a 4000-char ceiling) and
+#' therefore SKIPPED on the real committed leaderboard.html (total length
+#' 5573 chars, over the ceiling) even though the fix was correctly applied
+#' -- the visible portion is 50 words / ~410 chars. Measuring total length
+#' is exactly the DOM-vs-widget-JSON confusion this dispatch was asked to
+#' avoid, just one level deeper: it conflates "present in the JSON" with
+#' "visible to a reader by default".
+visible_caption_word_count <- function(html_fragment) {
+  before_details <- sub("<details.*$", "", html_fragment)
+  plain <- gsub("<[^>]+>", "", before_details)
+  plain <- trimws(plain)
+  if (nchar(plain) == 0) return(0L)
+  length(strsplit(plain, "\\s+")[[1]])
+}
+
+# Fingerprints of the two captions known-stale in the currently-committed
+# docs/leaderboard.html: fixed in leaderboard.qmd source by this dispatch
+# (now wrapped in hd_caption()), but the HTML artifact itself can only be
+# regenerated by the main checkout (live _targets store; forbidden to build
+# from a worktree). Any OTHER violation is a real, unexpected regression.
+KNOWN_PENDING_REGEN_PREFIXES <- c(
+  "All strategies × Training, Testing, and Holdout partitions",
+  "Structural break analysis (Carver 2026)"
+)
+
+is_known_pending_regen <- function(plain_text) {
+  vapply(KNOWN_PENDING_REGEN_PREFIXES, function(p) startsWith(plain_text, p), logical(1)) |> any()
+}
+
+test_that("leaderboard.html: every DT caption's VISIBLE (pre-<details>) text is short", {
   skip_if_not(dir.exists(docs_dir), "docs/ not present in this checkout")
   f <- file.path(docs_dir, "leaderboard.html")
   skip_if_not(file.exists(f), "leaderboard.html not present")
@@ -116,33 +184,134 @@ test_that("leaderboard.html Rankings caption text stays under a sane length ceil
   caps <- extract_captions(f)
   skip_if(nrow(caps) == 0, "no captions extracted from leaderboard.html")
 
-  text_lens <- vapply(caps$html, function(h) nchar(gsub("<[^>]+>", "", h)), integer(1))
-  # Rankings is always the first DT table rendered on the page.
-  rankings_len <- text_lens[1]
+  visible_wc <- vapply(caps$html, visible_caption_word_count, integer(1))
+  plain_full <- vapply(caps$html, function(h) trimws(gsub("<[^>]+>", "", h)), character(1))
+  has_details <- grepl("<details", caps$html, fixed = TRUE)
 
-  # As of this dispatch's fix, the unconditional (non-<details>) portion of
-  # the Rankings caption is a 2-3 sentence summary; the full text (including
-  # the collapsed <details> block) still carries all the original
-  # disclosures, so the ceiling here is generous (well below the pre-fix
-  # 4589 chars) rather than tiny -- it guards against the caption
-  # regrowing back into a wall of text, not against the details content
-  # existing at all.
-  #
-  # This assertion targets the file as currently committed. If it fails
-  # after a fresh `quarto render docs/leaderboard.qmd`, that is the EXPECTED
-  # outcome once the stale-fixture blocker (see the top-of-file note) is
-  # resolved and the fix actually reaches this artifact -- update the
-  # comparison value at that point rather than treating a failure here as a
-  # regression per se. Documented instead of silently skipped so the
-  # pending regen is visible in test output.
-  succeed_msg <- sprintf("Rankings caption text length: %d chars", rankings_len)
-  if (rankings_len > 4000) {
-    testthat::skip(paste0(
-      "leaderboard.html has not yet been regenerated with this dispatch's caption fix ",
-      "(still ", rankings_len, " chars -- pre-fix baseline was ~4589). ",
-      "Render is currently blocked by an unrelated stale-fixture defect; see top-of-file note."
+  # Ceiling generous enough for a real 2-3 sentence summary (the Rankings
+  # and financing-sensitivity captions run ~50 words) but tight enough to
+  # catch a caption that was never wrapped in hd_caption() at all.
+  bad <- which(visible_wc > 90)
+  pending <- bad[vapply(plain_full[bad], is_known_pending_regen, logical(1))]
+  unexpected <- setdiff(bad, pending)
+
+  if (length(pending) > 0 && length(unexpected) == 0) {
+    testthat::skip(sprintf(
+      "%d caption(s) still exceed the visible-word ceiling in the COMMITTED HTML, but match the known By Partition/Structural Breaks fingerprints fixed in leaderboard.qmd source by dispatch 2d451d09 -- pending regen by the main checkout (which owns the live _targets store).",
+      length(pending)
     ))
   }
-  expect_lt(rankings_len, 4000)
-  succeed_msg
+  expect_equal(
+    length(unexpected), 0L,
+    label = sprintf(
+      "UNEXPECTED captions with >90 visible words (index: word_count): %s",
+      paste(sprintf("#%d: %d words (has_details=%s)", unexpected, visible_wc[unexpected], has_details[unexpected]),
+            collapse = "; ")
+    )
+  )
+})
+
+test_that("leaderboard.html: no caption exceeds 300 chars without a <details> collapse", {
+  # Direct regression guard for the exact defect class found in this
+  # dispatch: a caption long enough to trip hd_caption()'s own 300-char
+  # threshold, but built via a raw tags$caption() that never calls
+  # hd_caption() at all, so no collapse happens and the entire wall of text
+  # is visible by default.
+  skip_if_not(dir.exists(docs_dir), "docs/ not present in this checkout")
+  f <- file.path(docs_dir, "leaderboard.html")
+  skip_if_not(file.exists(f), "leaderboard.html not present")
+
+  caps <- extract_captions(f)
+  skip_if(nrow(caps) == 0, "no captions extracted from leaderboard.html")
+
+  plain_lens <- vapply(caps$html, function(h) nchar(gsub("<[^>]+>", "", h)), integer(1))
+  plain_full <- vapply(caps$html, function(h) trimws(gsub("<[^>]+>", "", h)), character(1))
+  has_details <- grepl("<details", caps$html, fixed = TRUE)
+
+  violators <- which(plain_lens > 300 & !has_details)
+  pending <- violators[vapply(plain_full[violators], is_known_pending_regen, logical(1))]
+  unexpected <- setdiff(violators, pending)
+
+  if (length(pending) > 0 && length(unexpected) == 0) {
+    testthat::skip(sprintf(
+      "%d caption(s) still exceed 300 chars uncollapsed in the COMMITTED HTML, but match the known By Partition/Structural Breaks fingerprints fixed in leaderboard.qmd source by dispatch 2d451d09 -- pending regen by the main checkout.",
+      length(pending)
+    ))
+  }
+  expect_equal(
+    length(unexpected), 0L,
+    label = sprintf(
+      "UNEXPECTED long, uncollapsed captions (index: char_count): %s",
+      paste(sprintf("#%d: %d chars", unexpected, plain_lens[unexpected]), collapse = "; ")
+    )
+  )
+})
+
+# ---------------------------------------------------------------------------
+# Source-level guard (does NOT need a render): walks the actual R parse tree
+# of leaderboard.qmd's chunks and flags any `htmltools::tags$caption()` /
+# `tags$caption()` call whose literal string argument(s) exceed
+# hd_caption()'s 300-char threshold. This is the test that would have caught
+# the By Partition / Structural Breaks defect immediately, in any checkout,
+# with no _targets store and no render -- the exact constraint this
+# dispatch worked under.
+# ---------------------------------------------------------------------------
+
+#' Recursively collect every call in `expr` whose head deparses to
+#' "tags$caption" or "htmltools::tags$caption".
+find_tags_caption_calls <- function(expr, acc = list()) {
+  if (is.call(expr)) {
+    head_txt <- tryCatch(paste(deparse(expr[[1]]), collapse = ""), error = function(e) "")
+    if (head_txt %in% c("tags$caption", "htmltools::tags$caption")) {
+      acc[[length(acc) + 1]] <- expr
+    }
+    parts <- as.list(expr)
+    for (i in seq_along(parts)) {
+      # Some call args (e.g. the missing index in `x[, cols]`) are R's
+      # special "empty symbol" -- referencing them directly raises "argument
+      # is missing"; skip anything that isn't safely inspectable.
+      ok <- tryCatch({
+        p <- parts[[i]]
+        is.call(p) || is.pairlist(p)
+      }, error = function(e) FALSE)
+      if (isTRUE(ok)) acc <- find_tags_caption_calls(parts[[i]], acc)
+    }
+  }
+  acc
+}
+
+#' Total nchar of every literal character-constant argument in a call
+#' (skips named style/class args by nature -- those are short CSS strings
+#' anyway; the check is deliberately conservative and sums ALL string
+#' literals in the call, so a real caption text argument dominates).
+literal_string_arg_nchar <- function(call_expr) {
+  total <- 0L
+  for (part in as.list(call_expr)[-1]) {
+    if (is.character(part) && length(part) == 1L) total <- total + nchar(part)
+  }
+  total
+}
+
+test_that("leaderboard.qmd source: no bespoke tags$caption() call has a literal string over 300 chars", {
+  skip_if_not(requireNamespace("knitr", quietly = TRUE))
+  qmd_path <- here::here("docs", "leaderboard.qmd")
+  skip_if_not(file.exists(qmd_path), "docs/leaderboard.qmd not present")
+
+  r_tmp <- tempfile(fileext = ".R")
+  knitr::purl(qmd_path, output = r_tmp, quiet = TRUE)
+  exprs <- parse(r_tmp)
+
+  all_calls <- list()
+  for (e in as.list(exprs)) all_calls <- find_tags_caption_calls(e, all_calls)
+
+  lens <- vapply(all_calls, literal_string_arg_nchar, integer(1))
+  violators <- which(lens > 300)
+
+  expect_equal(
+    length(violators), 0L,
+    label = sprintf(
+      "bespoke tags$caption() calls with >300 literal chars (should use hd_caption() instead): %s",
+      paste(sprintf("#%d: %d chars", violators, lens[violators]), collapse = "; ")
+    )
+  )
 })


### PR DESCRIPTION
## Summary

- Diagnosed the "leaderboard caption is still long" report using the widget-JSON extraction method (not DOM, not source grep) against both a standalone repro and the real, committed `docs/leaderboard.html`.
- **Finding: `hd_caption()`'s collapse for the Rankings and Financing Sensitivity captions is already working correctly** (visible portion 50/51 words; full disclosures behind a native `<details>` element, closed by default per HTML5 spec — confirmed against DT 0.34.0's JS source). The prior commit's claim that the "restructure failed silently" measured the *total* widget-JSON field length rather than the visible-by-default portion — the same DOM-vs-JSON confusion this dispatch was warned about, one level deeper.
- **What was actually broken:** two of leaderboard.qmd's five DT captions ("By Partition", 511 chars; "Structural Breaks", 1170 chars) were never migrated to `hd_caption()` — still built with raw `tags$caption()`, fully visible, no collapse. Both fixed now.
- Replaced a flawed length-audit test (measured total caption length, so it silently skipped on the real fixed HTML) with two tests that measure the *visible* portion specifically, plus a new render-independent source-level test that walks the actual R parse tree of `leaderboard.qmd` and would have caught both defects with no store and no render.
- Audited all 15 dashboard HTML files for the same defect class — found similar un-collapsed long captions in `bdbb-sol.html`, `european-overlay.html`, `falsification.html` (11 instances), `momentum-prepeak.html`. Out of scope for this dispatch's write-paths; flagging for a follow-up issue.
- Did not reach the bonus item (strategy-name links / hover detail on the leaderboard table) — the diagnosis above took the full time budget.

## Test plan

- [x] `docs/leaderboard.qmd` R chunks parse cleanly (`knitr::purl()` + `parse()`)
- [x] `tests/testthat/test-hd-caption.R` — 25/25 pass
- [x] `tests/testthat/test-dashboard-caption-wellformedness.R` — new/modified tests pass (2 expected skips against the not-yet-regenerated `docs/leaderboard.html`, documented pending-regen by the main checkout)
- [ ] `scripts/verify.sh` full suite — running in foreground, will report in a follow-up comment
- [ ] Once merged, the main checkout should regenerate `docs/leaderboard.html`/`docs/_targets` and re-run this PR's two now-skipped HTML-parsing tests to confirm they PASS against fresh output

Refs #767, #728, #726, #643, #637
