### PR TITLE
fix(bootstrap,stock-backtest): full/left-join spine instead of inner_join chain (#603) (#656)

### DIFF
--- a/R/plan_bootstrap_ci.R
+++ b/R/plan_bootstrap_ci.R
@@ -34,6 +34,26 @@ plan_bootstrap_ci <- function() {
     # this IS a statistical-inference display (does the strategy's Sharpe
     # differ from zero), so it must use the same basis as what it is
     # implicitly being compared against.
+    #
+    # #603/#656: this used to be a 4-way inner_join chain, so any `ym`
+    # missing from ONE of the four constituents silently deleted that month
+    # for ALL FOUR (historically ~128 of ~190 rows -- see #603). Worse: the
+    # block bootstrap below (boot_draws) resamples CONTIGUOUS row-index
+    # blocks to preserve serial dependence, so a join that leaves calendar
+    # gaps let a "3-month block" splice two non-adjacent calendar months
+    # together, defeating the entire point of block resampling.
+    #
+    # Fix mirrors #651 (R/plan_portfolio_opt.R's port_returns, the same
+    # defect on the identical four constituents): an explicit
+    # calendar-complete monthly spine, bounded to the OVERLAP of the two
+    # stock-level series' own date ranges, with everything LEFT-joined onto
+    # it. A missing constituent is now an explicit NA in its own column,
+    # never a deleted row -- and because the spine is one row per calendar
+    # month, row order downstream is always calendar-contiguous, so a block
+    # sampled from it can never straddle a gap. calc_boot_metrics() in
+    # boot_metrics below drops NA pairwise per strategy/rf pair, so one
+    # strategy's gap cannot poison another strategy's draws for the same
+    # block (they use their own, independently-paired columns).
     targets::tar_target(boot_monthly_returns, {
       library(dplyr)
 
@@ -42,11 +62,58 @@ plan_bootstrap_ci <- function() {
       fac_max  <- fm_portfolio       |> select(ym, fac_max = portfolio_ret,  fac_max_rf = rf_ret)
       fac_drif <- drif_portfolio     |> select(ym, fac_drif = portfolio_ret, fac_drif_rf = rf_ret)
 
-      stk_max |>
-        inner_join(stk_drif, by = "ym") |>
-        inner_join(fac_max, by = "ym") |>
-        inner_join(fac_drif, by = "ym") |>
+      # Calendar-complete monthly spine bounded to the stock-level overlap
+      # window -- NOT the literal set of ym values present in stk_max/
+      # stk_drif, which is exactly what would silently re-drop a month if
+      # either ever loses one again (see the #651 comment on port_returns,
+      # R/plan_portfolio_opt.R, for the full rationale on this bound).
+      spine_start <- max(min(stk_max$ym), min(stk_drif$ym))
+      spine_end   <- min(max(stk_max$ym), max(stk_drif$ym))
+      spine <- tibble::tibble(
+        ym = format(
+          seq(as.Date(paste0(spine_start, "-01")),
+              as.Date(paste0(spine_end, "-01")),
+              by = "month"),
+          "%Y-%m"
+        )
+      )
+
+      combined <- spine |>
+        left_join(stk_max, by = "ym") |>
+        left_join(stk_drif, by = "ym") |>
+        left_join(fac_max, by = "ym") |>
+        left_join(fac_drif, by = "ym") |>
         arrange(ym)
+
+      # Fail loud, not null (fail-loud-not-null.md #4): report which months
+      # and strategies are missing rather than letting the gap pass
+      # silently. This is expected to be empty in the current data (#656
+      # measured 193/193 exact) -- it exists as a regression guard, not a
+      # live-defect report.
+      strat_cols <- c("stk_max", "stk_drif", "fac_max", "fac_drif")
+      avail <- rowSums(!is.na(as.matrix(combined[, strat_cols])))
+      thin <- combined[avail < length(strat_cols), , drop = FALSE]
+      if (nrow(thin) > 0L) {
+        thin_msgs <- vapply(seq_len(nrow(thin)), function(i) {
+          row <- thin[i, ]
+          missing_strats <- strat_cols[is.na(row[strat_cols])]
+          sprintf("  %s -- missing: %s", row$ym, paste(missing_strats, collapse = ", "))
+        }, character(1L))
+        cli::cli_warn(c(
+          "!" = paste0(
+            length(thin_msgs), " month(s) in boot_monthly_returns have at ",
+            "least one missing constituent strategy (#603/#656):"
+          ),
+          setNames(thin_msgs, rep("i", length(thin_msgs))),
+          "i" = paste0(
+            "calc_boot_metrics() (boot_metrics target below) drops NA ",
+            "pairwise per strategy, so this cannot poison another ",
+            "strategy's bootstrap draws."
+          )
+        ))
+      }
+
+      combined
     }),
 
     # Block bootstrap resampling
@@ -114,8 +181,22 @@ plan_bootstrap_ci <- function() {
       }
 
       # Compute rf-adjusted Sharpe, CAGR, max DD for a return + rf pair
+      #
+      # #603/#656: ret/rf can now contain NA (a missing constituent month,
+      # via the calendar spine built in boot_monthly_returns above). prod()/
+      # sd()/cumprod() on a vector containing any NA all return NA, so drop
+      # pairwise before computing -- this keeps one strategy's gap from
+      # poisoning ITS OWN cagr/vol/max_dd while leaving the other three
+      # strategies' draws for that same block untouched (each uses its own,
+      # independently-paired ret/rf columns).
       calc_boot_metrics <- function(ret, rf) {
+        keep <- !is.na(ret) & !is.na(rf)
+        ret <- ret[keep]
+        rf  <- rf[keep]
         n <- length(ret)
+        if (n < 2L) {
+          return(c(sharpe = NA_real_, cagr = NA_real_, max_dd = NA_real_))
+        }
         cagr <- prod(1 + ret)^(12 / n) - 1
         vol <- sd(ret) * sqrt(12)
         sr <- sharpe_ratio_rf(ret, rf, periods_per_year = 12L)

--- a/R/plan_interval_coverage.R
+++ b/R/plan_interval_coverage.R
@@ -35,12 +35,22 @@
 # Nothing computed inside or after the outcome window may be used to form the
 # interval or to define a stratum. See the look-ahead-bias-prevention rule.
 #
-# ── Known upstream defect (#603) ───────────────────────────────────────────
+# ── Structural contiguity guarantee (#603/#656) ─────────────────────────────
 #
-# boot_monthly_returns is NOT calendar-contiguous: an inner_join across four
-# strategies drops any month where one is missing (128 rows spanning ~190
-# calendar months). Block resampling over that row order splices non-adjacent
-# months. This plan reports the gap count rather than silently inheriting it.
+# boot_monthly_returns previously chained four inner_join()s across its
+# constituent strategies, so any month missing from ONE dropped that month
+# for ALL FOUR (128 rows spanning ~190 calendar months) -- and because block
+# resampling draws contiguous row-index blocks, that gap-riddled row order
+# let a block splice non-adjacent calendar months together, defeating the
+# purpose of block resampling. R/plan_bootstrap_ci.R now builds
+# boot_monthly_returns from an explicit calendar-complete monthly spine
+# (bounded to the stock-level overlap window) and LEFT-joins every
+# constituent onto it, so a missing constituent surfaces as an explicit NA
+# in its own column rather than a deleted row -- row order is therefore
+# always calendar-contiguous. ic_contiguity below (and S25,
+# R/plan_qa_gates.R) is now a permanent regression guard rather than a
+# live-defect report: if it ever fires again, the spine construction was
+# reverted or bypassed.
 
 plan_interval_coverage <- function() {
   list(
@@ -58,9 +68,14 @@ plan_interval_coverage <- function() {
       )
     }),
 
-    # ── Contiguity report (#603) ───────────────────────────────────────────
-    # Surfaces the gap defect in pipeline output instead of letting the
-    # coverage number silently absorb it.
+    # ── Contiguity regression guard (#603/#656) ─────────────────────────────
+    # boot_monthly_returns is now built from a calendar-complete spine
+    # (R/plan_bootstrap_ci.R) so this is expected to report zero missing
+    # months. Kept as a live check -- and the warning below kept as a warning,
+    # not an abort, matching S25's (R/plan_qa_gates.R) deliberate choice to
+    # abort on this exact condition instead -- so if this target's own
+    # dplyr::arrange/date handling ever diverges from the spine's guarantee,
+    # it is still visible here rather than only in the QA gate.
     targets::tar_target(ic_contiguity, {
       d <- as.Date(paste0(boot_monthly_returns$ym, "-01"))
       d <- sort(d)
@@ -79,8 +94,8 @@ plan_interval_coverage <- function() {
       if (out$missing_months > 0L) {
         cli::cli_warn(c(
           "!" = "boot_monthly_returns is not calendar-contiguous: {out$n_rows} rows over {out$calendar_months} months ({out$pct_missing}% missing).",
-          "i" = "Block resampling splices non-adjacent months. See issue #603.",
-          "i" = "Coverage numbers below inherit this defect."
+          "i" = "This should be structurally impossible given the calendar spine in R/plan_bootstrap_ci.R -- see #603/#656 and S25 (R/plan_qa_gates.R).",
+          "i" = "Block resampling splices non-adjacent months when this happens. Coverage numbers below would inherit that defect."
         ))
       }
       out

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -969,6 +969,192 @@ check_portfolio_join_coverage <- function(port_returns) {
 }
 
 
+#' Assert stk_all_comparison has no calendar-month gaps and flag
+#' thin-coverage months (S24)
+#'
+#' Guards against the #656 defect class: `stk_all_comparison`
+#' (R/plan_stock_backtest.R) used to chain four `inner_join()`s across its
+#' constituent strategies (`stk_max`, `stk_drif`, `fac_max`, `fac_drif`) --
+#' the SAME four constituents and the SAME hazard as the #641 `port_returns`
+#' defect (S13) -- so any month missing from ONE constituent silently
+#' deleted that month for ALL FOUR. Unlike `port_returns`, this target had
+#' ZERO instrumentation before #656 and feeds `stk_all_comparison_plot`,
+#' published on BOTH `leaderboard.qmd` and `stock-backtest.qmd`.
+#' `stk_all_comparison` is now built from a calendar-complete monthly spine
+#' (bounded to the stock-level overlap window) with everything LEFT-joined
+#' onto it -- a missing constituent surfaces as an explicit NA in its own
+#' column, never a deleted row.
+#'
+#' Two assertions, mirroring `check_portfolio_join_coverage()` (S13):
+#'   1. `cli_abort()` if the `ym` column has ANY calendar-month gap between
+#'      its min and max -- structurally this should be impossible given the
+#'      spine-based join described above, so a gap here means the spine
+#'      construction was changed back to using literal `ym` values, or
+#'      `stk_max_portfolio`/`stk_drif_portfolio` no longer overlap at all.
+#'   2. `cli_warn()` (deliberately NOT abort) for any row where fewer than
+#'      all 4 constituents report a value -- the equity-growth columns hold
+#'      flat (no compounding) across such a gap rather than propagating NA
+#'      forward (see `cumgrowth_na_safe()` in the `stk_all_comparison`
+#'      target), so a gap here degrades one curve's fidelity rather than
+#'      breaking the pipeline; still worth surfacing if it grows.
+#'
+#' @param stk_all_comparison Tibble from the `stk_all_comparison` target;
+#'   must have `ym`, `stk_max`, `stk_drif`, `fac_max`, `fac_drif`.
+#' @return `TRUE` invisibly (assertion 1 always holds on return; assertion 2
+#'   may have warned).
+#' @noRd
+check_stk_all_comparison_coverage <- function(stk_all_comparison) {
+  required_cols <- c("ym", "stk_max", "stk_drif", "fac_max", "fac_drif")
+  missing_cols <- setdiff(required_cols, names(stk_all_comparison))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "stk_all_comparison is missing {length(missing_cols)} required column(s): {missing_cols}.",
+      "i" = "check_stk_all_comparison_coverage() (S24) requires ym, stk_max, stk_drif, fac_max, fac_drif."
+    ))
+  }
+
+  # ── Assertion 1: no calendar-month gap in the ym sequence ───────────────
+  yms <- sort(unique(stk_all_comparison$ym))
+  expected_ym <- format(
+    seq(as.Date(paste0(min(yms), "-01")), as.Date(paste0(max(yms), "-01")), by = "month"),
+    "%Y-%m"
+  )
+  missing_months <- setdiff(expected_ym, yms)
+
+  if (length(missing_months) > 0L) {
+    cli::cli_abort(c(
+      "x" = paste0(
+        "stk_all_comparison has ", length(missing_months),
+        " calendar-month gap(s) in its ym sequence:"
+      ),
+      setNames(sprintf("  %s", missing_months), rep("i", length(missing_months))),
+      "i" = paste0(
+        "stk_all_comparison builds a calendar-complete spine specifically ",
+        "so this cannot happen (#656) -- check for a changed spine/join in ",
+        "R/plan_stock_backtest.R or a new gap in stk_max_portfolio / ",
+        "stk_drif_portfolio."
+      )
+    ))
+  }
+
+  # ── Assertion 2: flag (warn, don't abort) thin-coverage months ──────────
+  strat_cols <- c("stk_max", "stk_drif", "fac_max", "fac_drif")
+  avail <- rowSums(!is.na(as.matrix(stk_all_comparison[, strat_cols])))
+  thin <- stk_all_comparison[avail < length(strat_cols), , drop = FALSE]
+
+  if (nrow(thin) > 0L) {
+    thin_msgs <- vapply(seq_len(nrow(thin)), function(i) {
+      row <- thin[i, ]
+      missing_strats <- strat_cols[is.na(row[strat_cols])]
+      sprintf("  %s -- missing: %s", row$ym, paste(missing_strats, collapse = ", "))
+    }, character(1L))
+    cli::cli_warn(c(
+      "!" = paste0(
+        length(thin_msgs), " month(s) in stk_all_comparison have at least ",
+        "one missing constituent strategy (#656):"
+      ),
+      setNames(thin_msgs, rep("i", length(thin_msgs))),
+      "i" = "Usually the benign live-edge lag between stock-level and factor-level data feeds."
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+
+#' Assert boot_monthly_returns has no calendar-month gaps and flag
+#' thin-coverage months (S25)
+#'
+#' Guards against the #603 defect class: `boot_monthly_returns`
+#' (R/plan_bootstrap_ci.R) used to chain four `inner_join()`s across the
+#' same four constituent strategies as S13/S24 (`stk_max`, `stk_drif`,
+#' `fac_max`, `fac_drif`), silently deleting ~128 of an expected ~190+
+#' months. Worse than S13/S24: the block bootstrap in `boot_draws` resamples
+#' CONTIGUOUS row-index blocks to preserve serial dependence, so a
+#' non-contiguous join let a "3-month block" splice non-adjacent calendar
+#' months together, defeating the point of block resampling. These
+#' intervals feed `boot_ci_summary`'s `ci_crosses_zero` flag, joined onto
+#' the published leaderboard. `boot_monthly_returns` is now built from a
+#' calendar-complete monthly spine (bounded to the stock-level overlap
+#' window) with everything LEFT-joined onto it.
+#'
+#' Two assertions, mirroring `check_portfolio_join_coverage()` (S13) and
+#' `check_stk_all_comparison_coverage()` (S24):
+#'   1. `cli_abort()` if the `ym` column has ANY calendar-month gap --
+#'      structurally impossible given the spine-based join.
+#'   2. `cli_warn()` (deliberately NOT abort) for any row where fewer than
+#'      all 4 constituents report a value -- `calc_boot_metrics()` (the
+#'      `boot_metrics` target) drops NA pairwise per strategy/rf pair, so
+#'      this degrades that strategy's effective bootstrap sample size for
+#'      that block rather than breaking the pipeline.
+#'
+#' @param boot_monthly_returns Tibble from the `boot_monthly_returns`
+#'   target; must have `ym`, `stk_max`, `stk_drif`, `fac_max`, `fac_drif`
+#'   (the `_rf` columns are not required for this check).
+#' @return `TRUE` invisibly (assertion 1 always holds on return; assertion 2
+#'   may have warned).
+#' @noRd
+check_boot_monthly_returns_coverage <- function(boot_monthly_returns) {
+  required_cols <- c("ym", "stk_max", "stk_drif", "fac_max", "fac_drif")
+  missing_cols <- setdiff(required_cols, names(boot_monthly_returns))
+  if (length(missing_cols) > 0L) {
+    cli::cli_abort(c(
+      "x" = "boot_monthly_returns is missing {length(missing_cols)} required column(s): {missing_cols}.",
+      "i" = "check_boot_monthly_returns_coverage() (S25) requires ym, stk_max, stk_drif, fac_max, fac_drif."
+    ))
+  }
+
+  # ── Assertion 1: no calendar-month gap in the ym sequence ───────────────
+  yms <- sort(unique(boot_monthly_returns$ym))
+  expected_ym <- format(
+    seq(as.Date(paste0(min(yms), "-01")), as.Date(paste0(max(yms), "-01")), by = "month"),
+    "%Y-%m"
+  )
+  missing_months <- setdiff(expected_ym, yms)
+
+  if (length(missing_months) > 0L) {
+    cli::cli_abort(c(
+      "x" = paste0(
+        "boot_monthly_returns has ", length(missing_months),
+        " calendar-month gap(s) in its ym sequence:"
+      ),
+      setNames(sprintf("  %s", missing_months), rep("i", length(missing_months))),
+      "i" = paste0(
+        "boot_monthly_returns builds a calendar-complete spine specifically ",
+        "so this cannot happen (#603/#656) -- check for a changed spine/join ",
+        "in R/plan_bootstrap_ci.R or a new gap in stk_max_portfolio / ",
+        "stk_drif_portfolio. A gap here also means the block bootstrap in ",
+        "boot_draws would splice non-adjacent calendar months (the original ",
+        "#603 defect)."
+      )
+    ))
+  }
+
+  # ── Assertion 2: flag (warn, don't abort) thin-coverage months ──────────
+  strat_cols <- c("stk_max", "stk_drif", "fac_max", "fac_drif")
+  avail <- rowSums(!is.na(as.matrix(boot_monthly_returns[, strat_cols])))
+  thin <- boot_monthly_returns[avail < length(strat_cols), , drop = FALSE]
+
+  if (nrow(thin) > 0L) {
+    thin_msgs <- vapply(seq_len(nrow(thin)), function(i) {
+      row <- thin[i, ]
+      missing_strats <- strat_cols[is.na(row[strat_cols])]
+      sprintf("  %s -- missing: %s", row$ym, paste(missing_strats, collapse = ", "))
+    }, character(1L))
+    cli::cli_warn(c(
+      "!" = paste0(
+        length(thin_msgs), " month(s) in boot_monthly_returns have at ",
+        "least one missing constituent strategy (#603/#656):"
+      ),
+      setNames(thin_msgs, rep("i", length(thin_msgs))),
+      "i" = "calc_boot_metrics() drops NA pairwise per strategy, so this cannot poison another strategy's bootstrap draws."
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+
 #' Assert every strategy's borrow_status is derivable, in the allowed
 #' vocabulary, and consistent with borrow_rate_annual (S16)
 #'
@@ -2267,6 +2453,40 @@ plan_qa_gates <- function() {
       command = {
         check_leaderboard_cost_metrics_joint_presence(leaderboard)
         cli::cli_inform(c("v" = "qa_leaderboard_cost_metrics_coverage: S23 passed (net_cagr/cvar_95/credible jointly present or jointly NA on every row)"))
+        TRUE
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: stk_all_comparison has no calendar-month gaps, thin-coverage
+    # months are flagged (S24, #656) -- guards against the #656 defect class
+    # where a 4-way inner_join chain (the SAME constituents as the #641
+    # port_returns defect, S13) silently deleted any month missing from ONE
+    # constituent strategy for ALL FOUR. stk_all_comparison feeds
+    # stk_all_comparison_plot, published on BOTH leaderboard.qmd and
+    # stock-backtest.qmd, and previously had zero instrumentation.
+    targets::tar_target(
+      qa_stk_all_comparison_coverage,
+      command = {
+        check_stk_all_comparison_coverage(stk_all_comparison)
+        cli::cli_inform(c("v" = "qa_stk_all_comparison_coverage: S24 passed (no calendar-month gaps in stk_all_comparison)"))
+        TRUE
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: boot_monthly_returns has no calendar-month gaps, thin-coverage
+    # months are flagged (S25, #603/#656) -- guards against the #603 defect
+    # class where a 4-way inner_join chain dropped ~1/3 of months AND let
+    # the block bootstrap in boot_draws splice non-adjacent calendar months
+    # together, defeating serial-dependence-preserving resampling. These
+    # intervals feed boot_ci_summary's ci_crosses_zero flag, published on
+    # the leaderboard.
+    targets::tar_target(
+      qa_boot_monthly_returns_coverage,
+      command = {
+        check_boot_monthly_returns_coverage(boot_monthly_returns)
+        cli::cli_inform(c("v" = "qa_boot_monthly_returns_coverage: S25 passed (no calendar-month gaps in boot_monthly_returns)"))
         TRUE
       },
       cue = targets::tar_cue(mode = "always")

--- a/R/plan_stock_backtest.R
+++ b/R/plan_stock_backtest.R
@@ -1223,6 +1223,21 @@ plan_stock_backtest <- function() {
     }),
 
     # ── All strategies comparison ─────────────────────────────────
+    #
+    # #656: this used to be a 4-way inner_join chain identical to the #641
+    # port_returns defect and the #603 boot_monthly_returns defect -- any
+    # month missing from ONE constituent silently deleted that month for ALL
+    # FOUR. Unlike those two, stk_all_comparison had ZERO instrumentation
+    # (no contiguity diagnostic, no QA gate) and feeds
+    # stk_all_comparison_plot, published on BOTH leaderboard.qmd and
+    # stock-backtest.qmd.
+    #
+    # Fix mirrors #651/#603: a calendar-complete monthly spine bounded to
+    # the stock-level overlap window (see the identical comment on
+    # port_returns, R/plan_portfolio_opt.R, and boot_monthly_returns,
+    # R/plan_bootstrap_ci.R -- all three draw on these same four
+    # constituents), LEFT-joined so a missing constituent is an explicit NA
+    # in its own column rather than a deleted row.
     targets::tar_target(stk_all_comparison, {
       library(dplyr)
 
@@ -1231,16 +1246,69 @@ plan_stock_backtest <- function() {
       fac_max <- fm_portfolio |> select(ym, fac_max = portfolio_ret)
       fac_drif <- drif_portfolio |> select(ym, fac_drif = portfolio_ret)
 
-      stk_max |>
-        inner_join(stk_drif, by = "ym") |>
-        inner_join(fac_max, by = "ym") |>
-        inner_join(fac_drif, by = "ym") |>
+      spine_start <- max(min(stk_max$ym), min(stk_drif$ym))
+      spine_end   <- min(max(stk_max$ym), max(stk_drif$ym))
+      spine <- tibble::tibble(
+        ym = format(
+          seq(as.Date(paste0(spine_start, "-01")),
+              as.Date(paste0(spine_end, "-01")),
+              by = "month"),
+          "%Y-%m"
+        )
+      )
+
+      combined <- spine |>
+        left_join(stk_max, by = "ym") |>
+        left_join(stk_drif, by = "ym") |>
+        left_join(fac_max, by = "ym") |>
+        left_join(fac_drif, by = "ym")
+
+      # Fail loud, not null (fail-loud-not-null.md #4): report which months
+      # and strategies are missing rather than letting the gap pass
+      # silently. Expected to be empty in the current data -- this exists as
+      # a regression guard, not a live-defect report.
+      strat_cols <- c("stk_max", "stk_drif", "fac_max", "fac_drif")
+      avail <- rowSums(!is.na(as.matrix(combined[, strat_cols])))
+      thin <- combined[avail < length(strat_cols), , drop = FALSE]
+      if (nrow(thin) > 0L) {
+        thin_msgs <- vapply(seq_len(nrow(thin)), function(i) {
+          row <- thin[i, ]
+          missing_strats <- strat_cols[is.na(row[strat_cols])]
+          sprintf("  %s -- missing: %s", row$ym, paste(missing_strats, collapse = ", "))
+        }, character(1L))
+        cli::cli_warn(c(
+          "!" = paste0(
+            length(thin_msgs), " month(s) in stk_all_comparison have at ",
+            "least one missing constituent strategy (#656):"
+          ),
+          setNames(thin_msgs, rep("i", length(thin_msgs))),
+          "i" = paste0(
+            "Cumulative growth columns hold flat (no compounding) across a ",
+            "gap month instead of propagating NA forward -- see the ",
+            "cumgrowth_na_safe() comment below."
+          )
+        ))
+      }
+
+      # NA-safe cumulative growth: a missing month means "no observation",
+      # not "zero return", but cumprod(1 + NA) propagates NA forward to
+      # EVERY subsequent element (fail-loud-not-null.md's forward-
+      # propagation trap) -- which would permanently poison the equity
+      # curve and stk_all_caption's use of the LAST cum value
+      # (fmt_growth(last$stk_max_cum)) from that gap onward. Hold the
+      # cumulative value flat across a gap month instead; the underlying
+      # return column (stk_max/stk_drif/fac_max/fac_drif) keeps its real NA
+      # for NA-aware stats (stk_all_caption's fmt_vol() already uses
+      # sd(..., na.rm = TRUE)).
+      cumgrowth_na_safe <- function(ret) cumprod(1 + tidyr::replace_na(ret, 0))
+
+      combined |>
         mutate(
           date = as.Date(paste0(ym, "-15")),
-          stk_max_cum = cumprod(1 + stk_max),
-          stk_drif_cum = cumprod(1 + stk_drif),
-          fac_max_cum = cumprod(1 + fac_max),
-          fac_drif_cum = cumprod(1 + fac_drif)
+          stk_max_cum = cumgrowth_na_safe(stk_max),
+          stk_drif_cum = cumgrowth_na_safe(stk_drif),
+          fac_max_cum = cumgrowth_na_safe(fac_max),
+          fac_drif_cum = cumgrowth_na_safe(fac_drif)
         )
     }),
 

--- a/tests/testthat/_snaps/boot-monthly-returns-coverage.md
+++ b/tests/testthat/_snaps/boot-monthly-returns-coverage.md
@@ -1,0 +1,29 @@
+# check_boot_monthly_returns_coverage aborts when a calendar month is missing entirely (#603)
+
+    Code
+      check_boot_monthly_returns_coverage(gapped_boot_monthly_returns)
+    Condition
+      Error in `check_boot_monthly_returns_coverage()`:
+      x boot_monthly_returns has 1 calendar-month gap(s) in its ym sequence:
+      i  2021-03
+      i boot_monthly_returns builds a calendar-complete spine specifically so this cannot happen (#603/#656) -- check for a changed spine/join in R/plan_bootstrap_ci.R or a new gap in stk_max_portfolio / stk_drif_portfolio. A gap here also means the block bootstrap in boot_draws would splice non-adjacent calendar months (the original #603 defect).
+
+# check_boot_monthly_returns_coverage names the missing constituents for a thin-coverage month
+
+    Code
+      check_boot_monthly_returns_coverage(thin_march)
+    Condition
+      Warning:
+      ! 1 month(s) in boot_monthly_returns have at least one missing constituent strategy (#603/#656):
+      i  2021-03 -- missing: stk_drif, fac_max, fac_drif
+      i calc_boot_metrics() drops NA pairwise per strategy, so this cannot poison another strategy's bootstrap draws.
+
+# check_boot_monthly_returns_coverage throws when required columns are missing
+
+    Code
+      check_boot_monthly_returns_coverage(bad)
+    Condition
+      Error in `check_boot_monthly_returns_coverage()`:
+      x boot_monthly_returns is missing 1 required column(s): stk_drif.
+      i check_boot_monthly_returns_coverage() (S25) requires ym, stk_max, stk_drif, fac_max, fac_drif.
+

--- a/tests/testthat/_snaps/stk-all-comparison-coverage.md
+++ b/tests/testthat/_snaps/stk-all-comparison-coverage.md
@@ -1,0 +1,29 @@
+# check_stk_all_comparison_coverage aborts when a calendar month is missing entirely (#656)
+
+    Code
+      check_stk_all_comparison_coverage(gapped_stk_all_comparison)
+    Condition
+      Error in `check_stk_all_comparison_coverage()`:
+      x stk_all_comparison has 1 calendar-month gap(s) in its ym sequence:
+      i  2021-03
+      i stk_all_comparison builds a calendar-complete spine specifically so this cannot happen (#656) -- check for a changed spine/join in R/plan_stock_backtest.R or a new gap in stk_max_portfolio / stk_drif_portfolio.
+
+# check_stk_all_comparison_coverage names the missing constituents for a thin-coverage month
+
+    Code
+      check_stk_all_comparison_coverage(thin_march)
+    Condition
+      Warning:
+      ! 1 month(s) in stk_all_comparison have at least one missing constituent strategy (#656):
+      i  2021-03 -- missing: stk_drif, fac_max, fac_drif
+      i Usually the benign live-edge lag between stock-level and factor-level data feeds.
+
+# check_stk_all_comparison_coverage throws when required columns are missing
+
+    Code
+      check_stk_all_comparison_coverage(bad)
+    Condition
+      Error in `check_stk_all_comparison_coverage()`:
+      x stk_all_comparison is missing 1 required column(s): stk_drif.
+      i check_stk_all_comparison_coverage() (S24) requires ym, stk_max, stk_drif, fac_max, fac_drif.
+

--- a/tests/testthat/test-boot-monthly-returns-coverage.R
+++ b/tests/testthat/test-boot-monthly-returns-coverage.R
@@ -1,0 +1,101 @@
+testthat::local_edition(3)
+# Tests for check_boot_monthly_returns_coverage() — QA gate S25 (#603/#656)
+#
+# The function is defined in R/plan_qa_gates.R and depends on nothing else
+# in this repo, so it is exercised directly without running tar_make().
+#
+# Background (#603/#656): boot_monthly_returns used to chain four
+# inner_join()s across its constituent strategies (stk_max, stk_drif,
+# fac_max, fac_drif) — the SAME four constituents and the SAME hazard as the
+# #641 port_returns defect (S13) and the #656 stk_all_comparison defect
+# (S24) — so any month missing from ONE constituent silently deleted that
+# month for ALL FOUR (historically ~128 of ~190 rows, #603). Worse: the
+# block bootstrap in boot_draws (R/plan_bootstrap_ci.R) resamples
+# CONTIGUOUS row-index blocks, so a non-contiguous join let a block splice
+# non-adjacent calendar months together, defeating the point of block
+# resampling. The join in R/plan_bootstrap_ci.R is now a calendar-complete
+# spine with everything LEFT-joined onto it — a missing constituent
+# surfaces as an explicit NA in that column, not a deleted row. This gate
+# catches a recurrence of the deleted-row defect and flags (without
+# aborting) genuinely thin-coverage months.
+
+source(here::here("R/plan_qa_gates.R"))
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+# 12 calendar-complete months, all four constituents present every month.
+good_boot_monthly_returns <- tibble::tibble(
+  ym       = format(seq.Date(as.Date("2021-01-15"), as.Date("2021-12-15"), by = "month"), "%Y-%m"),
+  stk_max  = seq(0.01, 0.12, length.out = 12L),
+  stk_drif = seq(0.02, 0.13, length.out = 12L),
+  fac_max  = seq(0.005, 0.06, length.out = 12L),
+  fac_drif = seq(0.003, 0.05, length.out = 12L)
+)
+
+# March is entirely absent from the ym column -- the pre-#603 symptom (a row
+# deleted outright), which should be structurally impossible after the
+# spine fix and MUST abort if it recurs.
+gapped_boot_monthly_returns <- good_boot_monthly_returns[good_boot_monthly_returns$ym != "2021-03", ]
+
+# All 12 months present, but March has only 1 of 4 constituents (stk_max) --
+# the expected, benign live-edge-lag shape after the #603/#656 fix. Must
+# warn, not abort.
+thin_march <- good_boot_monthly_returns
+thin_march$stk_drif[thin_march$ym == "2021-03"] <- NA_real_
+thin_march$fac_max[thin_march$ym == "2021-03"]  <- NA_real_
+thin_march$fac_drif[thin_march$ym == "2021-03"] <- NA_real_
+
+# ── Tests: assertion 1 (no calendar-month gap) ─────────────────────────────
+
+test_that("check_boot_monthly_returns_coverage passes on a calendar-complete ym sequence", {
+  expect_true(check_boot_monthly_returns_coverage(good_boot_monthly_returns))
+})
+
+test_that("check_boot_monthly_returns_coverage aborts when a calendar month is missing entirely (#603)", {
+  expect_error(
+    check_boot_monthly_returns_coverage(gapped_boot_monthly_returns),
+    regexp = "2021-03"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_boot_monthly_returns_coverage(gapped_boot_monthly_returns)
+  )
+})
+
+# ── Tests: assertion 2 (thin-coverage warning, not abort) ──────────────────
+
+test_that("check_boot_monthly_returns_coverage warns (does not abort) on a thin-coverage month", {
+  expect_warning(
+    result <- check_boot_monthly_returns_coverage(thin_march),
+    regexp = "2021-03"
+  )
+  expect_true(result)  # still returns TRUE -- a warning is not a failure
+})
+
+test_that("check_boot_monthly_returns_coverage names the missing constituents for a thin-coverage month", {
+  expect_warning(
+    check_boot_monthly_returns_coverage(thin_march),
+    regexp = "stk_drif, fac_max, fac_drif"
+  )
+  expect_snapshot(
+    check_boot_monthly_returns_coverage(thin_march)
+  )
+})
+
+test_that("check_boot_monthly_returns_coverage does not warn when every month has all 4 constituents", {
+  expect_no_warning(check_boot_monthly_returns_coverage(good_boot_monthly_returns))
+})
+
+# ── Tests: required columns ───────────────────────────────────────────────────
+
+test_that("check_boot_monthly_returns_coverage throws when required columns are missing", {
+  bad <- dplyr::select(good_boot_monthly_returns, -stk_drif)
+  expect_error(
+    check_boot_monthly_returns_coverage(bad),
+    regexp = "stk_drif"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_boot_monthly_returns_coverage(bad)
+  )
+})

--- a/tests/testthat/test-stk-all-comparison-coverage.R
+++ b/tests/testthat/test-stk-all-comparison-coverage.R
@@ -1,0 +1,99 @@
+testthat::local_edition(3)
+# Tests for check_stk_all_comparison_coverage() — QA gate S24 (#656)
+#
+# The function is defined in R/plan_qa_gates.R and depends on nothing else
+# in this repo, so it is exercised directly without running tar_make().
+#
+# Background (#656): stk_all_comparison used to chain four inner_join()s
+# across its constituent strategies (stk_max, stk_drif, fac_max, fac_drif) —
+# the SAME four constituents and the SAME hazard as the #641 port_returns
+# defect (S13) — so any month missing from ONE constituent silently deleted
+# that month for ALL FOUR. Unlike port_returns, this target had ZERO
+# instrumentation before #656 and feeds stk_all_comparison_plot, published
+# on both leaderboard.qmd and stock-backtest.qmd. The join in
+# R/plan_stock_backtest.R is now a calendar-complete spine with everything
+# LEFT-joined onto it — a missing constituent surfaces as an explicit NA in
+# that column, not a deleted row. This gate catches a recurrence of the
+# deleted-row defect and flags (without aborting) genuinely thin-coverage
+# months.
+
+source(here::here("R/plan_qa_gates.R"))
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+# 12 calendar-complete months, all four constituents present every month.
+good_stk_all_comparison <- tibble::tibble(
+  ym       = format(seq.Date(as.Date("2021-01-15"), as.Date("2021-12-15"), by = "month"), "%Y-%m"),
+  stk_max  = seq(0.01, 0.12, length.out = 12L),
+  stk_drif = seq(0.02, 0.13, length.out = 12L),
+  fac_max  = seq(0.005, 0.06, length.out = 12L),
+  fac_drif = seq(0.003, 0.05, length.out = 12L)
+)
+
+# March is entirely absent from the ym column -- the pre-#656 symptom (a row
+# deleted outright), which should be structurally impossible after the
+# spine fix and MUST abort if it recurs.
+gapped_stk_all_comparison <- good_stk_all_comparison[good_stk_all_comparison$ym != "2021-03", ]
+
+# All 12 months present, but March has only 1 of 4 constituents (stk_max) --
+# the expected, benign live-edge-lag shape after the #656 fix. Must warn,
+# not abort.
+thin_march <- good_stk_all_comparison
+thin_march$stk_drif[thin_march$ym == "2021-03"] <- NA_real_
+thin_march$fac_max[thin_march$ym == "2021-03"]  <- NA_real_
+thin_march$fac_drif[thin_march$ym == "2021-03"] <- NA_real_
+
+# ── Tests: assertion 1 (no calendar-month gap) ─────────────────────────────
+
+test_that("check_stk_all_comparison_coverage passes on a calendar-complete ym sequence", {
+  expect_true(check_stk_all_comparison_coverage(good_stk_all_comparison))
+})
+
+test_that("check_stk_all_comparison_coverage aborts when a calendar month is missing entirely (#656)", {
+  expect_error(
+    check_stk_all_comparison_coverage(gapped_stk_all_comparison),
+    regexp = "2021-03"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_stk_all_comparison_coverage(gapped_stk_all_comparison)
+  )
+})
+
+# ── Tests: assertion 2 (thin-coverage warning, not abort) ──────────────────
+
+test_that("check_stk_all_comparison_coverage warns (does not abort) on a thin-coverage month", {
+  expect_warning(
+    result <- check_stk_all_comparison_coverage(thin_march),
+    regexp = "2021-03"
+  )
+  expect_true(result)  # still returns TRUE -- a warning is not a failure
+})
+
+test_that("check_stk_all_comparison_coverage names the missing constituents for a thin-coverage month", {
+  expect_warning(
+    check_stk_all_comparison_coverage(thin_march),
+    regexp = "stk_drif, fac_max, fac_drif"
+  )
+  expect_snapshot(
+    check_stk_all_comparison_coverage(thin_march)
+  )
+})
+
+test_that("check_stk_all_comparison_coverage does not warn when every month has all 4 constituents", {
+  expect_no_warning(check_stk_all_comparison_coverage(good_stk_all_comparison))
+})
+
+# ── Tests: required columns ───────────────────────────────────────────────────
+
+test_that("check_stk_all_comparison_coverage throws when required columns are missing", {
+  bad <- dplyr::select(good_stk_all_comparison, -stk_drif)
+  expect_error(
+    check_stk_all_comparison_coverage(bad),
+    regexp = "stk_drif"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_stk_all_comparison_coverage(bad)
+  )
+})


### PR DESCRIPTION
## Summary

Both `boot_monthly_returns` (#603) and `stk_all_comparison` (#656) chained
four `inner_join()`s over the same four constituent strategies
(`stk_max_portfolio`, `stk_drif_portfolio`, `fm_portfolio`, `drif_portfolio`)
as the #641 `port_returns` defect fixed in #651 — any month missing from ONE
constituent silently deleted that month for ALL FOUR. #603 additionally
broke the block bootstrap: `boot_draws` resamples contiguous row-index
blocks to preserve serial dependence, and the resulting non-contiguous row
order let a block splice non-adjacent calendar months together. #656 found
`stk_all_comparison` had zero instrumentation despite feeding
`stk_all_comparison_plot` on both `leaderboard.qmd` and `stock-backtest.qmd`.

- `boot_monthly_returns` / `stk_all_comparison` now build a calendar-complete
  monthly spine (bounded to the stock-level overlap window) and `left_join`
  all four constituents onto it — a missing constituent is an explicit `NA`
  in its own column, never a deleted row.
- `calc_boot_metrics()` drops `NA` pairwise per strategy/rf pair.
- `stk_all_comparison`'s cumulative-growth columns use a new
  `cumgrowth_na_safe()` helper (holds cumulative value flat across a gap
  instead of propagating `NA` forward).
- Both targets `cli_warn()` naming any month/strategy still missing a value.
- Two new QA gates: S24 (`qa_stk_all_comparison_coverage`) and S25
  (`qa_boot_monthly_returns_coverage`), matching the S13 style.
- Updated the stale `#603` comment in `R/plan_interval_coverage.R` (the
  root cause it described was already fixed by `4d04077`).
- New snapshot-tested unit tests for both `check_*_coverage()` functions.

## Test plan

- [x] `scripts/verify.sh` — PASS (root suite 830 total, 3 known baseline
      failures, 0 skip; package suite 726 total, 1 known baseline failure,
      15 known skips — no new failures)
- [x] New snapshot tests for S24/S25 exercise both the abort-on-gap and
      warn-on-thin-coverage paths, plus required-column validation
- [x] Existing `test-plan-bootstrap-ci.R` (boot_monthly_returns/boot_metrics
      regression tests) still pass unchanged

Closes #603
Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)
