### PR TITLE
fix(tests): tests/testthat.R sets NOT_CRAN + TESTTHAT_EDITION itself (#574)

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,21 +1,26 @@
 # Top-level test runner for tests/testthat/
-#
 # These tests exercise repo-root R/ scripts that are NOT part of the
 # packages/historicaldata package. They use source(here::here("R/..."))
 # to load standalone utilities (utils_metrics.R, utils_align.R, etc.)
-# directly — sourcing is intentional here because these functions live
+# directly - sourcing is intentional here because these functions live
 # only at the repo root, outside any package namespace.
 #
-# Run via:
-#   nix develop --command Rscript -e 'testthat::test_dir("tests/testthat")'
-# or:
+# CANONICAL entry point: scripts/verify.sh. Prefer it -- it also validates
+# both _targets.R pipelines, checks dashboard freshness, compares failures
+# against the known baseline (issue #569), and enforces the package-suite
+# skip-count baseline (#654).
+#
+# This script is that entry point's underlying test runner, and is also a
+# safe fallback if you need to run just the root suite directly:
 #   nix develop --command Rscript tests/testthat.R
+#
+# It sets NOT_CRAN and TESTTHAT_EDITION itself so it is safe however invoked.
+# Do NOT use a bare testthat::test_dir("tests/testthat") one-liner instead --
+# that leaves NOT_CRAN unset, silently skipping every skip_on_cran()-gated
+# test, and leaves TESTTHAT_EDITION unset, running edition 2 not 3 (#574).
+Sys.setenv(NOT_CRAN = "true")
+Sys.setenv(TESTTHAT_EDITION = "3")
 library(testthat)
-# Resolve tests/testthat relative to THIS script's own path, not the working
-# directory. here::here() anchors on DESCRIPTION from the cwd — when Rscript
-# is invoked from /tmp or another repo root it picks the wrong project root.
-# sys.frame(1)$ofile is set when the script is sourced; commandArgs("--file=")
-# is set when Rscript runs it directly. Both are normalised to absolute paths.
 this_file <- tryCatch(
   normalizePath(sys.frame(1)$ofile),
   error = function(e) {
@@ -25,4 +30,5 @@ this_file <- tryCatch(
   }
 )
 tests_dir <- file.path(dirname(this_file), "testthat")
+stopifnot(identical(edition_get(), 3L))
 testthat::test_dir(tests_dir)


### PR DESCRIPTION
## Summary

Refs #574. Fixes the core defect the issue describes (NOT_CRAN unset
silently skipping snapshot tests). Deliberately using "Refs" not "Closes" --
one item of the issue Scope is still open (see below); closing is a human call.

- `scripts/verify.sh` (from #573/#578/#579) already closed the gap for its
  own invocation path -- confirmed empirically: root suite SKIP count 0
  (not 41), edition 3 active, both suites match known baselines exactly.
- But `tests/testthat.R`'s own header recommended two invocation forms
  that still reproduce the bug -- a bare `test_dir()` one-liner, and
  `Rscript tests/testthat.R` itself -- neither set NOT_CRAN or
  TESTTHAT_EDITION. This PR fixes that: the runner now sets both itself
  and asserts edition 3 took effect before running, so it is safe however
  it is invoked, and the header now points at `scripts/verify.sh` as the
  canonical entry point.

## Checklist against issue #574's Scope section

1. Adopt `scripts/verify.sh` as the standard gate -- DONE (#573).
2. Review `_snaps/momentum-decomposition.md` before committing -- DONE (#579).
3. Re-audit the snapshot-test-policy table -- NOT done. The root suite
   alone now carries ~64 snapshot files vs the ~10 the table's
   2026-05-31 audit covered -- this is a large content-review task, not a
   quick fix, and deserves its own scoped follow-up issue rather than being
   rubber-stamped here.
4. Check CI -- checked. `r-tests.yml` uses `devtools::test()`, which sets
   NOT_CRAN=true internally (per devtools NEWS.md) and picks up edition 3
   from the package's own `Config/testthat/edition: 3` in DESCRIPTION --
   no gap there. The root suite has zero CI coverage at all, which is a
   separate, pre-existing, already-documented limitation, not the
   silent-skip failure mode this issue describes.
5. Confirm package-suite skip count is deliberate -- confirmed. 15 skips,
   all documented and gated on {alphavantager} absence or opt-in
   HD_TEST_LIVE, per #580/#654.

## Test plan

- [x] `Rscript tests/testthat.R` run directly: SKIP 0, FAIL 3 (matches the
  known #569 baseline exactly), edition-3 assertion passed.
- [x] `scripts/verify.sh` (full mode) re-run after the edit: PASS.
