### PR TITLE
fix(leaderboard): uniform not-computed blanks, gross CAGR column, widen Redundant to 16/17 strategies, S23 coherence gate

### DIFF
--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -1645,6 +1645,94 @@ check_leaderboard_deflated_sharpe_coverage <- function(leaderboard, exemptions =
 }
 
 
+#' Assert leaderboard `net_cagr`, `cvar_95`, and `credible` are jointly NA or
+#' jointly non-NA per row (S23, fail-loud-not-null.md)
+#'
+#' \code{net_cagr}, \code{cvar_95}, and \code{credible} are all produced in a
+#' single pass by \code{calc_cost_metrics()} (R/plan_leaderboard.R) from the
+#' SAME \code{cost_rows} join -- one matching \code{cost_rows} row (built by
+#' \code{slice_portfolio()} for the 5 core strategies plus PSO Optimal)
+#' produces all three columns at once; a strategy/period \code{cost_rows}
+#' never covers leaves all three NA together via the
+#' \code{all_metrics |> left_join(cost_rows, by = c("strategy", "period"))}
+#' join. \code{docs/leaderboard.qmd}'s Rankings table renders exactly this
+#' shared NA-ness as a single "not computed" verdict across all three
+#' columns (the "#637 follow-up" comment there) -- this gate is what keeps
+#' that assumption from silently going stale.
+#'
+#' Guards the \code{.claude/rules/fail-loud-not-null.md} defect class
+#' (#637/#640/#641/#643): a future change that extends \code{cost_rows} (or
+#' adds a second source) to populate ONE of these three columns for a new
+#' strategy/period without the other two would let
+#' \code{docs/leaderboard.qmd} render an internally inconsistent row -- e.g.
+#' a "Credible: yes" verdict with no Net CAGR value to have been judged
+#' credible about, or a Net CAGR figure with no CVaR 95% alongside it. The
+#' rule's Required Pattern item 5 ("Add a QA gate, not just a test") is what
+#' this target answers; the joint-presence check itself is exercised
+#' directly against synthetic fixtures in
+#' tests/testthat/test-leaderboard-cost-metrics-coverage.R, mirroring
+#' check_leaderboard_sharpe_coherence() (S17)'s shape.
+#'
+#' Unlike S17/S20/S21, this check is deliberately NOT scoped to
+#' \code{period == "Full Period"}: \code{cost_rows} produces a row per
+#' Training/Testing/Holdout/Full Period slice for every strategy it covers
+#' (\code{slice_portfolio()}), so the joint-presence property must hold on
+#' every period row, not just the full-sample one.
+#'
+#' @param leaderboard Tibble with at least \code{strategy}, \code{period},
+#'   \code{net_cagr}, \code{cvar_95}, \code{credible} columns (the output of
+#'   the \code{leaderboard} target).
+#' @return \code{TRUE} invisibly on success.
+#' @noRd
+check_leaderboard_cost_metrics_joint_presence <- function(leaderboard) {
+  required_cols <- c("strategy", "period", "net_cagr", "cvar_95", "credible")
+  missing_cols <- setdiff(required_cols, names(leaderboard))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "Leaderboard is missing {length(missing_cols)} required column(s): {missing_cols}.",
+      "i" = "check_leaderboard_cost_metrics_joint_presence() (S23) requires strategy, period, net_cagr, cvar_95, credible."
+    ))
+  }
+
+  has_net_cagr <- !is.na(leaderboard$net_cagr)
+  has_cvar_95  <- !is.na(leaderboard$cvar_95)
+  has_credible <- !is.na(leaderboard$credible)
+
+  disagree <- !(has_net_cagr == has_cvar_95 & has_cvar_95 == has_credible)
+
+  if (any(disagree)) {
+    idx <- which(disagree)
+    offenders <- sprintf(
+      "  %s / %s -- net_cagr %s, cvar_95 %s, credible %s",
+      leaderboard$strategy[idx], leaderboard$period[idx],
+      ifelse(has_net_cagr[idx], "present", "NA"),
+      ifelse(has_cvar_95[idx],  "present", "NA"),
+      ifelse(has_credible[idx], "present", "NA")
+    )
+    cli::cli_abort(c(
+      "x" = paste0(
+        "Leaderboard has ", length(idx),
+        " row(s) where net_cagr/cvar_95/credible disagree on presence -- ",
+        "these three columns come from the SAME cost_rows join and must be ",
+        "jointly NA or jointly non-NA:"
+      ),
+      setNames(offenders, rep("i", length(offenders))),
+      "i" = paste0(
+        "check_leaderboard_cost_metrics_joint_presence() (S23) guards the ",
+        "fail-loud-not-null.md defect class (#637/#640/#641/#643): if one of ",
+        "these three columns is populated for a strategy/period without the ",
+        "other two, docs/leaderboard.qmd's single 'not computed' verdict for ",
+        "Credible/Net CAGR/CVaR 95% no longer matches the underlying data. ",
+        "Check calc_cost_metrics() and the cost_rows join in ",
+        "R/plan_leaderboard.R's leaderboard target."
+      )
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+
 #' Assert the package-source digest mechanism is actually tracking something
 #' (S22, #753)
 #'
@@ -2165,6 +2253,20 @@ plan_qa_gates <- function() {
           "qa_pkg_source_tracked: S22 passed (%d package source file(s) tracked, digest %s)",
           length(pkg_source_files), substr(pkg_source_digest, 1, 12)
         )))
+        TRUE
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: net_cagr/cvar_95/credible are jointly present or jointly NA
+    # per row (S23, fail-loud-not-null.md) -- see
+    # check_leaderboard_cost_metrics_joint_presence() roxygen above for the
+    # #637/#640/#641/#643 defect class this closes.
+    targets::tar_target(
+      qa_leaderboard_cost_metrics_coverage,
+      command = {
+        check_leaderboard_cost_metrics_joint_presence(leaderboard)
+        cli::cli_inform(c("v" = "qa_leaderboard_cost_metrics_coverage: S23 passed (net_cagr/cvar_95/credible jointly present or jointly NA on every row)"))
         TRUE
       },
       cue = targets::tar_cue(mode = "always")

--- a/R/plan_strategy_correlation.R
+++ b/R/plan_strategy_correlation.R
@@ -345,24 +345,81 @@ plan_strategy_correlation <- function() {
     # ── Augmentation: correlation_max, redundant flag, incremental Sharpe ─────
     # Returns a tibble keyed by the leaderboard strategy label (short_name) so
     # plan_leaderboard can left_join by "strategy" (which uses short/display names).
+    #
+    # Widened from the original 5-strategy family (stk_max/stk_drif/fac_max/
+    # fac_drif/ltr, via strat_corr_matrix/strat_returns_aligned) to the same
+    # 16-strategy STRAT_RETURNS_WIDE_CODES scope as strat_corr_matrix_leaderboard
+    # (#728 items 1+2, #733) -- see docs/leaderboard.qmd's Rankings table,
+    # Redundant/Incremental Sharpe columns. Before this widening, 12 of 17
+    # leaderboard strategies showed "not computed" for both columns purely
+    # because plan_strategy_correlation.R had not yet been pointed at the
+    # wider matrix, even though that matrix (and the k_eff_leaderboard/
+    # deflated_sharpe it feeds via strat_keff_vertox_leaderboard,
+    # R/plan_leaderboard.R's strat_deflated_sharpe) already covers 16 of 17.
+    #
+    # Verified suitable before widening (not assumed): strat_returns_wide is
+    # entirely a MONTHLY `ym` spine (the five daily-frequency strategies are
+    # already resampled onto it by .resample_daily_to_monthly() -- see that
+    # target's own comment), so periods_per_year = 12L below is correct for
+    # every one of the 16 columns, unlike a naive mix of native frequencies.
+    # A live-store check (2026, docs/_targets) found 193 rows with non-NA
+    # data across all 16 STRAT_RETURNS_WIDE_CODES columns simultaneously --
+    # NOT a further-shrunk window: 193 equals Factor MAX/Factor DRIF's own
+    # individual non-NA count (193), i.e. the complete-case window is bounded
+    # by the tightest-history strategy already on the leaderboard, not by
+    # requiring 16-way agreement beyond what that strategy's own "Full
+    # Period" Sharpe is already computed over. A shared common window (not
+    # each strategy's own full individual history, unlike
+    # strat_deflated_sharpe's naive_sharpe) is deliberate here: comparing two
+    # strategies' Sharpe to decide which is "better" for the redundancy flag
+    # is only valid if both are measured over the SAME dates.
     targets::tar_target(strat_corr_augment, {
       library(dplyr)
 
-      # Map from code_name to the leaderboard display label
-      # (leaderboard uses "Factor MAX", "Factor DRIF", etc.)
+      # Map from code_name to the leaderboard display label. Matches the
+      # SAME code_name -> label vocabulary as col_map_monthly/col_map_daily
+      # in R/plan_leaderboard.R's strat_deflated_sharpe target, so a
+      # strategy's Redundant/Incremental Sharpe badge and its Rigour badge
+      # never disagree about which strategy a code_name refers to. (Not
+      # reused from plan_strategy_names.R's strategy_names target: that
+      # table's code_name vocabulary -- "drif", "rsc", "ev_ebit", "mf_tsm",
+      # "olmar" -- is a DIFFERENT, pre-existing convention from
+      # STRAT_RETURNS_WIDE_CODES's, an inconsistency out of scope to unify
+      # here.)
       name_map <- tibble::tibble(
-        code_name     = c("stk_max", "stk_drif", "fac_max", "fac_drif", "ltr"),
-        strategy_label = c("Stock MAX", "Stock DRIF", "Factor MAX",
-                            "Factor DRIF", "LTR")
+        code_name      = c("stk_max", "stk_drif", "fac_max", "fac_drif", "ltr",
+                            "xgb_drif", "mom_prepeak", "mom_postpeak", "mom_combined",
+                            "value_hml", "managed_futures",
+                            "cmr", "olmar_1", "tom", "risk_state", "avoid_worst"),
+        strategy_label = c("Stock MAX", "Stock DRIF", "Factor MAX", "Factor DRIF", "LTR",
+                            "XGB DRIF", "Mom Pre-Peak", "Mom Post-Peak", "Mom 12-2",
+                            "Value (HML)", "Managed Futures",
+                            "CMR", "OLMAR-1", "TOM", "Risk State", "Avoid Worst")
       )
 
-      strat_cols <- rownames(strat_corr_matrix)
+      strat_cols <- rownames(strat_corr_matrix_leaderboard)
       n_strat <- length(strat_cols)
 
-      # ── Full-period Sharpe per strategy (recompute for alignment) ─────────
-      full_rets <- strat_returns_aligned |>
+      # ── Full-period Sharpe per strategy, on a SHARED complete-case window ──
+      full_rets <- strat_returns_wide |>
         select(all_of(strat_cols)) |>
         filter(if_all(everything(), ~ !is.na(.x)))
+
+      # fail-loud-not-null.md: a row that cannot be checked must abort, not
+      # silently produce all-NA sharpe_full/incremental_sharpe values.
+      if (nrow(full_rets) < 2L) {
+        cli::cli_abort(c(
+          "x" = paste0(
+            "Only ", nrow(full_rets), " row(s) of strat_returns_wide have ",
+            "non-NA data for all ", n_strat, " widened correlation strategies."
+          ),
+          "i" = paste0(
+            "strat_corr_augment (Redundant/Incremental Sharpe) needs a shared ",
+            "common window across: ", paste(strat_cols, collapse = ", "), "."
+          ),
+          "i" = "Check strat_returns_wide (R/plan_strategy_correlation.R) for a strategy whose history no longer overlaps the others."
+        ))
+      }
 
       sharpe_full <- vapply(strat_cols, function(col) {
         r <- full_rets[[col]]
@@ -376,7 +433,7 @@ plan_strategy_correlation <- function() {
       # ── correlation_max: max |r| with any OTHER strategy ─────────────────
       corr_max <- vapply(strat_cols, function(s) {
         others <- setdiff(strat_cols, s)
-        max(abs(strat_corr_matrix[s, others]))
+        max(abs(strat_corr_matrix_leaderboard[s, others]))
       }, numeric(1L))
       names(corr_max) <- strat_cols
 
@@ -384,7 +441,7 @@ plan_strategy_correlation <- function() {
       redundant <- vapply(strat_cols, function(s) {
         peers <- setdiff(strat_cols, s)
         any(vapply(peers, function(p) {
-          high_corr <- abs(strat_corr_matrix[s, p]) >= REDUNDANCY_THRESH
+          high_corr <- abs(strat_corr_matrix_leaderboard[s, p]) >= REDUNDANCY_THRESH
           better    <- !is.na(sharpe_full[[p]]) && !is.na(sharpe_full[[s]]) &&
                        sharpe_full[[p]] > sharpe_full[[s]]
           high_corr && better
@@ -436,6 +493,25 @@ plan_strategy_correlation <- function() {
         # Expose by both code_name (for programmatic use) and strategy_label (for
         # leaderboard join)
         select(code_name, strategy_label, correlation_max, redundant, incremental_sharpe)
+
+      # fail-loud-not-null.md: an un-mapped code_name must abort, not
+      # silently produce an NA strategy_label that then fails to join onto
+      # the leaderboard by "strategy" (indistinguishable from "outside the
+      # correlation universe").
+      if (anyNA(result$strategy_label)) {
+        unmapped <- result$code_name[is.na(result$strategy_label)]
+        cli::cli_abort(c(
+          "x" = paste0(
+            length(unmapped), " strategy code_name(s) in strat_corr_matrix_leaderboard ",
+            "have no entry in strat_corr_augment's name_map: ", paste(unmapped, collapse = ", "), "."
+          ),
+          "i" = paste0(
+            "Add the missing code_name -> display label mapping to name_map above -- it ",
+            "must match col_map_monthly/col_map_daily in R/plan_leaderboard.R's ",
+            "strat_deflated_sharpe target."
+          )
+        ))
+      }
 
       result
     }),

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -254,9 +254,25 @@ if (!is.null(lb)) {
       .det_rank  = vapply(det, function(x) x$rank, integer(1)),
       Rigour     = vapply(rig, function(x) x$html, character(1)),
       .rig_rank  = vapply(rig, function(x) x$rank, integer(1)),
-      `Net CAGR` = ifelse(is.na(net_cagr),     "—", paste0(round(net_cagr * 100, 1), "%")),
+      # CAGR (gross, unadjusted) is a base metric every strategy's own
+      # metrics target computes -- 17/17 non-NA in the live store, unlike
+      # Net CAGR below (#637 follow-up: a reader seeing only "Net CAGR"
+      # populated for 6/17 strategies could reasonably conclude the other
+      # 11 have no CAGR at all, when in fact only the COST-ADJUSTED figure
+      # is out of scope for them).
+      CAGR       = ifelse(is.na(cagr),         "—", paste0(round(cagr * 100, 1), "%")),
+      # NA net_cagr/cvar_95 means cost-adjusted metrics were never computed
+      # for this strategy/period (cost_rows in R/plan_leaderboard.R only
+      # covers 5 core strategies + PSO Optimal; QA gate S23,
+      # check_leaderboard_cost_metrics_joint_presence(), asserts this NA-ness
+      # is always joint across Net CAGR/CVaR 95%/Credible) -- rendered as
+      # "not computed", the same out-of-scope state as Credible/Redundant
+      # below, not the bare "—" reserved for genuinely not-applicable cells
+      # (e.g. Gross/Cost (bps) below, where a meta-portfolio blend has no
+      # separate figure to measure) (#637 follow-up).
+      `Net CAGR` = ifelse(is.na(net_cagr),     "not computed", paste0(round(net_cagr * 100, 1), "%")),
       `Max DD`   = paste0(round(max_dd * 100, 1), "%"),
-      `CVaR 95%` = ifelse(is.na(cvar_95),      "—", paste0(round(cvar_95 * 100, 1), "%")),
+      `CVaR 95%` = ifelse(is.na(cvar_95),      "not computed", paste0(round(cvar_95 * 100, 1), "%")),
       Vol        = paste0(round(vol * 100, 1), "%"),
       Gross      = dplyr::case_when(
         !("gross_convention" %in% names(full)) | is.na(gross_convention) ~ "—",
@@ -268,8 +284,14 @@ if (!is.null(lb)) {
         cost_per_trade_bps == 0 ~ "0*",
         TRUE ~ as.character(round(cost_per_trade_bps))
       ),
-      SSR        = ifelse(is.na(ssr),           "—", as.character(round(ssr, 2))),
-      `Top5% Share` = ifelse(is.na(top5pct_share), "—", paste0(round(top5pct_share * 100, 1), "%")),
+      # NA ssr/top5pct_share means this strategy is outside the fixed list of
+      # strategies R/plan_leaderboard.R's ssr_map covers (9 of 17) -- same
+      # "never assessed" state as Net CAGR/Credible above, rendered
+      # identically as "not computed" rather than the bare "—" that used to
+      # make this indistinguishable from a genuinely not-applicable cell
+      # (#637 follow-up).
+      SSR        = ifelse(is.na(ssr),           "not computed", as.character(round(ssr, 2))),
+      `Top5% Share` = ifelse(is.na(top5pct_share), "not computed", paste0(round(top5pct_share * 100, 1), "%")),
       # NA credible means cost metrics were never computed for this strategy
       # (cost_rows in R/plan_leaderboard.R only covers 5 core strategies +
       # PSO Optimal) -- that is "unknown", not "explicitly failed". Conflating
@@ -291,12 +313,13 @@ if (!is.null(lb)) {
         !credible        ~ 2L,
         TRUE              ~ 1L
       ),
-      # NA redundant means this strategy is outside the 5-strategy correlation
-      # universe computed by R/plan_strategy_correlation.R (Stock MAX, Stock
-      # DRIF, Factor MAX, Factor DRIF, LTR only) -- that is "unassessed", not
-      # "assessed and found not redundant". Previously both NA and a computed
-      # FALSE fell through to the same ambiguous "—" (#643, same conflation
-      # class as Credible, #637 follow-up).
+      # NA redundant means this strategy is outside the correlation universe
+      # computed by R/plan_strategy_correlation.R's strat_corr_augment --
+      # widened from 5 to 16 of 17 strategies (STRAT_RETURNS_WIDE_CODES,
+      # #728/#733) -- that is "unassessed", not "assessed and found not
+      # redundant". Previously both NA and a computed FALSE fell through to
+      # the same ambiguous "—" (#643, same conflation class as Credible,
+      # #637 follow-up).
       Redundant  = if ("redundant" %in% names(full)) {
         dplyr::case_when(
           is.na(redundant) ~ "not computed",
@@ -315,17 +338,22 @@ if (!is.null(lb)) {
           TRUE              ~ 1L
         )
       } else 3L,
+      # Same "not computed" out-of-scope state as Redundant above -- both
+      # columns come from the SAME strat_corr_augment join, so their NA-ness
+      # is always identical (never one populated without the other).
       `Incremental Sharpe` = if ("incremental_sharpe" %in% names(full)) {
-        ifelse(is.na(incremental_sharpe), "—", as.character(round(incremental_sharpe, 3)))
-      } else "—"
+        ifelse(is.na(incremental_sharpe), "not computed", as.character(round(incremental_sharpe, 3)))
+      } else "not computed"
     ) |>
     # Detection sits immediately right of Sharpe per requirement 2 of the
     # `detection-power-required` rule ("beside its Sharpe, not in a distant
     # column"). Rigour sits next to SSR -- both are "how much should you
     # trust this Sharpe" columns, unlike Credible/Redundant which assess
-    # cost-plausibility and correlation-redundancy respectively.
+    # cost-plausibility and correlation-redundancy respectively. CAGR sits
+    # immediately left of Net CAGR (gross, then net of cost) per item B of
+    # the presentation-fix pass this column set belongs to.
     select(Strategy = strategy, Credible, .credible_rank, Sharpe, Detection, .det_rank,
-           `Net CAGR`, `Max DD`, `CVaR 95%`, Vol, Gross, `Cost (bps)`, SSR, Rigour, .rig_rank,
+           CAGR, `Net CAGR`, `Max DD`, `CVaR 95%`, Vol, Gross, `Cost (bps)`, SSR, Rigour, .rig_rank,
            `Top5% Share`, Redundant, .redundant_rank, `Incremental Sharpe`)
 
   # NA credible (not is.na(credible) | !credible) is deliberate here: `!NA`
@@ -436,17 +464,30 @@ if (!is.null(lb)) {
   )
   n_redundant <- if ("redundant" %in% names(full)) sum(full$redundant, na.rm = TRUE) else 0L
   n_redundant_na <- if ("redundant" %in% names(full)) sum(is.na(full$redundant)) else nrow(full)
+  # Dynamically computed, never hardcoded (#728/#733 widened
+  # strat_corr_augment's coverage from 5 to 16 of 17 strategies -- a
+  # hardcoded strategy list here would have gone stale the moment that
+  # widening shipped, exactly the failure mode this note exists to avoid).
+  corr_covered_n <- if ("redundant" %in% names(full)) sum(!is.na(full$redundant)) else 0L
+  corr_excluded_strats <- if ("redundant" %in% names(full)) {
+    full$strategy[is.na(full$redundant)]
+  } else full$strategy
   diversification_note <- htmltools::tagList(
     " Redundant = \"YES\" when a strategy's Full-Period monthly-return correlation with another, ",
     "higher-Sharpe strategy exceeds the threshold fixed in ", corr_registry_link,
     " (", n_redundant, " of ", nrow(full),
     " strategies currently flagged); \"not computed\" (", n_redundant_na,
-    " strategies) marks a strategy outside the 5-strategy correlation universe ",
-    "(Stock MAX, Stock DRIF, Factor MAX, Factor DRIF, LTR) that plan_strategy_correlation.R ",
-    "currently covers — that is unassessed, not assessed-and-passed. Incremental Sharpe = the ",
+    " strateg", if (n_redundant_na == 1L) "y" else "ies",
+    ") marks a strategy outside the ", corr_covered_n,
+    "-strategy correlation universe that plan_strategy_correlation.R currently covers",
+    if (length(corr_excluded_strats) > 0L) {
+      paste0(" (excluded: ", paste(corr_excluded_strats, collapse = ", "), ")")
+    } else "",
+    " — that is unassessed, not assessed-and-passed. Incremental Sharpe = the ",
     "change in equal-weight-portfolio Sharpe from including this strategy vs excluding it — ",
     "positive means it adds diversification value, negative means the portfolio is better off ",
-    "without it. Both feed the new-strategy value gate (#496)."
+    "without it; it shares the same \"not computed\" scope as Redundant above (both come from ",
+    "the same join). Both feed the new-strategy value gate (#496)."
   )
 
   # ── Detection-power / rigour disclosure note (#726, #728) — dynamically computed ──
@@ -468,18 +509,31 @@ if (!is.null(lb)) {
   # moves into a collapsed <details> block via hd_caption() (vignette_utils.R)
   # instead of being deleted.
   short_caption <- paste0(
-    "Strategies ranked by Sharpe (highest first); Net CAGR is net of a 0.20%/month round-trip ",
-    "cost where available. Values are not directly comparable across rows — gross exposure, ",
-    "cost basis, and the Credible/Redundant/Detection/Rigour flags vary by strategy; expand ",
-    "below for full column definitions."
+    "Strategies ranked by Sharpe (highest first); CAGR is unadjusted (gross), Net CAGR is net ",
+    "of a 0.20%/month round-trip cost where available. Values are not directly comparable ",
+    "across rows — gross exposure, cost basis, and the Credible/Redundant/Detection/Rigour ",
+    "flags vary by strategy; expand below for full column definitions."
   )
 
+  # ── Out-of-scope-column coverage counts (#637 follow-up, "not computed"
+  # uniformity pass) — dynamically computed, never hardcoded.
+  n_ssr_covered <- sum(!is.na(full$ssr))
+  n_ssr_na      <- sum(is.na(full$ssr))
+  n_net_covered <- sum(!is.na(full$net_cagr))
+
   full_notes <- htmltools::tagList(
+    "CAGR = unadjusted (gross) compound annual growth rate, computed for every strategy. ",
     "SSR = Sharpe Stability Ratio (HAC t-stat of rolling 36-month Sharpes; ≥2 = consistent). ",
-    "Top5% Share = fraction of total return from best 5% of months. ",
+    "Top5% Share = fraction of total return from best 5% of months. Both SSR and Top5% Share ",
+    "are computed for a fixed subset of strategies (", n_ssr_covered, " of ", nrow(full),
+    "); the remaining ", n_ssr_na, " show \"not computed\" — never assessed, not a computed ",
+    "absence of stability. ",
     "Credible = plausible CAGR (<20%) and cum P&L (<50x): \"NO\" marks a strategy that was ",
     "assessed and failed that check, \"not computed\" marks a strategy for which cost-adjusted ",
-    "metrics were never assessed at all (not the same as failing the check).",
+    "metrics were never assessed at all (not the same as failing the check). The Net CAGR and ",
+    "CVaR 95% columns share this exact same \"not computed\" scope (", n_net_covered, " of ",
+    nrow(full), " strategies covered) — all three come from the same cost_rows join and are ",
+    "jointly present or jointly absent per row (QA gate S23, R/plan_qa_gates.R).",
     flag_note, bias_note, gross_note, cost_note, diversification_note, detection_note
   )
 

--- a/tests/testthat/_snaps/leaderboard-cost-metrics-coverage.md
+++ b/tests/testthat/_snaps/leaderboard-cost-metrics-coverage.md
@@ -1,0 +1,19 @@
+# check_leaderboard_cost_metrics_joint_presence throws and names the offending strategy when only one column is populated
+
+    Code
+      check_leaderboard_cost_metrics_joint_presence(offender_leaderboard)
+    Condition
+      Error in `check_leaderboard_cost_metrics_joint_presence()`:
+      x Leaderboard has 1 row(s) where net_cagr/cvar_95/credible disagree on presence -- these three columns come from the SAME cost_rows join and must be jointly NA or jointly non-NA:
+      i  New Strategy / Full Period -- net_cagr present, cvar_95 NA, credible NA
+      i check_leaderboard_cost_metrics_joint_presence() (S23) guards the fail-loud-not-null.md defect class (#637/#640/#641/#643): if one of these three columns is populated for a strategy/period without the other two, docs/leaderboard.qmd's single 'not computed' verdict for Credible/Net CAGR/CVaR 95% no longer matches the underlying data. Check calc_cost_metrics() and the cost_rows join in R/plan_leaderboard.R's leaderboard target.
+
+# check_leaderboard_cost_metrics_joint_presence throws when leaderboard is missing required columns
+
+    Code
+      check_leaderboard_cost_metrics_joint_presence(bad)
+    Condition
+      Error in `check_leaderboard_cost_metrics_joint_presence()`:
+      x Leaderboard is missing 1 required column(s): cvar_95.
+      i check_leaderboard_cost_metrics_joint_presence() (S23) requires strategy, period, net_cagr, cvar_95, credible.
+

--- a/tests/testthat/test-leaderboard-cost-metrics-coverage.R
+++ b/tests/testthat/test-leaderboard-cost-metrics-coverage.R
@@ -1,0 +1,109 @@
+testthat::local_edition(3)
+# Tests for check_leaderboard_cost_metrics_joint_presence() — QA gate S23
+# (fail-loud-not-null.md)
+#
+# net_cagr, cvar_95, and credible are all produced together, in a single
+# pass, by calc_cost_metrics() (R/plan_leaderboard.R) from the SAME
+# cost_rows join. docs/leaderboard.qmd's Rankings table renders all three
+# NA-together as a single "not computed" verdict (Credible/Net CAGR/CVaR
+# 95% columns) -- this gate is what keeps that assumption from silently
+# going stale if a future change populates one of the three columns for a
+# strategy/period without the other two.
+#
+# The function is defined in R/plan_qa_gates.R. Tests exercise the gate
+# directly without running tar_make().
+
+source(here::here("R/plan_qa_gates.R"))
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+# "Factor MAX" has all three cost metrics computed (in cost_rows' 5-core-
+# strategies-plus-PSO-Optimal scope). "LTR" has none of the three -- outside
+# that scope, all jointly NA (the normal "not computed" case, not a defect).
+good_leaderboard <- tibble::tibble(
+  strategy = c("Factor MAX", "Factor MAX", "LTR",     "LTR"),
+  period   = c("Full Period", "Training",  "Full Period", "Training"),
+  net_cagr = c(0.035,          0.020,       NA_real_,      NA_real_),
+  cvar_95  = c(-0.045,        -0.030,       NA_real_,      NA_real_),
+  credible = c(TRUE,           TRUE,        NA,            NA)
+)
+
+# "New Strategy" has net_cagr computed but cvar_95/credible left NA -- the
+# regression this gate exists to catch (a future cost_rows change wired up
+# one column of the trio without the other two).
+offender_leaderboard <- tibble::tibble(
+  strategy = c("Factor MAX", "New Strategy"),
+  period   = c("Full Period", "Full Period"),
+  net_cagr = c(0.035,          0.120),
+  cvar_95  = c(-0.045,         NA_real_),
+  credible = c(TRUE,           NA)
+)
+
+# ── Tests: joint-presence assertion ─────────────────────────────────────────
+
+test_that("check_leaderboard_cost_metrics_joint_presence passes when all three are jointly present or jointly NA", {
+  expect_true(check_leaderboard_cost_metrics_joint_presence(good_leaderboard))
+})
+
+test_that("check_leaderboard_cost_metrics_joint_presence passes on an all-NA (never-computed) leaderboard", {
+  all_na <- tibble::tibble(
+    strategy = c("LTR", "CMR"),
+    period   = c("Full Period", "Full Period"),
+    net_cagr = NA_real_,
+    cvar_95  = NA_real_,
+    credible = NA
+  )
+  expect_true(check_leaderboard_cost_metrics_joint_presence(all_na))
+})
+
+test_that("check_leaderboard_cost_metrics_joint_presence checks every period row, not just Full Period", {
+  # good_leaderboard already includes a Training row for both strategies --
+  # confirm the gate does not silently ignore them (unlike S21, this gate
+  # is deliberately NOT scoped to Full Period only -- cost_rows produces a
+  # row per Training/Testing/Holdout/Full Period slice).
+  bad <- good_leaderboard
+  bad$cvar_95[bad$strategy == "Factor MAX" & bad$period == "Training"] <- NA_real_
+  expect_error(
+    check_leaderboard_cost_metrics_joint_presence(bad),
+    regexp = "Training"
+  )
+})
+
+test_that("check_leaderboard_cost_metrics_joint_presence throws and names the offending strategy when only one column is populated", {
+  expect_error(
+    check_leaderboard_cost_metrics_joint_presence(offender_leaderboard),
+    regexp = "New Strategy"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_cost_metrics_joint_presence(offender_leaderboard)
+  )
+})
+
+test_that("check_leaderboard_cost_metrics_joint_presence names every offending strategy/period when multiple rows disagree", {
+  bad <- tibble::tibble(
+    strategy = c("A", "B"),
+    period   = c("Full Period", "Full Period"),
+    net_cagr = c(0.05, NA_real_),
+    cvar_95  = c(NA_real_, 0.02),
+    credible = c(NA, NA)
+  )
+  expect_error(
+    check_leaderboard_cost_metrics_joint_presence(bad),
+    regexp = "2 row"
+  )
+})
+
+# ── Required columns ─────────────────────────────────────────────────────────
+
+test_that("check_leaderboard_cost_metrics_joint_presence throws when leaderboard is missing required columns", {
+  bad <- dplyr::select(good_leaderboard, -cvar_95)
+  expect_error(
+    check_leaderboard_cost_metrics_joint_presence(bad),
+    regexp = "cvar_95"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leaderboard_cost_metrics_joint_presence(bad)
+  )
+})


### PR DESCRIPTION
## Summary

The Rankings table on the leaderboard showed a Sharpe for all 17 strategies but a Net CAGR for only 6, with no explanation. Investigation confirmed this is **not a join bug**: `cagr` is a base metric every strategy's own metrics target computes (17/17), while `net_cagr`/`cvar_95`/`credible` come from a separate cost-adjustment pass fed by a hardcoded 5-strategy-plus-PSO-Optimal list (`cost_rows`, `R/plan_leaderboard.R`). The gap is real and documented, but the *presentation* was misleading — the same "never assessed" condition rendered as `"not computed"` for some columns and a bare `"—"` for others, and only 5 of 17 strategies had a Redundant/Incremental Sharpe verdict even though the correlation matrix that feeds K_eff/deflated Sharpe already covers 16 of 17.

Four fixes:

- **A — Uniform "not computed" blanks.** Net CAGR, CVaR 95%, SSR, Top5% Share, and Incremental Sharpe now render `"not computed"` for the same out-of-scope condition Credible/Redundant already use, instead of a bare `"—"` (reserved for genuinely not-applicable cells like Gross/Cost (bps) on a meta-portfolio blend). The collapsed caption now names each out-of-scope column group and its exact coverage count, computed dynamically from the leaderboard data — never hardcoded.
- **B — Show the plain CAGR.** Added a `CAGR` column (gross, unadjusted, 17/17 strategies) immediately left of `Net CAGR` (cost-adjusted, 6/17), so a reader no longer sees only `Net CAGR` populated for a minority of rows and concludes the rest have no CAGR at all.
- **C — Widen Redundant / Incremental Sharpe from 5 to 16 of 17 strategies.** `strat_corr_augment` (`R/plan_strategy_correlation.R`) was scoped to the original 5-strategy family (`strat_corr_matrix`/`strat_returns_aligned`). Repointed it at `strat_corr_matrix_leaderboard`/`strat_returns_wide` — the same 16-strategy `STRAT_RETURNS_WIDE_CODES` scope already used for `k_eff_leaderboard`/`deflated_sharpe` (#728/#733). **Verified suitable before repointing, not assumed**: read the live store and confirmed `strat_returns_wide` is entirely monthly-frequency (daily strategies already resampled onto its `ym` spine), and that the shared complete-case window across all 16 columns is 193 rows — not a further shrinkage, since 193 exactly equals Factor MAX/Factor DRIF's own individual non-NA count (the tightest-history strategy already on the leaderboard). Added a `cli_abort()` guard if that window ever collapses below 2 rows, and a guard for any code_name left unmapped to a display label.
- **D — QA gate S23** (`check_leaderboard_cost_metrics_joint_presence`, `R/plan_qa_gates.R`) asserting `net_cagr`/`cvar_95`/`credible` are jointly NA or jointly non-NA per row — they come from the same `cost_rows` join, and the Rankings table's single `"not computed"` verdict for all three depends on that invariant holding. Modelled on the existing S17 (`check_leaderboard_sharpe_coherence`) coherence-gate shape. New `cli_abort()` messages have `expect_snapshot(error = TRUE, ...)` coverage per this repo's `snapshot-test-policy`.

## Verification

`scripts/verify.sh` (full mode, foreground):

- `_targets.R` / `docs/_targets.R` parse and structurally validate — PASS
- testthat edition 3 active — PASS
- dashboard freshness Check 1 + Check 2 — PASS (leaderboard.qmd correctly flagged as source-newer-than-render, non-fatal — this PR does not render/build; no store exists in this worktree)
- root suite (`tests/testthat/`): failures match the exact 3-failure baseline (issue #569), 0 unexpected skips — new `test-leaderboard-cost-metrics-coverage.R` (8 tests) all pass
- package suite (`packages/historicaldata/`): failures match the exact 1-failure baseline, 15 known skips (unchanged) — PASS

All four items were verified read-only against the live `docs/_targets` store in the main checkout (`tar_read()`, no `tar_make()`/`build.sh`/render was run from this worktree, per the store-lock rule).

Not run/verified: the actual rendered HTML appearance of the widened table — this PR does not render `docs/leaderboard.qmd` (no store in this worktree). The next `tar_make()` + render in the main checkout will pick up the widened `strat_corr_augment` target and the new QA gate.

## Test plan

- [x] `scripts/verify.sh` full suite passes (see above)
- [x] `R/plan_strategy_correlation.R` and `R/plan_qa_gates.R` parse cleanly
- [x] Each R chunk in `docs/leaderboard.qmd` parses cleanly
- [x] New QA gate S23 has unit tests + snapshot coverage for its `cli_abort()` messages
- [ ] Render `docs/leaderboard.qmd` after the next `tar_make()` in the main checkout to visually confirm the widened Redundant/Incremental Sharpe coverage and the new CAGR column

🤖 Generated with [Claude Code](https://claude.com/claude-code)
