### PR TITLE
fix(dashboards): DT cell contrast, caption font size, plot/table grid overlap

### DIFF
--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -902,12 +902,14 @@ Rejection rates across 6 null environments (M = 100 simulations each). A low rat
 safe_tar_read("fals_vig_null_heatmap")
 ```
 
+::: {.fig-caption}
 ```{r}
 #| label: fals-heatmap-caption
 #| results: asis
 cap <- safe_tar_read("fals_vig_null_heatmap_caption")
 if (!is.null(cap)) cat(paste0("\n*", cap, "*\n"))
 ```
+:::
 
 #### Alpha vs Factor Exposure
 
@@ -920,12 +922,14 @@ Scatter plot of annualised alpha (%) against R² (%) from the Fama-French 5-Fact
 safe_tar_read("fals_vig_ff_alpha_plot")
 ```
 
+::: {.fig-caption}
 ```{r}
 #| label: fals-alpha-caption
 #| results: asis
 cap <- safe_tar_read("fals_vig_ff_caption")
 if (!is.null(cap)) cat(paste0("\n*", cap, "*\n"))
 ```
+:::
 
 #### See Also
 
@@ -1339,6 +1343,7 @@ if (!is.null(sb_sum) && !is.null(snames)) {
 }
 ```
 
+::: {.fig-caption}
 ```{r}
 #| label: sb-dotplot-caption
 #| results: asis
@@ -1363,6 +1368,7 @@ fig_cap <- paste0(
 )
 cat(paste0("\n*", fig_cap, "*\n"))
 ```
+:::
 
 # Details
 

--- a/docs/vignette-shared.css
+++ b/docs/vignette-shared.css
@@ -77,6 +77,34 @@ body { font-size: var(--base-font-size, 1.3em); }
   max-height: none !important; overflow: visible !important;
 }
 
+/* Table/caption rendering ON TOP OF the plot above it (reported on
+   #robustness Bootstrap CI/Regime/Kelly Sizing, #structural-breaks Sharpe
+   Comparison, and the falsification null-rejection heatmap -- confirmed by
+   fetching the deployed HTML: every one of these tabs is a `.bslib-grid`
+   with `display: grid; grid-template-rows: minmax(3em, 1fr) minmax(3em,
+   1fr)` or a max-content/1fr mix, e.g. plot in row 1, table in row 2).
+   `1fr` splits the grid's height into equal FRACTIONS regardless of how
+   tall each row's actual content is -- unlike normal block flow, a CSS
+   Grid row's track size does not grow to accommodate an oversized sibling.
+   Combined with `overflow: visible !important` above (kept deliberately so
+   nothing gets CLIPPED), content taller than its 1fr share does not get
+   clipped either -- it visually spills into the next row's box, which is
+   exactly "table on top of plot". Implicit (auto-placed) rows have the
+   same problem via `grid-auto-rows: minmax(0, 1fr)`, so both properties
+   need overriding.
+   This project has no side-by-side (multi-column) dashboard layout to
+   protect: every `grid-template-columns`/`grid-auto-columns` value on
+   every rendered page is a single track (no `## Column` anywhere in
+   docs/*.qmd, verified against the deployed HTML), so every `.bslib-grid`
+   here exists only to STACK items vertically. Forcing rows to size to
+   their own content is therefore safe everywhere and fixes every reported
+   tab in one place -- grid-template-columns/grid-auto-columns are
+   untouched so a future side-by-side layout still works. */
+.bslib-grid {
+  grid-template-rows: none !important;
+  grid-auto-rows: auto !important;
+}
+
 /* Cell outputs: block layout, no overlap */
 .cell-output-display {
   display: block !important; position: relative !important;
@@ -109,6 +137,46 @@ body { font-size: var(--base-font-size, 1.3em); }
 table.dataTable { white-space: nowrap; }
 table caption, .dataTables_wrapper caption { caption-side: top !important; }
 
+/* Table CELL text invisible on Chrome, fine on Edge (reported on
+   #rankings AND #sp-500-analysis -- confirmed the same mechanism on both
+   by fetching the deployed page and its CSS bundle for each: both load
+   the identical dt-core-1.13.6 bundle, and BOTH pages' plain (unstyled)
+   cells -- Strategy/Credible/Sharpe on the leaderboard, every column on
+   avoid-worst-days' Asymmetry/Metrics tables, since neither page's
+   R code applies DT::formatStyle color -- are governed by this one rule).
+   `jquery.dataTables.extra.css` (bundled with DT, loaded on every
+   dashboard) ships `div.datatables { color: #333; }` unconditionally, as
+   a fix for an unrelated RStudio/Cobalt-theme issue (see that file's own
+   comment, https://github.com/rstudio/DT/issues/447) -- it has no
+   awareness of our dark-by-default theme. #333 near-black text on this
+   site's near-black dashboard background is ~1.3:1 contrast (WCAG
+   minimum is 4.5:1), i.e. genuinely near-invisible, not just "hard to
+   read" -- consistent with rendering differences between browsers/
+   monitors making it look flatly invisible in one and faintly legible in
+   another. Columns with their OWN explicit color (the Detection/Rigour
+   `.det-badge`/`.rig-badge` spans, 2 classes = higher specificity) already
+   win against this and were never affected -- exactly the "some but not
+   all other columns" pattern reported. Only 2 of 9 DT-table dashboards
+   (leaderboard, falsification) carry a per-table `initComplete` JS patch
+   for this at all, and even there it only fires ONCE at first table draw
+   and only touches the outer wrapper, not a live/reactive per-cell rule --
+   the other 7 (avoid-worst-days, evidence, european-overlay,
+   macro-defense-rotation, stock-backtest, momentum-prepeak, bdbb-sol) have
+   no patch whatsoever. Fixing it here, once, in the shared stylesheet
+   that already loads after dt-core's CSS on every dashboard, replaces
+   every one of those per-table JS patches with a single rule that also
+   responds live to a light/dark toggle (the JS one-shot does not). */
+div.datatables, .dataTables_wrapper,
+div.datatables table.dataTable td, .dataTables_wrapper table.dataTable td {
+  color: #ddd;
+}
+[data-bs-theme="light"] div.datatables,
+[data-bs-theme="light"] .dataTables_wrapper,
+[data-bs-theme="light"] div.datatables table.dataTable td,
+[data-bs-theme="light"] .dataTables_wrapper table.dataTable td {
+  color: #1a1a1a;
+}
+
 /* Captions: wrap text to window width; font-size matches body (#348); margin-top avoids overlap with plot (#349) */
 .fig-caption {
   display: block; font-size: 1em; color: #ffffff;
@@ -117,9 +185,21 @@ table caption, .dataTables_wrapper caption { caption-side: top !important; }
   max-width: 100%;
   clear: both;
 }
+/* Caption font too small (reported on #rankings, "repeat throughout the
+   document"): Bootstrap's own bundled CSS ships `caption { font-size:
+   0.875em; ... }` (confirmed in the deployed bootstrap-dark bundle) --
+   87.5% of whatever the surrounding context is, applied to EVERY <caption>
+   element site-wide since it is a bare type selector. hd_caption()
+   (vignette_utils.R) never set an explicit font-size, so this always won.
+   font-size: 1em here matches the same fix already applied to .fig-caption
+   above (#348) -- both become "whatever the ancestor's computed size is",
+   i.e. the body text size -- and `table caption` (2 type selectors) beats
+   Bootstrap's plain `caption` (1 type selector) on specificity alone, so
+   no !important is needed to win the cascade. */
 table caption, .dataTables_wrapper caption, .dt-caption {
   word-wrap: break-word; overflow-wrap: break-word;
   white-space: normal !important; max-width: 100%;
+  font-size: 1em;
   color: #ffffff !important;
 }
 [data-bs-theme="light"] table caption,


### PR DESCRIPTION
## Summary

Three dashboard defects reported directly by the repo owner against the live site:

1. **Table text invisible in Chrome, fine in Edge** — https://johngavin.github.io/historical/leaderboard.html#rankings and https://johngavin.github.io/historical/avoid-worst-days.html#sp-500-analysis
2. **Caption font too small** — throughout every dashboard
3. **Table/caption rendered on top of the plot above it** — `#robustness` (Bootstrap CI, Regime, Kelly Sizing), `#structural-breaks` (Sharpe Comparison), falsification null-rejection heatmap

All three are fixed as single, shared-CSS-layer changes in `docs/vignette-shared.css`, verified against the actually-deployed HTML/CSS bundles (fetched with `curl`), not guessed. Full root-cause reasoning is in the commit message and inline CSS comments.

- **Defect 1 root cause:** DT's own bundled `jquery.dataTables.extra.css` ships `div.datatables { color: #333; }` unconditionally (an RStudio Cobalt-theme workaround, unrelated to us). On this site's dark background that's ~1.3:1 contrast (WCAG needs 4.5:1) for any table cell with no more-specific color rule. Confirmed the same mechanism is present on both `leaderboard.html` and `avoid-worst-days.html` (identical `dt-core-1.13.6` bundle, identical missing per-cell color styling in both pages' R code).
- **Defect 2 root cause:** Bootstrap's bundled CSS ships a bare `caption { font-size: 0.875em; }` that applied to every `<caption>` site-wide since `hd_caption()` never set an explicit font-size.
- **Defect 3 root cause:** every affected tab is a `.bslib-grid` using `grid-template-rows: minmax(3em, 1fr) minmax(3em, 1fr)` (or a max-content/1fr mix) to stack a plot above a table. `1fr` gives each row an equal height *fraction* regardless of actual content size; combined with this file's pre-existing `overflow: visible !important`, oversized content spills into the next row instead of being clipped or pushing it down.

## Dashboard coverage (per-page, `checks-must-distinguish-unknown`)

DT-table-bearing pages (Defect 1 applies, fixed by the shared CSS): `leaderboard.qmd`, `avoid-worst-days.qmd`, `evidence.qmd`, `european-overlay.qmd`, `macro-defense-rotation.qmd`, `falsification.qmd`, `stock-backtest.qmd`, `momentum-prepeak.qmd`, `bdbb-sol.qmd` (9 of 15 — verified via `grep -l "DT::datatable\|hd_dt(" docs/*.qmd`).

Pages with no DT table (Defect 1 does not apply — verified zero matches, not indeterminate): `index.qmd`, `drif.qmd`, `jst-dashboard.qmd`, `factor-max.qmd`, `negative-results.qmd`, `quiz.qmd`.

Defects 2 and 3 are structural (`<caption>` element, `.bslib-grid` row sizing) and apply to every page that has a caption or a stacked plot+table tab respectively — the CSS fix is unconditional, not keyed to any particular page's content, so all 15 dashboards get it.

**PREDICTED, not OBSERVED** — `tar_make()`/`quarto render` were not run (the main checkout owns the store/lock, per this worktree's task scope). Falsification: after the next full render + deploy, fetch each dashboard, screenshot the previously-affected tabs, and confirm (a) plain DT cell text has visible contrast in a real Chrome instance, (b) caption font-size matches body text when measured via devtools, (c) no visual overlap between a plot and the table/caption beneath it on Bootstrap CI / Regime / Kelly Sizing / Sharpe Comparison / Null Rejection.

## Test plan

- [ ] `scripts/verify.sh` (structure-only; cannot render)
- [ ] After merge + CI render, fetch each of the 9 DT-bearing dashboards and confirm no `color: #333`-style invisible cells
- [ ] Visually confirm caption font size matches body text on at least 3 dashboards
- [ ] Visually confirm no plot/table overlap on the 5 explicitly reported tabs, in a real Chrome browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)
