### PR TITLE
feat(dashboards): table-ify Biases/Caveats tabs, rich build-info tabset

### DIFF
--- a/docs/_includes/build-info-footer.qmd
+++ b/docs/_includes/build-info-footer.qmd
@@ -2,10 +2,10 @@
 #| label: build-info
 #| echo: false
 #| results: asis
-if (!exists("build_info", mode = "function")) {
+if (!exists("build_info_tabset", mode = "function")) {
   utils_path <- if (file.exists("vignette_utils.R")) "vignette_utils.R" else
     file.path(here::here(), "docs/vignette_utils.R")
   source(utils_path)
 }
-build_info()
+build_info_tabset()
 ```

--- a/docs/european-overlay.qmd
+++ b/docs/european-overlay.qmd
@@ -318,4 +318,9 @@ if (!is.null(ecb_raw)) {
 
 #### Build Info
 
-`r build_info()`
+```{r}
+#| label: build-info
+#| echo: false
+#| results: asis
+build_info_tabset()
+```

--- a/docs/evidence.qmd
+++ b/docs/evidence.qmd
@@ -446,7 +446,7 @@ All target computations are defined in [`R/plan_jst.R`](https://github.com/JohnG
 ```{r build-info}
 #| label: build-info
 #| results: asis
-build_info()
+build_info_tabset()
 ```
 
 ## Related vignettes

--- a/docs/falsification.qmd
+++ b/docs/falsification.qmd
@@ -793,7 +793,7 @@ Neither value governs the other, and **`filter_liquidity()` runs in `filter_mode
 ```{r}
 #| label: build-info
 #| results: asis
-build_info()
+build_info_tabset()
 ```
 
 # Causal Graph {#causal}

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -475,5 +475,5 @@ cat(if (is.na(n_targets)) "(could not parse)"
 utils_path <- if (file.exists("vignette_utils.R")) "vignette_utils.R" else
   file.path(here::here(), "docs/vignette_utils.R")
 source(utils_path)
-build_info()
+build_info_tabset()
 ```

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -1500,7 +1500,7 @@ if (!is.null(params)) {
 #| label: build-info
 #| echo: false
 #| results: asis
-build_info()
+build_info_tabset()
 ```
 
 # Biases and Caveats
@@ -1531,8 +1531,40 @@ if (exists("full") && "survivorship_biased" %in% names(full)) {
   } else {
     cat("No strategy is currently flagged `survivorship_biased = TRUE` on the [Rankings](#rankings) table.\n")
   }
+}
+```
+
+```{r}
+#| label: caveats-survivorship-table
+# A single sentence naming the flagged strategies reads as thin -- expand it
+# into the actual table so this tab carries data, not just prose (owner
+# feedback: a tab holding one paragraph looks broken, not explanatory).
+# Pulled from the SAME `full$survivorship_biased` column the Rankings table
+# itself renders (computed at R/plan_leaderboard.R:552) -- never a
+# hand-typed strategy list, which would silently drift the moment the flag
+# changes (`reproducible-ingestion`/`fail-loud-not-null` rules).
+if (exists("full") && "survivorship_biased" %in% names(full)) {
+  sb_tbl <- full |>
+    mutate(
+      Flagged = ifelse(is.na(survivorship_biased), "not computed",
+                        ifelse(survivorship_biased, "YES", "no")),
+      Universe = ifelse(is.na(survivorship_biased) | !survivorship_biased, "—", "`stk_universe`"),
+      Sharpe = ifelse(is.na(sharpe), "—", as.character(round(sharpe, 2)))
+    ) |>
+    filter(!is.na(survivorship_biased) & survivorship_biased) |>
+    select(Strategy = strategy, Flagged, Universe, Sharpe)
+
+  if (nrow(sb_tbl) > 0) {
+    hd_dt(sb_tbl, paste0(
+      "Strategies currently flagged `survivorship_biased = TRUE` -- see the [Rankings](#rankings) ",
+      "table for the full metrics row and its own caption note. `stk_universe` restricts to the ",
+      "top-N tickers by current market cap (#150 Option C); delisted firms are absent from history."
+    ))
+  } else {
+    cat("*No strategy is currently flagged `survivorship_biased = TRUE` on the [Rankings](#rankings) table.*\n")
+  }
 } else {
-  cat("*`leaderboard` target not available -- per-strategy flag list cannot be computed.*\n")
+  cat("*`leaderboard` target not available -- per-strategy flag table cannot be computed.*\n")
 }
 ```
 
@@ -1544,7 +1576,61 @@ if (exists("full") && "survivorship_biased" %in% names(full)) {
 
 See the **Detection** and **Rigour** columns on the [Rankings](#rankings) table for the
 per-strategy verdict — hover any badge for the full numeric detail (Sharpe threshold,
-years of data needed, K_eff, deflated Sharpe, DSR p-value).
+years of data needed, K_eff, deflated Sharpe, DSR p-value). The same numbers, as plain
+columns rather than hover-only badges, are below.
+
+```{r}
+#| label: caveats-detection-rigour-table
+# Surfaces the numbers behind the Detection/Rigour badges as a real table --
+# previously the ONLY way to see a strategy's threshold Sharpe, years-of-data
+# requirement, K_eff, deflated Sharpe, or DSR p-value was to hover a badge on
+# the Rankings table (owner feedback: this tab showed nothing useful on its
+# own). Built from the SAME `full` data frame and the SAME
+# DEFLATED_SHARPE_EXEMPTIONS source (R/plan_qa_gates.R) the badges use --
+# never a re-derived or hand-typed verdict.
+det_rig_cols <- c("sharpe", "detection_underpowered", "detection_min_n_years",
+                   "detection_underpowered_mt", "detection_min_n_years_mt",
+                   "deflated_sharpe", "dsr_pvalue", "k_eff_leaderboard")
+if (exists("full") && all(det_rig_cols %in% names(full)) && exists("DEFLATED_SHARPE_EXEMPTIONS")) {
+  det_rig_tbl <- full |>
+    mutate(
+      Sharpe = ifelse(is.na(sharpe), "—", as.character(round(sharpe, 2))),
+      Verdict = dplyr::case_when(
+        is.na(sharpe) | sharpe <= 0        ~ "N/A (Sharpe ≤ 0)",
+        is.na(detection_underpowered)      ~ "NOT COMPUTED",
+        isTRUE(detection_underpowered)     ~ "Underpowered",
+        is.na(detection_underpowered_mt)   ~ "Detectable (MT-corrected verdict not computed)",
+        isTRUE(detection_underpowered_mt)  ~ "Detectable, fails MT-correction",
+        TRUE                                ~ "Detectable"
+      ),
+      `Years Needed` = ifelse(is.na(detection_min_n_years), "—", as.character(round(detection_min_n_years, 1))),
+      `Years Needed (MT-corrected)` = ifelse(is.na(detection_min_n_years_mt), "—", as.character(round(detection_min_n_years_mt, 1))),
+      K_eff = ifelse(is.na(k_eff_leaderboard), "—", as.character(round(k_eff_leaderboard, 1))),
+      `Deflated Sharpe` = ifelse(is.na(deflated_sharpe), "—", as.character(round(deflated_sharpe, 2))),
+      `DSR p-value` = ifelse(is.na(dsr_pvalue), "—", as.character(round(dsr_pvalue, 3))),
+      .rig_present = rowSums(!is.na(cbind(deflated_sharpe, dsr_pvalue, k_eff_leaderboard))),
+      .rig_exempt = strategy %in% DEFLATED_SHARPE_EXEMPTIONS$strategy,
+      `Rigour Coverage` = dplyr::case_when(
+        .rig_exempt              ~ "Excluded (documented)",
+        .rig_present == 3L       ~ "Full (3/3)",
+        .rig_present > 0L        ~ paste0("Partial (", .rig_present, "/3)"),
+        TRUE                     ~ "NOT COMPUTED (0/3)"
+      )
+    ) |>
+    select(Strategy = strategy, Sharpe, Verdict, `Years Needed`, `Years Needed (MT-corrected)`,
+           K_eff, `Deflated Sharpe`, `DSR p-value`, `Rigour Coverage`)
+
+  hd_dt(det_rig_tbl, paste0(
+    "Per-strategy statistical detection power and rigour, this build. Verdict/Years Needed follow ",
+    "`hd_detection_power()` (`detection-power-required` rule); K_eff/Deflated Sharpe/DSR p-value are ",
+    "the deflated-Sharpe correction for testing multiple strategies. See ",
+    "[#726](https://github.com/JohnGavin/historical/issues/726) (detection power) and ",
+    "[#728](https://github.com/JohnGavin/historical/issues/728) (rigour coverage)."
+  ))
+} else {
+  cat("*`leaderboard` target not available -- per-strategy detection/rigour table cannot be computed.*\n")
+}
+```
 
 #### About This Page
 
@@ -1552,10 +1638,20 @@ All dashboard-wide caveats that would otherwise sit at the top of a page,
 interrupting the first thing a reader sees, are collected here instead. Each
 caveat still carries a compact, discoverable marker at its original
 location — a one-line pointer callout on [Rankings](#rankings), or the
-Detection/Rigour table columns themselves — that links back here, and every
-tab on this page links back to where the affected rows live. Nothing here
+Detection/Rigour table columns themselves — that links back here. Nothing here
 replaces the underlying data or its per-row flags; this page is a navigation
 aid, not a new source of truth.
+
+**Caveats collected on this page:**
+
+- **[Survivorship Bias](#biases-and-caveats)** — `stk_universe` (used by Stock MAX,
+  Stock DRIF, XGB DRIF) restricts to top-N tickers by current market cap; delisted
+  firms are absent from history. See [issue #150](https://github.com/JohnGavin/historical/issues/150).
+- **[Statistical Detection Power and Rigour](#biases-and-caveats)** — whether each
+  strategy's sample has enough data to distinguish its Sharpe from zero, before and
+  after correcting for testing multiple strategies. See
+  [issue #726](https://github.com/JohnGavin/historical/issues/726) (detection power) and
+  [issue #728](https://github.com/JohnGavin/historical/issues/728) (rigour coverage).
 
 The [Stock-Level Backtests](stock-backtest.html#biases-and-caveats) dashboard
 carries the same survivorship-bias caveat at its own equivalent page — Stock

--- a/docs/momentum-prepeak.qmd
+++ b/docs/momentum-prepeak.qmd
@@ -1160,5 +1160,5 @@ This vignette was developed with assistance from Anthropic's Claude (model: Opus
 #| label: build-info
 #| echo: false
 #| results: asis
-build_info()
+build_info_tabset()
 ```

--- a/docs/quiz.qmd
+++ b/docs/quiz.qmd
@@ -101,5 +101,5 @@ if (!is.null(quiz_json)) {
 ```{r}
 #| label: build-info
 #| results: asis
-build_info()
+build_info_tabset()
 ```

--- a/docs/stock-backtest.qmd
+++ b/docs/stock-backtest.qmd
@@ -668,7 +668,7 @@ if (!is.null(params)) {
 #| label: build-info
 #| echo: false
 #| results: asis
-build_info()
+build_info_tabset()
 ```
 
 # Biases and Caveats
@@ -688,12 +688,52 @@ and [XGBoost DRIF](#xgboost-drif) — all draw on the same `stk_universe`. See
 the [Comparison](#comparison) page for the strategy overview these results
 feed into.
 
+```{r}
+#| label: caveats-survivorship-table
+# A prose sentence naming the three affected strategies reads as thin on its
+# own -- expand it into a table (owner feedback: a tab with one paragraph
+# looks broken). Pulled from the same `leaderboard` target and the same
+# `survivorship_biased` flag the Strategy Leaderboard dashboard renders
+# (R/plan_leaderboard.R:552) -- never a hand-typed strategy list, which
+# would silently drift the moment the flag changes
+# (`reproducible-ingestion`/`fail-loud-not-null` rules).
+sb_lb <- safe_tar_read("leaderboard")
+if (!is.null(sb_lb) && "survivorship_biased" %in% names(sb_lb)) {
+  sb_tbl <- sb_lb |>
+    filter(period == "Full Period", !is.na(survivorship_biased), survivorship_biased) |>
+    mutate(
+      Universe = "`stk_universe`",
+      Sharpe = ifelse(is.na(sharpe), "—", as.character(round(sharpe, 2)))
+    ) |>
+    select(Strategy = strategy, Universe, Sharpe)
+
+  if (nrow(sb_tbl) > 0) {
+    hd_dt(sb_tbl, paste0(
+      "Strategies on this dashboard flagged `survivorship_biased = TRUE` in the ",
+      "[Strategy Leaderboard](leaderboard.html#rankings) target -- see issue #150 for the ",
+      "data-availability constraint. `stk_universe` restricts to the top-N tickers by ",
+      "current market cap; delisted firms are absent from history."
+    ))
+  } else {
+    cat("*No strategy on this dashboard is currently flagged `survivorship_biased = TRUE`.*\n")
+  }
+} else {
+  cat("*`leaderboard` target not available -- per-strategy flag table cannot be computed.*\n")
+}
+```
+
 #### About This Page
 
 This dashboard-wide caveat used to sit at the very top of the [Comparison](#comparison)
 page, ahead of any content. It moved here so a first-time reader sees the
 strategy comparison before the caveat, while a compact pointer at the top of
 [Comparison](#comparison) keeps it one click away rather than hidden.
+
+**Caveats collected on this page:**
+
+- **[Survivorship Bias](#biases-and-caveats)** — `stk_universe` (used by Stock MAX,
+  Stock DRIF, XGB DRIF above) restricts to top-N tickers by current market cap;
+  delisted firms are absent from history. See [issue #150](https://github.com/JohnGavin/historical/issues/150).
 
 The **[Strategy Leaderboard](leaderboard.html#biases-and-caveats)** dashboard
 collects the same caveat, plus a second one (statistical detection power and

--- a/docs/vignette_utils.R
+++ b/docs/vignette_utils.R
@@ -400,6 +400,61 @@ hd_data_sources_used <- function() {
   )
 }
 
+#' Format `git status --porcelain` lines into a human display string
+#'
+#' Pure function (no git calls, no filesystem access) so the display logic
+#' is unit-testable independent of a real git repo or a Quarto render
+#' context. `NA` (git unavailable / not a repo / command failed) is an
+#' indeterminate result and must render as `"unknown"`, never silently as
+#' `"clean"` -- a false "clean" is the worst of the three outcomes because
+#' it asserts something reassuring that was never actually checked
+#' (`checks-must-distinguish-unknown` rule).
+#'
+#' @param status_lines character vector of porcelain lines (already
+#'   filtered to whatever pathspec the caller used), or `NA` to signal the
+#'   underlying `git status` call could not be run at all
+#' @param max_shown maximum number of file paths to list before truncating
+#' @return a single display string: `"unknown"`, `"clean"`, or
+#'   `"dirty (N source file(s) modified: a, b, c (+K more))"`
+.hd_tree_status_display <- function(status_lines, max_shown = 10L) {
+  if (length(status_lines) == 1L && identical(status_lines, NA)) {
+    return("unknown")
+  }
+  if (length(status_lines) == 0L) {
+    return("clean")
+  }
+  # Porcelain v1 format: two status chars + one space + path.
+  dirty_paths <- trimws(substring(status_lines, 4L))
+  n_dirty <- length(dirty_paths)
+  shown <- utils::head(dirty_paths, max_shown)
+  more_txt <- if (n_dirty > length(shown)) sprintf(", +%d more", n_dirty - length(shown)) else ""
+  sprintf(
+    "dirty (%d source file%s modified: %s%s)",
+    n_dirty, if (n_dirty != 1L) "s" else "", paste(shown, collapse = ", "), more_txt
+  )
+}
+
+#' Resolve a display string for the current git branch, handling detached HEAD
+#'
+#' `git rev-parse --abbrev-ref HEAD` returns the literal string `"HEAD"`
+#' when the checkout is detached (common in CI checkouts, or after
+#' `git checkout <sha>`) -- printing that literally answers nothing ("branch:
+#' HEAD"). Pure function so this is unit-testable without a real git repo.
+#'
+#' @param raw_branch the raw `git rev-parse --abbrev-ref HEAD` output, or
+#'   `"unknown"` if that call already failed upstream
+#' @param sha_short the short commit SHA, or `"unknown"`
+#' @return a display string: the branch name, `"HEAD (detached at <sha>)"`,
+#'   or `"unknown"`
+.hd_branch_display <- function(raw_branch, sha_short) {
+  if (identical(raw_branch, "unknown")) return("unknown")
+  if (identical(raw_branch, "HEAD")) {
+    if (identical(sha_short, "unknown")) return("unknown")
+    return(sprintf("HEAD (detached at %s)", sha_short))
+  }
+  raw_branch
+}
+
 #' Rich "Built with" tabset: Data / R environment / This page
 #'
 #' `build_info()` above stays as a one-line footer for any caller that only
@@ -430,15 +485,35 @@ build_info_tabset <- function(pkg_name = "historicaldata") {
 
   git_branch <- tryCatch(system("git rev-parse --abbrev-ref HEAD 2>/dev/null", intern = TRUE), error = function(e) character(0))
   git_branch <- if (length(git_branch) == 0 || !nzchar(git_branch)) "unknown" else git_branch
+  git_branch <- .hd_branch_display(git_branch, git_sha_short)
 
-  git_status <- tryCatch(system("git status --porcelain 2>/dev/null", intern = TRUE), error = function(e) NA)
-  tree_clean <- if (identical(git_status, NA)) {
-    "unknown"
-  } else if (length(git_status) == 0) {
-    "clean"
-  } else {
-    paste0("dirty (", length(git_status), " file", if (length(git_status) != 1L) "s" else "", " modified)")
-  }
+  # Our publish flow is always render -> inspect -> commit the rendered
+  # output, so `docs/*.html`/`docs/*_files/**` (committed for GitHub Pages,
+  # per .gitignore) and the per-build `docs/_targets_meta_snapshot.csv` are
+  # *necessarily* dirty at render time -- they are this very render's own
+  # output, not uncommitted source. A raw `git status --porcelain` therefore
+  # always reported "dirty" regardless of whether the actual source was
+  # clean, which conveys no information (the failure mode
+  # `checks-must-distinguish-unknown` describes). Exclude those render
+  # byproducts via pathspec so the field reflects the *source* tree instead.
+  # `-C <repo_root>` anchors both git's cwd and the (repo-root-relative)
+  # exclude pathspecs, regardless of R's own working directory at render
+  # time (docs/ under Quarto, repo root under a plain script).
+  git_status <- tryCatch({
+    exclude_pathspecs <- c(
+      ".",
+      ":(exclude)docs/*.html",
+      ":(exclude,glob)docs/*_files/**",
+      ":(exclude)docs/_targets_meta_snapshot.csv"
+    )
+    cmd <- paste(
+      "git", "-C", shQuote(.hd_repo_root()), "status", "--porcelain", "--",
+      paste(shQuote(exclude_pathspecs), collapse = " "),
+      "2>/dev/null"
+    )
+    system(cmd, intern = TRUE)
+  }, error = function(e) NA)
+  tree_clean <- .hd_tree_status_display(git_status)
 
   sha_display <- if (!is.null(gh_url) && git_sha_short != "unknown") {
     sprintf("[`%s`](%s/commit/%s)", git_sha_short, gh_url, git_sha_full)
@@ -520,8 +595,8 @@ build_info_tabset <- function(pkg_name = "historicaldata") {
     "*Hover any item for its exact provenance. This is a static snapshot — it does not refresh itself.*\n\n",
     "| Item | Value |\n|---|---|\n",
     "| ", .hd_ttl("Commit", "git rev-parse HEAD, resolved at render time"), " | ", sha_display, " |\n",
-    "| ", .hd_ttl("Branch", "git rev-parse --abbrev-ref HEAD"), " | `", git_branch, "` |\n",
-    "| ", .hd_ttl("Working tree", "git status --porcelain at render time"), " | ", tree_clean, " |\n",
+    "| ", .hd_ttl("Branch", "git rev-parse --abbrev-ref HEAD (detached HEAD resolves to the commit SHA instead)"), " | `", git_branch, "` |\n",
+    "| ", .hd_ttl("Source tree", "git status --porcelain at render time, excluding this render's own output (docs/*.html, docs/*_files/**, docs/_targets_meta_snapshot.csv) -- our publish flow is render, then commit the rendered output, so those are always dirty at render time and would otherwise swamp this field"), " | ", tree_clean, " |\n",
     "| ", .hd_ttl("Data sources referenced", "scanned from R/ and packages/historicaldata/R/ at render time"), " | ", sources_txt, " |\n",
     "| ", .hd_ttl("Targets in store", "nrow(targets::tar_meta(store = ...))"), " | ", n_targets, " |\n",
     "| ", .hd_ttl("Store last built", "max(targets::tar_meta()$time)"), " | ", last_built, " |\n",

--- a/docs/vignette_utils.R
+++ b/docs/vignette_utils.R
@@ -434,6 +434,45 @@ hd_data_sources_used <- function() {
   )
 }
 
+#' Build the `git status --porcelain` command for the "Source tree" field
+#'
+#' Extracted from `build_info_tabset()` so the untracked-files scope
+#' decision is unit-testable without a live git repo (pure string-building,
+#' no git call). Two exclusions compose here, both required:
+#'
+#' - `--untracked-files=no` restricts the report to the *committed* source
+#'   tree. The field answers "was the committed source that produced this
+#'   page clean?" -- an untracked local file (scratch output, a stray
+#'   fixture, a local clone dir) was never part of that committed source, so
+#'   it cannot change the answer. Without this flag, arbitrary local
+#'   clutter both misreports the field's meaning and can publish local
+#'   machine paths -- some PII-adjacent -- to a public site.
+#' - The exclude pathspecs drop this render's own output
+#'   (`docs/*.html`, `docs/*_files/**`, `docs/_targets_meta_snapshot.csv`):
+#'   our publish flow is render, then commit the rendered output, so those
+#'   are always dirty at render time and would otherwise swamp this field.
+#'
+#' `-C <repo_root>` anchors both git's cwd and the (repo-root-relative)
+#' exclude pathspecs, regardless of R's own working directory at render
+#' time (docs/ under Quarto, repo root under a plain script).
+#'
+#' @param repo_root path to the repo root (`.hd_repo_root()` at the call site)
+#' @return a single shell command string, ready for `system(cmd, intern = TRUE)`
+.hd_tree_status_cmd <- function(repo_root) {
+  exclude_pathspecs <- c(
+    ".",
+    ":(exclude)docs/*.html",
+    ":(exclude,glob)docs/*_files/**",
+    ":(exclude)docs/_targets_meta_snapshot.csv"
+  )
+  paste(
+    "git", "-C", shQuote(repo_root), "status", "--porcelain",
+    "--untracked-files=no", "--",
+    paste(shQuote(exclude_pathspecs), collapse = " "),
+    "2>/dev/null"
+  )
+}
+
 #' Resolve a display string for the current git branch, handling detached HEAD
 #'
 #' `git rev-parse --abbrev-ref HEAD` returns the literal string `"HEAD"`
@@ -487,32 +526,15 @@ build_info_tabset <- function(pkg_name = "historicaldata") {
   git_branch <- if (length(git_branch) == 0 || !nzchar(git_branch)) "unknown" else git_branch
   git_branch <- .hd_branch_display(git_branch, git_sha_short)
 
-  # Our publish flow is always render -> inspect -> commit the rendered
-  # output, so `docs/*.html`/`docs/*_files/**` (committed for GitHub Pages,
-  # per .gitignore) and the per-build `docs/_targets_meta_snapshot.csv` are
-  # *necessarily* dirty at render time -- they are this very render's own
-  # output, not uncommitted source. A raw `git status --porcelain` therefore
-  # always reported "dirty" regardless of whether the actual source was
-  # clean, which conveys no information (the failure mode
-  # `checks-must-distinguish-unknown` describes). Exclude those render
-  # byproducts via pathspec so the field reflects the *source* tree instead.
-  # `-C <repo_root>` anchors both git's cwd and the (repo-root-relative)
-  # exclude pathspecs, regardless of R's own working directory at render
-  # time (docs/ under Quarto, repo root under a plain script).
-  git_status <- tryCatch({
-    exclude_pathspecs <- c(
-      ".",
-      ":(exclude)docs/*.html",
-      ":(exclude,glob)docs/*_files/**",
-      ":(exclude)docs/_targets_meta_snapshot.csv"
-    )
-    cmd <- paste(
-      "git", "-C", shQuote(.hd_repo_root()), "status", "--porcelain", "--",
-      paste(shQuote(exclude_pathspecs), collapse = " "),
-      "2>/dev/null"
-    )
-    system(cmd, intern = TRUE)
-  }, error = function(e) NA)
+  # See .hd_tree_status_cmd() for why both the untracked-files exclusion and
+  # the render-output pathspec exclusions are required -- a raw
+  # `git status --porcelain` always reported "dirty" regardless of whether
+  # the actual committed source was clean, which conveys no information
+  # (the failure mode `checks-must-distinguish-unknown` describes).
+  git_status <- tryCatch(
+    system(.hd_tree_status_cmd(.hd_repo_root()), intern = TRUE),
+    error = function(e) NA
+  )
   tree_clean <- .hd_tree_status_display(git_status)
 
   sha_display <- if (!is.null(gh_url) && git_sha_short != "unknown") {
@@ -596,7 +618,7 @@ build_info_tabset <- function(pkg_name = "historicaldata") {
     "| Item | Value |\n|---|---|\n",
     "| ", .hd_ttl("Commit", "git rev-parse HEAD, resolved at render time"), " | ", sha_display, " |\n",
     "| ", .hd_ttl("Branch", "git rev-parse --abbrev-ref HEAD (detached HEAD resolves to the commit SHA instead)"), " | `", git_branch, "` |\n",
-    "| ", .hd_ttl("Source tree", "git status --porcelain at render time, excluding this render's own output (docs/*.html, docs/*_files/**, docs/_targets_meta_snapshot.csv) -- our publish flow is render, then commit the rendered output, so those are always dirty at render time and would otherwise swamp this field"), " | ", tree_clean, " |\n",
+    "| ", .hd_ttl("Source tree", "git status --porcelain --untracked-files=no at render time -- reports the COMMITTED source only. Excludes this render's own output (docs/*.html, docs/*_files/**, docs/_targets_meta_snapshot.csv), since our publish flow is render then commit the rendered output, and excludes ALL untracked files/directories, since those were never part of the committed source this page was built from. 'clean' means no tracked source file differs from HEAD -- it says nothing about untracked local clutter on the machine that rendered it"), " | ", tree_clean, " |\n",
     "| ", .hd_ttl("Data sources referenced", "scanned from R/ and packages/historicaldata/R/ at render time"), " | ", sources_txt, " |\n",
     "| ", .hd_ttl("Targets in store", "nrow(targets::tar_meta(store = ...))"), " | ", n_targets, " |\n",
     "| ", .hd_ttl("Store last built", "max(targets::tar_meta()$time)"), " | ", last_built, " |\n",

--- a/docs/vignette_utils.R
+++ b/docs/vignette_utils.R
@@ -312,3 +312,230 @@ build_info <- function(pkg_name = "historicaldata") {
     pkg_name, ver_link, sha_link, r_link, build_time
   )
 }
+
+#' Inline hover span — same mechanism the Detection/Rigour badges on
+#' Rankings already use (`<span title="...">`), reused here rather than
+#' inventing a second tooltip convention (issue request, #build-info-tabset).
+.hd_ttl <- function(label, title) {
+  sprintf('<span title="%s">%s</span>', gsub('"', "&quot;", title, fixed = TRUE), label)
+}
+
+#' Resolve the repo root, working around the here::here() cwd-trap
+#'
+#' `here::here()` returns `docs/` itself under Quarto render, because
+#' `docs/_quarto.yml` is picked up as a project-root marker before the
+#' search climbs to the actual repo root -- the same trap documented at
+#' every other `here::here()` call site in this project (see e.g.
+#' `index.qmd`'s `flake_dir`/`root` variables, `european-overlay.qmd`,
+#' `avoid-worst-days.qmd`). Reuses that project's exact self-correcting
+#' idiom: if `here()` already points at a directory containing `flake.nix`
+#' (i.e. cwd was the repo root, no trap), use it as-is; otherwise assume
+#' the trap fired and take `dirname()`.
+.hd_repo_root <- function() {
+  root_guess <- here::here()
+  if (file.exists(file.path(root_guess, "flake.nix"))) root_guess else dirname(root_guess)
+}
+
+#' Read the Imports field of a DESCRIPTION file, stripping version constraints
+#'
+#' Base-R only (`read.dcf`) — deliberately avoids a dependency on `desc`,
+#' which is not declared anywhere in this project (DESCRIPTION Imports/Suggests,
+#' flake.nix). Returns character(0) on any failure rather than erroring, so a
+#' caller can render "unknown" instead of aborting the whole page.
+.hd_pkg_imports <- function(desc_path) {
+  if (!file.exists(desc_path)) return(character(0))
+  dcf <- tryCatch(read.dcf(desc_path, fields = "Imports"), error = function(e) NULL)
+  if (is.null(dcf) || is.na(dcf[1, "Imports"])) return(character(0))
+  parts <- strsplit(dcf[1, "Imports"], ",\\s*\\n?\\s*")[[1]]
+  parts <- trimws(sub("\\s*\\(.*\\)$", "", parts))
+  parts[nzchar(parts)]
+}
+
+#' External data sources referenced in this project's R/ code, computed by
+#' scanning the actual source tree at render time (never hand-typed — the
+#' `reproducible-ingestion` rule treats a hand-typed provider list as
+#' technical debt: it silently drifts the moment a source is added or
+#' dropped and nobody remembers to update the list here).
+#'
+#' @return Character vector of provider display names found (possibly empty)
+hd_data_sources_used <- function() {
+  providers <- tibble::tribble(
+    ~pattern,                                     ~label,
+    "hf://|[Hh]ugging[- ]?[Ff]ace",                "HuggingFace (parquet via hf://)",
+    "\\bFRED\\b",                                  "FRED (Federal Reserve Economic Data)",
+    "Ken French|French Data Library",              "Ken French Data Library",
+    "\\bECB\\b|European Central Bank",             "ECB (European Central Bank, CISS)",
+    "\\bJST\\b|Jord.-Schularick-Taylor",           "JST Macrohistory Database",
+    "\\bCBOE\\b",                                  "CBOE (VIX/VVIX)",
+    "Yahoo Finance",                               "Yahoo Finance",
+    "[Aa]lpha ?[Vv]antage",                        "Alpha Vantage"
+  )
+  root <- .hd_repo_root()
+  dirs <- c(file.path(root, "R"), file.path(root, "packages/historicaldata/R"))
+  dirs <- dirs[dir.exists(dirs)]
+  if (length(dirs) == 0) return(character(0))
+  files <- unlist(lapply(dirs, list.files, pattern = "\\.R$", full.names = TRUE))
+  if (length(files) == 0) return(character(0))
+  text <- vapply(files, function(f) paste(readLines(f, warn = FALSE), collapse = "\n"), character(1))
+  found <- vapply(providers$pattern, function(p) any(grepl(p, text, perl = TRUE)), logical(1))
+  providers$label[found]
+}
+
+#' Read this page's own YAML front matter without a hard dependency on the
+#' `rmarkdown`/`yaml` packages (neither is declared in DESCRIPTION or
+#' flake.nix) -- base-R line scan of the fenced `---` block bounded by the
+#' first two `---` lines, same file `knitr::current_input()` names.
+#'
+#' @return list(dark=, light=) or NULL if the page/theme cannot be located
+.hd_page_theme <- function(page_lines) {
+  dashes <- which(page_lines == "---")
+  if (length(dashes) < 2) return(NULL)
+  yaml_lines <- page_lines[(dashes[1] + 1):(dashes[2] - 1)]
+  dark  <- sub(".*dark:\\s*", "", grep("^\\s*dark:", yaml_lines, value = TRUE)[1])
+  light <- sub(".*light:\\s*", "", grep("^\\s*light:", yaml_lines, value = TRUE)[1])
+  if (is.na(dark) && is.na(light)) return(NULL)
+  list(
+    dark  = if (is.na(dark)) "unknown" else trimws(dark),
+    light = if (is.na(light)) "unknown" else trimws(light)
+  )
+}
+
+#' Rich "Built with" tabset: Data / R environment / This page
+#'
+#' `build_info()` above stays as a one-line footer for any caller that only
+#' wants the compact form. This is the richer replacement requested directly
+#' by the project owner (#build-info-tabset): a "Built with" callout,
+#' hover-for-detail via the same `<span title=>` mechanism the Detection/
+#' Rigour badges on Rankings already use, split into three tabs.
+#'
+#' Every value is computed at render time (`dynamic-prose-values` rule) --
+#' nothing here is a hardcoded version, date, count, or SHA. Where a value
+#' genuinely cannot be derived (no git remote, no targets store yet built,
+#' page source unreadable), the cell prints an explicit "unknown" rather
+#' than being silently omitted or backfilled with a plausible-looking
+#' constant (`checks-must-distinguish-unknown` rule).
+#'
+#' @param pkg_name Package name (default: "historicaldata")
+build_info_tabset <- function(pkg_name = "historicaldata") {
+  # ---- git ----
+  gh_url <- tryCatch({
+    remote <- system("git remote get-url origin 2>/dev/null", intern = TRUE)
+    if (length(remote) == 0 || !nzchar(remote)) NULL else
+      sub("\\.git$", "", sub("^git@github\\.com:", "https://github.com/", remote))
+  }, error = function(e) NULL)
+
+  git_sha_short <- tryCatch(system("git rev-parse --short HEAD 2>/dev/null", intern = TRUE), error = function(e) character(0))
+  git_sha_short <- if (length(git_sha_short) == 0 || !nzchar(git_sha_short)) "unknown" else git_sha_short
+  git_sha_full  <- tryCatch(system("git rev-parse HEAD 2>/dev/null", intern = TRUE), error = function(e) git_sha_short)
+
+  git_branch <- tryCatch(system("git rev-parse --abbrev-ref HEAD 2>/dev/null", intern = TRUE), error = function(e) character(0))
+  git_branch <- if (length(git_branch) == 0 || !nzchar(git_branch)) "unknown" else git_branch
+
+  git_status <- tryCatch(system("git status --porcelain 2>/dev/null", intern = TRUE), error = function(e) NA)
+  tree_clean <- if (identical(git_status, NA)) {
+    "unknown"
+  } else if (length(git_status) == 0) {
+    "clean"
+  } else {
+    paste0("dirty (", length(git_status), " file", if (length(git_status) != 1L) "s" else "", " modified)")
+  }
+
+  sha_display <- if (!is.null(gh_url) && git_sha_short != "unknown") {
+    sprintf("[`%s`](%s/commit/%s)", git_sha_short, gh_url, git_sha_full)
+  } else if (git_sha_short != "unknown") {
+    sprintf("`%s` (local HEAD, no remote)", git_sha_short)
+  } else {
+    "unknown"
+  }
+
+  issues_link <- if (!is.null(gh_url)) sprintf("[Open issues](%s/issues)", gh_url) else "unknown (no remote configured)"
+
+  # ---- targets store ----
+  # dir.exists() is checked explicitly BEFORE calling tar_meta(): tar_meta()
+  # on a missing store does not error, it warns and returns a 0-row tibble --
+  # indistinguishable from "the store exists and genuinely has 0 targets"
+  # unless the missing-store case is ruled out first
+  # (`checks-must-distinguish-unknown` rule; an unknown must never render
+  # identically to a computed zero).
+  store_path <- if (dir.exists("_targets")) "_targets" else
+    file.path(.hd_repo_root(), "docs/_targets")
+  store_meta <- if (dir.exists(store_path)) {
+    tryCatch(targets::tar_meta(store = store_path), error = function(e) NULL)
+  } else {
+    NULL
+  }
+  n_targets  <- if (is.null(store_meta)) "unknown (store unavailable)" else as.character(nrow(store_meta))
+  last_built <- if (is.null(store_meta) || !("time" %in% names(store_meta)) || all(is.na(store_meta$time))) {
+    "unknown (store unavailable)"
+  } else {
+    format(max(store_meta$time, na.rm = TRUE), "%Y-%m-%d %H:%M %Z")
+  }
+
+  # ---- data sources (project-wide; this page draws on a subset) ----
+  sources <- tryCatch(hd_data_sources_used(), error = function(e) character(0))
+  sources_txt <- if (length(sources) == 0) "unknown (no provider references found)" else paste(sources, collapse = ", ")
+
+  # ---- R environment ----
+  r_ver <- as.character(getRversion())
+  desc_path <- file.path(.hd_repo_root(), "packages/historicaldata/DESCRIPTION")
+  imports <- tryCatch(.hd_pkg_imports(desc_path), error = function(e) character(0))
+  pkg_versions <- vapply(imports, function(p) {
+    v <- tryCatch(as.character(utils::packageVersion(p)), error = function(e) "not installed")
+    sprintf("`%s %s`", p, v)
+  }, character(1))
+  pkg_versions_txt <- if (length(pkg_versions) == 0) "unknown" else paste(pkg_versions, collapse = ", ")
+
+  # ---- this page: read its own source, not a hand-typed description ----
+  page_path  <- tryCatch(knitr::current_input(dir = TRUE), error = function(e) NULL)
+  page_lines <- if (!is.null(page_path) && file.exists(page_path)) readLines(page_path, warn = FALSE) else character(0)
+
+  theme <- if (length(page_lines) > 0) .hd_page_theme(page_lines) else NULL
+  theme_txt <- if (is.null(theme)) "unknown" else
+    sprintf("dark = `%s`, light = `%s` (Bootswatch)", theme$dark, theme$light)
+
+  page_text <- paste(page_lines, collapse = "\n")
+  table_engine <- if (length(page_lines) == 0) {
+    "unknown"
+  } else if (grepl("DT::datatable\\(|hd_dt\\(|hd_dt_wide\\(", page_text)) {
+    sprintf("DT `%s`", tryCatch(as.character(utils::packageVersion("DT")), error = function(e) "not installed"))
+  } else if (grepl("knitr::kable\\(", page_text)) {
+    "knitr::kable() (base HTML table, no DT)"
+  } else {
+    "no tables detected on this page"
+  }
+  chart_engine <- if (length(page_lines) == 0) {
+    "unknown"
+  } else if (grepl("plotly::|library\\(plotly\\)|ggplotly\\(", page_text)) {
+    sprintf("plotly `%s` (interactive)", tryCatch(as.character(utils::packageVersion("plotly")), error = function(e) "not installed"))
+  } else if (grepl("ggplot\\(|library\\(ggplot2\\)", page_text)) {
+    "ggplot2 (static PNG/SVG via knitr)"
+  } else {
+    "no charts detected on this page"
+  }
+  font_txt <- "no custom `font-family` override in vignette-shared.css — inherits the Bootswatch theme's default stack"
+
+  knitr::asis_output(paste0(
+    "::: {.panel-tabset}\n\n",
+    "##### Data\n\n",
+    "*Hover any item for its exact provenance. This is a static snapshot — it does not refresh itself.*\n\n",
+    "| Item | Value |\n|---|---|\n",
+    "| ", .hd_ttl("Commit", "git rev-parse HEAD, resolved at render time"), " | ", sha_display, " |\n",
+    "| ", .hd_ttl("Branch", "git rev-parse --abbrev-ref HEAD"), " | `", git_branch, "` |\n",
+    "| ", .hd_ttl("Working tree", "git status --porcelain at render time"), " | ", tree_clean, " |\n",
+    "| ", .hd_ttl("Data sources referenced", "scanned from R/ and packages/historicaldata/R/ at render time"), " | ", sources_txt, " |\n",
+    "| ", .hd_ttl("Targets in store", "nrow(targets::tar_meta(store = ...))"), " | ", n_targets, " |\n",
+    "| ", .hd_ttl("Store last built", "max(targets::tar_meta()$time)"), " | ", last_built, " |\n",
+    "| ", .hd_ttl("Open issues", "GitHub issue tracker for this repo"), " | ", issues_link, " |\n",
+    "\n##### R environment\n\n",
+    "| Item | Value |\n|---|---|\n",
+    "| ", .hd_ttl("R", "getRversion() at render time"), " | `", r_ver, "` |\n",
+    "| ", .hd_ttl(paste0(pkg_name, " package Imports"), "versions via utils::packageVersion(), read from packages/historicaldata/DESCRIPTION"), " | ", pkg_versions_txt, " |\n",
+    "\n##### This page\n\n",
+    "| Item | Value |\n|---|---|\n",
+    "| ", .hd_ttl("Theme", "this page's own YAML front matter, read at render time"), " | ", theme_txt, " |\n",
+    "| ", .hd_ttl("Fonts", "docs/vignette-shared.css, scanned for font-family at render time"), " | ", font_txt, " |\n",
+    "| ", .hd_ttl("Chart engine", "this page's own source, scanned for plotly:: vs ggplot() at render time"), " | ", chart_engine, " |\n",
+    "| ", .hd_ttl("Table engine", "this page's own source, scanned for DT::datatable()/hd_dt() vs knitr::kable() at render time"), " | ", table_engine, " |\n",
+    "\n:::\n"
+  ))
+}

--- a/tests/testthat/_snaps/vignette-utils.md
+++ b/tests/testthat/_snaps/vignette-utils.md
@@ -78,3 +78,19 @@
       function (target_name) 
       NULL
 
+---
+
+    Code
+      args(.hd_tree_status_display)
+    Output
+      function (status_lines, max_shown = 10L) 
+      NULL
+
+---
+
+    Code
+      args(.hd_branch_display)
+    Output
+      function (raw_branch, sha_short) 
+      NULL
+

--- a/tests/testthat/_snaps/vignette-utils.md
+++ b/tests/testthat/_snaps/vignette-utils.md
@@ -89,6 +89,14 @@
 ---
 
     Code
+      args(.hd_tree_status_cmd)
+    Output
+      function (repo_root) 
+      NULL
+
+---
+
+    Code
       args(.hd_branch_display)
     Output
       function (raw_branch, sha_short) 

--- a/tests/testthat/test-vignette-utils.R
+++ b/tests/testthat/test-vignette-utils.R
@@ -303,6 +303,66 @@ test_that(".hd_tree_status_display: truncates the file list past max_shown and r
 })
 
 # ---------------------------------------------------------------------------
+# .hd_tree_status_cmd — the "Source tree" field's untracked-files scope
+#
+# `.hd_tree_status_display()` above is a pure formatter: it treats every
+# porcelain line it is handed identically, whether that line came from a
+# tracked modification (` M`) or an untracked file (`??`). The scope
+# decision -- untracked files must never reach that formatter at all --
+# lives in the `git status` invocation itself, via `--untracked-files=no`.
+# These tests cover that command-building in isolation (pure string
+# assembly, no git call needed) and then, below, against a real scratch git
+# repo to prove the untracked case end-to-end.
+# ---------------------------------------------------------------------------
+
+test_that(".hd_tree_status_cmd excludes untracked files via --untracked-files=no", {
+  cmd <- .hd_tree_status_cmd("/fake/repo/root")
+  expect_match(cmd, "--untracked-files=no", fixed = TRUE)
+})
+
+test_that(".hd_tree_status_cmd still excludes this render's own output pathspecs", {
+  cmd <- .hd_tree_status_cmd("/fake/repo/root")
+  expect_match(cmd, "exclude.*docs/\\*\\.html")
+  expect_match(cmd, "exclude.*docs/_targets_meta_snapshot\\.csv")
+})
+
+test_that(".hd_tree_status_cmd anchors git's cwd at the given repo_root via -C", {
+  cmd <- .hd_tree_status_cmd("/fake/repo/root")
+  expect_match(cmd, "-C '?/fake/repo/root'?")
+})
+
+test_that(".hd_tree_status_cmd end-to-end: untracked junk is excluded, tracked mods are not", {
+  # Reproduces the observed defect directly: an untracked file/dir (scratch
+  # output, a stray fixture, a local clone dir) must never appear in the
+  # "Source tree" status, while a genuinely modified TRACKED file must
+  # still flip the field to dirty.
+  repo <- withr::local_tempdir()
+  system2("git", c("-C", repo, "init", "-q"))
+  system2("git", c("-C", repo, "config", "user.email", "test@example.com"))
+  system2("git", c("-C", repo, "config", "user.name", "Test"))
+  writeLines("content", file.path(repo, "tracked.R"))
+  system2("git", c("-C", repo, "add", "tracked.R"))
+  system2("git", c("-C", repo, "commit", "-q", "-m", "add tracked.R"))
+
+  # Untracked junk: a stray directory and a stray file, the same shape as
+  # the observed .clone/, archive/<name>-dir/, docs/_full_render_marker.txt.
+  dir.create(file.path(repo, "scratch_junk"))
+  writeLines("junk", file.path(repo, "scratch_junk", "stray.parquet"))
+  writeLines("marker", file.path(repo, "render_marker.txt"))
+
+  status_untracked_only <- system(.hd_tree_status_cmd(repo), intern = TRUE)
+  expect_equal(.hd_tree_status_display(status_untracked_only), "clean")
+
+  # Now modify the tracked file -- this MUST still show as dirty.
+  writeLines("modified content", file.path(repo, "tracked.R"))
+  status_with_tracked_mod <- system(.hd_tree_status_cmd(repo), intern = TRUE)
+  expect_equal(
+    .hd_tree_status_display(status_with_tracked_mod),
+    "dirty (1 source file modified: tracked.R)"
+  )
+})
+
+# ---------------------------------------------------------------------------
 # .hd_branch_display — build_info_tabset "Branch" field, detached HEAD case
 # ---------------------------------------------------------------------------
 
@@ -335,5 +395,6 @@ test_that("function signatures are stable (catches API drift)", {
   expect_snapshot(args(is_stale_marker))
   expect_snapshot(args(show_code))
   expect_snapshot(args(.hd_tree_status_display))
+  expect_snapshot(args(.hd_tree_status_cmd))
   expect_snapshot(args(.hd_branch_display))
 })

--- a/tests/testthat/test-vignette-utils.R
+++ b/tests/testthat/test-vignette-utils.R
@@ -258,6 +258,74 @@ test_that(".parse_vignette_strict: typo warning fires AT MOST ONCE across N call
 })
 
 # ---------------------------------------------------------------------------
+# .hd_tree_status_display — build_info_tabset "Source tree" field
+#
+# Pure function so the display logic is testable without a real git repo or
+# a Quarto render. The caller (build_info_tabset()) supplies already-filtered
+# `git status --porcelain` output (render byproducts like docs/*.html
+# excluded via pathspec) or NA when the git call itself failed.
+# ---------------------------------------------------------------------------
+
+test_that(".hd_tree_status_display: NA (git unavailable) returns 'unknown', not 'clean'", {
+  # An indeterminate result must never collapse into the negative-result
+  # value — checks-must-distinguish-unknown.
+  expect_equal(.hd_tree_status_display(NA), "unknown")
+})
+
+test_that(".hd_tree_status_display: empty character(0) returns 'clean'", {
+  expect_equal(.hd_tree_status_display(character(0)), "clean")
+})
+
+test_that(".hd_tree_status_display: single modified file is singular ('file', not 'files')", {
+  expect_equal(
+    .hd_tree_status_display(" M docs/vignette_utils.R"),
+    "dirty (1 source file modified: docs/vignette_utils.R)"
+  )
+})
+
+test_that(".hd_tree_status_display: multiple files are plural and listed", {
+  expect_equal(
+    .hd_tree_status_display(c(" M R/a.R", " M R/b.R", "?? R/c.R")),
+    "dirty (3 source files modified: R/a.R, R/b.R, R/c.R)"
+  )
+})
+
+test_that(".hd_tree_status_display: truncates the file list past max_shown and reports the remainder", {
+  lines <- sprintf(" M R/file%02d.R", seq_len(12))
+  result <- .hd_tree_status_display(lines, max_shown = 10L)
+  expect_match(result, "^dirty \\(12 source files modified: ")
+  expect_match(result, ", \\+2 more\\)$")
+  expect_false(grepl("file11", result))
+  expect_true(grepl("file10", result))
+  # No doubled closing paren -- the "more" marker must not nest a second
+  # "(...)" inside the outer "dirty (...)" wrapper.
+  expect_false(grepl("\\)\\)$", result))
+})
+
+# ---------------------------------------------------------------------------
+# .hd_branch_display — build_info_tabset "Branch" field, detached HEAD case
+# ---------------------------------------------------------------------------
+
+test_that(".hd_branch_display: normal branch name passes through unchanged", {
+  expect_equal(.hd_branch_display("main", "abc1234"), "main")
+})
+
+test_that(".hd_branch_display: detached HEAD resolves to the commit SHA, not the literal 'HEAD'", {
+  expect_equal(
+    .hd_branch_display("HEAD", "abc1234"),
+    "HEAD (detached at abc1234)"
+  )
+})
+
+test_that(".hd_branch_display: detached HEAD with no resolvable SHA is 'unknown', not a bare 'HEAD'", {
+  expect_equal(.hd_branch_display("HEAD", "unknown"), "unknown")
+})
+
+test_that(".hd_branch_display: upstream 'unknown' (git call already failed) passes through", {
+  expect_equal(.hd_branch_display("unknown", "abc1234"), "unknown")
+})
+
+# ---------------------------------------------------------------------------
 # Function signature stability (catches API drift) — Tier A snapshots
 # ---------------------------------------------------------------------------
 
@@ -266,4 +334,6 @@ test_that("function signatures are stable (catches API drift)", {
   expect_snapshot(args(safe_tar_read))
   expect_snapshot(args(is_stale_marker))
   expect_snapshot(args(show_code))
+  expect_snapshot(args(.hd_tree_status_display))
+  expect_snapshot(args(.hd_branch_display))
 })


### PR DESCRIPTION
## Summary

- **Biases and Caveats tabset** (leaderboard.qmd, stock-backtest.qmd): Survivorship Bias and Statistical Detection Power/Rigour tabs previously held a single paragraph of prose — a tab with one sentence reads as broken, not explanatory. Both now render a real `hd_dt()` table, sourced from the same `leaderboard$survivorship_biased` flag and detection/rigour columns the Rankings badges already compute — never a hand-typed strategy list. "About This Page" on both is now a linked contents list of every caveat on the page instead of a paragraph.
- **Build Info tabset**: replaces the one-line `build_info()` footer with `build_info_tabset()` (`docs/vignette_utils.R`) — a Data / R environment / This page nested `panel-tabset`. Every value is computed at render time (git SHA/branch/working-tree state, targets-store size and freshness, R package versions read from `packages/historicaldata/DESCRIPTION`, this page's own theme/chart-engine/table-engine read from its own YAML front matter and source). An indeterminate value prints `unknown` — never silently omitted or defaulted to a plausible-looking constant. Rolled out to all 11 real dashboards (8 direct call sites + the shared `_includes/build-info-footer.qmd` include used by 3 more); the 4 redirect-stub pages (drif/factor-max/jst-dashboard/negative-results) have no Build Info section and were left alone.

## Audit of other thin/single-paragraph tabs (requested scope)

Scanned all `{.tabset}` blocks across all 15 `docs/*.qmd` files for tabs holding only prose with no supporting table/chart. Findings:

- Every genuinely thin tab found (`Build Info` on avoid-worst-days/european-overlay/macro-defense-rotation/stock-backtest, `Survivorship Bias` and `Statistical Detection Power and Rigour` on leaderboard/stock-backtest) is fixed by this PR.
- Two script-flagged false positives checked and left alone: `index.qmd`'s "R (pak)" tab (has a real install code block, just not in a `{r}` fence so the scan missed it) and `stock-backtest.qmd`'s "Universe" tab (has a real markdown pipe-table, same scan miss).
- Remaining short tabs project-wide (`Definition`, `Notes`, `Glossary`, `References`, `Related Vignettes`, etc.) are narrative explanation with no underlying per-row dataset to tabulate — not the same defect class as a caveat page that *has* structured data sitting one hover away and shows none of it. Left as-is; flagging as a candidate for a follow-up issue if further enrichment is wanted.

## Test plan

- [x] `knitr::purl()` + `parse()` on every touched `.qmd` — all OK
- [x] `build_info_tabset()` executed standalone (outside knitr) to sanity-check every branch
- [x] `build_info_tabset()` executed via a real `knitr::knit()` render of a throwaway test doc placed at `docs/_zzz_test_build_info.Rmd` (removed before commit, never committed) to confirm `knitr::current_input()`-dependent fields (theme, chart engine, table engine) resolve correctly under real render conditions — this also caught and fixed a `here::here()` cwd-trap bug (`docs/_quarto.yml` is picked up as a false project-root marker) that would otherwise have silently mis-resolved the DESCRIPTION and data-source scan paths
- [x] `scripts/verify.sh` (full suite, foreground): **PASS** — parse OK, `docs/_targets.R` structurally valid, testthat edition 3 active, dashboard freshness Check 1/2 pass (staleness reported but non-blocking, expected since no render happened), root suite 3/3 known baseline failures only (0 unexpected), package suite 1/1 known baseline failure only (15 skips, matches documented baseline)
- [ ] Rendered appearance is **PREDICTED**, not observed — no `quarto render` was run in this worktree (no `_targets` store here per defect #766; running it is out of scope/forbidden for this dispatch). Owner should render and eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
