### PR TITLE
fix(leaderboard,vignette-utils): vectorize isTRUE() in case_when + git SHA fallback + pkg_name desc_path

### DIFF
--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -1598,9 +1598,9 @@ if (exists("full") && all(det_rig_cols %in% names(full)) && exists("DEFLATED_SHA
       Verdict = dplyr::case_when(
         is.na(sharpe) | sharpe <= 0        ~ "N/A (Sharpe ≤ 0)",
         is.na(detection_underpowered)      ~ "NOT COMPUTED",
-        isTRUE(detection_underpowered)     ~ "Underpowered",
+        detection_underpowered             ~ "Underpowered",
         is.na(detection_underpowered_mt)   ~ "Detectable (MT-corrected verdict not computed)",
-        isTRUE(detection_underpowered_mt)  ~ "Detectable, fails MT-correction",
+        detection_underpowered_mt          ~ "Detectable, fails MT-correction",
         TRUE                                ~ "Detectable"
       ),
       `Years Needed` = ifelse(is.na(detection_min_n_years), "—", as.character(round(detection_min_n_years, 1))),

--- a/docs/vignette_utils.R
+++ b/docs/vignette_utils.R
@@ -521,6 +521,7 @@ build_info_tabset <- function(pkg_name = "historicaldata") {
   git_sha_short <- tryCatch(system("git rev-parse --short HEAD 2>/dev/null", intern = TRUE), error = function(e) character(0))
   git_sha_short <- if (length(git_sha_short) == 0 || !nzchar(git_sha_short)) "unknown" else git_sha_short
   git_sha_full  <- tryCatch(system("git rev-parse HEAD 2>/dev/null", intern = TRUE), error = function(e) git_sha_short)
+  git_sha_full  <- if (length(git_sha_full) == 0 || !nzchar(git_sha_full)) git_sha_short else git_sha_full
 
   git_branch <- tryCatch(system("git rev-parse --abbrev-ref HEAD 2>/dev/null", intern = TRUE), error = function(e) character(0))
   git_branch <- if (length(git_branch) == 0 || !nzchar(git_branch)) "unknown" else git_branch
@@ -574,7 +575,7 @@ build_info_tabset <- function(pkg_name = "historicaldata") {
 
   # ---- R environment ----
   r_ver <- as.character(getRversion())
-  desc_path <- file.path(.hd_repo_root(), "packages/historicaldata/DESCRIPTION")
+  desc_path <- file.path(.hd_repo_root(), "packages", pkg_name, "DESCRIPTION")
   imports <- tryCatch(.hd_pkg_imports(desc_path), error = function(e) character(0))
   pkg_versions <- vapply(imports, function(p) {
     v <- tryCatch(as.character(utils::packageVersion(p)), error = function(e) "not installed")


### PR DESCRIPTION
## Summary

roborev finding [#9756](https://github.com/JohnGavin/historical/issues/9756) (job 12867) bundled 3 findings in `docs/leaderboard.qmd` and `docs/vignette_utils.R`:

1. **High** — `docs/leaderboard.qmd`, `caveats-detection-rigour-table` chunk: `isTRUE(detection_underpowered)` / `isTRUE(detection_underpowered_mt)` were applied to whole data-frame columns inside `case_when()`, not scalars. `isTRUE()` on a vector with length > 1 always evaluates to a single `FALSE`, which `case_when()` recycles across every row — the "Underpowered" and "Detectable, fails MT-correction" branches could never fire, mislabelling underpowered strategies as "Detectable". This matches the known pattern already documented in `detection-power-required.md` ([#726](https://github.com/JohnGavin/historical/issues/726)). Fixed by using the already-logical column directly — NA is already excluded by the preceding `is.na()` branch — matching the vectorized idiom already used correctly elsewhere in the same file (`!full_dp$detection_underpowered`, around lines 79–80).

2. **Medium** — `docs/vignette_utils.R`, `build_info_tabset()`: `git_sha_full` lacked the same empty-result guard that `git_sha_short` already has a few lines above. A failing `git rev-parse HEAD` raises an R **warning**, not an error, so `tryCatch(..., error = ...)` doesn't catch it — `git_sha_full` could silently become `character(0)`, and the downstream `sprintf()`/`paste0()` would render a blank cell instead of the documented `"unknown"` fallback. Applied the identical guard pattern used for `git_sha_short`.

3. **Low** — `docs/vignette_utils.R`, `build_info_tabset()`: `desc_path` was hardcoded to `packages/historicaldata/DESCRIPTION`, ignoring the `pkg_name` parameter (which is already used elsewhere in the same function, for the Imports table title). Built `desc_path` from `pkg_name` instead.

## Verification

- `docs/vignette_utils.R` still parses (`parse()` check).
- `tests/testthat/test-vignette-utils.R` (56 tests, sources this file directly) passes clean, before and after the change: `[ FAIL 0 | WARN 0 | SKIP 6 | PASS 56 ]`.
- Full `testthat::test_dir()` run shows 3 failures (`test-crypto-momentum.R`, `test-qa-summary-deps.R`, `test-stock-backtest.R`) — confirmed **identical on the unmodified baseline** via `git stash` + re-run, so these are pre-existing and unrelated to this change (POSIXct/Date coercion and `qa_summary` target coverage — neither file touches `leaderboard.qmd` or `vignette_utils.R`).

No new test added. The `case_when()` block lives inline in a `.qmd` code chunk — not extracted into `R/` the way `check_leaderboard_detection_power_coverage()` is in `R/plan_qa_gates.R` (which *is* unit-tested) — and the `git_sha_full` fallback is inline in `build_info_tabset()` rather than extracted into a small testable helper the way `.hd_branch_display()` / `.hd_tree_status_display()` are. Extracting either into a new testable helper would be a scope-expanding refactor beyond this minimal fix, so it's flagged here rather than done unilaterally.

## Test plan

- [x] `docs/vignette_utils.R` parses
- [x] `tests/testthat/test-vignette-utils.R` passes (56/56)
- [x] Full suite's 3 failures confirmed pre-existing via baseline comparison
- [ ] Reviewer: confirm the `case_when()` branch ordering reads correctly with the new plain-column conditions (line numbers may have drifted; verify against the merged file)
