### PR TITLE
feat(leaderboard): prop-constrained re-ranking view (#586)

### DIFF
--- a/R/plan_leaderboard.R
+++ b/R/plan_leaderboard.R
@@ -214,6 +214,44 @@ STRATEGY_OBS_ANN_FACTOR <- .build_strategy_obs_ann_factor(
 
 STRATEGY_COST_BASIS <- .strategy_turnover_cost_basis(hd_strategy_names_tbl())
 
+# ── Prop-constrained view scenarios (#586 second comment, "Proposed shape") ──
+# The per-row "Breach Risk (+/-20% DD)" column above (fp_breach_prob_20pct)
+# is a single fixed-barrier diagnostic that INFORMS the primary leaderboard
+# without re-ranking it. `leaderboard_prop_constrained` below builds the
+# separately agreed second half of the two-portfolio design: a re-ranked
+# VIEW of the same Full Period targets, parameterised by (floor, target)
+# pairs -- "would this strategy survive a drawdown mandate", answered
+# separately from "is the edge real" (the unconstrained leaderboard).
+#
+# These three rows are NOT any specific prop-trading firm's rules (#586:
+# "We are not going to trade prop-firm challenges") -- floor/target are the
+# caller-supplied INPUTS the source article's maths generalises to any
+# capital with a redemption trigger, a risk-committee drawdown limit, or a
+# review period. `target` is held FIXED at 10% across all three rows and
+# only `floor` (the drawdown mandate) tightens -- this is deliberate, not an
+# oversight: for the two-barrier gambler's-ruin formula, decreasing the
+# distance to ONE barrier while holding the other fixed monotonically
+# decreases the probability of hitting the FIXED barrier first, for any
+# drift/vol (Karlin & Taylor, see packages/historicaldata/R/first_passage.R).
+# A design that scaled floor and target together (e.g. symmetric 10/10,
+# 15/15, 20/20) would NOT have this monotone property -- wider symmetric
+# barriers give MORE room for genuine drift to dominate noise, which moves
+# pass_prob further from 50% in the direction of the strategy's own edge
+# sign, not predictably up or down -- so it would not read as "tightening a
+# mandate" the way this ordering does.
+#
+# `daily_limit` and finite `horizon` are deliberately NOT parameterised
+# here -- see `leaderboard_prop_constrained`'s own comment for why
+# (`hd_first_passage()` does not implement either; both remain documented,
+# deferred follow-up work, same as that function's own scope note).
+PROP_CONSTRAINED_SCENARIOS <- tibble::tibble(
+  label  = c("Strict (5% floor / 10% target)",
+             "Standard (10% floor / 10% target)",
+             "Lenient (20% floor / 10% target)"),
+  floor  = c(0.05, 0.10, 0.20),
+  target = c(0.10, 0.10, 0.10)
+)
+
 plan_leaderboard <- function() {
   list(
     # Explicit deps — targets must be named as function args
@@ -1176,6 +1214,77 @@ plan_leaderboard <- function() {
         dplyr::select(-obs_ann_factor, -obs_ann_factor_source)
 
       all_metrics
+    }),
+
+    # ── Prop-constrained re-ranking view (#586 second comment) ────────────
+    # Long-format: one row per (strategy x PROP_CONSTRAINED_SCENARIOS row),
+    # for the Full Period rows of `leaderboard` only -- this is a VIEW of
+    # the same targets, not a new set of strategies (dashboard-output-first,
+    # subtractive-first). A strategy failing every scenario here is
+    # FLAGGED on the "Prop-Constrained View" tab only; it is never removed
+    # from the primary leaderboard (#586's "Proposed shape": "flagged,
+    # never removed").
+    #
+    # PARAMETERISATION -- what is and is not implemented:
+    #   floor / target (hd_first_passage()'s lower/upper barriers) ARE the
+    #     caller-supplied inputs swept below, via PROP_CONSTRAINED_SCENARIOS
+    #     (module-level constant above plan_leaderboard()). Any (floor,
+    #     target) pair can be added as a new scenario row without touching
+    #     this target's logic.
+    #   daily_limit and horizon are NOT implemented. hd_first_passage()
+    #     itself documents both as deferred (see the file-level scope note
+    #     at the top of packages/historicaldata/R/first_passage.R: "finite-
+    #     horizon conditioning... requires the inverse-Gaussian first-
+    #     passage-TIME distribution... neither of which is implemented
+    #     here"). Every pass_prob/breach_prob below is therefore
+    #     INFINITE-HORIZON (no evaluation window) and has NO per-day loss
+    #     cap -- an honest CEILING on survivability under a real time-boxed
+    #     mandate, not a point estimate of it (docs/leaderboard.qmd's tab
+    #     prose carries the matching caveat). Closing this gap is
+    #     separately scoped, deferred follow-up; it is not attempted here.
+    #
+    # mu_period/sigma_period use the IDENTICAL derivation as the per-row
+    # fp_breach_prob_20pct diagnostic above -- (1+cagr)^(1/af)-1 and
+    # vol/sqrt(af) -- so the two views can never silently disagree on the
+    # underlying drift/vol estimate, only on the barrier distances.
+    targets::tar_target(leaderboard_prop_constrained, {
+      library(dplyr)
+
+      full <- leaderboard |>
+        filter(period == "Full Period") |>
+        left_join(STRATEGY_OBS_ANN_FACTOR, by = "strategy")
+
+      .pc_pass_prob <- function(cagr, vol, af, floor, target) {
+        if (is.na(cagr) || is.na(vol) || is.na(af) || af <= 0 || vol <= 0) {
+          return(NA_real_)
+        }
+        mu_period    <- (1 + cagr)^(1 / af) - 1
+        sigma_period <- vol / sqrt(af)
+        fp <- tryCatch(
+          historicaldata::hd_first_passage(
+            mu = mu_period, sigma = sigma_period, upper = target, lower = floor
+          ),
+          error = function(e) NULL
+        )
+        if (is.null(fp) || is.na(fp$pass_prob)) NA_real_ else fp$pass_prob
+      }
+
+      purrr::map_dfr(seq_len(nrow(PROP_CONSTRAINED_SCENARIOS)), function(i) {
+        scen <- PROP_CONSTRAINED_SCENARIOS[i, ]
+        full |>
+          transmute(
+            strategy,
+            sharpe, cagr, vol, max_dd,
+            scenario  = scen$label,
+            floor     = scen$floor,
+            target    = scen$target,
+            pass_prob = purrr::pmap_dbl(
+              list(cagr, vol, obs_ann_factor),
+              function(c, v, a) .pc_pass_prob(c, v, a, scen$floor, scen$target)
+            ),
+            breach_prob = ifelse(is.na(pass_prob), NA_real_, 1 - pass_prob)
+          )
+      })
     }),
 
     # ── Correlation matrix of monthly returns across strategies ───────

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -66,8 +66,9 @@ source(partitions_path)
 universe, and per-strategy statistical detection power/rigour limits (see the
 **Detection** and **Rigour** columns below). The **Breach Risk (±20% DD)**
 column is a secondary, informational diagnostic (issue #586) — it does NOT
-affect this table's ranking. Full detail, collected in one place:
-[Biases and Caveats](#biases-and-caveats).
+affect this table's ranking. For a separate re-ranking by survivability under
+a drawdown mandate, see the **Prop-Constrained View** tab. Full detail,
+collected in one place: [Biases and Caveats](#biases-and-caveats).
 :::
 
 ## Row
@@ -759,6 +760,168 @@ if (!is.null(lb)) {
   .rig-badge.partial      { color: #fbbf24; }
   .fp-badge                { color: #9ca3af; }
   .sharpe-ci-flag         { color: #ff6b6b; }
+}
+</style>
+```
+
+#### Prop-Constrained View
+
+This is the separately agreed second half of [#586](https://github.com/JohnGavin/historical/issues/586)'s two-portfolio design. The Full Period tab above answers *is the edge real* — Sharpe, deflated Sharpe, detection power, rigour. This tab answers a different question — *would this strategy survive a drawdown mandate*, such as a redemption trigger, a risk-committee drawdown limit, or an evaluation window — as a **separate ranking**, never folded into the primary one. The per-row Breach Risk (±20% DD) badge on the Full Period tab is a single fixed-barrier diagnostic; this tab is the fuller, parameterised view the issue asked for: three drawdown-floor scenarios (profit target held fixed at 10%), re-ranking the same strategies by survival probability. A strategy scoring poorly here is **flagged, never removed**, from the primary board above.
+
+```{r}
+#| label: prop-constrained-view
+pc <- safe_tar_read("leaderboard_prop_constrained")
+if (!is.null(pc)) {
+  gh_url <- tryCatch({
+    remote <- system("git remote get-url origin 2>/dev/null", intern = TRUE)
+    sub("\\.git$", "", sub("^git@github\\.com:", "https://github.com/", remote))
+  }, error = function(e) NULL)
+  git_sha <- tryCatch(
+    system("git rev-parse HEAD 2>/dev/null", intern = TRUE),
+    error = function(e) "main"
+  )
+  git_sha <- if (length(git_sha) == 0 || !nzchar(git_sha)) "main" else git_sha
+  gh_base <- if (!is.null(gh_url) && length(gh_url) > 0) gh_url else
+    "https://github.com/JohnGavin/historical"
+
+  fp_fn_link <- hd_link(
+    htmltools::tags$code("hd_first_passage()"),
+    sprintf("%s/blob/%s/packages/historicaldata/R/first_passage.R#L117", gh_base, git_sha)
+  )
+  pc_tgt_link <- hd_link(
+    htmltools::tags$code("leaderboard_prop_constrained"),
+    sprintf("%s/blob/%s/R/plan_leaderboard.R#L1250", gh_base, git_sha)
+  )
+
+  # Scenario column order == PROP_CONSTRAINED_SCENARIOS row order (R/plan_
+  # leaderboard.R), preserved by purrr::map_dfr appending one scenario's
+  # rows for ALL strategies before moving to the next.
+  scenario_order <- unique(pc$scenario)
+  standard_scenario <- scenario_order[grepl("^Standard", scenario_order)]
+  if (length(standard_scenario) == 0) standard_scenario <- scenario_order[1]
+
+  base_cols <- pc |>
+    dplyr::distinct(strategy, sharpe, cagr, max_dd)
+
+  pct_wide <- pc |>
+    dplyr::mutate(
+      pct_label = ifelse(is.na(pass_prob), "not computed", paste0(round(pass_prob * 100), "%"))
+    ) |>
+    dplyr::select(strategy, scenario, pct_label) |>
+    tidyr::pivot_wider(names_from = scenario, values_from = pct_label)
+
+  rank_key <- pc |>
+    dplyr::filter(scenario == standard_scenario) |>
+    dplyr::select(strategy, .rank_key = pass_prob)
+
+  n_strats  <- dplyr::n_distinct(pc$strategy)
+  n_flagged <- sum(rank_key$.rank_key < 0.5, na.rm = TRUE)
+  n_na      <- sum(is.na(rank_key$.rank_key))
+
+  flag_badge <- function(p) {
+    if (is.na(p)) {
+      return("<span class='fp-badge' title='Not computed -- see leaderboard_prop_constrained target comment for the NA paths.'>not computed</span>")
+    }
+    if (p < 0.5) {
+      return(sprintf(
+        "<span class='pc-flag warn' title='Survival probability under the %s scenario is below 50%%. Flagged here only -- NOT removed from the primary Full Period leaderboard above.'>&#9888; flagged</span>",
+        gsub("'", "&#39;", standard_scenario, fixed = TRUE)
+      ))
+    }
+    "<span class='pc-flag ok'>&#10003;</span>"
+  }
+
+  view_table <- base_cols |>
+    dplyr::left_join(pct_wide, by = "strategy") |>
+    dplyr::left_join(rank_key, by = "strategy") |>
+    dplyr::mutate(
+      Flag   = vapply(.rank_key, flag_badge, character(1)),
+      Sharpe = ifelse(is.na(sharpe), "—", as.character(round(sharpe, 2))),
+      CAGR   = ifelse(is.na(cagr),   "—", paste0(round(cagr * 100, 1), "%")),
+      `Max DD` = paste0(round(max_dd * 100, 1), "%")
+    ) |>
+    dplyr::arrange(dplyr::desc(.rank_key)) |>
+    dplyr::select(strategy, Sharpe, CAGR, `Max DD`, dplyr::all_of(scenario_order), Flag, .rank_key) |>
+    dplyr::rename(Strategy = strategy) |>
+    dplyr::rename_with(~ paste0("Survival: ", .x), .cols = dplyr::all_of(scenario_order))
+
+  pc_short <- paste0(
+    "Re-ranked view of the same ", n_strats, " Full Period strategies by survivability under a ",
+    "drawdown-mandate constraint — profit target fixed at 10%, drawdown floor tightening from 20% ",
+    "(Lenient) to 5% (Strict). Ordered by Survival: ", standard_scenario, " (descending). ",
+    n_flagged, " of ", n_strats, " strategies fall below 50% survival under that scenario",
+    if (n_na > 0) paste0(" (", n_na, " not computed)") else "", " — those are flagged here only, ",
+    "never removed from the primary Full Period ranking above. Expand for the full methodology note."
+  )
+
+  pc_notes <- htmltools::tagList(
+    "Infinite-horizon, drifted-Brownian-motion approximation, computed per strategy by ", fp_fn_link,
+    " and assembled in ", pc_tgt_link, " — issue #586's agreed two-portfolio design: this view answers ",
+    "\"would this strategy survive a drawdown mandate\", separately from the primary leaderboard's ",
+    "\"is the edge real\". Each scenario holds the profit target fixed at 10% and varies only the ",
+    "drawdown floor (5% / 10% / 20%): decreasing the floor distance while the target stays fixed ",
+    "monotonically decreases survival probability for any strategy, regardless of its own drift/vol — ",
+    "which is why this ordering reads as \"tightening a mandate\" the way a naive symmetric floor/",
+    "target sweep would not (see the PROP_CONSTRAINED_SCENARIOS comment in R/plan_leaderboard.R for the ",
+    "full reasoning). This is deliberately NOT a new dashboard and NOT a new set of strategies — the ",
+    "same Full Period rows shown above, re-ranked. Two parameters this view does NOT yet support: a ",
+    "per-day loss limit, and a finite evaluation horizon (\"within N months\", as opposed to \"ever\") — ",
+    "both remain deferred, same as ", fp_fn_link, "'s own documented scope limits. Every probability ",
+    "here is therefore an infinite-horizon, Gaussian-iid approximation: real fat-tailed paths and any ",
+    "time-boxed evaluation window make breaches MORE likely than these numbers imply, so treat the ",
+    "Survival columns as an optimistic ceiling on survivability, not a point estimate of it."
+  )
+
+  pc_caption <- hd_caption(pc_notes, short = pc_short, summary_label = "Full methodology note")
+
+  pc_display <- view_table |> dplyr::select(-.rank_key)
+  numeric_cols <- which(sapply(pc_display, function(x) is.numeric(x) ||
+                                  grepl("^[0-9.%$,-]+$", as.character(x[1]))))
+
+  DT::datatable(
+    pc_display,
+    caption = pc_caption,
+    escape = FALSE,
+    rownames = FALSE,
+    filter = "top",
+    options = list(
+      pageLength = 15,
+      scrollX = TRUE,
+      autoWidth = FALSE,
+      dom = "frtip",
+      order = list(),
+      search = list(regex = TRUE, caseInsensitive = TRUE),
+      columnDefs = list(
+        list(className = 'dt-right', targets = numeric_cols - 1)
+      ),
+      initComplete = DT::JS(
+        "function(settings, json) {",
+        "  var isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark'",
+        "    || document.body.classList.contains('dark-mode');",
+        "  if (isDark) {",
+        "    $(this.api().table().container()).css({'color': '#ddd', 'background-color': '#1a1a1a'});",
+        "    $(this.api().table().header()).css({'color': '#ddd', 'background-color': '#222'});",
+        "    $('input', this.api().table().container()).css({'color': '#ddd', 'background-color': '#333', 'border-color': '#555'});",
+        "  }",
+        "}"
+      )
+    )
+  )
+} else {
+  cat("*`leaderboard_prop_constrained` target not available.*")
+}
+```
+
+```{=html}
+<style>
+.pc-flag { font-weight: 600; padding: 1px 6px; border-radius: 3px; white-space: nowrap; }
+.pc-flag.warn { color: #9a5b00; }
+.pc-flag.ok   { color: #1a7f37; }
+[data-bs-theme="dark"] .pc-flag.warn, body.dark-mode .pc-flag.warn { color: #fbbf24; }
+[data-bs-theme="dark"] .pc-flag.ok,   body.dark-mode .pc-flag.ok   { color: #4ade80; }
+@media (prefers-color-scheme: dark) {
+  .pc-flag.warn { color: #fbbf24; }
+  .pc-flag.ok   { color: #4ade80; }
 }
 </style>
 ```


### PR DESCRIPTION
## Summary

Builds the deferred second half of #586's agreed two-portfolio design — see the issue's second comment ("Scope addition: prop-constrained vs unconstrained portfolios") for the full spec this implements against. The Calmar/CDAP fix and the primary-leaderboard "Breach Risk (±20% DD)" column (`hd_first_passage()`, [PR #818](https://github.com/JohnGavin/historical/pull/818)) already merged; this PR is the remaining piece named in that PR's own closing comment: *"the parameterised prop-constrained re-ranking view (the second half of the two-portfolio design)."*

- New target `leaderboard_prop_constrained` (`R/plan_leaderboard.R`) — long-format survival/breach probability per (Full Period strategy × scenario), computed via the existing `historicaldata::hd_first_passage()` closed-form barrier-crossing formula. Reuses the identical `mu_period`/`sigma_period` derivation as the existing `fp_breach_prob_20pct` diagnostic, so the two views can never silently disagree on the underlying drift/vol estimate.
- `PROP_CONSTRAINED_SCENARIOS` — three documented `(floor, target)` scenarios holding the profit target fixed at 10% and tightening only the drawdown floor (5% / 10% / 20%). This is deliberate, not arbitrary: for the two-barrier gambler's-ruin formula, decreasing the distance to one barrier while holding the other fixed monotonically decreases the probability of hitting the fixed barrier first, for any drift/vol — verified numerically in a standalone smoke test (see below). A symmetric floor/target sweep (10/10, 15/15, 20/20) would **not** have this monotone property, so it would not read as "tightening a mandate."
- New **Prop-Constrained View** tab (`docs/leaderboard.qmd`) — pivots the long-format target wide, re-ranks strategies by the Standard (10%/10%) scenario's survival probability, and flags (never removes) any strategy below 50% survival there. Updated the Rankings top-of-page callout to point at the new tab.

## What remains explicitly deferred

`daily_limit` and finite evaluation `horizon` are **not** parameterised — `hd_first_passage()` itself documents both as deferred (its own file-level scope note), so neither is implemented by the underlying closed form and neither is faked here. Every probability in this view is infinite-horizon and Gaussian-iid, same caveat as the existing per-row badge; the tab prose says so explicitly. A fat-tail-aware simulation fallback also remains out of scope, per #586's own proposed-scope ordering.

## Verification

- `scripts/verify.sh` — **exit 0**. `parse("_targets.R")` OK, `docs/_targets.R` parses and passes `tar_validate()` (structural — does not execute target bodies), dead-target-reference check PASS (confirms `leaderboard_prop_constrained` and the new tab's `safe_tar_read()` call resolve to a real target name), both testthat suites (root: 959 total, 3 known baseline failures, 0 new; package: 857 total, 1 known baseline failure, 15 known skips, 0 new).
- Since `verify.sh`'s `tar_validate()` does not execute target bodies, and this worktree has no `docs/_targets` store to build one against (must not build one that could race the main checkout's store), I additionally ran two standalone smoke tests reproducing the exact logic against mocked data:
  - The target's probability computation: confirmed NA propagation for missing `cagr`/`vol`, and confirmed `pass_prob` increases monotonically as `floor` widens (5% → 10% → 20%) for a positive-drift mock strategy (0.484 → 0.704 → 0.890) and a negative-drift one (0.292 → 0.436 → 0.579).
  - The qmd's pivot/rank/flag logic: confirmed correct wide-pivot column names, correct descending sort by the Standard-scenario survival probability with NA sorting last, correct 50%-threshold flagging, and a valid `DT::datatable` object construction.

## Test plan

- [x] `scripts/verify.sh` exit 0 (see above)
- [x] Standalone smoke test of `leaderboard_prop_constrained` probability logic (monotonicity, NA handling)
- [x] Standalone smoke test of the qmd's pivot/rank/flag/DT logic against mocked data
- [ ] Manual `quarto render docs/leaderboard.qmd` against a real `docs/_targets` store (main checkout only) before merge, per this repo's own render-time-only failure mode for `tar_read()` chunks

Refs #586 — not closing, since the fat-tail-aware simulation fallback and finite-horizon conditioning named in the issue remain unimplemented, consistent with its own deferred-scope list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
