### PR TITLE
fix(docs): match evidence/bdbb-sol/quiz vignette width to dashboard pages

### DIFF
--- a/docs/bdbb-sol.qmd
+++ b/docs/bdbb-sol.qmd
@@ -4,6 +4,10 @@ description: |
   M/G/infinity queueing model (Varma 2026) applied to SOL/USD Kraken hourly data.
   Replicates resilience half-life estimation and tail-risk predictivity test.
 date: "`r Sys.Date()`"
+# page-layout: full so this page matches the window-width layout of the
+# dashboard-format vignettes (e.g. european-overlay.qmd) instead of Quarto's
+# default constrained article column.
+page-layout: full
 format:
   html:
     theme:

--- a/docs/evidence.qmd
+++ b/docs/evidence.qmd
@@ -1,14 +1,18 @@
 ---
 title: "Evidence & Context"
 subtitle: "Strategy Verdicts and Long-Run Historical Evidence"
+# page-layout: full + no TOC so this page matches the window-width layout of
+# the dashboard-format vignettes (e.g. european-overlay.qmd) instead of
+# Quarto's default constrained article column (issue: layout/style report,
+# 2026-08). toc: true removed -- was the only vignette in the project with a
+# TOC sidebar, which reserved horizontal space this page does not need.
+page-layout: full
 format:
   html:
     embed-resources: false
     theme:
       dark: darkly
       light: cosmo
-    toc: true
-    toc-depth: 2
     code-fold: true
     include-in-header:
       - _includes/color-scheme-meta.html

--- a/docs/quiz.qmd
+++ b/docs/quiz.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Which is Real?"
+# page-layout: full so this page matches the window-width layout of the
+# dashboard-format vignettes (e.g. european-overlay.qmd) instead of Quarto's
+# default constrained article column. The quiz UI itself
+# (#quiz-app{max-width:900px}) already self-constrains, so this only removes
+# the outer article column that was clipping it below its own intended width.
+page-layout: full
 format:
   html:
     embed-resources: false
@@ -10,6 +16,7 @@ format:
     include-in-header:
       - _includes/color-scheme-meta.html
       - text: |
+          <link rel="stylesheet" href="vignette-shared.css">
           <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
           <script src="https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js"></script>
           <style>

--- a/docs/vignette-shared.css
+++ b/docs/vignette-shared.css
@@ -270,3 +270,30 @@ details summary { cursor: pointer; color: #6c9bd2; }
 .hd-font-btn:hover, .hd-font-btn:focus-visible {
   opacity: 1; background: rgba(128, 128, 128, 0.25);
 }
+
+/* Full window width for html-format (non-dashboard) vignette pages, matching
+   dashboard-format vignettes such as european-overlay.qmd (layout/style
+   report, 2026-08). Each affected page's YAML also sets `page-layout: full`
+   (Quarto's own documented mechanism for this), but that alone assigns the
+   `column-page` class to `<main>`, which shares the SAME CSS specificity as
+   the default `.page-columns .content { grid-column: body-content-start /
+   body-content-end }` rule (confirmed by reading the compiled bootstrap
+   bundle: .page-columns{grid-template-columns:[screen-start] 1.5em
+   [screen-start-inset] 5fr [page-start...] ... minmax(500px, calc(850px -
+   3em)) ...[page-end] 5fr [screen-end-inset] 1.5em [screen-end]}) -- so
+   which one wins depends on cascade order, not something verifiable without
+   a render. This rule forces the outcome directly and unconditionally
+   (grid-column: screen-start/screen-end, not just page-start/page-end,
+   because page-start/page-end still leaves the two flexible 5fr side
+   gutters that create the empty margins being reported). Scoped to
+   `.page-columns` so it can only ever match html-format article pages --
+   dashboard pages render `page-layout-custom` and never carry the
+   `page-columns` class at all (verified against the deployed HTML for both
+   european-overlay.html and evidence.html), so this rule cannot affect
+   them. */
+.page-columns .content,
+.page-columns #quarto-document-content {
+  grid-column: screen-start / screen-end !important;
+  padding-left: 1.5em;
+  padding-right: 1.5em;
+}


### PR DESCRIPTION
## Summary

Owner report on [evidence.html](https://johngavin.github.io/historical/evidence.html):

> "the format for this vignette violates the template for layout and style. remove table of contents. make the page width match the window width as per the other vignettes such as european-overlay.html. check all other vignettes as well."

## Audit (all 15 `docs/*.qmd`)

| format | pages |
|---|---|
| `dashboard` (full window width by design) | avoid-worst-days, european-overlay, falsification, index, leaderboard, macro-defense-rotation, momentum-prepeak, stock-backtest |
| `html` — redirect stubs, left untouched | drif, factor-max, jst-dashboard, negative-results (auto-`<meta refresh>`, minimal content) |
| `html` — **fixed in this PR** | **evidence** (only page with `toc: true`), **bdbb-sol**, **quiz** |

`evidence.html`'s narrowness was not a CSS bug — Quarto's default `format: html` article layout (`page-layout: article`) reserves a narrow content column (confirmed in the compiled bootstrap bundle: `.page-columns{grid-template-columns:...minmax(500px, calc(850px - 3em))...}`) regardless of TOC. Dashboard pages never carry the `.page-columns` class at all — different rendering engine entirely — which is why `european-overlay.html` already spans the window.

## Decision: CSS/layout fix, not dashboard conversion

Considered converting the three pages to `format: dashboard` (truest match to the template) vs. keeping `format: html` and fixing width/TOC directly. Chose the latter: `evidence.qmd` is 457 lines of narrative prose with tabsets, callouts, and a crisis timeline — restructuring that into dashboard rows/tabsets risked mangling the content for no clear benefit. `bdbb-sol.qmd` is a similar narrative writeup. Converting would trade a template mismatch for a worse-reading page, which is not what was asked.

## Changes

- **`docs/evidence.qmd`**: removed `toc: true` / `toc-depth: 2` (only vignette in the project with a TOC sidebar); added `page-layout: full`.
- **`docs/bdbb-sol.qmd`**: added `page-layout: full`.
- **`docs/quiz.qmd`**: added `page-layout: full`; also added the `vignette-shared.css` link it was missing entirely (the only vignette not loading it) — its own `#quiz-app{max-width:900px}` was being clipped by the narrower outer article column, so this lets the quiz UI reach its own intended width.
- **`docs/vignette-shared.css`**: added a defensive override forcing `.page-columns .content` / `#quarto-document-content` to `grid-column: screen-start/screen-end`. `page-layout: full` alone assigns Quarto's `column-page` class, which shares equal CSS specificity with the default narrow-column rule — which one wins the cascade isn't verifiable without a render, so this forces the outcome directly. Scoped to `.page-columns`, which dashboard pages never carry, so it cannot affect them.

## What I could not verify

I was scoped away from rendering (`quarto render`/`scripts/build.sh` — the main checkout owns the `_targets` store/lock). This is a **predicted** fix based on reading the actual compiled Quarto/bootstrap CSS grid for this exact deployed build, not a rendered confirmation. What would falsify it:

- If `page-layout: full` and the CSS override still don't win (e.g. some other rule outranks both) — check the rendered `#quarto-content .content` computed `grid-column` in devtools.
- If forcing edge-to-edge width makes `evidence.qmd`'s prose sections read worse at wide viewports (long line-length) — the page mixes headings/callouts/tables with prose rather than being wall-to-wall text, so this seemed low-risk, but it's a genuine trade-off the owner may want to revisit.
- If widening quiz.qmd's outer column has any interaction with the newly-added `vignette-shared.css` rules (font-size, DT/bslib overrides) — these are all scoped to elements/classes quiz.qmd doesn't use, so expected to be inert, but not rendered to confirm.

## Verification

`scripts/verify.sh` (full suite, foreground): **PASS** — 0 new failures. Root suite matched the documented 3-failure baseline exactly; package suite matched the 1-failure baseline exactly (15 skips, all documented/expected). No R code was touched (pure `.qmd` YAML + shared CSS), so this is expected.

## Test plan

- [ ] Render `docs/evidence.qmd`, `docs/bdbb-sol.qmd`, `docs/quiz.qmd` and confirm content spans the window width, matching `european-overlay.html`
- [ ] Confirm `evidence.html` no longer shows a TOC sidebar
- [ ] Confirm `quiz.html`'s quiz UI renders correctly (no layout regression from the newly-added shared stylesheet)
- [ ] Spot-check `evidence.html` prose readability at a wide (≥1920px) viewport
