### PR TITLE
docs(avoid-worst-days): correct overstated VIX-leads-SPX causal claim (#611)

### DIFF
--- a/docs/avoid-worst-days.qmd
+++ b/docs/avoid-worst-days.qmd
@@ -334,7 +334,7 @@ Mkt-RF is not identical to the S&P 500 — it is the value-weighted CRSP market 
 
 A tradeable approximation: after a large daily move (shock) or when the <abbr title="CBOE Volatility Index — implied volatility of S&P 500 options">VIX</abbr> exceeds a threshold (forward-looking implied volatility), go to cash. Re-enter when VIX subsides below a re-entry threshold, with a minimum cooling-off period.
 
-The VIX is forward-looking — it prices the market's expectation of 30-day volatility from S&P 500 options. Unlike realized volatility (backward-looking), VIX rises *before* the worst days cluster, making it a practical trigger.
+The VIX is forward-looking by construction — it prices the market's expectation of 30-day volatility from S&P 500 options — but that does not by itself mean it forecasts tomorrow's SPX return. A direct SPX↔VIX lead-lag test ([#611](https://github.com/JohnGavin/historical/issues/611)) found the relationship is overwhelmingly same-day (contemporaneous correlation −0.79); VIX's level carries a small, statistically significant edge over next-day SPX returns (t = 3.15, p = 0.0016) but the effect is weak (model R² = 0.008) — consistent with the Alpha Decay finding below that honest (t+1) execution shows no exploitable speed advantage.
 
 ```{r}
 #| fig-height: 6
@@ -374,7 +374,7 @@ if (!is.null(sens)) {
 | 2 | Minimum 5 trading days in cash | Stay out (cooling-off) |
 | 3 | VIX drops below 25 **and** cooloff expired | Re-enter market |
 
-**Why VIX, not realized vol?** Realized volatility is backward-looking — by the time it spikes, the worst days have already happened. VIX is forward-looking (implied from options prices) and rises *in anticipation* of volatility, giving earlier exit signals.
+**Why VIX, not realized vol?** Realized volatility is backward-looking — by the time it spikes, the worst days have already happened. VIX is forward-looking by construction (implied from options prices), but [#611](https://github.com/JohnGavin/historical/issues/611)'s direct lead-lag test found only a small, statistically significant edge of VIX over next-day SPX (R² = 0.008) rather than the meaningful early-warning this framing implies — see Alpha Decay below, which shows no exploitable speed advantage in practice.
 
 **Why both shock AND VIX triggers?** Flash crashes (Aug 2015, Feb 2018) cause single-day shocks without sustained VIX elevation. The shock trigger catches these. Slow-building crises (2008, 2022) elevate VIX gradually — the VIX trigger catches these.
 


### PR DESCRIPTION
## Summary

#611 (aligrithm SPX/VIX lead-lag replication) found the article's causal claim ("SPX leads VIX, don't time SPX off VIX") is reversed under test -- but only weakly: VIX has a small, statistically significant edge over next-day SPX (t=3.15, p=0.0016, R2=0.008), while SPX has none over next-day VIX. The issue author's own N1 note already flags this as "not a refutation" of `avoid_worst`, just the first direct test of its premise, worth a future head-to-head (VIX-level vs SPX-drawdown/RSI trigger) as a separate research task.

## Investigation findings

**Mechanism vs narrative -- these separate cleanly:**

- `avoid_worst`'s trading rule (`R/plan_avoid_worst.R`, `aw_practical_backtest`) goes to cash when yesterday's VIX level exceeds a threshold (25/30/35/40 swept) or after a >3% daily shock. This IS "use VIX to time SPX" -- the mechanism #611 tested.
- The leaderboard's headline CAGR/Sharpe/vol/max_dd for avoid_worst (via `avoid_worst_register_runs` -> `aw_metrics`) actually come from the "Full Period / All Days" SPY buy-and-hold row, NOT the VIX-timed strategy -- so those specific published numbers are untouched by this finding either way. (This full/all-days-as-registered-metric wiring looks like it may deserve its own look, separate from #611 -- noted below, not touched here.)
- The falsification framework (HAC t-stat, 5 null environments, GARCH nulls, FF5 alpha, deflated Sharpe) and the shadow-trade entry/exit sensitivity analysis DO use `aw_practical_backtest$ret_strategy` -- i.e. they test the actual VIX-threshold mechanism's statistical significance.
- `docs/avoid-worst-days.qmd` already contains a self-critical **Alpha Decay** section (pre-existing, unrelated to #611) stating that at honest t+1 execution the VIX-protection strategy *underperforms* buy & hold and has "no exploitable speed advantage."
- But the **narrative prose** immediately above it ("VIX-Triggered Protection" and "How It Works" tabs) claimed VIX "rises *before* the worst days cluster" and gives "earlier exit signals" -- a materially stronger causal claim than either #611's own regression (R2=0.008) or the page's own Alpha Decay finding supports. The two sections of the same page were internally inconsistent.
- `strategy_names` metadata for avoid_worst was already honest (`research_paper_doi = NA -- "folk wisdom; no single paper"`) -- no false claim there.

**Change made:** narrow prose correction to `docs/avoid-worst-days.qmd` (2 sentences), softening the causal framing and citing #611's actual numbers, so it agrees with the page's own Alpha Decay section. No trading logic, VIX thresholds, registered metrics, or strategy weighting changed.

**Deferred to a human decision (not attempted here):**

1. Whether `avoid_worst`'s registered leaderboard metrics (SPY buy-and-hold "All Days") vs. the actual VIX-timed strategy return series (`aw_practical_backtest`) being two different things feeding the same `strategy_id = "avoid_worst"` registry row is itself a defect worth its own issue -- out of scope for #611 specifically, flagging since it surfaced during investigation.
2. #611's own N1 recommendation (VIX-level trigger vs SPX-drawdown/RSI trigger head-to-head, same series/cost model) -- a real backtesting design task, not a narrow fix, and the issue author already scoped it as future work.
3. Whether `avoid_worst`'s detection-power / ranking confidence should be adjusted given the weak (R2=0.008) direct-test result -- ambiguous given the evidence is described by the issue author as "not a refutation"; a human call, not mine to make unilaterally.

## Verification

`scripts/verify.sh` (foreground, full mode) -- exit 0, PASS. Root suite: 3/3 known baseline failures match exactly (0 unexpected). Package suite: 1/1 known baseline failure matches exactly, 15/15 known skips.

Refs #611
