### PR TITLE
feat(registry): add missing registration sentinels for ev_ebit, mf_tsm, olmar (#587 Phase 1)

### DIFF
--- a/R/plan_ev_ebit.R
+++ b/R/plan_ev_ebit.R
@@ -290,7 +290,124 @@ plan_ev_ebit <- function() {
         "Value premium meets cross-geography-pervasiveness bar: documented in US, ",
         "international, and EM markets over 90+ years."
       )
+    }),
+
+    # ── Registry sentinel (#587 Phase 1) ────────────────────────────────────
+    # Upserts bt.strategy row for "ev_ebit", records one bt.run + bt.metric
+    # rows (full-period slice of ev_metrics, "Pure Value (100% HML, EV/EBIT
+    # proxy)" -- the same row R/plan_leaderboard.R's .norm_value() selects as
+    # the canonical leaderboard row for "Value (HML)"). Guard: returns empty
+    # tibble if DBI / duckdb are unavailable.
+    #
+    # #587: this strategy sat in the strategy_names single-source-of-truth
+    # tibble (#426) but never got a registration sentinel, so bt.strategy
+    # never carried a row for it -- one of the 3 gaps issue #587's comment
+    # (Flaw 1) identified (ev_ebit, mf_tsm, olmar; olmar itself already
+    # fixed by #629, this is the remaining 2 of 3).
+    targets::tar_target(ev_register_runs, {
+      .ev_register_runs(
+        strategy_names = strategy_names,
+        ev_metrics     = ev_metrics,
+        ev_portfolios  = ev_portfolios
+      )
     })
 
   )
+}
+
+
+# ── Internal helper ────────────────────────────────────────────────────────────
+# Prefixed .ev_* (private; not exported from the package).
+# Mirrors .ltr_register_runs() from plan_ltr_momentum.R.
+
+#' Register the EV/EBIT ("Value (HML)") backtest run in the strategy registry
+#'
+#' @param strategy_names Tibble from the `strategy_names` target.
+#' @param ev_metrics Tibble from the `ev_metrics` target; the "Pure Value
+#'   (100% HML, EV/EBIT proxy)" / "Full" row is registered -- the same row
+#'   R/plan_leaderboard.R's `.norm_value()` selects as the canonical
+#'   leaderboard row for "Value (HML)".
+#' @param ev_portfolios Tibble from the `ev_portfolios` target; used to
+#'   extract returns for SSR/top5pct stability metrics.
+#'
+#' @return Tibble with columns: strategy_id, run_uuid.
+#' @noRd
+.ev_register_runs <- function(strategy_names, ev_metrics, ev_portfolios) {
+  if (!requireNamespace("DBI", quietly = TRUE) ||
+      !requireNamespace("duckdb", quietly = TRUE)) {
+    return(tibble::tibble(
+      strategy_id = character(),
+      run_uuid    = character()
+    ))
+  }
+
+  path <- historicaldata::hd_registry_path()
+  historicaldata::hd_registry_init(path)
+  con <- historicaldata::hd_registry_open(path, read_only = FALSE)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  strat_row <- strategy_names |>
+    dplyr::filter(.data$code_name == "ev_ebit") |>
+    dplyr::transmute(
+      strategy_id        = .data$code_name,
+      short_name         = .data$short_name,
+      long_name          = .data$long_name,
+      asset_class        = .data$asset_class,
+      frequency          = .data$frequency,
+      ann_factor         = as.integer(.data$ann_factor),
+      directionality     = as.character(.data$directionality),
+      liquidity_tier     = as.character(.data$liquidity_tier),
+      time_horizon_days  = as.integer(.data$time_horizon_days_avg),
+      trades_per_year    = as.numeric(.data$trades_per_year_avg),
+      turnover_pct       = as.numeric(.data$turnover_pct_per_period_avg),
+      tags               = .data$tags,
+      research_paper_doi = .data$research_paper_doi
+    )
+
+  historicaldata::hd_strategy_upsert(con, strat_row)
+
+  uu <- historicaldata::hd_run_upsert(
+    con,
+    strategy_id      = "ev_ebit",
+    partition        = "phase1",
+    pipeline_version = "phase1"
+  )
+
+  # Record full-period metrics row for the canonical "Pure Value" leg.
+  # Units (fail-loud-not-null.md): cagr/vol/max_dd/ann_rf are PERCENT
+  # (R/plan_ev_ebit.R's calc_metrics() stores x*100), sharpe/calmar are
+  # scale-free ratios, n_months is a count. window_start/window_end are
+  # Date columns and are auto-skipped by hd_metric_record()'s wide-form
+  # numeric-only filter (is.numeric(Date) is FALSE).
+  full_row <- ev_metrics[
+    ev_metrics$strategy == "Pure Value (100% HML, EV/EBIT proxy)" &
+      ev_metrics$period == "Full",
+    , drop = FALSE
+  ]
+  if (nrow(full_row) == 1L) {
+    metric_cols <- setdiff(names(full_row), c("strategy", "period"))
+    ev_units <- c(
+      n_months = "count", cagr = "percent", vol = "percent",
+      sharpe = "ratio", ann_rf = "percent", max_dd = "percent",
+      calmar = "ratio"
+    )
+    historicaldata::hd_metric_record(
+      con, uu, full_row[, metric_cols, drop = FALSE], units = ev_units
+    )
+  }
+
+  # Record SSR + top5pct stability metrics (#400). Monthly: w=36, ann_factor=12.
+  rets <- ev_portfolios$ret_value_hml
+  rets <- rets[!is.na(rets)]
+  if (length(rets) > 0L) {
+    historicaldata::hd_record_stability_metrics(
+      con        = con,
+      run_uuid   = uu,
+      returns    = rets,
+      w          = 36L,
+      ann_factor = 12L
+    )
+  }
+
+  tibble::tibble(strategy_id = "ev_ebit", run_uuid = uu)
 }

--- a/R/plan_managed_futures.R
+++ b/R/plan_managed_futures.R
@@ -431,6 +431,26 @@ plan_managed_futures <- function() {
         # on a detection-power-cleared strategy (e.g. OLMAR-1).
         detection_caveat = "sample is detection_underpowered per #726 -- see comment above target"
       )
+    }),
+
+    # ── Registry sentinel (#587 Phase 1) ────────────────────────────────────
+    # Upserts bt.strategy row for "mf_tsm", records one bt.run + bt.metric
+    # rows (full-period slice of mf_metrics, "Long-Short TS-Mom (MOP 2012,
+    # vol-targeted)" -- the same row R/plan_leaderboard.R's .norm_mf()
+    # selects as the canonical leaderboard row for "Managed Futures").
+    # Guard: returns empty tibble if DBI / duckdb are unavailable.
+    #
+    # #587: this strategy sat in the strategy_names single-source-of-truth
+    # tibble (#427) but never got a registration sentinel, so bt.strategy
+    # never carried a row for it -- one of the 3 gaps issue #587's comment
+    # (Flaw 1) identified (ev_ebit, mf_tsm, olmar; olmar itself already
+    # fixed by #629, this is the remaining 2 of 3).
+    targets::tar_target(mf_register_runs, {
+      .mf_register_runs(
+        strategy_names = strategy_names,
+        mf_metrics     = mf_metrics,
+        mf_portfolios  = mf_portfolios
+      )
     })
 
   )
@@ -488,4 +508,98 @@ plan_managed_futures <- function() {
     pos_null$GLD * df$exc_GLD +
     pos_null$DBC * df$exc_DBC
   ) / 4 - cost
+}
+
+#' Register the Managed Futures ("mf_tsm") backtest run in the strategy registry
+#'
+#' Mirrors `.ev_register_runs()` from plan_ev_ebit.R.
+#'
+#' @param strategy_names Tibble from the `strategy_names` target.
+#' @param mf_metrics Tibble from the `mf_metrics` target; the "Long-Short
+#'   TS-Mom (MOP 2012, vol-targeted)" / "Full" row is registered -- the same
+#'   row R/plan_leaderboard.R's `.norm_mf()` selects as the canonical
+#'   leaderboard row for "Managed Futures".
+#' @param mf_portfolios Tibble from the `mf_portfolios` target; used to
+#'   extract returns for SSR/top5pct stability metrics.
+#'
+#' @return Tibble with columns: strategy_id, run_uuid.
+#' @noRd
+.mf_register_runs <- function(strategy_names, mf_metrics, mf_portfolios) {
+  if (!requireNamespace("DBI", quietly = TRUE) ||
+      !requireNamespace("duckdb", quietly = TRUE)) {
+    return(tibble::tibble(
+      strategy_id = character(),
+      run_uuid    = character()
+    ))
+  }
+
+  path <- historicaldata::hd_registry_path()
+  historicaldata::hd_registry_init(path)
+  con <- historicaldata::hd_registry_open(path, read_only = FALSE)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  strat_row <- strategy_names |>
+    dplyr::filter(.data$code_name == "mf_tsm") |>
+    dplyr::transmute(
+      strategy_id        = .data$code_name,
+      short_name         = .data$short_name,
+      long_name          = .data$long_name,
+      asset_class        = .data$asset_class,
+      frequency          = .data$frequency,
+      ann_factor         = as.integer(.data$ann_factor),
+      directionality     = as.character(.data$directionality),
+      liquidity_tier     = as.character(.data$liquidity_tier),
+      time_horizon_days  = as.integer(.data$time_horizon_days_avg),
+      trades_per_year    = as.numeric(.data$trades_per_year_avg),
+      turnover_pct       = as.numeric(.data$turnover_pct_per_period_avg),
+      tags               = .data$tags,
+      research_paper_doi = .data$research_paper_doi
+    )
+
+  historicaldata::hd_strategy_upsert(con, strat_row)
+
+  uu <- historicaldata::hd_run_upsert(
+    con,
+    strategy_id      = "mf_tsm",
+    partition        = "phase1",
+    pipeline_version = "phase1"
+  )
+
+  # Record full-period metrics row for the canonical MOP 2012 long-short leg.
+  # Units (fail-loud-not-null.md): cagr/vol/max_dd/ann_rf are PERCENT
+  # (R/plan_managed_futures.R's calc_metrics() stores x*100), sharpe/calmar
+  # are scale-free ratios, n_months is a count. window_start/window_end are
+  # Date columns and are auto-skipped by hd_metric_record()'s wide-form
+  # numeric-only filter (is.numeric(Date) is FALSE).
+  full_row <- mf_metrics[
+    mf_metrics$strategy == "Long-Short TS-Mom (MOP 2012, vol-targeted)" &
+      mf_metrics$period == "Full",
+    , drop = FALSE
+  ]
+  if (nrow(full_row) == 1L) {
+    metric_cols <- setdiff(names(full_row), c("strategy", "period"))
+    mf_units <- c(
+      n_months = "count", cagr = "percent", vol = "percent",
+      sharpe = "ratio", ann_rf = "percent", max_dd = "percent",
+      calmar = "ratio"
+    )
+    historicaldata::hd_metric_record(
+      con, uu, full_row[, metric_cols, drop = FALSE], units = mf_units
+    )
+  }
+
+  # Record SSR + top5pct stability metrics (#400). Monthly: w=36, ann_factor=12.
+  rets <- mf_portfolios$ret_ls
+  rets <- rets[!is.na(rets)]
+  if (length(rets) > 0L) {
+    historicaldata::hd_record_stability_metrics(
+      con        = con,
+      run_uuid   = uu,
+      returns    = rets,
+      w          = 36L,
+      ann_factor = 12L
+    )
+  }
+
+  tibble::tibble(strategy_id = "mf_tsm", run_uuid = uu)
 }

--- a/R/plan_olmar.R
+++ b/R/plan_olmar.R
@@ -403,6 +403,25 @@ plan_olmar <- function() {
         rank_pct       = rank$rank_pct,
         null_dominates = rank$null_dominates
       )
+    }),
+
+    # ── Registry sentinel (#587 Phase 1) ────────────────────────────────────
+    # Upserts bt.strategy row for "olmar", records one bt.run + bt.metric
+    # rows (full-period slice of olmar_metrics). Guard: returns empty tibble
+    # if DBI / duckdb are unavailable.
+    #
+    # #587: OLMAR-1 was already ranked on the leaderboard (STRATEGY_OBS_ANN_
+    # FACTOR, R/plan_leaderboard.R) and #629 added its row to the
+    # strategy_names single-source-of-truth tibble, but neither of those
+    # writes bt.strategy -- this was the "OLMAR-1 has zero registry
+    # presence" gap issue #587's comment (Flaw 1) named explicitly. This
+    # target closes it the same way #629 closed the strategy_names gap.
+    targets::tar_target(olmar_register_runs, {
+      .olmar_register_runs(
+        strategy_names  = strategy_names,
+        olmar_metrics   = olmar_metrics,
+        olmar_portfolio = olmar_portfolio
+      )
     })
 
   )
@@ -434,4 +453,96 @@ plan_olmar <- function() {
     df_label = "olmar_portfolio", strategy_label = "OLMAR-1",
     period_noun = "date", df_arg_name = "port"
   )
+}
+
+#' Register the OLMAR-1 ("olmar") backtest run in the strategy registry
+#'
+#' Mirrors `.ev_register_runs()` from plan_ev_ebit.R / `.avoid_worst_register_runs()`
+#' from plan_avoid_worst.R (both daily-frequency strategies).
+#'
+#' @param strategy_names Tibble from the `strategy_names` target.
+#' @param olmar_metrics Tibble from the `olmar_metrics` target; the "Full
+#'   Period" row is registered.
+#' @param olmar_portfolio Tibble from the `olmar_portfolio` target; used to
+#'   extract returns for SSR/top5pct stability metrics.
+#'
+#' @return Tibble with columns: strategy_id, run_uuid.
+#' @noRd
+.olmar_register_runs <- function(strategy_names, olmar_metrics, olmar_portfolio) {
+  if (!requireNamespace("DBI", quietly = TRUE) ||
+      !requireNamespace("duckdb", quietly = TRUE)) {
+    return(tibble::tibble(
+      strategy_id = character(),
+      run_uuid    = character()
+    ))
+  }
+
+  path <- historicaldata::hd_registry_path()
+  historicaldata::hd_registry_init(path)
+  con <- historicaldata::hd_registry_open(path, read_only = FALSE)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  strat_row <- strategy_names |>
+    dplyr::filter(.data$code_name == "olmar") |>
+    dplyr::transmute(
+      strategy_id        = .data$code_name,
+      short_name         = .data$short_name,
+      long_name          = .data$long_name,
+      asset_class        = .data$asset_class,
+      frequency          = .data$frequency,
+      ann_factor         = as.integer(.data$ann_factor),
+      directionality     = as.character(.data$directionality),
+      liquidity_tier     = as.character(.data$liquidity_tier),
+      time_horizon_days  = as.integer(.data$time_horizon_days_avg),
+      trades_per_year    = as.numeric(.data$trades_per_year_avg),
+      turnover_pct       = as.numeric(.data$turnover_pct_per_period_avg),
+      tags               = .data$tags,
+      research_paper_doi = .data$research_paper_doi
+    )
+
+  historicaldata::hd_strategy_upsert(con, strat_row)
+
+  uu <- historicaldata::hd_run_upsert(
+    con,
+    strategy_id      = "olmar",
+    partition        = "phase1",
+    pipeline_version = "phase1"
+  )
+
+  # Record full-period metrics row.
+  # Units (fail-loud-not-null.md): cagr/vol/max_dd/ann_rf are PERCENT
+  # (this file's olmar_metrics target stores round(x * 100, 2)), sharpe is
+  # a scale-free ratio, days is a count of daily observations, years is a
+  # year-duration, avg_turnover_daily is a decimal fraction of portfolio
+  # value turned over per day.
+  full_row <- olmar_metrics[
+    olmar_metrics$period == "Full Period",
+    , drop = FALSE
+  ]
+  if (nrow(full_row) == 1L) {
+    metric_cols <- setdiff(names(full_row), "period")
+    olmar_units <- c(
+      days = "count", years = "years", cagr = "percent", vol = "percent",
+      sharpe = "ratio", ann_rf = "percent", max_dd = "percent",
+      avg_turnover_daily = "fraction"
+    )
+    historicaldata::hd_metric_record(
+      con, uu, full_row[, metric_cols, drop = FALSE], units = olmar_units
+    )
+  }
+
+  # Record SSR + top5pct stability metrics (#400). Daily: w=252, ann_factor=252.
+  rets <- olmar_portfolio$net_ret
+  rets <- rets[!is.na(rets)]
+  if (length(rets) > 0L) {
+    historicaldata::hd_record_stability_metrics(
+      con        = con,
+      run_uuid   = uu,
+      returns    = rets,
+      w          = 252L,
+      ann_factor = 252L
+    )
+  }
+
+  tibble::tibble(strategy_id = "olmar", run_uuid = uu)
 }


### PR DESCRIPTION
## Summary

Phase 1 (and only Phase 1) of #587: closes the strategy-registry presence gap for `ev_ebit`, `mf_tsm`, and `olmar`.

`R/plan_strategy_names.R`'s `hd_strategy_names_tbl()` (the descriptive single source of truth) already lists all 17 strategies — `ev_ebit` was added in #426, `mf_tsm` in #427, `olmar` in #629. But **none of the three ever got a registration sentinel** — no plan file called `hd_strategy_upsert()` for them — so `bt.strategy` silently held at most 14 of 17 rows. This is exactly the gap issue #587's implementation-plan comment (Flaw 1) identified: *"OLMAR-1 appears on the leaderboard with no registry row at all... `ev_ebit` and `mf_tsm` sit in the tibble with no registration sentinel."*

Verified directly: grepped every `hd_strategy_upsert()` call site against all 17 `code_name`s — 14 covered (5 Tier 1 + 3 Tier 2 + 3 Tier 3 + 3 `mom_prepeak` siblings), 0 for `plan_ev_ebit.R`, `plan_managed_futures.R`, `plan_olmar.R`.

### What this PR adds

A registration sentinel in each of the three plan files, mirroring the existing `#442` Tier-1 pattern (`.ltr_register_runs()`, `.cmr_register_runs()`):

- `ev_register_runs` / `.ev_register_runs()` in `R/plan_ev_ebit.R` — registers `ev_ebit` against the "Pure Value (100% HML, EV/EBIT proxy)" / Full row (the same row `R/plan_leaderboard.R`'s `.norm_value()` selects for the leaderboard).
- `mf_register_runs` / `.mf_register_runs()` in `R/plan_managed_futures.R` — registers `mf_tsm` against the "Long-Short TS-Mom (MOP 2012, vol-targeted)" / Full row (matches `.norm_mf()`).
- `olmar_register_runs` / `.olmar_register_runs()` in `R/plan_olmar.R` — registers `olmar` against the "Full Period" row of `olmar_metrics`.

Each sentinel upserts the `bt.strategy` row, records one `bt.run` row (`partition = "phase1"`, `pipeline_version = "phase1"`), records the full-period `bt.metric` row with explicit units, and records SSR/top5pct stability metrics (`hd_record_stability_metrics()`) — monthly `w=36`/`ann_factor=12` for `ev_ebit`/`mf_tsm`, daily `w=252`/`ann_factor=252` for `olmar`.

### Out of scope (deferred)

Per the issue's own phased plan, this PR does **only** Phase 1. It does **not** touch:
- `mechanism`, `assumed_regime`, `kill_observable`, `mechanism_status`, `mechanism_reviewed_at`, `falsification_run_id` schema fields (Phase 2)
- Leaderboard `mechanism_status` column / ordering-demotion rule (Phase 3)
- Narrative population for any of the 17 strategies (Phase 4)
- Falsification `bt.run` sentinel + status adjudication (Phase 5)

## Test plan

- [x] `scripts/verify.sh` run in the foreground, full suite: **PASS**
  - `parse("_targets.R")`, `parse("docs/_targets.R")`, `tar_validate(script = "docs/_targets.R")`: PASS
  - testthat edition 3 active: PASS
  - root suite: 0 new failures/skips; matches the 3 documented baseline failures exactly (issue #569)
  - package suite: matches the 1 documented baseline failure exactly; skip count 15 (matches documented baseline)
- [ ] `scripts/build.sh` (main checkout only, not run from this worktree) — recommended before merge to prove `tar_make()` actually rebuilds the three new registry-sentinel targets against real data and that `check_pkg_staleness.R` / `check_pipeline_errors.R` report clean, per this repo's `.claude/CLAUDE.md` "Verifying a change" table (`verify.sh` proves structure only, not that target bodies run cleanly against live data).

Refs #587
