### PR TITLE
docs+comments: macro_daily/equity_daily are archived, not stale-pending-refresh

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,6 +6,8 @@
 
 **Automation (issue #438):** A project-local Stop hook (`.claude/hooks/pkgctx_regen_on_stop.sh`) runs automatically at session end. If `packages/historicaldata/R/` was touched during the session it invokes `scripts/regen_api_context.sh`; otherwise it exits silently. The hook is fail-open — a regen failure prints a warning but never blocks the session. A CI check (`.github/workflows/pkgctx-check.yml`) catches any stale doc on PRs that touch `packages/historicaldata/R/` or `docs/api-historicaldata.md`.
 
+**`macro_daily`/`equity_daily` are archived, not stale-pending-refresh (#619, #655, #673):** both HuggingFace-backed datasets read by `hd_macro()`/`hd_ohlcv()` were seeded once (2026-05-06) by duplicating `dsfefvx/finance-historical-data`, which was itself already inactive by then and has had no commits since 2026-04-23. No replacement source is currently being sourced — this is a decision, not an open outage. See [`docs/DATA_SOURCING_LESSONS.md`](../docs/DATA_SOURCING_LESSONS.md) for the full retrospective (what happened, what was tried, lessons for next time) before touching any code that reasons about these datasets' staleness or the Validation-seal boundary (`R/plan_partitions.R`, `R/plan_risk_state.R`).
+
 ## Verifying a change (issue #569)
 
 **Run `scripts/verify.sh` — it is the one command to run before claiming a change is verified.** `scripts/verify.sh --quick` does a fast parse-only check; plain `scripts/verify.sh` runs the full suite. Do not hand-roll a verification sequence — every fact below was learned the slow way by agents that got it wrong.

--- a/R/plan_partitions.R
+++ b/R/plan_partitions.R
@@ -100,6 +100,30 @@
 # observation count, so an empty window silently contributes zero rows
 # rather than erroring or emitting a spurious NA row (verified per source
 # target as part of #660; see the PR report for the full list).
+#
+# ── Why the data boundary itself is not expected to move (#619/#673) ───────
+# The above described the boundary as a moving target that would eventually
+# reach val_start on its own. It will not. #619 found that `macro_daily` and
+# `equity_daily` -- the datasets that set the equity/factor/macro boundaries
+# above -- have NO producer: they were seeded once (2026-05-06) by duplicating
+# `dsfefvx/finance-historical-data` on HuggingFace, and nothing in this repo
+# has refreshed them since. #619's follow-up investigation found the upstream
+# itself went inactive on 2026-04-23 -- BEFORE we even duplicated it -- so
+# re-syncing from it gains nothing; there is no live source to catch up to.
+# #673 confirmed the same for `equity_daily` specifically (frozen at
+# 2026-04-13) and found the Validation seal on `rsc_subperiod` was, as a
+# result, being held by this outage rather than by the #660 design (fixed by
+# bounding that target at `holdout_end` -- see R/plan_risk_state.R).
+#
+# Per the project decision recorded in #619/#655/#673 and
+# docs/DATA_SOURCING_LESSONS.md, these two datasets are ARCHIVED, not
+# "pending refresh": no active work is sourcing a replacement, so treat the
+# boundary above as structurally stationary rather than "hasn't caught up
+# yet". Advancing it past val_start requires a deliberate decision to source
+# new data (see #619's revised plan: `scripts/build_macro_daily.R` +
+# `scripts/fetch_equity.py` + an upload step, none of which currently run on
+# a schedule) -- not the mere passage of time, and not another duplication of
+# the same dead upstream.
 PERIOD_LABELS_ALLOWED <- c(
   "Training", "Testing", "Holdout", "Validation", "Full Period", "OOS"
 )

--- a/R/plan_risk_state.R
+++ b/R/plan_risk_state.R
@@ -710,12 +710,25 @@ plan_risk_state <- function() {
     # the slice held no sealed data at that moment. It held none only because
     # equity_daily has NO SCHEDULED REFRESH (#673): the boundary is stationary
     # because the fetcher is unscheduled, not because it has yet to catch up.
-    # The first run of scripts/fetch_equity.py would have carried it past
-    # val_start and pulled sealed Validation returns in here, unlabelled, on
-    # the next tar_make() -- and that fetch is the PREREQUISITE for the
-    # one-shot evaluation in scripts/evaluate_validation.R. The protection
-    # would have vanished in the same action that needed it. Now bounded at
-    # holdout_end so the refresh is safe whenever it happens.
+    # A future run of scripts/fetch_equity.py would carry it past val_start
+    # and pull sealed Validation returns in here, unlabelled, on the next
+    # tar_make() -- and that fetch is the PREREQUISITE for the one-shot
+    # evaluation in scripts/evaluate_validation.R. The protection would
+    # vanish in the same action that needed it. Now bounded at holdout_end so
+    # a refresh is safe IF one ever happens.
+    #
+    # Whether one ever happens is now a settled question, not an open one:
+    # #619's follow-up investigation found `dsfefvx/finance-historical-data`
+    # (the upstream `equity_daily`/`macro_daily` were duplicated from) went
+    # inactive on 2026-04-23, before the 2026-05-06 duplication that seeded
+    # our copy -- there is no live upstream to re-sync from, and per the
+    # project decision recorded in #619/#655/#673 and
+    # docs/DATA_SOURCING_LESSONS.md, no replacement source is currently being
+    # sourced. Treat `equity_daily` as ARCHIVED (permanently frozen at
+    # 2026-04-13 absent a deliberate future decision to build a new producer),
+    # not as an outage that will resolve on its own. The bound at holdout_end
+    # stays regardless -- it is what makes ANY future refresh (scheduled or
+    # manual, from this source or a replacement) safe by construction.
     #
     # Bound is holdout_end (2026-04-30), NOT test_end (2023-12-31): this is a
     # descriptive breakdown that spans Testing and Holdout on purpose, and

--- a/docs/DATA_SOURCING_LESSONS.md
+++ b/docs/DATA_SOURCING_LESSONS.md
@@ -1,0 +1,174 @@
+# Data Sourcing: Lessons Learned
+
+Retrospective on `macro_daily` / `equity_daily` going permanently stale
+(#619, #655, #673). Follows the format of `docs/t-lang-lessons.md` — a
+project-local lessons doc, not a wiki page, because this is an engineering
+process failure rather than research content.
+
+## Status (decided, not pending)
+
+`macro_daily` and `equity_daily` — the two HuggingFace-backed datasets read
+by `historicaldata::hd_macro()` and `historicaldata::hd_ohlcv()` — are
+**archived**, not "temporarily stale" or "an outage awaiting resolution":
+
+- `macro_daily`: frozen at 2026-04-20 (measured 2026-08-01, #619)
+- `equity_daily`: frozen at 2026-04-13 (measured 2026-08-09, #673)
+
+No active work is sourcing a replacement. This is a deliberate decision, not
+an oversight — see "What we decided" below. If that decision changes, update
+this file and the code comments in `R/plan_partitions.R` and
+`R/plan_risk_state.R` that reference it.
+
+## What happened
+
+Both datasets were seeded once, on 2026-05-06, by duplicating
+`dsfefvx/finance-historical-data` on HuggingFace into our own
+`JohnGavin/finance-data` repo. Nothing in this repo has refreshed either
+file since (#619, root-cause comment, 2026-08-01):
+
+- The weekly data poll (`.github/workflows/data-poll.yml`) covers `kalshi`,
+  `ecb`, `guardian`, `commodities`, `cboe_vol` (and later `macro`,
+  `intl_vol` — see below) — it never covered `macro_daily` or `equity_daily`
+  as combined, served datasets.
+- The fetch scripts that exist (`scripts/fetch_macro.R`,
+  `scripts/fetch_equity.py`) write to different filenames
+  (`data/raw/fred_macro.parquet`, `data/raw/yfinance_equity.parquet`) than
+  what `hd_macro()`/`hd_ohlcv()` actually read
+  (`macro_daily.parquet`, `equity_daily.parquet`) — so even a manual run of
+  the fetch scripts would not have refreshed the served data.
+- Only one uploader script existed at all (`scripts/upload_kraken_hf.sh`),
+  and it is kraken-only.
+
+So this was never a job that broke — it was work that was never scheduled.
+No CI failure, no alert, nothing "red" anywhere: `hd_macro()` and
+`hd_ohlcv()` kept returning perfectly valid-looking rows, just with a
+tail that stopped moving. That is why it went unnoticed for roughly three
+months, and why it was found by chance — a one-off coverage baseline for a
+different issue (#617) — rather than by any dedicated check.
+
+The same silent staleness held the Validation seal open on `rsc_subperiod`
+(#673): `bt_partitions$equity$val_start` is 2026-05-01, and with
+`equity_daily`'s boundary stuck at 2026-04-13, the Validation window looked
+"correctly empty, as designed" (the #660 partition re-cut's stated
+rationale) when it was actually empty because the feed had stopped, not
+because the calendar hadn't caught up. The first successful
+`fetch_equity.py` run would have carried the boundary past `val_start` and
+pulled sealed Validation returns into an unbounded window
+(`rsc_subperiod`'s old trailing slice), unlabelled, in the same action that
+was supposed to produce the fix. `rsc_subperiod` is now explicitly bounded
+at `holdout_end` so this is safe regardless of whether/when a refresh
+happens — but the near-miss is the lesson: a comment asserting "this window
+is empty, that's expected" needs to say **why** it expects that, because
+the assumption behind it (the data will eventually catch up) can quietly
+stop being true.
+
+## What was tried
+
+`#619`'s investigation (2026-08-01) ran the root-cause chain to the end
+rather than stopping at "the pipe is broken":
+
+1. Confirmed no GitHub Actions workflow references `fetch_macro`,
+   `fetch_equity`, `fetch_factors`, or `fetch_crypto`.
+2. Confirmed the fetch-script output filenames do not match the served
+   dataset filenames (an undocumented rename+upload step that was never
+   built).
+3. Ran `scripts/fetch_macro.R` by hand and confirmed it still works —
+   167,150 observations, current to the day it was run, no bit rot.
+4. Checked composition against the upstream's own last commit message
+   ("78 series = 27 FRED + 46 CBOE + 5 international") and found two of the
+   three components (`fetch_macro.R`, `fetch_cboe_vol.R`) already run and
+   already write a compatible schema — the missing piece was only the
+   combine step, not new data-fetching work. `scripts/build_macro_daily.R`
+   was written to close that gap (concatenate the three raw parquets into
+   the served schema; publishing is a separate, deliberate step via
+   `scripts/upload_hf.sh`, gated on `HF_TOKEN`).
+5. Checked whether re-syncing from the upstream HuggingFace repo
+   (`dsfefvx/finance-historical-data`) would be a cheaper fix than owning
+   generation ourselves. Its commit history showed ~11 days of intense
+   activity in April 2026 (2026-04-13 through 2026-04-23), then silence —
+   100+ days with no commits as of the check. **We had duplicated an
+   upstream that had already gone quiet 13 days earlier.** Re-syncing from
+   it gains nothing: there is no live source to catch up to.
+
+`#673` separately confirmed the equity side of the same shape (no scheduled
+refresh, `.py` fetcher not wired into the `.R`-only poll matrix) and traced
+its consequence forward into the Validation-seal near-miss described above.
+
+## What we decided
+
+Given the upstream is confirmed dead and building/scheduling our own
+`equity_daily` producer (1,622 tickers, 7.1M rows, untested end-to-end) is
+real, non-trivial work, the project decision (recorded in #619, #655, #673)
+is: **do not treat this as an outage pending resolution.** Mark both
+datasets archived, correct the code comments that reasoned about the
+Validation-seal boundary as if it would naturally advance
+(`R/plan_partitions.R`, `R/plan_risk_state.R`), and leave the partial
+producer work that already exists (`scripts/build_macro_daily.R`,
+`scripts/fetch_macro.R`, `scripts/fetch_cboe_vol.R`,
+`scripts/fetch_intl_vol.R`) in place, unscheduled, as a starting point for
+if and when a future decision is made to source new data. `dv_freshness`
+(#617) — a check that would have surfaced this in days rather than months —
+remains open and unbuilt.
+
+## Lessons for next time
+
+1. **Vet an upstream's maintenance activity before depending on it as a
+   sole source.** A one-line check of `dsfefvx/finance-historical-data`'s
+   commit history (`GET /api/datasets/.../commits/main`) would have shown
+   it had already gone quiet before we ever duplicated it. That check takes
+   seconds and would have changed the decision at seed time, not three
+   months later.
+
+2. **A one-time duplication is not a producer, and nothing marks the
+   difference.** `hd_macro()`/`hd_ohlcv()` returned valid-looking data the
+   entire time; there was no error state to distinguish "actively
+   refreshed" from "seeded once, frozen forever." Any dataset brought in
+   this way needs either a real scheduled refresh wired up before it ships,
+   or an explicit, visible "archived / no refresh" marker from day one —
+   not silence that looks identical to health.
+
+3. **Consider mirroring/vendoring critical data with a generation path we
+   own**, rather than relying indefinitely on a duplicated third-party
+   snapshot with no maintenance guarantee from the source. The 2026-05-06
+   duplication was a reasonable fast start; the mistake was never following
+   it with our own producer, not the duplication itself.
+
+4. **Decide, explicitly, what "stale" means vs. "archived" for a dataset
+   with no active refresh — and say so in the code that reasons about data
+   boundaries**, not just in an issue thread. `R/plan_partitions.R` had a
+   comment calling the empty Validation window "expected, not a bug"
+   without saying whether that expectation depended on the boundary moving
+   naturally (it doesn't) — a comment that was accurate about the symptom
+   and silent about the cause is exactly the kind of gap `fail-loud-not-null`
+   is meant to close, applied to documentation rather than code.
+
+5. **A staleness check needs to distinguish "hasn't caught up yet" from
+   "there is no producer at all."** These have different fixes (wait, vs.
+   build something) and different implications for anything downstream that
+   assumes the boundary will move — like a Validation seal keyed to "the
+   first month past the current data boundary." `dv_freshness` (#617) is
+   still the right fix for surfacing this quickly next time; it did not
+   exist when this outage started, which is a large part of why it ran for
+   three months undetected.
+
+## Related
+
+- [#619](https://github.com/JohnGavin/historical/issues/619) — root-cause
+  investigation; confirmed no producer, confirmed upstream dead
+- [#655](https://github.com/JohnGavin/historical/issues/655) — a distinct
+  but adjacent case: `leaderboard_snapshot.parquet` is *deliberately* frozen
+  (a digest baseline, not a live feed) — worth reading alongside #619/#673
+  as the contrast case for lesson 4: sometimes staleness is a bug that
+  became permanent, sometimes it is the intended design, and the failure
+  mode in both directions is not saying which, explicitly, where a reader
+  will find it
+- [#673](https://github.com/JohnGavin/historical/issues/673) — `equity_daily`
+  staleness and the Validation-seal near-miss
+- [#617](https://github.com/JohnGavin/historical/issues/617) — the still-open
+  `dv_freshness` check that would have caught this sooner
+- `.claude/rules/backtest-partitions.md` — the Validation-seal rule this
+  incident's near-miss bears on
+- `.claude/rules/fail-loud-not-null.md` — the general pattern this
+  retrospective's lesson 4 and 5 are instances of
+- `R/plan_partitions.R`, `R/plan_risk_state.R` — code comments updated
+  alongside this document to reflect the archived status


### PR DESCRIPTION
## Summary

`macro_daily`/`equity_daily` (the HuggingFace-backed datasets `hd_macro()`/`hd_ohlcv()` read) are permanently frozen: their upstream (`dsfefvx/finance-historical-data`) went inactive on 2026-04-23, before we even seeded our copy on 2026-05-06 (#619's follow-up investigation). No replacement source is currently being sourced — this is a decision, not an open outage awaiting resolution.

This PR does not fetch new data or restore a refresh. It corrects how the repo *reasons about* that staleness:

- `R/plan_partitions.R` — the comment explaining why the Validation window (`val_start = 2026-05-01`) is currently empty previously framed it as "expected, not a bug" against "the current data boundary", implying the boundary would naturally catch up. It will not, absent a deliberate future decision to build a new producer. Added a section citing #619/#673 correcting this.
- `R/plan_risk_state.R` — the `rsc_subperiod` comment (already correctly bounded at `holdout_end` per #673's earlier fix) described a "future run of `scripts/fetch_equity.py`" as an expected event. Updated to note the upstream is confirmed dead and no refresh is currently planned; the bound stays regardless, since it's what makes *any* future refresh safe.
- `docs/DATA_SOURCING_LESSONS.md` (new) — the retrospective: what happened, what was tried (root-cause chain from #619, the re-sync feasibility check that found the upstream dead, the partial producer work already written in `scripts/build_macro_daily.R`), and lessons for next time (vet upstream maintenance cadence before depending on it as a sole source; a one-time duplication is not a producer; decide explicitly what "stale" vs "archived" means and say so in the code, not just an issue thread).
- `.claude/CLAUDE.md` — links the new doc so it's discoverable before anyone next touches code that reasons about these datasets' staleness or the Validation-seal boundary.

No data was deleted, no targets were removed, and no functional/logic changes were made — `rsc_subperiod`'s bound at `holdout_end` (the actual #673 fix) is unchanged.

Refs #619
Refs #655
Refs #673

These describe a permanent decision already made by the user, not a fix in the traditional sense — left for a human to decide whether/how to close each issue.

## Verification

`scripts/verify.sh` run in the foreground, full mode, exit 0:

```
PASS: _targets.R parses
PASS: docs/_targets.R parses
PASS: docs/_targets.R is structurally valid (tar_validate, 7.51s)
PASS: testthat edition 3 active
PASS: dashboard freshness (Check 1 + Check 2)

=== root suite ===
SKIP count this run: 0
PASS: failures match the known baseline exactly (3/3 baseline failures, #569)

=== package suite ===
SKIP count this run: 15
PASS: failures match the known baseline exactly (1/1 baseline failure, #569)

=== scripts/verify.sh: PASS ===
```

## Test plan

- [x] `scripts/verify.sh` (full mode) — exit 0, PASS, all baselines matched exactly, skip counts at documented baselines (0 root / 15 package)
- [ ] Human review: confirm the "archived, no active refresh" framing matches the intended decision before closing #619/#655/#673
- [ ] Human decision: whether/when to schedule the partial producer work (`scripts/build_macro_daily.R` + `scripts/fetch_macro.R`/`fetch_cboe_vol.R`/`fetch_intl_vol.R`, and the untested `equity_daily` side) if the archived decision is ever revisited

🤖 Generated with [Claude Code](https://claude.com/claude-code)
