### PR TITLE
feat(leverage): live sigma_target target + regime stress re-check (#635)

### DIFF
--- a/R/plan_leverage.R
+++ b/R/plan_leverage.R
@@ -1,0 +1,197 @@
+# Plan: Live leverage sigma_target computation (#635)
+#
+# #635 derived sigma_target -- the per-strategy volatility target that sets
+# G_i = sigma_target / vol_per_unit_gross_i -- by hand, in an issue comment,
+# FOUR separate times (2026-08-05, 2026-08-18, 2026-08-22, 2026-08-23), each
+# time re-typing the same arithmetic against a fresh `tar_read(leaderboard)`
+# snapshot. Three of those four derivations were invalidated by a data-
+# quality bug discovered AFTER the number had been posted and, in two cases,
+# provisionally adopted (#641 truncated PSO Optimal; #717 CMR annualised at
+# the wrong factor; #722 CMR's risk-free rate inherited the wrong constant).
+# Each time the arithmetic was correct and an input was wrong -- see the
+# issue's own "Nth derivation of this number" table.
+#
+# This plan closes that loop: sigma_target is now a `targets` target,
+# computed directly from `leaderboard` (R/plan_leaderboard.R) and
+# `strategy_gross_convention` (R/plan_exposure.R, already joined into
+# `leaderboard`). The NEXT time an upstream data bug changes `vol` or
+# `gross_convention`, this number moves automatically on the next
+# `tar_make()` instead of requiring a fifth manual re-derivation.
+#
+# ── Definition: budget-neutral sigma_target ─────────────────────────────────
+# #635's Option B ("anchor on the book's current realised volatility") could
+# not be executed as originally framed -- the only whole-book return series
+# in the pipeline is `PSO Optimal`, and per-strategy `vol`/`gross_convention`
+# are what #635's own recommendation actually needs (a PER-STRATEGY target,
+# not a book-level one -- see G_i = sigma_target / vol_per_unit_gross_i).
+# The adopted substitute, unchanged since #635's 2026-08-05 decision comment,
+# is the level at which introducing the control changes NO strategy's gross
+# budget on day one:
+#
+#   sigma_target such that  sum(G_i) == sum(gross_convention_i)
+#
+# Since G_i = sigma_target / vol_per_unit_gross_i = sigma_target * gross_i / vol_i,
+# solving for sigma_target:
+#
+#   sigma_target = sum(gross_convention_i) / sum(gross_convention_i / vol_i)
+#
+# This is a GROSS-BUDGET-NEUTRALITY statement, not a book-volatility claim --
+# it ignores cross-strategy correlation entirely (see #635's repeated
+# caveat: "do not quote this as the book's volatility anywhere"). The
+# genuine book-level anchor is `tar_read(port_metrics)` / PSO Optimal's own
+# vol (~6.6% at last measurement) and is a separate, already-live figure.
+#
+# `is_cap` rows (Managed Futures, TOM, Risk State, Avoid Worst -- see
+# R/plan_exposure.R) are INCLUDED in this sum, matching every one of #635's
+# four manual derivations: excluding them was never how the historical
+# figure was computed, only the *interpretation* of their resulting implied
+# G_i was flagged as understated. `Value (HML)` and `PSO Optimal` are
+# excluded by construction -- both carry NA `gross_convention` (no explicit
+# weight vector to measure; see R/plan_exposure.R header).
+#
+# ── Regime check (#635 DoD item 7) ──────────────────────────────────────────
+# `leverage_regime_stress_ratio` reproduces the Training-vs-Testing stress
+# ratio table #635's 2026-08-05/08-18 comments computed by hand
+# (vol_per_unit_gross in the Testing partition divided by the Training
+# partition, per strategy) as a live target, so it re-derives automatically
+# alongside sigma_target rather than needing a matching manual re-run every
+# time an upstream fix (#717, #722, #667) changes the underlying vol.
+
+# compute_vol_per_unit_gross(): per-(strategy, period) vol_per_unit_gross =
+# vol / gross_convention, restricted to rows with a measurable
+# gross_convention (excludes Value (HML) and PSO Optimal, both NA by
+# construction) and a non-NA vol. `is_cap` is carried through unchanged so
+# downstream consumers can flag ceiling rows as understated per #635/#626.
+compute_vol_per_unit_gross <- function(leaderboard_df,
+                                        periods = c("Training", "Testing", "Full Period")) {
+  if (!is.data.frame(leaderboard_df)) {
+    cli::cli_abort(c(
+      "x" = "{.arg leaderboard_df} must be a data frame, not {.cls {class(leaderboard_df)}}.",
+      "i" = "compute_vol_per_unit_gross() expects the {.field leaderboard} target."
+    ))
+  }
+  required_cols <- c("strategy", "period", "vol", "gross_convention", "is_cap")
+  missing_cols <- setdiff(required_cols, names(leaderboard_df))
+  if (length(missing_cols) > 0) {
+    cli::cli_abort(c(
+      "x" = "{.arg leaderboard_df} is missing required column{?s}: {.field {missing_cols}}.",
+      "i" = "compute_vol_per_unit_gross() needs {.field {required_cols}}."
+    ))
+  }
+
+  leaderboard_df |>
+    dplyr::filter(
+      period %in% periods,
+      !is.na(gross_convention),
+      gross_convention > 0,
+      !is.na(vol)
+    ) |>
+    dplyr::transmute(
+      strategy,
+      period,
+      vol,
+      gross_convention,
+      is_cap,
+      vol_per_unit_gross = vol / gross_convention
+    ) |>
+    dplyr::arrange(period, vol_per_unit_gross)
+}
+
+# compute_budget_neutral_sigma(): sigma_target per partition, defined so that
+# sum(G_i) == sum(gross_convention_i) within that partition -- see the plan
+# header derivation. `is_headline` flags the Full Period row: that is the
+# figure #635 adopted (0.1354 at the 2026-08-23 hand derivation) and the one
+# any consumer citing "sigma_target" should read.
+compute_budget_neutral_sigma <- function(vpug_df) {
+  required_cols <- c("period", "vol", "gross_convention", "vol_per_unit_gross")
+  missing_cols <- setdiff(required_cols, names(vpug_df))
+  if (length(missing_cols) > 0) {
+    cli::cli_abort(c(
+      "x" = "{.arg vpug_df} is missing required column{?s}: {.field {missing_cols}}.",
+      "i" = "compute_budget_neutral_sigma() needs {.field {required_cols}} (see compute_vol_per_unit_gross())."
+    ))
+  }
+  if (nrow(vpug_df) == 0) {
+    cli::cli_abort(c(
+      "x" = "{.arg vpug_df} has zero rows.",
+      "i" = "No strategy has a measurable gross_convention -- check the {.field leaderboard} and {.field strategy_gross_convention} targets."
+    ))
+  }
+
+  vpug_df |>
+    dplyr::group_by(period) |>
+    dplyr::summarise(
+      n = dplyr::n(),
+      mean_vol_per_unit_gross = mean(vol_per_unit_gross),
+      sum_gross_convention = sum(gross_convention),
+      sum_gross_over_vol = sum(gross_convention / vol),
+      sigma_target_budget_neutral = sum_gross_convention / sum_gross_over_vol,
+      .groups = "drop"
+    ) |>
+    dplyr::select(-sum_gross_over_vol) |>
+    dplyr::mutate(is_headline = period == "Full Period") |>
+    dplyr::arrange(dplyr::desc(is_headline), period)
+}
+
+# compute_regime_stress_ratio(): per-strategy Testing/Training ratio of
+# vol_per_unit_gross -- how much a strategy's risk-per-unit-of-gross rose
+# (or fell) in the 2020-22 stress partition relative to the calm Training
+# partition. Strategies missing either partition (the #648 coverage gap:
+# CMR, Mom Pre-Peak, Mom Post-Peak, Mom 12-2 have no Training row; Managed
+# Futures has no Testing row) are silently absent from the result -- this is
+# a real coverage limitation, not a bug, and is reported as such by callers
+# (see docs/leaderboard.qmd and the #635 PR body), not papered over here.
+compute_regime_stress_ratio <- function(vpug_df) {
+  required_cols <- c("strategy", "period", "vol_per_unit_gross")
+  missing_cols <- setdiff(required_cols, names(vpug_df))
+  if (length(missing_cols) > 0) {
+    cli::cli_abort(c(
+      "x" = "{.arg vpug_df} is missing required column{?s}: {.field {missing_cols}}.",
+      "i" = "compute_regime_stress_ratio() needs {.field {required_cols}} (see compute_vol_per_unit_gross())."
+    ))
+  }
+
+  wide <- vpug_df |>
+    dplyr::filter(period %in% c("Training", "Testing")) |>
+    dplyr::select(strategy, period, vol_per_unit_gross) |>
+    tidyr::pivot_wider(names_from = period, values_from = vol_per_unit_gross)
+
+  # Both columns may legitimately be absent if the leaderboard currently has
+  # zero rows in one of the two partitions -- abort loudly rather than
+  # returning a silently-empty/malformed table (fail-loud-not-null.md).
+  missing_partition <- setdiff(c("Training", "Testing"), names(wide))
+  if (length(missing_partition) > 0) {
+    cli::cli_abort(c(
+      "x" = "leaderboard has no {.field {missing_partition}} rows with a measurable gross_convention.",
+      "i" = "compute_regime_stress_ratio() needs at least one strategy with both a Training and a Testing row."
+    ))
+  }
+
+  wide |>
+    dplyr::filter(!is.na(Training), !is.na(Testing)) |>
+    dplyr::mutate(stress_ratio = Testing / Training) |>
+    dplyr::arrange(dplyr::desc(stress_ratio))
+}
+
+plan_leverage <- function() {
+  list(
+    # Per-(strategy, period) vol_per_unit_gross -- the intermediate #635's
+    # own derivations recomputed by hand at every re-measurement.
+    targets::tar_target(leverage_vol_per_unit_gross, {
+      compute_vol_per_unit_gross(leaderboard)
+    }),
+
+    # The live replacement for #635's hand-typed sigma_target. Read the
+    # `is_headline == TRUE` (Full Period) row for the figure any consumer
+    # should cite as "sigma_target".
+    targets::tar_target(leverage_sigma_target, {
+      compute_budget_neutral_sigma(leverage_vol_per_unit_gross)
+    }),
+
+    # Training-vs-Testing stress ratio of vol_per_unit_gross, per strategy --
+    # the live replacement for #635's hand-run regime check.
+    targets::tar_target(leverage_regime_stress_ratio, {
+      compute_regime_stress_ratio(leverage_vol_per_unit_gross)
+    })
+  )
+}

--- a/docs/_targets.R
+++ b/docs/_targets.R
@@ -171,6 +171,10 @@ source(here::here("R/plan_strategy_correlation.R"))
 source(here::here("R/plan_exposure.R"))
 # #624: per-strategy transaction-cost convention registry (measurement only)
 source(here::here("R/plan_cost_convention.R"))
+# #635: live sigma_target (budget-neutral leverage level) + regime stress
+# check, computed from `leaderboard` -- see the file header for the
+# derivation and why this replaces a hand-typed issue-comment constant.
+source(here::here("R/plan_leverage.R"))
 source(here::here("R/plan_avoid_worst.R"))
 source(here::here("R/plan_risk_state.R"))
 source(here::here("R/plan_qa_vignette.R"))
@@ -272,6 +276,7 @@ c(plan_strategy_names(),
   plan_exposure(),
   plan_cost_convention(),
   plan_leaderboard(), plan_strategy_digest(), plan_qa_vignette(),
+  plan_leverage(),
   plan_falsification(),
   plan_falsification_vignette(),
   plan_stop_rule_test(),

--- a/tests/testthat/_snaps/leverage.md
+++ b/tests/testthat/_snaps/leverage.md
@@ -1,0 +1,70 @@
+# compute_vol_per_unit_gross: errors on non-data-frame input
+
+    Code
+      compute_vol_per_unit_gross(list(a = 1))
+    Condition
+      Error in `compute_vol_per_unit_gross()`:
+      x `leaderboard_df` must be a data frame, not <list>.
+      i compute_vol_per_unit_gross() expects the leaderboard target.
+
+# compute_vol_per_unit_gross: errors on missing required columns
+
+    Code
+      compute_vol_per_unit_gross(bad)
+    Condition
+      Error in `compute_vol_per_unit_gross()`:
+      x `leaderboard_df` is missing required column: gross_convention.
+      i compute_vol_per_unit_gross() needs strategy, period, vol, gross_convention, and is_cap.
+
+# compute_vol_per_unit_gross: function signature is stable (catches API drift)
+
+    Code
+      args(compute_vol_per_unit_gross)
+    Output
+      function (leaderboard_df, periods = c("Training", "Testing", 
+          "Full Period")) 
+      NULL
+
+# compute_budget_neutral_sigma: errors on missing required columns
+
+    Code
+      compute_budget_neutral_sigma(tibble::tibble(period = "Full Period"))
+    Condition
+      Error in `compute_budget_neutral_sigma()`:
+      x `vpug_df` is missing required columns: vol, gross_convention, and vol_per_unit_gross.
+      i compute_budget_neutral_sigma() needs period, vol, gross_convention, and vol_per_unit_gross (see compute_vol_per_unit_gross()).
+
+# compute_budget_neutral_sigma: errors on zero-row input
+
+    Code
+      compute_budget_neutral_sigma(empty)
+    Condition
+      Error in `compute_budget_neutral_sigma()`:
+      x `vpug_df` has zero rows.
+      i No strategy has a measurable gross_convention -- check the leaderboard and strategy_gross_convention targets.
+
+# compute_budget_neutral_sigma: function signature is stable (catches API drift)
+
+    Code
+      args(compute_budget_neutral_sigma)
+    Output
+      function (vpug_df) 
+      NULL
+
+# compute_regime_stress_ratio: errors when Training/Testing partitions are entirely absent
+
+    Code
+      compute_regime_stress_ratio(vpug)
+    Condition
+      Error in `compute_regime_stress_ratio()`:
+      x leaderboard has no Training and Testing rows with a measurable gross_convention.
+      i compute_regime_stress_ratio() needs at least one strategy with both a Training and a Testing row.
+
+# compute_regime_stress_ratio: function signature is stable (catches API drift)
+
+    Code
+      args(compute_regime_stress_ratio)
+    Output
+      function (vpug_df) 
+      NULL
+

--- a/tests/testthat/test-leverage.R
+++ b/tests/testthat/test-leverage.R
@@ -1,0 +1,202 @@
+testthat::local_edition(3)
+
+# compute_vol_per_unit_gross(), compute_budget_neutral_sigma(), and
+# compute_regime_stress_ratio() are genuine top-level (non-tar_target)
+# functions in R/plan_leverage.R (#635) -- source the real file rather than
+# reproducing it, same pattern as test-plan-portfolio-opt.R's
+# .port_weighted_return() tests.
+source(here::here("R/plan_leverage.R"))
+
+# ── Fixture: a small leaderboard slice mirroring the real column set ───────
+# Values are NOT the real leaderboard data (that lives only in the built
+# `docs/_targets` store) -- they are synthetic, chosen to make the expected
+# budget-neutral sigma easy to hand-verify.
+
+.leaderboard_fixture <- function() {
+  tibble::tibble(
+    strategy = c(
+      "A", "A", "A",
+      "B", "B",
+      "C",
+      "D", "D",
+      "NoGross", "NoGross"
+    ),
+    period = c(
+      "Training", "Testing", "Full Period",
+      "Training", "Full Period",
+      "Full Period",
+      "Testing", "Full Period",
+      "Full Period", "Training"
+    ),
+    vol = c(
+      0.10, 0.12, 0.11,
+      0.20, 0.22,
+      0.05,
+      0.30, 0.33,
+      0.08, 0.09
+    ),
+    gross_convention = c(
+      2, 2, 2,
+      1, 1,
+      1,
+      2, 2,
+      NA_real_, NA_real_
+    ),
+    is_cap = c(
+      FALSE, FALSE, FALSE,
+      TRUE, TRUE,
+      FALSE,
+      FALSE, FALSE,
+      FALSE, FALSE
+    )
+  )
+}
+
+# ── compute_vol_per_unit_gross() ────────────────────────────────────────────
+
+test_that("compute_vol_per_unit_gross: computes vol / gross_convention per row", {
+  out <- compute_vol_per_unit_gross(.leaderboard_fixture())
+
+  a_full <- out[out$strategy == "A" & out$period == "Full Period", ]
+  expect_equal(a_full$vol_per_unit_gross, 0.11 / 2, tolerance = 1e-12)
+
+  b_train <- out[out$strategy == "B" & out$period == "Training", ]
+  expect_equal(b_train$vol_per_unit_gross, 0.20 / 1, tolerance = 1e-12)
+})
+
+test_that("compute_vol_per_unit_gross: excludes rows with NA gross_convention", {
+  out <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  expect_false("NoGross" %in% out$strategy)
+})
+
+test_that("compute_vol_per_unit_gross: is_cap is carried through unchanged", {
+  out <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  b_rows <- out[out$strategy == "B", ]
+  expect_true(all(b_rows$is_cap))
+})
+
+test_that("compute_vol_per_unit_gross: default periods restrict to Training/Testing/Full Period", {
+  fixture <- .leaderboard_fixture()
+  fixture <- dplyr::bind_rows(
+    fixture,
+    tibble::tibble(
+      strategy = "A", period = "Holdout", vol = 0.5,
+      gross_convention = 2, is_cap = FALSE
+    )
+  )
+  out <- compute_vol_per_unit_gross(fixture)
+  expect_false("Holdout" %in% out$period)
+})
+
+test_that("compute_vol_per_unit_gross: errors on non-data-frame input", {
+  expect_snapshot(error = TRUE, compute_vol_per_unit_gross(list(a = 1)))
+})
+
+test_that("compute_vol_per_unit_gross: errors on missing required columns", {
+  bad <- .leaderboard_fixture()
+  bad$gross_convention <- NULL
+  expect_snapshot(error = TRUE, compute_vol_per_unit_gross(bad))
+})
+
+test_that("compute_vol_per_unit_gross: function signature is stable (catches API drift)", {
+  expect_snapshot(args(compute_vol_per_unit_gross))
+})
+
+# ── compute_budget_neutral_sigma() ──────────────────────────────────────────
+# Full Period rows: A (vol=0.11, gross=2), B (vol=0.22, gross=1), C (vol=0.05, gross=1),
+# D (vol=0.33, gross=2). sum(gross) = 2+1+1+2 = 6.
+# sum(gross/vol) = 2/0.11 + 1/0.22 + 1/0.05 + 2/0.33
+#                = 18.181818 + 4.545455 + 20 + 6.060606 = 48.787879
+# sigma = 6 / 48.787879 = 0.122991...
+
+test_that("compute_budget_neutral_sigma: reproduces sum(G_i) == sum(gross_i) by construction", {
+  vpug <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  sigma_tbl <- compute_budget_neutral_sigma(vpug)
+
+  full <- sigma_tbl[sigma_tbl$period == "Full Period", ]
+  sigma <- full$sigma_target_budget_neutral
+
+  full_vpug <- vpug[vpug$period == "Full Period", ]
+  implied_gross <- sigma / full_vpug$vol_per_unit_gross
+
+  expect_equal(sum(implied_gross), sum(full_vpug$gross_convention), tolerance = 1e-9)
+})
+
+test_that("compute_budget_neutral_sigma: matches hand-derived value on the fixture", {
+  vpug <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  sigma_tbl <- compute_budget_neutral_sigma(vpug)
+
+  full <- sigma_tbl[sigma_tbl$period == "Full Period", ]
+  expected_sigma <- 6 / (2 / 0.11 + 1 / 0.22 + 1 / 0.05 + 2 / 0.33)
+  expect_equal(full$sigma_target_budget_neutral, expected_sigma, tolerance = 1e-9)
+  expect_equal(full$n, 4L)
+})
+
+test_that("compute_budget_neutral_sigma: is_headline flags exactly the Full Period row", {
+  vpug <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  sigma_tbl <- compute_budget_neutral_sigma(vpug)
+
+  expect_equal(sigma_tbl$period[sigma_tbl$is_headline], "Full Period")
+  expect_true(sum(sigma_tbl$is_headline) == 1L)
+})
+
+test_that("compute_budget_neutral_sigma: errors on missing required columns", {
+  expect_snapshot(error = TRUE, compute_budget_neutral_sigma(tibble::tibble(period = "Full Period")))
+})
+
+test_that("compute_budget_neutral_sigma: errors on zero-row input", {
+  empty <- compute_vol_per_unit_gross(.leaderboard_fixture())[0, ]
+  expect_snapshot(error = TRUE, compute_budget_neutral_sigma(empty))
+})
+
+test_that("compute_budget_neutral_sigma: function signature is stable (catches API drift)", {
+  expect_snapshot(args(compute_budget_neutral_sigma))
+})
+
+# ── compute_regime_stress_ratio() ───────────────────────────────────────────
+
+test_that("compute_regime_stress_ratio: computes Testing / Training per strategy", {
+  vpug <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  stress <- compute_regime_stress_ratio(vpug)
+
+  a_row <- stress[stress$strategy == "A", ]
+  expect_equal(a_row$stress_ratio, 0.12 / 0.10, tolerance = 1e-12)
+})
+
+test_that("compute_regime_stress_ratio: strategies missing either partition are excluded", {
+  vpug <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  stress <- compute_regime_stress_ratio(vpug)
+
+  # B has Training but no Testing row; C has neither; D has Testing but no Training.
+  expect_false("B" %in% stress$strategy)
+  expect_false("C" %in% stress$strategy)
+  expect_false("D" %in% stress$strategy)
+  expect_equal(stress$strategy, "A")
+})
+
+test_that("compute_regime_stress_ratio: sorted descending by stress_ratio", {
+  fixture <- .leaderboard_fixture()
+  fixture <- dplyr::bind_rows(
+    fixture,
+    tibble::tibble(
+      strategy = c("E", "E"), period = c("Training", "Testing"),
+      vol = c(0.10, 0.50), gross_convention = c(1, 1), is_cap = c(FALSE, FALSE)
+    )
+  )
+  vpug <- compute_vol_per_unit_gross(fixture)
+  stress <- compute_regime_stress_ratio(vpug)
+
+  expect_true(all(diff(stress$stress_ratio) <= 0))
+  expect_equal(stress$strategy[1], "E")  # 5x stress ratio, the largest
+})
+
+test_that("compute_regime_stress_ratio: errors when Training/Testing partitions are entirely absent", {
+  full_only <- .leaderboard_fixture()
+  full_only <- full_only[full_only$period == "Full Period", ]
+  vpug <- compute_vol_per_unit_gross(full_only)
+  expect_snapshot(error = TRUE, compute_regime_stress_ratio(vpug))
+})
+
+test_that("compute_regime_stress_ratio: function signature is stable (catches API drift)", {
+  expect_snapshot(args(compute_regime_stress_ratio))
+})


### PR DESCRIPTION
## Summary

Closes the two remaining unchecked items on #635's Definition of Done — the number was decided, but two follow-ups were left open:

1. **σ_target is now a live `targets` target**, not a hand-typed issue-comment constant.
2. **The Training/Testing regime stress check is re-run on the corrected CMR data** ("should be confirmed rather than assumed" per #635's last comment), rather than left as an assumption.

Does not build the allocator itself (#626) — deliberately out of scope, per the dispatch.

## Item 1 — live `sigma_target`

`#635`'s σ_target had been hand-derived in issue comments **four separate times** (2026-08-05, 08-18, 08-22, 08-23). Three of those four derivations were invalidated after the fact by an upstream data-quality bug that nobody had checked at the time (#641 truncated PSO Optimal, #717 CMR's `ann_factor`, #722 CMR's risk-free rate). Each time the arithmetic was correct and an input was wrong.

New file `R/plan_leverage.R`, wired into `docs/_targets.R` right after `plan_leaderboard()`:

- **`leverage_vol_per_unit_gross`** — per-(strategy, period) `vol / gross_convention`, restricted to rows with a measurable `gross_convention` (excludes `Value (HML)` and `PSO Optimal`, both NA by construction).
- **`leverage_sigma_target`** — budget-neutral σ per partition: the level at which `sum(G_i) == sum(gross_convention_i)`, i.e. `sigma = sum(gross_i) / sum(gross_i / vol_i)`. This is exactly the formula #635's own comments used by hand. The Full Period row is flagged `is_headline == TRUE` — that's the figure to cite as "sigma_target".
- **`leverage_regime_stress_ratio`** — per-strategy Testing/Training ratio of `vol_per_unit_gross`, the live replacement for #635's hand-run regime check (Item 2, below).

The three functions underneath (`compute_vol_per_unit_gross()`, `compute_budget_neutral_sigma()`, `compute_regime_stress_ratio()`) are genuine top-level functions, not locked inside `tar_target()` bodies — same pattern as `.port_weighted_return()` in `R/plan_portfolio_opt.R` — so they're directly testable.

### Live value, verified read-only against the current main-checkout store (2026-08-31)

| partition | n | sigma_target_budget_neutral |
|---|---:|---:|
| Full Period (**headline**) | 15 | **0.1369** |
| Testing | 10 | 0.1463 |
| Training | 11 | 0.1181 |

This **already differs from the last hand-derived figure** (0.1354, posted 2026-08-23) — it moved to 0.1369 in the week since, because `#751` (a 6-commit CMR overhaul: tradeable-era truncation, universe deduplication, calendar-window lookback, fixed-fraction leg sizing) landed on `main` after that comment and materially changed CMR's own volatility. Training and Testing are **unchanged to 4dp** from the 2026-08-23 figures, because CMR has no Training/Testing partition rows (the `#648` coverage gap) — so its change could only move the Full Period number.

This is exactly the failure mode this issue exists to close: a number that moved on `main` with nobody re-deriving it. It will now move automatically on the next `tar_make()` instead of needing a fifth manual re-derivation.

## Item 2 — regime stress check, re-confirmed on corrected data

Re-ran `compute_regime_stress_ratio()` against the current store (post `#717`/`#722`/`#751` CMR fixes):

| strategy | Testing vpug | Training vpug | stress ratio |
|---|---:|---:|---:|
| OLMAR-1 | 0.246 | 0.165 | **1.50** |
| Factor MAX | 0.109 | 0.088 | 1.23 |
| Stock MAX | 0.098 | 0.085 | 1.16 |
| Avoid Worst | 0.201 | 0.176 | 1.14 |
| Factor DRIF | 0.117 | 0.103 | 1.13 |
| TOM | 0.089 | 0.080 | 1.12 |
| LTR | 0.094 | 0.084 | 1.11 |
| Stock DRIF | 0.069 | 0.070 | 0.99 |
| XGB DRIF | 0.079 | 0.082 | 0.96 |
| Risk State | 0.105 | 0.157 | **0.67** |

**Result: the regime check still holds, unchanged from the 2026-08-18 measurement.** Median stress ratio ~1.12, OLMAR-1 remains the stress outlier at 1.50, Risk State still de-risks in stress (0.67 — it's the only strategy whose vol-per-unit-gross *falls* in the Testing window). This is expected: CMR is the strategy whose data changed, and CMR has no Training/Testing rows at all, so it cannot appear in — or move — this table. The overshoot handling #635 already decided (keep σ at the calm-state level, let the 3.5×-ish gross backstop absorb the tail rather than adopting a stress-conditional target) is unaffected.

The five-strategy partition-coverage gap (CMR, Mom Pre-Peak, Mom Post-Peak, Mom 12-2, Managed Futures — the `#643`/`#645`/`#648` population) is unchanged and remains the least well-characterised part of the sizing picture; that's a separate, already-tracked thread, not something this PR closes.

## Tests

`tests/testthat/test-leverage.R` — 18 `test_that()` blocks, 8 snapshots (44%, above the 30% minimum for 9+ blocks per `snapshot-test-policy`):
- `compute_budget_neutral_sigma()` verified against a hand-derived fixture value, and independently by reconstructing `sum(G_i)` from the output and checking it equals `sum(gross_convention_i)`.
- `is_cap` rows carried through unchanged (matches every one of #635's four manual derivations — cap rows were always included in the sum, only their *interpretation* was flagged as understated).
- NA-`gross_convention` rows (`Value (HML)`, `PSO Optimal`) excluded.
- Every `cli_abort()` path snapshot-tested (missing columns, non-data-frame input, zero rows, missing Training/Testing partitions entirely).
- Function-signature snapshots on all three exported functions.

## Verification

`scripts/verify.sh` run in the foreground (full mode — parse + `docs/_targets.R` structural validate + root suite + package suite):

```
PASS: _targets.R parses
PASS: docs/_targets.R parses
PASS: docs/_targets.R is structurally valid (tar_validate, 7.45s)
PASS: testthat edition 3 active
PASS: dashboard freshness

=== root suite === SKIP count this run: 0
PASS: failures match the known baseline exactly (3 baseline failures, #569)

=== package suite === SKIP count this run: 15
PASS: failures match the known baseline exactly (1 baseline failure, #569)

=== scripts/verify.sh: PASS ===
```

No regressions; failure/skip counts match the documented `#569` baselines exactly. Note: `verify.sh` validates pipeline *structure*, not that `tar_make()` builds the new targets cleanly — that needs a real `tar_make()` in the main checkout, which this PR (from a worktree with no store) cannot run itself. The read-only verification above against the live main-checkout store confirms the functions produce correct, sane output on real data.

## Out of scope (deliberately, per the dispatch and per #635 itself)

- Building the volatility-normalised allocator (#626) — the number is now live, the allocator that *uses* it is separate work.
- Re-deriving the gross backstop (currently 3.5×, adopted from a p90 computed on since-superseded CMR data) — not part of this issue's DoD item list and not requested by this dispatch. Worth a follow-up: with CMR's vpug now 0.148 (mid-pack, not the outlier it once was), the backstop's p90 has almost certainly moved again.

Refs #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)
