### PR TITLE
fix: sweep hardcoded rf (#608) + verify borrow_status complete (#664)

### DIFF
--- a/R/plan_commodities_momentum.R
+++ b/R/plan_commodities_momentum.R
@@ -73,9 +73,13 @@ plan_commodities_momentum <- function() {
 
     # ── Performance summary ──────────────────────────────────────────────
     targets::tar_target(commodities_perf_summary, {
+      # #608 sweep: derive rf from the shared FF3 stk_rf series (annualised
+      # arithmetic mean, same convention as sharpe_ratio_rf()'s ann_rf,
+      # R/utils_metrics.R) instead of the hardcoded 2%/yr default this
+      # function still carries for standalone/test callers.
       summarize_commodity_performance(
         backtest_results = commodities_backtest,
-        annual_rf = 0.02
+        annual_rf = mean(stk_rf$rf_ret) * 12
       )
     }),
 

--- a/R/plan_momentum_decomposition.R
+++ b/R/plan_momentum_decomposition.R
@@ -281,9 +281,13 @@ plan_momentum_decomposition <- function() {
     tar_target(
       performance_summary,
       {
+        # #608 sweep: derive rf from the shared FF3 stk_rf series (annualised
+        # arithmetic mean, same convention as sharpe_ratio_rf()'s ann_rf,
+        # R/utils_metrics.R) instead of the hardcoded 2%/yr default this
+        # function still carries for standalone/test callers.
         summarize_backtest_performance(
           backtest_results,
-          annual_rf = 0.02
+          annual_rf = mean(stk_rf$rf_ret) * 12
         ) |>
           mutate(
             scheme_label = recode(

--- a/R/plan_regime_momentum.R
+++ b/R/plan_regime_momentum.R
@@ -39,9 +39,14 @@ plan_regime_momentum <- function() {
         library(dplyr)
         source(here::here("R/regime_momentum.R"))
 
+        # #608 sweep: derive rf from the shared FF3 stk_rf series (annualised
+        # arithmetic mean, same convention as sharpe_ratio_rf()'s ann_rf,
+        # R/utils_metrics.R) instead of the hardcoded 2%/yr default this
+        # function still carries for standalone/test callers.
         regime_conditional_performance(
           momentum_by_regime |> filter(scheme == "baseline"),
-          regime_filter = "all"
+          regime_filter = "all",
+          annual_rf = mean(stk_rf$rf_ret) * 12
         )
       }
     ),
@@ -53,9 +58,12 @@ plan_regime_momentum <- function() {
         library(dplyr)
         source(here::here("R/regime_momentum.R"))
 
+        # #608 sweep: derive rf from the shared FF3 stk_rf series -- see
+        # baseline_regime_performance above for the full rationale.
         regime_conditional_performance(
           momentum_by_regime |> filter(scheme != "baseline"),
-          regime_filter = "all"
+          regime_filter = "all",
+          annual_rf = mean(stk_rf$rf_ret) * 12
         )
       }
     ),
@@ -68,9 +76,12 @@ plan_regime_momentum <- function() {
         source(here::here("R/regime_momentum.R"))
 
         # Compute performance for all strategies across all regimes
+        # #608 sweep: derive rf from the shared FF3 stk_rf series -- see
+        # baseline_regime_performance above for the full rationale.
         all_performance <- regime_conditional_performance(
           momentum_by_regime,
-          regime_filter = "all"
+          regime_filter = "all",
+          annual_rf = mean(stk_rf$rf_ret) * 12
         )
 
         # Format for display
@@ -157,9 +168,12 @@ plan_regime_momentum <- function() {
         source(here::here("R/regime_momentum.R"))
 
         # Get all performance metrics
+        # #608 sweep: derive rf from the shared FF3 stk_rf series -- see
+        # baseline_regime_performance above for the full rationale.
         all_performance <- regime_conditional_performance(
           momentum_by_regime,
-          regime_filter = "all"
+          regime_filter = "all",
+          annual_rf = mean(stk_rf$rf_ret) * 12
         )
 
         plot_regime_sharpe(all_performance)
@@ -209,9 +223,12 @@ plan_regime_momentum <- function() {
         library(dplyr)
         source(here::here("R/regime_momentum.R"))
 
+        # #608 sweep: derive rf from the shared FF3 stk_rf series -- see
+        # baseline_regime_performance above for the full rationale.
         all_performance <- regime_conditional_performance(
           momentum_by_regime,
-          regime_filter = "all"
+          regime_filter = "all",
+          annual_rf = mean(stk_rf$rf_ret) * 12
         )
 
         # For each strategy, find best and worst regime
@@ -252,9 +269,12 @@ plan_regime_momentum <- function() {
         library(dplyr)
         source(here::here("R/regime_momentum.R"))
 
+        # #608 sweep: derive rf from the shared FF3 stk_rf series -- see
+        # baseline_regime_performance above for the full rationale.
         all_performance <- regime_conditional_performance(
           momentum_by_regime,
-          regime_filter = "all"
+          regime_filter = "all",
+          annual_rf = mean(stk_rf$rf_ret) * 12
         )
 
         # Test: Are there any positive Sharpes in decomposed strategies?

--- a/R/plan_zakamulin_allocation.R
+++ b/R/plan_zakamulin_allocation.R
@@ -210,7 +210,14 @@ plan_zakamulin_allocation <- function() {
       {
         source(here::here("R/zakamulin_allocation.R"))
 
-        summarize_regime_allocation(zak_all_backtests) |>
+        # #608 sweep: derive rf from the shared FF3 stk_rf series (annualised
+        # arithmetic mean, same convention as sharpe_ratio_rf()'s ann_rf,
+        # R/utils_metrics.R) instead of the hardcoded 2%/yr default this
+        # function still carries for standalone/test callers.
+        summarize_regime_allocation(
+          zak_all_backtests,
+          annual_rf = mean(stk_rf$rf_ret) * 12
+        ) |>
           mutate(
             allocation_label = recode(
               allocation_fn,
@@ -463,7 +470,12 @@ plan_zakamulin_allocation <- function() {
       {
         library(dplyr)
 
-        perf <- summarize_regime_allocation(zak_all_backtests)
+        # #608 sweep: derive rf from the shared FF3 stk_rf series -- see
+        # zak_performance_table above for the full rationale.
+        perf <- summarize_regime_allocation(
+          zak_all_backtests,
+          annual_rf = mean(stk_rf$rf_ret) * 12
+        )
 
         best <- perf |>
           arrange(desc(sharpe_allocated)) |>


### PR DESCRIPTION
## Summary

Closes #608, Closes #664.

Both issues turned out to be substantially already resolved before this PR —
this PR finishes #608's sweep and verifies #664 is complete.

### #608 — rf_annual hardcoded at 2% in plan_backtest.R

The issue's own named defect (`R/plan_backtest.R:184`) was already fixed by
#677 (Sharpe, merged) and #746 (Sortino, merged) before this PR. The
maintainer's issue comment (2026-08-24) explicitly left it open pending a
sweep: *"Leaving this open only if there is a remaining rf assumption
elsewhere worth sweeping; the plan_backtest.R instance this issue names is
resolved."*

That sweep is what this PR does. It found **10 call sites across 4
exploratory research plans** (Issue #121/#123/#134 investigations — none feed
the leaderboard) still using each function's own `annual_rf = 0.02` default
instead of the canonical shared `stk_rf` series (FF3 daily RF resampled
monthly, already available to every target in the pipeline):

| File | Target(s) | Call sites |
|---|---|---|
| `R/plan_commodities_momentum.R` | `commodities_perf_summary` | 1 |
| `R/plan_momentum_decomposition.R` | `performance_summary` | 1 |
| `R/plan_zakamulin_allocation.R` | `zak_performance_table`, `zak_summary` | 2 |
| `R/plan_regime_momentum.R` | 6 targets calling `regime_conditional_performance()` | 6 |

Each now passes `annual_rf = mean(stk_rf$rf_ret) * 12` — the same
annualisation convention `sharpe_ratio_rf()` already uses for `ann_rf`
(`R/utils_metrics.R`), so this is consistent with the canonical family rather
than a second convention. The underlying functions keep their own
`annual_rf = 0.02` default unchanged (only the pipeline call sites were
swept) — `tests/testthat/test-zakamulin-allocation.R` calls
`summarize_regime_allocation()` directly with an explicit `annual_rf = 0.02`,
so that default stays a valid, testable fallback for standalone callers.

Verified: `grep -rn "annual_rf\s*=\s*0\." R/ packages/historicaldata/R/` and
`grep -rn "rf_annual\s*<-\s*0\."` now return nothing outside doc comments and
`@param ... (default 0.02)` roxygen tags (which describe the *function's*
documented default, not a pipeline hardcode).

### #664 — borrow_rate_annual == NA conflates two states

Investigated expecting to implement the borrow-status disambiguation. It was
already fully implemented by #675 and #676 (both merged, neither PR used a
closing keyword):

- `BORROW_STATUS_ALLOWED` vocabulary + `derive_borrow_status()`
  (`R/plan_cost_convention.R`) — machine-readable `borrow_status` column,
  derived from `strategy_names$directionality` + `borrow_rate_annual`
  presence, with 5 documented overrides for cases directionality alone can't
  resolve (Value HML, PSO Optimal, Avoid Worst, Managed Futures, CMR).
- `cli_warn` at pipeline time listing any strategy whose status is
  `"unmodelled"` (`strategy_cost_convention` target).
- QA gate **S16** (`check_borrow_status_registry`) + sibling **S18**,
  asserting `borrow_status` is derivable, in-vocabulary, and consistent with
  `borrow_rate_annual`.
- Surfaced on the leaderboard: `docs/leaderboard.qmd`'s borrow-rate
  sensitivity sweep tab renders a "Borrow Status" column.
- #676 also fixed the three overstated strategies #664's own body named:
  Mom Pre-Peak, Mom Post-Peak, Mom 12-2 moved from `"unmodelled"` to
  `"modelled"` (0.5%/yr GC-rate borrow charge added); CMR reclassified
  `"not_applicable"` (commodity futures, no equity-style short leg).
  **Currently zero strategies derive to `"unmodelled"`.**

No code change was needed for #664 — this PR closes it on verification.

#### Two already-tracked or newly-flagged loose ends (not fixed here)

1. The 0.5%/yr GC borrow rate itself is a `# MANUAL: no source` estimate.
   This is **already tracked and deliberately parked in #688**, which
   explains why: no free machine-readable equity/GC-borrow series exists,
   buying an institutional one is judged the wrong trade for a research repo,
   and `borrow_sensitivity_sweep` publishes the CAGR/Sharpe impact across a
   range of rates instead of asserting one number to false precision.
   Nothing new to do here — flagged only so the reviewer doesn't need to
   re-derive that this is a known, considered gap.
2. **Newly flagged, not yet tracked in any issue**: `#676`'s own PR body
   noted *"the walk-forward gauntlet (plan_mom_prepeak_gauntlet.R) still
   evaluates on the pre-#665 zero-borrow cost basis — an apples-to-oranges
   gap of the #624/#664 class, deliberately left for a separate decision"*.
   That gap is still present (`R/plan_mom_prepeak_gauntlet.R` does not pass
   `mom_prepeak_params$borrow_rate_annual` into its calls). This dispatch's
   task scope only authorised `gh issue view` / `gh pr create`, not
   `gh issue create`, so I have not filed a tracking issue for it — flagging
   it here for the maintainer to decide whether it warrants one.

## Verification

`scripts/verify.sh` run in the foreground, full mode (parse + docs/_targets.R
structural validate + root suite + package suite):

```
::VERIFY:PARSE_OK::
::VERIFY:DOCS_PARSE_OK:: TRUE
::VERIFY:TAR_VALIDATE_OK:: TRUE
::VERIFY:EDITION:: 3
::VERIFY:PKG_SUMMARY:: total=726 failed=1 skipped=15

=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly

=== scripts/verify.sh: PASS ===
```

Exit code `0`. Root suite: 3/3 baseline failures matched exactly, 0
unexpected. Package suite: 726 total, 1/1 baseline failure matched exactly,
15/15 baseline skips matched exactly (4 `{alphavantager}` not installed + 11
`HD_TEST_LIVE`-gated). No new failures, no new skips.

`scripts/build.sh` (full `tar_make()` against the real pipeline) was **not**
run — per `.claude/CLAUDE.md`'s verification table it is main-checkout-only
(a worktree has no store and must not build one that could race the main
checkout's `docs/_targets` store) and takes 40+ minutes. The 4 files touched
here are exploratory-only plans (none feed `leaderboard`), so `verify.sh`'s
structural validation (`tar_validate()` against `docs/_targets.R`) plus the
parse checks are the applicable gate for this change; a maintainer running
`scripts/build.sh` locally will exercise the actual target bodies.

## Test plan

- [x] `scripts/verify.sh` (foreground, full mode) — PASS, exit 0
- [x] Swept `R/` and `packages/historicaldata/R/` for any remaining hardcoded
      `annual_rf`/`rf_annual` pipeline call sites — none found
- [ ] Maintainer: confirm closing #608/#664 is correct given the analysis
      above, and decide whether the gauntlet gap (item 2) warrants its own
      issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
