### PR TITLE
fix(typography): remove inline caption font-size/color overrides across dashboards

### DIFF
--- a/docs/avoid-worst-days.qmd
+++ b/docs/avoid-worst-days.qmd
@@ -46,13 +46,13 @@ format:
             overflow: visible !important; margin-bottom: 1em; }
           .cell-output-display img { display: block; width: 100%; height: auto; min-height: 400px; }
           .fig-caption { display: block; position: relative; clear: both;
-            margin-top: 0.5em; margin-bottom: 1em; font-size: 0.85em; color: #e0e0e0; }
+            margin-top: 0.5em; margin-bottom: 1em; }
           .datatables, .dataTables_wrapper { display: block !important;
             position: relative !important; overflow-x: auto !important; margin-bottom: 1em; }
           table.dataTable { white-space: nowrap; }
           table caption { caption-side: top !important; }
           details { margin-bottom: 0.5em; }
-          details summary { cursor: pointer; color: #6c9bd2; font-size: 0.9em; }
+          details summary { cursor: pointer; color: #6c9bd2; }
           .fullscreen-overlay {
             position: fixed !important; top: 0 !important; left: 0 !important;
             width: 100vw !important; height: 100vh !important;
@@ -179,7 +179,7 @@ asym <- safe_tar_read("aw_asymmetry_table")
 if (!is.null(asym)) {
   DT::datatable(asym,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       "Asymmetry of removing N worst vs N best days. Ratio > 1 means avoiding losses matters more than capturing gains."
     ),
     rownames = FALSE,
@@ -195,7 +195,7 @@ met <- safe_tar_read("aw_metrics")
 if (!is.null(met)) {
   DT::datatable(met,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       "SPY metrics by scenario and partition. Training: pre-2020, Testing: 2020+."
     ),
     rownames = FALSE,
@@ -234,7 +234,7 @@ if (!is.null(cl)) {
   worst <- cl$worst |> select(date, ret_pct, nearest_best, days_to_nearest_best)
   DT::datatable(worst,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       "SPY's 10 worst days and distance to the nearest best day. Short distances confirm clustering."
     ),
     rownames = FALSE,
@@ -251,7 +251,7 @@ if (!is.null(cl)) {
   best <- cl$best |> select(date, ret_pct, nearest_worst, days_to_nearest_worst)
   DT::datatable(best,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       "SPY's 10 best days and distance to the nearest worst day."
     ),
     rownames = FALSE,
@@ -309,7 +309,7 @@ mi <- safe_tar_read("aw_multi_index")
 if (!is.null(mi)) {
   DT::datatable(mi,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       "Asymmetry analysis across US index ETFs. Ratio > 1 = avoiding worst days matters more."
     ),
     rownames = FALSE,
@@ -357,7 +357,7 @@ sens <- safe_tar_read("aw_practical_sensitivity")
 if (!is.null(sens)) {
   DT::datatable(sens,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       "Sensitivity to VIX and shock thresholds. pct_cash = fraction of days out of market. Look for broad plateau, not sharp peak."
     ),
     rownames = FALSE,
@@ -400,7 +400,7 @@ wf <- safe_tar_read("aw_walkforward")
 if (!is.null(wf)) {
   DT::datatable(wf,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       paste0("Walk-forward: yearly OOS results. Mean OOS CAGR: ",
              round(mean(wf$oos_cagr, na.rm = TRUE), 1),
              "% vs mean B&H: ", round(mean(wf$bh_cagr, na.rm = TRUE), 1), "%.")
@@ -419,7 +419,7 @@ tc <- safe_tar_read("aw_transaction_costs")
 if (!is.null(tc)) {
   DT::datatable(tc,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       "Transaction costs at 5bps per switch. 334 switches over 33 years. Net CAGR drops from 18.4% to 17.8% — costs are modest because switches are infrequent (~10/year)."
     ),
     rownames = FALSE,
@@ -435,7 +435,7 @@ sp <- safe_tar_read("aw_subperiod")
 if (!is.null(sp)) {
   DT::datatable(sp,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       "Subperiod stability: strategy outperforms in all three subperiods. Max DD reduction is consistent (~3-5x improvement). Not driven by a single crisis."
     ),
     rownames = FALSE,
@@ -451,7 +451,7 @@ cm <- safe_tar_read("aw_cross_market")
 if (!is.null(cm)) {
   DT::datatable(cm,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       "Same VIX > 30 rule applied to 4 US index ETFs. Strategy improves CAGR and Sharpe across all indices. QQQ max DD drops from -83% to -34%."
     ),
     rownames = FALSE,
@@ -467,7 +467,7 @@ bci <- safe_tar_read("aw_bootstrap_ci")
 if (!is.null(bci)) {
   DT::datatable(bci,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       "Block bootstrap (1000 draws, 3-month blocks) 90% CI on annualised Sharpe. Neither CI crosses zero. VIX protection Sharpe (1.27-1.79) does not overlap buy & hold (0.39-0.91)."
     ),
     rownames = FALSE,
@@ -485,7 +485,7 @@ ad <- safe_tar_read("aw_alpha_decay")
 if (!is.null(ad)) {
   DT::datatable(ad,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       "Alpha decay (t+1 to t+10). At t+1 (next-day execution): CAGR 5.3%, max DD -52% — the strategy underperforms buy & hold (10.6%) and provides no drawdown protection. The signal is flat across all delays: there is no exploitable speed advantage."
     ),
     rownames = FALSE,

--- a/docs/evidence.qmd
+++ b/docs/evidence.qmd
@@ -18,10 +18,9 @@ format:
       - text: |
           <style>
           body { font-size: 1.3em; line-height: 1.6; }
-          caption, figcaption, .figure-caption { color: #fff !important; }
           .cell-output-display { margin: 1.5em 0; }
           figure { margin: 2em 0; }
-          figcaption { font-size: 0.9em; opacity: 0.8; margin-top: 0.5em; }
+          figcaption { margin-top: 0.5em; }
           table { margin: 1.5em auto; }
           .negative-card {
             background: #1a1a2e; border: 1px solid #d73027; border-radius: 8px;

--- a/docs/falsification.qmd
+++ b/docs/falsification.qmd
@@ -164,7 +164,7 @@ fals_dt <- function(df, caption_text) {
     container = sketch,
     escape = FALSE,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #ddd;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       htmltools::HTML(caption_text)
     ),
     rownames = FALSE,
@@ -824,7 +824,7 @@ cat('<div id="dag-full-mount"></div>')
 
 Node colours: <abbr title="Fama-French factors: HML (value), SMB (size), Mom (momentum), RMW (profitability), CMA (investment)">Factors</abbr> (blue) | <abbr title="VIX, VVIX, Fed rate, Inflation — observable macro indicators">Macro</abbr> (gold) | <abbr title="Classified market state: Vol Regime (VIX-based), Rate Regime (Fed-based)">Regime</abbr> (orange) | <abbr title="Strategy-specific trading signals derived from factors and regimes">Signals</abbr> (purple) | <abbr title="Realised strategy returns after applying signals">Returns</abbr> (green) | <abbr title="Portfolio-level metrics: Sharpe ratio, max drawdown">Outcomes</abbr> (red) | <abbr title="Structural factors: factor crowding, premium decay, rebalancing costs">Structural</abbr> (grey). Yellow dashed = <abbr title="Conditional independence test failed (|partial r| >= 0.15) — DAG is missing an edge">violated implication</abbr>. Green = tested, holds. Source: <a href="https://github.com/JohnGavin/historical/blob/main/R/plan_causal_graph.R" target="_blank" rel="noopener noreferrer">plan_causal_graph.R</a>.
 
-`r paste0('<p style="color:#888;font-size:0.8em;">Full DAG tab rendered: ', format(Sys.time(), "%Y-%m-%d %H:%M:%S %Z"), ' | commit: ', system("git rev-parse --short HEAD", intern=TRUE), '</p>')`
+`r paste0('<p>Full DAG tab rendered: ', format(Sys.time(), "%Y-%m-%d %H:%M:%S %Z"), ' | commit: ', system("git rev-parse --short HEAD", intern=TRUE), '</p>')`
 
 #### DRIF
 
@@ -837,7 +837,7 @@ cat('<div id="dag-drif-mount"></div>')
 
 <abbr title="Dynamic Rotation Into Factors — each month selects the FF factor with highest trailing return">DRIF</abbr> selects the best-performing FF factor each month. Loads on <abbr title="High Minus Low — value factor: cheap stocks minus expensive stocks">HML</abbr>, <abbr title="Small Minus Big — size factor: small-cap minus large-cap returns">SMB</abbr>, <abbr title="Momentum — past 12-month winners minus losers">Mom</abbr>, <abbr title="Robust Minus Weak — profitability factor">RMW</abbr>. Yellow dashed edge: VIX affects HML in crises (<abbr title="Partial correlation between HML and VIX = -0.17, indicating they co-move in crises">r=-0.17</abbr>). Source: [plan_drif.R](https://github.com/JohnGavin/historical/blob/main/R/plan_drif.R).
 
-`r paste0('<p style="color:#888;font-size:0.8em;">DRIF tab rendered: ', format(Sys.time(), "%Y-%m-%d %H:%M:%S %Z"), ' | commit: ', system("git rev-parse --short HEAD", intern=TRUE), '</p>')`
+`r paste0('<p>DRIF tab rendered: ', format(Sys.time(), "%Y-%m-%d %H:%M:%S %Z"), ' | commit: ', system("git rev-parse --short HEAD", intern=TRUE), '</p>')`
 
 #### Factor MAX
 

--- a/docs/macro-defense-rotation.qmd
+++ b/docs/macro-defense-rotation.qmd
@@ -49,13 +49,13 @@ format:
             overflow: visible !important; margin-bottom: 1em; }
           .cell-output-display img { display: block; width: 100%; height: auto; min-height: 400px; }
           .fig-caption { display: block; position: relative; clear: both;
-            margin-top: 0.5em; margin-bottom: 1em; font-size: 0.85em; color: #888; }
+            margin-top: 0.5em; margin-bottom: 1em; }
           .datatables, .dataTables_wrapper { display: block !important;
             position: relative !important; overflow-x: auto !important; margin-bottom: 1em; }
           table.dataTable { white-space: nowrap; }
           table caption { caption-side: top !important; }
           details { margin-bottom: 0.5em; }
-          details summary { cursor: pointer; color: #6c9bd2; font-size: 0.9em; }
+          details summary { cursor: pointer; color: #6c9bd2; }
           .fullscreen-overlay {
             position: fixed !important; top: 0 !important; left: 0 !important;
             width: 100vw !important; height: 100vh !important;
@@ -123,7 +123,7 @@ hd_dt <- function(df, caption_text) {
       df[[col]] <- round(df[[col]], 2)
   }
   DT::datatable(df, caption = htmltools::tags$caption(
-    style = "caption-side: top; text-align: left; font-weight: bold; color: #ddd;",
+    style = "caption-side: top; text-align: left; font-weight: bold;",
     caption_text), rownames = FALSE, options = list(pageLength = 15, scrollX = TRUE, dom = "frtip"))
 }
 ```

--- a/docs/momentum-prepeak.qmd
+++ b/docs/momentum-prepeak.qmd
@@ -47,13 +47,13 @@ format:
             overflow: visible !important; margin-bottom: 1em; }
           .cell-output-display img { display: block; width: 100%; height: auto; min-height: 400px; }
           .fig-caption { display: block; position: relative; clear: both;
-            margin-top: 0.5em; margin-bottom: 1em; font-size: 0.85em; color: #e0e0e0; }
+            margin-top: 0.5em; margin-bottom: 1em; }
           .datatables, .dataTables_wrapper { display: block !important;
             position: relative !important; overflow-x: auto !important; margin-bottom: 1em; }
           table.dataTable { white-space: nowrap; }
           table caption { caption-side: top !important; }
           details { margin-bottom: 0.5em; }
-          details summary { cursor: pointer; color: #6c9bd2; font-size: 0.9em; }
+          details summary { cursor: pointer; color: #6c9bd2; }
           .bankrupt-row { background-color: rgba(240, 128, 128, 0.25) !important; }
           </style>
           <script>
@@ -365,7 +365,7 @@ if (!is.null(summary_tbl)) {
   DT::datatable(
     display_df,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       paste0(
         "Pre-peak / post-peak 12-2 momentum decomposition summary. ",
         "Annualised metrics from ", if (!is.na(pre_nmonths)) pre_nmonths else "N/A",
@@ -538,7 +538,7 @@ if (!is.null(ret_pre)) {
   DT::datatable(
     display_ret,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       "Monthly long-short returns for all three decomposition strategies. ret_ls = ret_long - ret_short - 2 × 10 bps transaction cost. Negative ret_ls in the same month caused the bankruptcy in post-peak and combined strategies."
     ),
     rownames = FALSE,
@@ -653,7 +653,7 @@ skew_tbl <- tibble::tibble(
 DT::datatable(
   skew_tbl,
   caption = htmltools::tags$caption(
-    style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+    style = "caption-side: top; text-align: left; font-weight: bold;",
     paste0(
       "Skewness of monthly L/S returns for each decomposition strategy. ",
       "Positive skewness implies fewer large-magnitude negative months, ",
@@ -756,7 +756,7 @@ if (p8_available) {
   DT::datatable(
     p8_display,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       paste0(
         "Pillar-8 risk metrics for all three momentum decomposition strategies. ",
         "Avg/Max DD duration is measured in months (index positions, no date column). ",
@@ -817,7 +817,7 @@ if (wfc_available) {
   DT::datatable(
     wfc_display,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       paste0(
         "Walk-Forward Correlation grid for mom_prepeak over n_quantiles ∈ {5, 10, 20}. ",
         "IS = annualised Sharpe on the first half of the sample (~1973–mid). ",
@@ -926,7 +926,7 @@ if (rand_available) {
   DT::datatable(
     null_display,
     caption = htmltools::tags$caption(
-      style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+      style = "caption-side: top; text-align: left; font-weight: bold;",
       paste0(
         "Random-day-as-peak null test. The null strategy uses the same ",
         "formation window, portfolio construction, and transaction costs, ",
@@ -1016,7 +1016,7 @@ stat_display <- tibble::tibble(
 DT::datatable(
   stat_display,
   caption = htmltools::tags$caption(
-    style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+    style = "caption-side: top; text-align: left; font-weight: bold;",
     paste0(
       "Statistical hardening metrics for mom_prepeak. ",
       "HAC inference uses Newey-West bandwidth (floor(4*(T/100)^(2/9))). ",
@@ -1092,7 +1092,7 @@ ssr_display <- tibble::tibble(
 DT::datatable(
   ssr_display,
   caption = htmltools::tags$caption(
-    style = "caption-side: top; text-align: left; font-weight: bold; color: #e0e0e0;",
+    style = "caption-side: top; text-align: left; font-weight: bold;",
     paste0(
       "Sharpe Stability Ratio (SSR) for mom_prepeak — 36-month rolling windows, ann_factor = 12. ",
       "Calibration anchors: S\\u00B950 500 daily since 1995: SSR \\u224 5.3; macro FX cross-asset: SSR \\u224 4.4. ",

--- a/docs/quiz.qmd
+++ b/docs/quiz.qmd
@@ -14,7 +14,6 @@ format:
           <script src="https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js"></script>
           <style>
           body{font-size:1.3em}
-          caption,figcaption,.figure-caption{color:#fff!important}
           #quiz-app{max-width:900px;margin:0 auto;padding:20px}
           .quiz-intro h2{color:#6c9bd2;margin-bottom:.5em}
           .quiz-intro ul{font-size:1.05em;line-height:1.8}

--- a/docs/vignette-shared.css
+++ b/docs/vignette-shared.css
@@ -230,9 +230,13 @@ table caption, .dataTables_wrapper caption, .dt-caption {
   font-size: inherit !important;
 }
 
-/* Code details toggle */
+/* Code details toggle. Accent colour (#6c9bd2) marks it as an
+   interactive toggle, same as inline links; font-size intentionally NOT
+   overridden -- a <details> summary is body prose (uniform-typography
+   rule, "details summary { font-size: 0.9em }" forbidden pattern) and
+   must render at the inherited body size. */
 details { margin-bottom: 0.5em; }
-details summary { cursor: pointer; color: #6c9bd2; font-size: 0.9em; }
+details summary { cursor: pointer; color: #6c9bd2; }
 
 /* Prevent tab click from scrolling to top */
 .nav-link[data-bs-toggle="tab"] { scroll-behavior: auto; }


### PR DESCRIPTION
## Summary

Sweeps out inline `font-size` and `color` overrides on caption/text elements
across the 15 `docs/*.qmd` dashboards, following the user report that
captions render smaller than body text and the fact that PR #776's
stylesheet-level fix (`docs/vignette-shared.css`) cannot reach inline
overrides emitted from R code or per-page `<style>` blocks.

### Root cause 1 — `.fig-caption` per-page override beats the shared fix

`avoid-worst-days.qmd`, `macro-defense-rotation.qmd`, and
`momentum-prepeak.qmd` each ship a local `<style>` block loaded **after**
`<link rel="stylesheet" href="vignette-shared.css">`. Their local
`.fig-caption { font-size: 0.85em; color: ...}` rule has the same
specificity as the shared, theme-aware `.fig-caption { font-size: 1em;
color: #ffffff }` rule (the #348/#776 fix) but wins on source order —
silently reintroducing the "caption too small" bug on exactly these three
dashboards. Removed the `font-size`/`color` declarations from the local
rule so captions inherit the shared rule.

### Root cause 2 — DT captions built with a raw hardcoded-color style string

Many `DT::datatable()` captions are built with a raw
`htmltools::tags$caption(style = "...color: #e0e0e0/#ddd/#888;", ...)`
instead of the shared `hd_caption()` helper (`docs/vignette_utils.R`), which
never hardcodes color. These are mostly masked today by
`vignette-shared.css`'s `table caption { color: #ffffff !important }` /
light-mode override (an `!important` stylesheet rule beats a non-important
inline style regardless of source order), but they are dead weight that
silently reintroduces a real bug the moment that selector changes. Stripped
for maintainability:
- `avoid-worst-days.qmd`: 12 call sites
- `momentum-prepeak.qmd`: 8 call sites
- `macro-defense-rotation.qmd`: 1 helper (`hd_dt()`, feeds 5 call sites)
- `falsification.qmd`: 1 call site (`fals_dt()`)

### Root cause 3 — `figcaption` hardcode, NOT masked by shared CSS

`evidence.qmd` and `quiz.qmd` each carry `caption, figcaption,
.figure-caption { color: #fff !important; }`. `vignette-shared.css` has no
rule at all targeting the native `<figcaption>` element, so this one is
**not** masked — it renders white-on-white in light mode. Removed.
`evidence.qmd`'s `figcaption` also had `font-size: 0.9em` + `opacity: 0.8`;
removed both (the opacity de-emphasis was only meaningful alongside the
forced-white color it rode along with).

### Root cause 4 — build-info footer text

`falsification.qmd`'s two "tab rendered" timestamps used `<p
style="color:#888;font-size:0.8em;">`, violating
`vignette-build-info-block`'s "not a place for small grey text". Inline
style removed; now inherits body size/color.

### Bonus — recurring `details summary` forbidden pattern

`uniform-typography`'s own recurrence log already flags `details summary {
font-size: 0.9em }` as a repeat offender. Fixed at its source in
`docs/vignette-shared.css`, plus the three dashboards that duplicated it
locally (duplicates had to move together, or the local copy would have
reintroduced the override after the shared fix).

### Left alone (documented, not fixed)

- `navbar .nav-link { font-size: 0.9em }` — site-wide nav chrome convention,
  identical across every dashboard, not a caption/body-prose surface.
- `index.qmd` / `quiz.qmd` decorative UI sizing (stat blocks, badges, quiz
  buttons) — a deliberate bespoke design system, not captions.
- `vignette-shared.css`'s explicitly-named `.callout.small` (0.85em, opt-in
  utility class) and `.hd-font-controls` (font +/- buttons) — intentional,
  named exceptions, not caption drift.
- `#6c9bd2` accent/link colour on `details summary` and inline anchors — a
  deliberate hyperlink affordance colour, not a body/caption text colour.

## Test plan

- [x] `scripts/verify.sh` (full suite, foreground): **PASS** — root suite
      matches the documented 3-failure baseline exactly, package suite
      matches the documented 1-failure baseline exactly (skip counts 0/15,
      both match documented baselines).
- [x] `parse("_targets.R")`, `docs/_targets.R` parse + `tar_validate()`: PASS
- [ ] Cannot render (`tar_make()` / `quarto render`) from this worktree — the
      main checkout owns the `_targets` store lock. Rendered appearance is
      **predicted, not verified**: reviewer should render and confirm
      captions now match body text size/color in both themes before merge.

Refs #776
