### PR TITLE
chore(strategy-names): remove now-stale OLMAR-1 join-gap workarounds (#629)

### DIFF
--- a/R/plan_cost_convention.R
+++ b/R/plan_cost_convention.R
@@ -17,8 +17,10 @@
 # `strategy` values match the display labels used by the `leaderboard`
 # target's own `strategy` column (see R/plan_leaderboard.R, `add_meta()`
 # calls) -- the same join key used by `strategy_gross_convention`
-# (R/plan_exposure.R), including the "OLMAR-1" naming gap documented there
-# (#626, #629: `strategy_names` is missing an `olmar` row).
+# (R/plan_exposure.R). `strategy_names` was missing an `olmar` row when this
+# file was authored (#626, #629), but that gap was closed in #747; the
+# `by = "strategy"` join key is retained here for consistency with
+# `strategy_gross_convention`, not because of any remaining gap.
 #
 # `cost_per_trade_bps`: the transaction-cost figure the strategy's own code
 #   deducts, in basis points, verified against source at the commit this
@@ -129,8 +131,8 @@ BORROW_STATUS_OVERRIDES <- tibble::tibble(
 #' @param directionality Character vector (same length as `strategy`). Values
 #'   from `strategy_names$directionality` (R/plan_strategy_names.R):
 #'   long_only, long_short, market_neutral, overlay -- or NA if the strategy
-#'   has no `strategy_names` row (see the OLMAR-1 fill in the
-#'   `strategy_cost_convention` target below) and no override.
+#'   has no `strategy_names` row and no override (see #629/#747: this used
+#'   to be OLMAR-1's state before it gained a `strategy_names` row).
 #' @param has_borrow_rate Logical vector (same length). `TRUE` where
 #'   `borrow_rate_annual` is non-NA in the cost registry.
 #' @param override Character vector (same length), or NA where no override
@@ -458,12 +460,16 @@ plan_cost_convention <- function() {
       # (R/plan_strategy_names.R). Join on strategy == short_name -- the
       # same join key strategy_gross_convention (R/plan_exposure.R) uses.
       #
-      # OLMAR-1 has no row in strategy_names (#626/#629 known join gap) --
-      # filled explicitly (long-only simplex projection, R/plan_olmar.R:30)
-      # rather than left NA (fail-loud-not-null.md): a silently-NA
-      # directionality would make derive_borrow_status() abort below, which
-      # is correct for a GENUINELY unknown strategy but wrong for a known,
-      # documented gap.
+      # OLMAR-1 previously had no row in strategy_names (#626/#629 known
+      # join gap) and required an explicit post-join fill here. #747 added
+      # the missing `olmar` row (directionality = "long_only", matching
+      # what this file used to fill in by hand -- verified against
+      # R/plan_olmar.R:30's long-only simplex projection), so the join
+      # alone now resolves OLMAR-1 correctly and the fill was removed. A
+      # genuinely undeclared strategy still fails loud below, via
+      # derive_borrow_status()'s NA-directionality abort (fail-loud-not-
+      # null.md) -- and via QA gate S7's reverse leaderboard/strategy_names
+      # set-equality check (R/plan_qa_gates.R, check_leaderboard_coverage()).
       sn_lookup <- dplyr::transmute(
         strategy_names,
         strategy = short_name,
@@ -472,11 +478,6 @@ plan_cost_convention <- function() {
 
       with_direction <- base |>
         dplyr::left_join(sn_lookup, by = "strategy") |>
-        dplyr::mutate(
-          directionality = dplyr::if_else(
-            strategy == "OLMAR-1", "long_only", directionality
-          )
-        ) |>
         dplyr::left_join(BORROW_STATUS_OVERRIDES, by = "strategy")
 
       with_status <- with_direction |>

--- a/R/plan_exposure.R
+++ b/R/plan_exposure.R
@@ -9,12 +9,13 @@
 #
 # `strategy` values below match the display labels used by the `leaderboard`
 # target's own `strategy` column (see R/plan_leaderboard.R, `add_meta()`
-# calls) -- NOT `strategy_names$code_name`, because one leaderboard row
-# ("OLMAR-1") has no corresponding row in `strategy_names` (audited 2026-08,
-# #626: `strategy_names` currently lists 16 code_names and is missing
-# `olmar`). Joins onto `leaderboard` therefore use `by = "strategy"`,
-# matching the existing pattern used for `strat_corr_augment`,
-# `wfc_all_summary`, and `add_crowding` in R/plan_leaderboard.R.
+# calls) -- NOT `strategy_names$code_name`. Joins onto `leaderboard` use
+# `by = "strategy"`, matching the existing pattern used for
+# `strat_corr_augment`, `wfc_all_summary`, and `add_crowding` in
+# R/plan_leaderboard.R. (`strategy_names` was missing an `olmar` row when
+# this file was authored -- #626/#629 -- but that gap was closed in #747;
+# the `by = "strategy"` choice here is retained for consistency with the
+# rest of R/plan_leaderboard.R's joins, not because of any remaining gap.)
 #
 # `gross_convention`: the gross exposure (`sum(abs(w))`) implemented by the
 #   strategy's own weight-construction code, verified against source at the

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -195,6 +195,17 @@ check_anchor_in_range <- function(html_dir,
 #' running `tar_make()`.  The `qa_leaderboard_coverage` target calls this
 #' function directly.
 #'
+#' Deliberately one-directional: every declared `strategy_names` row must
+#' appear on the leaderboard, but the leaderboard MAY carry extra rows with
+#' no `strategy_names` entry (e.g. benchmark rows) -- see
+#' `packages/historicaldata/tests/testthat/test-leaderboard-coverage.R::
+#' "returns TRUE when leaderboard has extra strategies"`, which documents
+#' this as intentional. A stricter, bidirectional (reverse-setdiff) version
+#' was tried while closing out #629 (OLMAR-1 was ranked on the leaderboard
+#' with no `strategy_names` row) and reverted after it broke that documented
+#' contract -- the missing-`olmar` bug itself is closed by #747's added row,
+#' not by tightening this gate.
+#'
 #' Also asserts that the `ssr` and `top5pct_share` columns are present in the
 #' leaderboard tibble and that at least one row has a non-NA value for each
 #' (i.e. the stability metrics were computed for at least one strategy).


### PR DESCRIPTION
## Summary

Issue #629's primary defect (`strategy_names` missing an `olmar` row while OLMAR-1 was ranked on the leaderboard) was already fixed and merged in #747. This PR closes out the issue's "worth checking at the same time" follow-up: it removes now-stale ad-hoc `"OLMAR-1"` workarounds that existed specifically because that row was missing, and documents why one further tightening (a reverse leaderboard→strategy_names coverage check) was tried and reverted.

## Changes

- **`R/plan_cost_convention.R`**: the `strategy_cost_convention` target's post-join `if_else(strategy == "OLMAR-1", "long_only", directionality)` fill is now dead code — `strategy_names` already carries `directionality = "long_only"` for `olmar` (the exact value the fill hardcoded, sourced from `R/plan_olmar.R:30`'s long-only simplex projection), so `left_join(sn_lookup, ...)` resolves OLMAR-1 correctly without it. Removed the fill; updated the surrounding comment and `derive_borrow_status()`'s roxygen `@param directionality` note, both of which described the now-removed workaround.
- **`R/plan_exposure.R`, `R/plan_cost_convention.R`**: updated header comments that stated OLMAR-1 "has no corresponding row in `strategy_names`" / "known join gap" — no longer true since #747. The `by = "strategy"` join key itself is **unchanged** and intentionally kept for consistency with the rest of `R/plan_leaderboard.R`'s joins (`strat_corr_augment`, `wfc_all_summary`, `add_crowding`) — migrating just these two files to `code_name` would be a larger, unrelated refactor, not a small fix.
- **`R/plan_qa_gates.R`**: `check_leaderboard_coverage()` docstring only — documents why QA gate S7 stays one-directional (`strategy_names` → leaderboard) rather than also asserting the reverse (leaderboard → `strategy_names`, which the issue's "worth checking" section suggested as a one-line `setdiff()`). I tried the reverse check and reverted it after it broke `packages/historicaldata/tests/testthat/test-leaderboard-coverage.R`'s documented contract that extra leaderboard rows (e.g. benchmarks) with no `strategy_names` entry are intentionally allowed. No code change from that attempt survives in this PR — the note is doc-only, so a future contributor doesn't re-attempt the same tightening without knowing why it was reverted.

## Not changed

- The `strategy_names` row itself — already added in #747.
- The `by = "strategy"` join key convention in `plan_exposure.R`/`plan_cost_convention.R` — a deliberate, established pattern across `plan_leaderboard.R`, not something to change opportunistically here.
- Other hand-maintained per-strategy lists that mention `"OLMAR-1"` alongside every other strategy (`plan_structural_breaks.R`, `plan_strategy_correlation.R`, `plan_stock_backtest.R`) — these are a consistent codebase-wide pattern applied uniformly to all 17 strategies, not an OLMAR-specific workaround, so out of scope for this fix.

## Verification

`scripts/verify.sh`, full mode, foreground:

```
=== scripts/verify.sh: PASS ===
```

- Root suite: 819 tests, 3 failures — matches the documented baseline exactly (`test-crypto-momentum.R::C1`, `test-qa-summary-deps.R`, `test-stock-backtest.R`).
- Package suite: 726 tests, 1 failure, 15 skips — matches the documented baseline exactly (`test-mom-prepeak-portfolio.R`).

Closes #629
