### PR TITLE
feat(liquidity): percentile-indexed ADV threshold + dead-code cleanup (#625)

### DIFF
--- a/R/liquidity.R
+++ b/R/liquidity.R
@@ -27,32 +27,94 @@ calculate_adv <- function(df, window_days = 20) {
 
 #' Apply liquidity filter based on minimum ADV
 #'
-#' @param df Tibble with adv_usd column
-#' @param min_adv_usd Minimum average daily volume in USD (default $1M)
+#' Two threshold modes are supported (#625):
+#'
+#' - `"nominal"` (default) flags rows below a fixed dollar `min_adv_usd`.
+#'   This is a fixed cut that drifts in liquidity-percentile terms as
+#'   market-wide ADV grows over a multi-decade sample -- see the issue's
+#'   "A real modelling concern" section.
+#' - `"percentile"` flags the bottom `min_adv_percentile` fraction of the
+#'   cross-section defined by `by` (default `"date"`) each period, so the
+#'   threshold is recomputed from current data and is regime-invariant
+#'   against ADV growth/inflation over the sample -- the "principled fix"
+#'   option in #625.
+#'
+#' @param df Tibble with adv_usd column (and, for `threshold_mode =
+#'   "percentile"`, the column named by `by`)
+#' @param min_adv_usd Minimum average daily volume in USD (default $1M).
+#'   Used when `threshold_mode = "nominal"`.
 #' @param filter_mode "warn" (default) or "remove"
+#' @param threshold_mode "nominal" (default, fixed dollar cut) or
+#'   "percentile" (cross-sectional percentile cut, recomputed per `by`
+#'   group)
+#' @param min_adv_percentile Minimum ADV percentile rank within each `by`
+#'   group (default 0.30, i.e. the bottom 30% by ADV are flagged illiquid).
+#'   Used when `threshold_mode = "percentile"`.
+#' @param by Column defining the cross-section percentile is computed
+#'   within (default `"date"`). Used when `threshold_mode = "percentile"`.
 #' @return Filtered tibble with liquidity_flag column
 #' @export
-filter_liquidity <- function(df, min_adv_usd = 1e6, filter_mode = "warn") {
+filter_liquidity <- function(df,
+                              min_adv_usd = 1e6,
+                              filter_mode = "warn",
+                              threshold_mode = c("nominal", "percentile"),
+                              min_adv_percentile = 0.30,
+                              by = "date") {
+  threshold_mode <- match.arg(threshold_mode)
+
   if (!"adv_usd" %in% names(df)) {
     cli::cli_abort("adv_usd column missing. Run calculate_adv() first.")
   }
 
-  df <- df |>
-    dplyr::mutate(
-      liquidity_flag = dplyr::case_when(
-        is.na(adv_usd) ~ "insufficient_data",
-        adv_usd < min_adv_usd ~ "illiquid",
-        TRUE ~ "liquid"
+  if (threshold_mode == "percentile") {
+    if (!by %in% names(df)) {
+      cli::cli_abort(
+        "Column {.val {by}} (threshold_mode = 'percentile' cross-section key, `by`) not found in df."
       )
-    )
+    }
+    df <- df |>
+      dplyr::mutate(.pctile_grp = .data[[by]]) |>
+      dplyr::group_by(.pctile_grp) |>
+      dplyr::mutate(
+        .adv_pctile = dplyr::if_else(
+          is.na(adv_usd),
+          NA_real_,
+          dplyr::percent_rank(adv_usd)
+        ),
+        liquidity_flag = dplyr::case_when(
+          is.na(adv_usd) ~ "insufficient_data",
+          .adv_pctile < min_adv_percentile ~ "illiquid",
+          TRUE ~ "liquid"
+        )
+      ) |>
+      dplyr::ungroup() |>
+      dplyr::select(-.pctile_grp, -.adv_pctile)
+  } else {
+    df <- df |>
+      dplyr::mutate(
+        liquidity_flag = dplyr::case_when(
+          is.na(adv_usd) ~ "insufficient_data",
+          adv_usd < min_adv_usd ~ "illiquid",
+          TRUE ~ "liquid"
+        )
+      )
+  }
 
   n_illiquid <- sum(df$liquidity_flag == "illiquid", na.rm = TRUE)
   n_total <- nrow(df)
   pct_illiquid <- round(100 * n_illiquid / n_total, 1)
 
   if (n_illiquid > 0) {
+    threshold_desc <- if (threshold_mode == "percentile") {
+      "ADV percentile rank < {min_adv_percentile} within each '{by}' cross-section"
+    } else {
+      "ADV < ${scales::comma(min_adv_usd)}"
+    }
     cli::cli_warn(c(
-      "!" = "{n_illiquid} / {n_total} ({pct_illiquid}%) observations flagged as illiquid (ADV < ${scales::comma(min_adv_usd)})",
+      "!" = paste0(
+        "{n_illiquid} / {n_total} ({pct_illiquid}%) observations flagged as illiquid (",
+        threshold_desc, ")"
+      ),
       "i" = "Set filter_mode='remove' to exclude them"
     ))
   }

--- a/R/plan_integration.R
+++ b/R/plan_integration.R
@@ -103,48 +103,17 @@ plan_integration <- function() {
       }
     ),
 
-    # === LIQUIDITY: equity with ADV ===
-    # Note: Uses full equity universe from hd_ohlcv()
-    # For production use, may want to filter to liquid universe first
-    targets::tar_target(
-      equity_with_adv,
-      {
-        # Get SPY as example - full universe would be hd_universe("equity")
-        # but that's 50+ tickers and slow for demo
-        equity_data <- hd_ohlcv("SPY") |>
-          dplyr::mutate(ticker = "SPY") |>
-          dplyr::select(date, ticker, open, high, low, close, adjusted_close, volume)
-
-        calculate_adv(equity_data, window_days = 20)
-      }
-    ),
-
-    # === LIQUIDITY: filtered equity ===
-    targets::tar_target(
-      equity_liquidity_filtered,
-      {
-        filter_liquidity(
-          equity_with_adv,
-          min_adv_usd = 1e6,  # $1M minimum ADV
-          filter_mode = "warn"  # Warn but don't remove
-        )
-      }
-    ),
-
-    # === LIQUIDITY: summary table ===
-    targets::tar_target(
-      liquidity_summary_table,
-      {
-        liquidity_summary(equity_liquidity_filtered) |>
-          DT::datatable(
-            caption = "Liquidity Summary by Ticker (SPY Example)",
-            options = list(pageLength = 20),
-            rownames = FALSE
-          ) |>
-          DT::formatCurrency(columns = c("median_adv_usd", "p25_adv_usd", "p75_adv_usd"), digits = 0) |>
-          DT::formatRound(columns = "n_obs", digits = 0)
-      }
-    ),
+    # LIQUIDITY targets deliberately removed here (#625, proposed-work item 6):
+    # this file's equity_with_adv/equity_liquidity_filtered/liquidity_summary_table
+    # trio (a) duplicated target NAMES already defined by plan_liquidity()
+    # (R/plan_liquidity.R), which would collide if this file were ever sourced
+    # alongside it, and (b) liquidity_summary_table's DT::formatCurrency() call
+    # referenced p25_adv_usd/p75_adv_usd columns that liquidity_summary()
+    # (R/liquidity.R) does not return, so it would have errored on first build.
+    # plan_integration() is not sourced by any _targets.R (root or docs/) --
+    # see the commented-out `source(here::here("R/plan_integration.R"))` and
+    # `# plan_integration(),` lines in docs/_targets.R -- so removing this
+    # dead code changes no currently-running pipeline.
 
     # === TRACKING ERROR / IR: calculate for all strategies ===
     targets::tar_target(

--- a/R/plan_liquidity.R
+++ b/R/plan_liquidity.R
@@ -173,6 +173,57 @@ plan_liquidity_dashboard <- function() {
             min_adv_threshold = 1e6
           )
       }
+    ),
+
+    # ── Percentile-indexed threshold variant (#625 "principled fix") ──────
+    #
+    # The nominal $1M cut above is a fixed dollar figure applied across the
+    # full sample. As market-wide ADV grows over a multi-decade span, $1M
+    # sits at a different liquidity percentile in 2005 than in 2025, so the
+    # nominal gate silently tightens or loosens over time (#625, "A real
+    # modelling concern" section). This variant recomputes the cutoff from
+    # the current day's cross-section instead: it flags the bottom
+    # min_adv_percentile (30%) of names by ADV each day, which is invariant
+    # to the absolute dollar level and comparable across liquidity regimes
+    # (e.g. 2008, 2020).
+    #
+    # Deliberately scoped to this dashboard-visible, informational flag only
+    # (filter_mode stays "warn" -- nothing is removed from any backtest by
+    # this target, same as the nominal-threshold targets above). The other
+    # nominal ADV gate in this codebase, stk_params$adv_threshold ($5M,
+    # R/plan_stock_backtest.R:483), is a production INVESTABILITY gate that
+    # is filtered into directly during Factor MAX / DRIF decile construction
+    # (R/plan_stock_backtest.R:1141, R/plan_xgb_signal.R:133) -- switching
+    # that one to a percentile basis would change published backtest
+    # returns and needs its own before/after comparison, exactly like the
+    # filter_mode flip this issue explicitly keeps out of scope. Not done
+    # here; see the #625 follow-up issue.
+    targets::tar_target(
+      equity_daily_liquidity_filtered_pctile,
+      {
+        equity_daily_with_adv |>
+          filter_liquidity(
+            threshold_mode = "percentile",
+            min_adv_percentile = 0.30,
+            by = "date",
+            filter_mode = "warn"
+          )
+      }
+    ),
+
+    targets::tar_target(
+      equity_daily_volume_stats_pctile,
+      {
+        equity_daily_liquidity_filtered_pctile |>
+          dplyr::summarise(
+            total_tickers = dplyr::n_distinct(ticker),
+            total_observations = dplyr::n(),
+            median_adv_all = median(adv_usd, na.rm = TRUE),
+            pct_liquid = 100 * mean(liquidity_flag == "liquid", na.rm = TRUE),
+            pct_illiquid = 100 * mean(liquidity_flag == "illiquid", na.rm = TRUE),
+            min_adv_percentile = 0.30
+          )
+      }
     )
   )
 }

--- a/docs/falsification.qmd
+++ b/docs/falsification.qmd
@@ -693,6 +693,41 @@ if (!is.null(vol_stats)) {
 }
 ```
 
+#### Percentile-Indexed Threshold
+
+```{r}
+#| label: liquidity-volume-stats-pctile
+#| results: asis
+vol_stats_pctile <- safe_tar_read("equity_daily_volume_stats_pctile")
+if (!is.null(vol_stats_pctile)) {
+  cap <- paste0(
+    "**Dashboard-universe liquid/illiquid split, percentile-indexed threshold.** ",
+    "Same universe and `calculate_adv()` output as the Volume Stats tab, but the ",
+    "liquidity cutoff is recomputed each day as the bottom ",
+    scales::percent(vol_stats_pctile$min_adv_percentile, accuracy = 1),
+    " of that day's cross-sectional ADV, rather than a fixed dollar figure. ",
+    "This is the regime-invariant \"principled fix\" from ",
+    "[#625](https://github.com/JohnGavin/historical/issues/625){target=\"_blank\" rel=\"noopener noreferrer\"}: ",
+    "a fixed $1M cut sits at a different liquidity percentile in 2005 than in 2025 as ",
+    "market-wide ADV grows, so the nominal gate on the Volume Stats tab silently ",
+    "tightens or loosens over the sample; this table does not. ",
+    "Sourced from [`filter_liquidity(threshold_mode = \"percentile\")`]",
+    "(https://github.com/JohnGavin/historical/blob/main/R/liquidity.R#L35){target=\"_blank\" rel=\"noopener noreferrer\"} ",
+    "via `equity_daily_volume_stats_pctile` ",
+    "([`R/plan_liquidity.R`](https://github.com/JohnGavin/historical/blob/main/R/plan_liquidity.R){target=\"_blank\" rel=\"noopener noreferrer\"}). ",
+    "Informational only, same as the Volume Stats tab: `filter_mode = \"warn\"` here too, ",
+    "so nothing is removed from any backtest by this table."
+  )
+  fals_dt(vol_stats_pctile, cap)
+} else {
+  cat(paste0(
+    "*Not available: `equity_daily_volume_stats_pctile` has not been built by this run of ",
+    "`tar_make()` yet — see the “How to Read This” tab and ",
+    "[#625](https://github.com/JohnGavin/historical/issues/625){target=\"_blank\" rel=\"noopener noreferrer\"}.*"
+  ))
+}
+```
+
 #### ADV-Cap Impact (MAX HRP)
 
 ```{r}
@@ -750,6 +785,8 @@ if (!is.null(adv_impact) && !is.null(sp)) {
 Neither value governs the other, and **`filter_liquidity()` runs in `filter_mode = "warn"`** — it flags illiquid rows but removes nothing, for both the ingestion-side (`equity_liquidity_filtered`) and dashboard-side (`equity_daily_liquidity_filtered`) targets. `stk_universe` ([`R/plan_stock_backtest.R:421`](https://github.com/JohnGavin/historical/blob/main/R/plan_stock_backtest.R#L421){target="_blank" rel="noopener noreferrer"}) does not depend on either filtered target — the dependency runs the other way (`equity_daily_liquidity_filtered` is derived *from* `stk_universe`, not vice versa). **Illiquid stocks are not excluded from any backtest portfolio shown on this dashboard today.** Do not read the Universe Summary / Volume Stats tabs as implying otherwise; they are a diagnostic, not a filter.
 
 **Universe Summary / Volume Stats now wired in (#625, resolved 2026-08-04):** the two tabs above are computed by [`plan_liquidity_dashboard()`](https://github.com/JohnGavin/historical/blob/main/R/plan_liquidity.R){target="_blank" rel="noopener noreferrer"} in `R/plan_liquidity.R`, which re-expresses the same `calculate_adv()` → `filter_liquidity()` → `liquidity_summary()` pipeline against `stk_universe` instead of `consolidated_equity` (which only exists in the root ingestion pipeline). This means the two tabs describe the **top-market-cap dashboard universe**, not the full ingested equity universe — see the per-table captions above for the exact scope. The original `plan_liquidity()` targets (`liquidity_summary_tbl`, `volume_stats`) are unchanged and still run only in the ingestion pipeline (root `_targets.R`); this dashboard has never depended on them. **Provenance risk:** nothing asserts the two equity sources (`consolidated_equity` vs. `stk_universe`) agree, so the ingestion-side and dashboard-side liquidity summaries can diverge — this is flagged as a follow-up in [#625](https://github.com/JohnGavin/historical/issues/625){target="_blank" rel="noopener noreferrer"}, not resolved here. **Also unverified:** this PR could not run `tar_make()` (concurrent-store conflict with other work on this repo), so neither of these two tabs has been confirmed to actually render — the "Not available" fallback text above will show if the target has not yet been built by a subsequent pipeline run.
+
+**Percentile-Indexed Threshold (#625, added 2026-08-31):** the nominal $1M cut used by the Universe Summary / Volume Stats tabs is a fixed dollar figure applied across the full 2005–2026 sample; as market-wide ADV grows over that span, $1M sits at a different liquidity percentile in 2005 than in 2025, so the nominal gate silently tightens or loosens over time. The Percentile-Indexed Threshold tab surfaces the alternative flagged as "the principled fix" in [#625](https://github.com/JohnGavin/historical/issues/625){target="_blank" rel="noopener noreferrer"}: recompute the cutoff from each day's cross-sectional ADV distribution (bottom 30% flagged illiquid) instead of a fixed dollar amount. This is deliberately scoped to this dashboard-visible, informational flag only — `filter_mode` stays `"warn"` here too, so nothing is removed from any backtest. The *other* nominal ADV gate in this codebase, `stk_params$adv_threshold` ($5M, used directly inside Factor MAX / DRIF decile construction), is a production investability gate whose numbers feed the leaderboard; switching it to a percentile basis would change published backtest returns and needs its own before/after comparison, so it is intentionally left nominal here — tracked as a follow-up, not resolved in this change.
 
 **ADV-Cap Impact (MAX HRP) is a live target** ([`stk_max_adv_cap_impact`](https://github.com/JohnGavin/historical/blob/main/R/plan_stock_backtest.R#L656){target="_blank" rel="noopener noreferrer"}) already built by the deployed pipeline — it compares the [HRP-weighted](https://github.com/JohnGavin/historical/blob/main/R/plan_stock_backtest.R#L609){target="_blank" rel="noopener noreferrer"} Stock MAX portfolio with and without the 10% ADV participation cap, and this tab is the first place it is displayed.
 

--- a/tests/testthat/_snaps/liquidity.md
+++ b/tests/testthat/_snaps/liquidity.md
@@ -6,6 +6,15 @@
       Error in `filter_liquidity()`:
       ! adv_usd column missing. Run calculate_adv() first.
 
+# filter_liquidity threshold_mode='percentile' aborts when the `by` column is absent
+
+    Code
+      filter_liquidity(tibble::tibble(ticker = "AAA", adv_usd = 1e+06),
+      threshold_mode = "percentile", by = "date")
+    Condition
+      Error in `filter_liquidity()`:
+      ! Column "date" (threshold_mode = 'percentile' cross-section key, `by`) not found in df.
+
 # liquidity function signatures are stable (catches API drift)
 
     Code
@@ -19,7 +28,8 @@
     Code
       args(filter_liquidity)
     Output
-      function (df, min_adv_usd = 1e+06, filter_mode = "warn") 
+      function (df, min_adv_usd = 1e+06, filter_mode = "warn", threshold_mode = c("nominal", 
+          "percentile"), min_adv_percentile = 0.3, by = "date") 
       NULL
 
 ---

--- a/tests/testthat/test-liquidity.R
+++ b/tests/testthat/test-liquidity.R
@@ -81,6 +81,87 @@ test_that("filter_liquidity aborts with an informative error when adv_usd is mis
   )
 })
 
+# ── filter_liquidity() percentile threshold_mode (#625) ──────────────────
+#
+# The nominal $ threshold drifts in liquidity-percentile terms as ADV grows
+# over a multi-decade sample -- see .claude/rules/valuation-spread-threshold.md
+# and issue #625's "A real modelling concern" section. threshold_mode =
+# "percentile" recomputes the cutoff from the current cross-section (`by`,
+# default "date") each period instead of a fixed dollar figure, so the gate
+# is regime-invariant.
+
+test_that("filter_liquidity threshold_mode='nominal' is unchanged default behaviour", {
+  df <- tibble::tibble(
+    ticker = c("AAA", "AAA", "BBB"),
+    adv_usd = c(NA_real_, 5e6, 1e5)
+  )
+  expect_warning(
+    result <- filter_liquidity(df, min_adv_usd = 1e6),
+    "illiquid"
+  )
+  expect_equal(result$liquidity_flag, c("insufficient_data", "liquid", "illiquid"))
+})
+
+test_that("filter_liquidity threshold_mode='percentile' flags the bottom fraction per cross-section", {
+  # Two dates, 4 tickers each. adv_usd ranks are stable within each date, but
+  # the ABSOLUTE dollar levels double from date 1 to date 2 -- a nominal
+  # threshold would misclassify a differently-sized bottom fraction on each
+  # date; a percentile threshold flags the same rank fraction on both.
+  df <- tibble::tibble(
+    date = rep(as.Date(c("2024-01-01", "2024-01-02")), each = 4),
+    ticker = rep(c("AAA", "BBB", "CCC", "DDD"), 2),
+    adv_usd = c(1e5, 2e5, 3e5, 4e5, 2e5, 4e5, 6e5, 8e5)
+  )
+  result <- suppressWarnings(filter_liquidity(
+    df,
+    threshold_mode = "percentile",
+    min_adv_percentile = 0.30,
+    by = "date"
+  ))
+  # Bottom 30% by rank (percent_rank < 0.30) is the single lowest-ADV name
+  # (percent_rank 0) on each date -- AAA on date 1, AAA (2e5) on date 2.
+  expect_equal(
+    result$liquidity_flag[result$date == as.Date("2024-01-01") & result$ticker == "AAA"],
+    "illiquid"
+  )
+  expect_equal(
+    result$liquidity_flag[result$date == as.Date("2024-01-02") & result$ticker == "AAA"],
+    "illiquid"
+  )
+  # DDD (highest ADV on both dates) is always liquid despite the absolute
+  # dollar level doubling between dates -- this is the regime-invariance
+  # property nominal thresholds lack.
+  expect_true(all(
+    result$liquidity_flag[result$ticker == "DDD"] == "liquid"
+  ))
+})
+
+test_that("filter_liquidity threshold_mode='percentile' preserves insufficient_data for NA adv_usd", {
+  df <- tibble::tibble(
+    date = as.Date("2024-01-01"),
+    ticker = c("AAA", "BBB", "CCC"),
+    adv_usd = c(NA_real_, 1e5, 2e5)
+  )
+  result <- suppressWarnings(filter_liquidity(
+    df,
+    threshold_mode = "percentile",
+    min_adv_percentile = 0.30,
+    by = "date"
+  ))
+  expect_equal(result$liquidity_flag[result$ticker == "AAA"], "insufficient_data")
+})
+
+test_that("filter_liquidity threshold_mode='percentile' aborts when the `by` column is absent", {
+  expect_snapshot(
+    error = TRUE,
+    filter_liquidity(
+      tibble::tibble(ticker = "AAA", adv_usd = 1e6),
+      threshold_mode = "percentile",
+      by = "date"
+    )
+  )
+})
+
 # ── liquidity_summary() ───────────────────────────────────────────────────
 
 test_that("liquidity_summary computes correct per-ticker medians and orders by median_adv_usd desc", {


### PR DESCRIPTION
## Summary

Closes the remaining work items from #625.

**Load-bearing check done first, per the issue's own comment thread:** verified
that Option A (re-expressing `plan_liquidity()` against
`hd_datasets()[["equity_daily"]]` via `stk_universe`) was **already implemented
and merged** on `main` — PRs #634 and #636. `stk_universe` carries a usable
`volume` column, and the non-US yfinance volume-corruption guard
(`hd_unreliable_volume_ticker()`) is already applied explicitly to it before
`calculate_adv()` runs (see the existing "Volume-corruption guard note" in
`R/plan_liquidity.R`). No duplicate corruption-handling logic was needed. The
dashboard/ingestion wiring, threshold reconciliation, dashboard tab, and the
`cakici_design_ab/run.R` assertion (proposed-work items 1–4) were all already
done — this PR only had genuinely new work to do on items 5 and 6.

**Item 5 — percentile-indexed ADV threshold (the issue's "principled fix"):**

- `filter_liquidity()` (`R/liquidity.R`) gains a `threshold_mode` argument:
  `"nominal"` (default, unchanged, fixed-dollar cut) or `"percentile"`
  (recomputes the illiquid cutoff each period from that period's
  cross-sectional ADV distribution — default: bottom 30%). Fully additive and
  backward-compatible; every existing call site is untouched.
- Wired into `plan_liquidity_dashboard()` as two new targets
  (`equity_daily_liquidity_filtered_pctile`, `equity_daily_volume_stats_pctile`)
  and surfaced as a new **"Percentile-Indexed Threshold"** sub-tab on
  `falsification.qmd`'s existing Liquidity section — no new dashboard, per
  `dashboard-output-first`.
- **Deliberately scoped to the informational $1M universe-wide flag only.**
  The *other* nominal ADV gate, `stk_params$adv_threshold` ($5M,
  `R/plan_stock_backtest.R:483`), is filtered into directly during Factor
  MAX / DRIF decile construction (`R/plan_stock_backtest.R:1141`,
  `R/plan_xgb_signal.R:133`) — its numbers feed the leaderboard, so switching
  its basis to percentile would change published backtest returns and needs
  its own before/after comparison. Filed as
  [#822](https://github.com/JohnGavin/historical/issues/822).

**Item 6 — dead duplicate deletion:** removed the duplicate
`equity_with_adv` / `equity_liquidity_filtered` / `liquidity_summary_table`
trio from `R/plan_integration.R` (never sourced by any `_targets.R`; would
have collided on target names with `plan_liquidity()` and errored on
`p25_adv_usd`/`p75_adv_usd` columns `liquidity_summary()` doesn't return, had
it ever been wired in).

**Kept out of scope, per the issue's own exclusion:** flipping
`filter_mode` from `"warn"` to `"remove"` — filed as
[#821](https://github.com/JohnGavin/historical/issues/821), since that changes
which names backtests actually trade and needs a before/after comparison.

## Test plan

- [x] `filter_liquidity()` new tests: nominal-mode-unchanged, percentile-mode
      cross-sectional flagging (regime-invariance property), NA handling,
      missing-`by`-column abort — all pass, snapshot for the new error
      auto-written, `args()` signature snapshot updated for the new
      parameters
- [x] `scripts/verify.sh` (full mode) — PASS, both baselines (root 3, package
      1) match exactly, `docs/_targets.R` structurally validates with the new
      targets
- [x] `R/plan_integration.R` parses after the deletion

## Follow-ups filed

- [#821](https://github.com/JohnGavin/historical/issues/821) — flip
  `filter_mode` to `"remove"`
- [#822](https://github.com/JohnGavin/historical/issues/822) — percentile-index
  the $5M production decile-construction ADV gate

Closes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)
