### PR TITLE
ci(data-poll): warn before HF_TOKEN expiry, not after it fails a run (#705)

### DIFF
--- a/.github/workflows/data-poll.yml
+++ b/.github/workflows/data-poll.yml
@@ -252,22 +252,57 @@ jobs:
       # revoked, wrong scope) means the build that follows is wasted work —
       # the parquet cannot be published either way, so stop before spending
       # runner minutes on setup-r/apt-get/R-install/build_macro_daily.R.
+      #
+      # Also warns (does not fail) when a valid token is close to expiring
+      # (#705 Problem 2), so rotation happens on a schedule instead of on
+      # the next scheduled run's failure. whoami-v2's response carries an
+      # `auth.expiresAt` ISO-8601 field for tokens created WITH an expiry —
+      # confirmed against huggingface.js's own AuthInfo type
+      # (packages/hub/src/lib/who-am-i.ts, the official JS client's typed
+      # mirror of this exact endpoint's `auth` object: `type`,
+      # `accessToken`, `expiresAt`), since testing against the live field
+      # would require a real token, which this preflight is explicitly not
+      # given. A token created WITHOUT an expiry omits the field — jq's
+      # `// empty` renders that as "no expiry", not an error.
       - name: Preflight — validate HF_TOKEN before any build work
         if: env.HF_TOKEN != ''
+        env:
+          HF_TOKEN_EXPIRY_WARN_DAYS: '30'
         run: |
           set -euo pipefail
-          # -o /dev/null: never capture/echo the response body just in case
-          # it ever changed shape to include anything sensitive. Only the
-          # HTTP status is inspected. -H passes the token but the value is
-          # masked by Actions' log redaction; no -v, no echo of $HF_TOKEN.
-          status=$(curl -s -o /dev/null -w '%{http_code}' \
+          # Body IS captured now (needed for the expiry field below) but is
+          # never echoed or logged anywhere — only the two fields pulled out
+          # via jq (http status, auth.expiresAt) ever reach a log line. No
+          # -v, no echo of $HF_TOKEN, no echo of $body. -H passes the token
+          # but the value is masked by Actions' log redaction regardless.
+          response=$(curl -s -w '\n%{http_code}' \
             -H "Authorization: Bearer ${HF_TOKEN}" \
             https://huggingface.co/api/whoami-v2)
+          status="${response##*$'\n'}"
+          body="${response%$'\n'*}"
           if [ "$status" != "200" ]; then
             echo "::error::HF_TOKEN is invalid or expired — https://huggingface.co/api/whoami-v2 returned HTTP $status instead of 200. Publishing to HuggingFace would fail with this token, so failing now rather than after ~4 minutes of setup and build. Rotate it: (1) generate a new token with write access to JohnGavin/finance-data at https://huggingface.co/settings/tokens, (2) gh secret set HF_TOKEN --repo JohnGavin/historical."
             exit 1
           fi
           echo "HF_TOKEN preflight OK — whoami-v2 returned 200."
+
+          expires_at=$(printf '%s' "$body" | jq -r '.auth.expiresAt // empty' 2>/dev/null || true)
+          if [ -z "$expires_at" ] || [ "$expires_at" = "null" ]; then
+            echo "HF_TOKEN preflight: no expiry set on this token (or the field was absent from the API response) — nothing to warn about."
+          else
+            expires_epoch=$(date -u -d "$expires_at" +%s 2>/dev/null || echo '')
+            if [ -z "$expires_epoch" ]; then
+              echo "::notice::HF_TOKEN preflight: whoami-v2 returned an auth.expiresAt value that could not be parsed as a date ($expires_at). Skipping the expiry-warning check; token itself is still valid (HTTP 200 above)."
+            else
+              now_epoch=$(date -u +%s)
+              days_left=$(( (expires_epoch - now_epoch) / 86400 ))
+              if [ "$days_left" -le "$HF_TOKEN_EXPIRY_WARN_DAYS" ]; then
+                echo "::warning::HF_TOKEN expires in ${days_left} day(s) ($expires_at). Rotate it before it fails a scheduled run: (1) generate a new token with write access to JohnGavin/finance-data at https://huggingface.co/settings/tokens, (2) gh secret set HF_TOKEN --repo JohnGavin/historical."
+              else
+                echo "HF_TOKEN preflight: expires in ${days_left} day(s) ($expires_at) — beyond the ${HF_TOKEN_EXPIRY_WARN_DAYS}-day warning window, no action needed yet."
+              fi
+            fi
+          fi
 
       # The poll jobs commit their parquets during this same run, so the
       # checkout above predates them.


### PR DESCRIPTION
## Summary

Completes #705. Problem 1 ("the check happens after the work") was already
fixed and merged in #706 — this PR is Problem 2 only: warn well before a
token's expiry date, so rotation happens on a schedule instead of on the
next scheduled run's 401.

## What changed

Extended the existing "Preflight — validate HF_TOKEN before any build work"
step in `.github/workflows/data-poll.yml` (`publish-macro-daily` job). The
`curl` call now captures the response body (previously discarded via
`-o /dev/null`) alongside the HTTP status, and after the existing
valid/invalid check, parses `auth.expiresAt` out of it with `jq`.

| `auth.expiresAt` | Behaviour |
|---|---|
| absent (token has no expiry) | `HF_TOKEN preflight: no expiry set...` — no warning |
| explicit `null` | same as absent |
| present, > 30 days out | `HF_TOKEN preflight: expires in N day(s)...` — informational only |
| present, ≤ 30 days out | `::warning::` naming the days remaining and the rotation steps. Job still proceeds — this is advance notice, not a new failure mode |
| present but unparseable as a date | `::notice::`, skip the check, job still proceeds (token itself is already known-valid from the status check above) |

The 30-day threshold is a local `HF_TOKEN_EXPIRY_WARN_DAYS` env var on the
step, matching the number the issue itself suggested as reasonable.

## Establishing that the field exists (the part #706 left open)

#706 explicitly did not investigate this because it would have required a
real, currently-valid `HF_TOKEN`, and its author was told not to obtain or
use one. Same constraint applies here — I have no real token in this
environment either. So I did not probe the live endpoint's `auth` object
directly. Instead I read the **official Hugging Face JS client's own type
definition** for this exact response shape:
[`packages/hub/src/lib/who-am-i.ts`](https://github.com/huggingface/huggingface.js/blob/main/packages/hub/src/lib/who-am-i.ts)
defines:

```ts
export interface AuthInfo {
	type: AuthType;
	accessToken?: {
		displayName: string;
		role: AccessTokenRole;
		createdAt: Date;
	};
	expiresAt?: Date;
}
```

and the `whoAmI()` function in the same file assigns the raw
`whoami-v2` JSON directly onto this type (its only transform is converting
`accessToken.createdAt` from string to `Date` — it does not rename or
relocate any field). `expiresAt` is optional, consistent with the "field
absent when the token has no expiry" case the workflow now handles. This is
the maintainers' own typed mirror of the endpoint this preflight already
calls, so I'm treating it as authoritative rather than reconstructing the
schema from search snippets — no `huggingface_hub` Python source or public
API docs page documents this field explicitly, which is presumably why
#706 flagged it as unestablished.

**What I still could not do:** call the live endpoint with a real token and
observe the field firsthand. If it turns out the raw JSON key differs from
`expiresAt` (e.g. a different casing, or the JS client renames it), the
symptom will be silent — every token looks like "no expiry set", never a
false warning — because of the `// empty` fallback in the `jq` filter. That
is deliberately the fail-safe direction: worst case this PR's Problem 2
never fires and #705 needs reopening with a corrected field name; it cannot
falsely warn or falsely fail a build.

## Testing

No R surface is touched, so `scripts/verify.sh` (structure/tests only)
was still run for the standard gate and passes with only the two
pre-existing baselines (3 root suite, 1 package suite — both unrelated to
this change).

Since this is a workflow-YAML + bash change with no R code, the actual
logic was verified separately, offline, with **no real HF_TOKEN**:

1. `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/data-poll.yml'))"` → `YAML OK`.
2. A standalone script exercised the exact `jq`/`date` extraction logic
   against five synthetic whoami-v2-shaped JSON bodies (expires soon,
   expires later, no expiry field, explicit null, unparseable date) —
   all five produced the intended branch. Used `gdate` (GNU coreutils, via
   Homebrew) to mirror the GNU `date -d` behaviour of the `ubuntu-latest`
   runner, since this was tested on macOS.
3. The `curl -w '\n%{http_code}'` body/status split
   (`${response##*$'\n'}` / `${response%$'\n'*}`) was separately verified
   against a synthetic multi-line JSON body to confirm it degrades safely
   even if the response body itself ever contained embedded newlines.
4. Confirmed the actual valid-token / 200 path is still **not** tested end
   to end in CI by this PR (same limitation #706 stated) — this can only
   be observed on the next real scheduled run.

## No secret / PII leakage

Same posture as #706, extended to the now-captured body:

- No `-v`, no `echo "$HF_TOKEN"`, no echo of `$body` anywhere.
- Only two values are ever logged: the HTTP status code, and the single
  `auth.expiresAt` string pulled out via `jq -r`. The rest of the body
  (name, email, org roles) is held in a shell variable for one `jq` call
  and never printed.
- `::warning::`/`::notice::` messages name the token's *role* (rotate it,
  how) and the expiry date — never a value that could be replayed as a
  credential.

## Not in scope

Rotating the current token, or changing the threshold beyond 30 days —
this is about making the *next* expiry cheap to see coming.

Closes #705
