### PR TITLE
feat(stock-backtest): opt-in market-impact cost + Sharpe-vs-eta panel (#490 Gap 4)

### DIFF
--- a/R/plan_stock_backtest.R
+++ b/R/plan_stock_backtest.R
@@ -252,6 +252,78 @@ apply_adv_cap <- function(w, adv_by_ticker, adv_pct_cap = 0.10) {
   list(capped_w = w_capped, hit_cap = hit_cap)
 }
 
+#' Market-impact cost, square-root law (local helper; #490 Gap 4)
+#' @param order_usd,adv_usd,sigma,eta See historicaldata::hd_market_impact.
+#' @return Numeric fraction of order_usd.
+#' @noRd
+market_impact_cost <- function(order_usd, adv_usd, sigma, eta = 1) {
+  if (!is.numeric(order_usd) || anyNA(order_usd) || any(order_usd < 0)) {
+    cli::cli_abort(c(
+      "x" = "{.arg order_usd} must be numeric, non-NA, and >= 0.",
+      "i" = "Got {.val {order_usd}}."
+    ))
+  }
+  if (!is.numeric(adv_usd) || anyNA(adv_usd) || any(adv_usd <= 0)) {
+    cli::cli_abort(c(
+      "x" = "{.arg adv_usd} must be numeric, non-NA, and > 0.",
+      "i" = "Got {.val {adv_usd}}."
+    ))
+  }
+  if (!is.numeric(sigma) || anyNA(sigma) || any(sigma < 0)) {
+    cli::cli_abort(c(
+      "x" = "{.arg sigma} must be numeric, non-NA, and >= 0.",
+      "i" = "Got {.val {sigma}}."
+    ))
+  }
+  if (!is.numeric(eta) || length(eta) != 1L || is.na(eta) || eta <= 0) {
+    cli::cli_abort(c(
+      "x" = "{.arg eta} must be a single positive number.",
+      "i" = "Got {.val {eta}}."
+    ))
+  }
+  eta * sigma * sqrt(order_usd / adv_usd)
+}
+
+#' Validate impact_eta/impact_aum/impact_sigma args (#490 Gap 4)
+#' @noRd
+validate_impact_args <- function(adv_monthly, impact_aum, impact_sigma, impact_eta) {
+  bad_num <- function(x) !is.numeric(x) || length(x) != 1L || is.na(x)
+  if (is.null(adv_monthly)) {
+    cli::cli_abort("impact_eta requires adv_monthly to be supplied.")
+  }
+  if (bad_num(impact_aum) || impact_aum <= 0) {
+    cli::cli_abort(c("x" = "impact_aum must be a single positive number.", "i" = "Got {.val {impact_aum}}."))
+  }
+  if (bad_num(impact_sigma) || impact_sigma < 0) {
+    cli::cli_abort(c("x" = "impact_sigma must be a single non-negative number.", "i" = "Got {.val {impact_sigma}}."))
+  }
+  if (bad_num(impact_eta) || impact_eta <= 0) {
+    cli::cli_abort(c("x" = "impact_eta must be a single positive number, or NULL to disable.", "i" = "Got {.val {impact_eta}}."))
+  }
+  invisible(TRUE)
+}
+
+#' Market-impact cost for one rebalance, both legs (#490 Gap 4)
+#' @noRd
+compute_impact_cost_frac <- function(use_impact, w_long, w_short, adv_vec,
+                                      turnover_long, turnover_short,
+                                      impact_aum, impact_sigma, impact_eta) {
+  if (!use_impact) return(0)
+  adv_long_total  <- sum(adv_vec[intersect(names(w_long),  names(adv_vec))], na.rm = TRUE)
+  adv_short_total <- sum(adv_vec[intersect(names(w_short), names(adv_vec))], na.rm = TRUE)
+  order_long_usd  <- impact_aum * turnover_long
+  order_short_usd <- impact_aum * turnover_short
+  impact_long_frac <- 0
+  if (adv_long_total > 0 && order_long_usd > 0) {
+    impact_long_frac <- market_impact_cost(order_long_usd, adv_long_total, impact_sigma, eta = impact_eta) * turnover_long
+  }
+  impact_short_frac <- 0
+  if (adv_short_total > 0 && order_short_usd > 0) {
+    impact_short_frac <- market_impact_cost(order_short_usd, adv_short_total, impact_sigma, eta = impact_eta) * turnover_short
+  }
+  2 * (impact_long_frac + impact_short_frac)
+}
+
 #' Long-short portfolio with HRP weighting per leg (Lopez de Prado 2016)
 #' @param df Data frame with ym, ticker, decile, monthly_ret (signal-to-return merged)
 #' @param returns_wide Wide tibble: rows = ym, cols = ticker, values = monthly_ret
@@ -263,7 +335,16 @@ apply_adv_cap <- function(w, adv_by_ticker, adv_pct_cap = 0.10) {
 #' @param max_monthly_ret Winsorise monthly returns at ±this (default 0.20 = 20%)
 #' @param adv_monthly Monthly ADV data: tibble(ym, ticker, adv_dollars). NULL = no cap.
 #' @param adv_pct_cap Maximum participation per stock as multiple of ADV-weight share × n (default 0.10)
-#' @return Tibble with same shape as portfolio_longshort, plus adv_cap columns when adv_monthly supplied
+#' @param impact_eta NULL (default) or a positive number: square-root-law
+#'   market-impact eta (#490 Gap 4), opt-in cost term on top of
+#'   cost_per_trade. Requires adv_monthly, impact_aum, impact_sigma.
+#' @param impact_aum Assumed AUM (single positive number) used to size
+#'   orders for the impact-cost term. Required when impact_eta is set.
+#' @param impact_sigma Return volatility (single non-negative number) used
+#'   in the impact-cost formula. Required when impact_eta is set.
+#' @return Tibble with same shape as portfolio_longshort, plus adv_cap
+#'   columns when adv_monthly supplied, plus impact_cost_frac (0 when
+#'   impact_eta is NULL).
 portfolio_longshort_hrp <- function(df, returns_wide,
                                     long_decile = 1L, short_decile = 10L,
                                     lookback_months = 36L,
@@ -271,11 +352,18 @@ portfolio_longshort_hrp <- function(df, returns_wide,
                                     borrow_rate_annual = 0.03,
                                     max_monthly_ret = 0.20,
                                     adv_monthly = NULL,
-                                    adv_pct_cap = 0.10) {
+                                    adv_pct_cap = 0.10,
+                                    impact_eta = NULL,
+                                    impact_aum = NULL,
+                                    impact_sigma = NULL) {
   if (!requireNamespace("HierPortfolios", quietly = TRUE)) {
     cli::cli_abort("HierPortfolios package required for HRP weighting")
   }
   use_adv_cap <- !is.null(adv_monthly)
+  use_impact  <- !is.null(impact_eta)
+  if (use_impact) {
+    validate_impact_args(adv_monthly, impact_aum, impact_sigma, impact_eta)
+  }
   # Winsorise returns
   df <- df |>
     dplyr::mutate(monthly_ret = pmin(pmax(monthly_ret, -max_monthly_ret), max_monthly_ret))
@@ -338,10 +426,12 @@ portfolio_longshort_hrp <- function(df, returns_wide,
     # ADV participation cap (applied AFTER HRP, BEFORE return computation)
     n_cap_long  <- 0L
     n_cap_short <- 0L
-    if (use_adv_cap) {
-      adv_t <- adv_monthly[adv_monthly$ym == ym_t, c("ticker", "adv_dollars")]
+    adv_vec <- NULL
+    if (use_adv_cap || use_impact) {
+      adv_t   <- adv_monthly[adv_monthly$ym == ym_t, c("ticker", "adv_dollars")]
       adv_vec <- setNames(adv_t$adv_dollars, adv_t$ticker)
-
+    }
+    if (use_adv_cap) {
       cap_long  <- apply_adv_cap(w_long,  adv_vec, adv_pct_cap)
       cap_short <- apply_adv_cap(w_short, adv_vec, adv_pct_cap)
 
@@ -396,7 +486,11 @@ portfolio_longshort_hrp <- function(df, returns_wide,
 
     trade_cost  <- turnover * cost_per_trade * 2 * 2   # both legs, buy + sell
     borrow_cost <- borrow_rate_annual / 12
-    total_cost  <- trade_cost + borrow_cost
+    impact_cost_frac <- compute_impact_cost_frac(
+      use_impact, w_long, w_short, adv_vec, turnover_long, turnover_short,
+      impact_aum, impact_sigma, impact_eta
+    )
+    total_cost  <- trade_cost + borrow_cost + impact_cost_frac
     port_ret    <- long_ret - short_ret - total_cost
 
     out[[i]] <- dplyr::tibble(
@@ -409,7 +503,8 @@ portfolio_longshort_hrp <- function(df, returns_wide,
       turnover   = turnover,
       total_cost = total_cost,
       n_cap_long  = n_cap_long,
-      n_cap_short = n_cap_short
+      n_cap_short = n_cap_short,
+      impact_cost_frac = impact_cost_frac
     )
 
     prev_w_long  <- w_long
@@ -425,6 +520,81 @@ portfolio_longshort_hrp <- function(df, returns_wide,
     )
   }
   dplyr::bind_rows(out)
+}
+
+#' Validate eta_grid for market_impact_sensitivity (#490 Gap 4)
+#' @noRd
+validate_eta_grid <- function(eta_grid, adv_monthly) {
+  bad <- !is.numeric(eta_grid) || length(eta_grid) == 0L || anyNA(eta_grid) || any(eta_grid <= 0)
+  if (bad) {
+    cli::cli_abort(c(
+      "x" = "eta_grid must be a non-empty numeric vector of positive values.",
+      "i" = "Got {.val {eta_grid}}."
+    ))
+  }
+  if (is.null(adv_monthly)) {
+    cli::cli_abort("adv_monthly is required to sweep market-impact cost.")
+  }
+  invisible(TRUE)
+}
+
+#' One row of the impact sensitivity panel, for one eta (#490 Gap 4)
+#' @noRd
+sensitivity_panel_row <- function(eta, df, returns_wide, long_decile, short_decile,
+                                   lookback_months, cost_per_trade, borrow_rate_annual,
+                                   max_monthly_ret, adv_monthly, adv_pct_cap,
+                                   impact_aum, impact_sigma, rf, rf_col) {
+  port <- portfolio_longshort_hrp(
+    df, returns_wide, long_decile = long_decile, short_decile = short_decile,
+    lookback_months = lookback_months, cost_per_trade = cost_per_trade,
+    borrow_rate_annual = borrow_rate_annual, max_monthly_ret = max_monthly_ret,
+    adv_monthly = adv_monthly, adv_pct_cap = adv_pct_cap,
+    impact_eta = eta, impact_aum = impact_aum, impact_sigma = impact_sigma
+  )
+  if (!is.null(rf)) port <- dplyr::left_join(port, rf, by = "ym")
+
+  n <- nrow(port)
+  if (n < 2L) {
+    return(tibble::tibble(eta = eta, months = n, sharpe = NA_real_,
+                           cagr = NA_real_, vol = NA_real_,
+                           avg_impact_cost_frac = NA_real_))
+  }
+  ann_ret <- prod(1 + port$port_ret)^(12 / n) - 1
+  ann_vol <- stats::sd(port$port_ret) * sqrt(12)
+  have_rf <- !is.null(rf) && rf_col %in% names(port)
+  rf_ann  <- if (have_rf) mean(port[[rf_col]], na.rm = TRUE) * 12 else 0
+  sharpe  <- if (ann_vol > 0) (ann_ret - rf_ann) / ann_vol else NA_real_
+
+  tibble::tibble(
+    eta = eta, months = n, sharpe = sharpe, cagr = ann_ret, vol = ann_vol,
+    avg_impact_cost_frac = mean(port$impact_cost_frac, na.rm = TRUE)
+  )
+}
+
+#' Sharpe-vs-impact-coefficient sensitivity panel (#490 Gap 4)
+#' @inheritParams portfolio_longshort_hrp
+#' @param eta_grid Numeric vector of eta values to sweep (each > 0).
+#' @param rf Optional tibble(ym, rf_col), joined before computing Sharpe.
+#' @return Tibble: eta, months, sharpe, cagr, vol, avg_impact_cost_frac.
+#' @noRd
+market_impact_sensitivity <- function(df, returns_wide, eta_grid,
+                                       long_decile = 1L, short_decile = 10L,
+                                       lookback_months = 36L,
+                                       cost_per_trade = 0.005,
+                                       borrow_rate_annual = 0.03,
+                                       max_monthly_ret = 0.20,
+                                       adv_monthly, adv_pct_cap = 0.10,
+                                       impact_aum, impact_sigma,
+                                       rf = NULL, rf_col = "rf_ret") {
+  validate_eta_grid(eta_grid, adv_monthly)
+  rows <- lapply(eta_grid, function(eta) {
+    sensitivity_panel_row(
+      eta, df, returns_wide, long_decile, short_decile, lookback_months,
+      cost_per_trade, borrow_rate_annual, max_monthly_ret,
+      adv_monthly, adv_pct_cap, impact_aum, impact_sigma, rf, rf_col
+    )
+  })
+  dplyr::bind_rows(rows)
 }
 
 #' Standard backtest metrics

--- a/tests/testthat/_snaps/stock-backtest.md
+++ b/tests/testthat/_snaps/stock-backtest.md
@@ -15,3 +15,129 @@
       ! apply_adv_cap: 10% of portfolio left as uninvested cash.
       i ADV caps are too tight to fully invest. Increase `adv_pct_cap` or accept the cash drag.
 
+# market_impact_cost rejects negative order_usd
+
+    Code
+      market_impact_cost(order_usd = -1, adv_usd = 1e+08, sigma = 0.02)
+    Condition
+      Error in `market_impact_cost()`:
+      x `order_usd` must be numeric, non-NA, and >= 0.
+      i Got -1.
+
+# market_impact_cost rejects non-positive adv_usd
+
+    Code
+      market_impact_cost(order_usd = 1e+06, adv_usd = 0, sigma = 0.02)
+    Condition
+      Error in `market_impact_cost()`:
+      x `adv_usd` must be numeric, non-NA, and > 0.
+      i Got 0.
+
+# market_impact_cost rejects negative sigma
+
+    Code
+      market_impact_cost(order_usd = 1e+06, adv_usd = 1e+08, sigma = -0.01)
+    Condition
+      Error in `market_impact_cost()`:
+      x `sigma` must be numeric, non-NA, and >= 0.
+      i Got -0.01.
+
+# market_impact_cost rejects non-positive eta
+
+    Code
+      market_impact_cost(order_usd = 1e+06, adv_usd = 1e+08, sigma = 0.02, eta = 0)
+    Condition
+      Error in `market_impact_cost()`:
+      x `eta` must be a single positive number.
+      i Got 0.
+
+# market_impact_cost function signature is stable
+
+    Code
+      args(market_impact_cost)
+    Output
+      function (order_usd, adv_usd, sigma, eta = 1) 
+      NULL
+
+# portfolio_longshort_hrp: impact_eta requires adv_monthly
+
+    Code
+      portfolio_longshort_hrp(fx$df, fx$returns_wide, lookback_months = 1L,
+      impact_eta = 1, impact_aum = 1e+07, impact_sigma = 0.02)
+    Condition
+      Error in `validate_impact_args()`:
+      ! impact_eta requires adv_monthly to be supplied.
+
+# portfolio_longshort_hrp: impact_eta requires impact_aum
+
+    Code
+      portfolio_longshort_hrp(fx$df, fx$returns_wide, lookback_months = 1L,
+      adv_monthly = fx$adv_monthly, impact_eta = 1, impact_sigma = 0.02)
+    Condition
+      Error in `validate_impact_args()`:
+      x impact_aum must be a single positive number.
+      i Got .
+
+# portfolio_longshort_hrp: impact_eta requires impact_sigma
+
+    Code
+      portfolio_longshort_hrp(fx$df, fx$returns_wide, lookback_months = 1L,
+      adv_monthly = fx$adv_monthly, impact_eta = 1, impact_aum = 1e+07)
+    Condition
+      Error in `validate_impact_args()`:
+      x impact_sigma must be a single non-negative number.
+      i Got .
+
+# portfolio_longshort_hrp: invalid impact_eta value errors
+
+    Code
+      portfolio_longshort_hrp(fx$df, fx$returns_wide, lookback_months = 1L,
+      adv_monthly = fx$adv_monthly, impact_eta = -1, impact_aum = 1e+07,
+      impact_sigma = 0.02)
+    Condition
+      Error in `validate_impact_args()`:
+      x impact_eta must be a single positive number, or NULL to disable.
+      i Got -1.
+
+# portfolio_longshort_hrp: function signature is stable (impact params present)
+
+    Code
+      args(portfolio_longshort_hrp)
+    Output
+      function (df, returns_wide, long_decile = 1L, short_decile = 10L, 
+          lookback_months = 36L, cost_per_trade = 0.005, borrow_rate_annual = 0.03, 
+          max_monthly_ret = 0.2, adv_monthly = NULL, adv_pct_cap = 0.1, 
+          impact_eta = NULL, impact_aum = NULL, impact_sigma = NULL) 
+      NULL
+
+# market_impact_sensitivity rejects an empty eta_grid
+
+    Code
+      market_impact_sensitivity(fx$df, fx$returns_wide, eta_grid = numeric(0),
+      lookback_months = 1L, adv_monthly = fx$adv_monthly, impact_aum = 1e+07,
+      impact_sigma = 0.02)
+    Condition
+      Error in `validate_eta_grid()`:
+      x eta_grid must be a non-empty numeric vector of positive values.
+      i Got .
+
+# market_impact_sensitivity requires adv_monthly
+
+    Code
+      market_impact_sensitivity(fx$df, fx$returns_wide, eta_grid = 1,
+      lookback_months = 1L, adv_monthly = NULL, impact_aum = 1e+07, impact_sigma = 0.02)
+    Condition
+      Error in `validate_eta_grid()`:
+      ! adv_monthly is required to sweep market-impact cost.
+
+# market_impact_sensitivity function signature is stable
+
+    Code
+      args(market_impact_sensitivity)
+    Output
+      function (df, returns_wide, eta_grid, long_decile = 1L, short_decile = 10L, 
+          lookback_months = 36L, cost_per_trade = 0.005, borrow_rate_annual = 0.03, 
+          max_monthly_ret = 0.2, adv_monthly, adv_pct_cap = 0.1, impact_aum, 
+          impact_sigma, rf = NULL, rf_col = "rf_ret") 
+      NULL
+

--- a/tests/testthat/test-stock-backtest.R
+++ b/tests/testthat/test-stock-backtest.R
@@ -13,6 +13,13 @@ suppressWarnings(
   )
 )
 apply_adv_cap <- local_env$apply_adv_cap
+market_impact_cost        <- local_env$market_impact_cost
+validate_impact_args      <- local_env$validate_impact_args
+compute_impact_cost_frac  <- local_env$compute_impact_cost_frac
+portfolio_longshort_hrp   <- local_env$portfolio_longshort_hrp
+validate_eta_grid         <- local_env$validate_eta_grid
+sensitivity_panel_row     <- local_env$sensitivity_panel_row
+market_impact_sensitivity <- local_env$market_impact_sensitivity
 
 # ── F3: apply_adv_cap iterative convergence ────────────────────────────────
 
@@ -184,4 +191,198 @@ test_that("raw POSIXct vs Date comparison emits Ops.POSIXt warning (baseline)", 
     df |> filter(date >= start_date),
     regexp = "Incompatible methods"
   )
+})
+
+# ── #490 Gap 4: market_impact_cost() — hand-derived square-root law ─────────
+
+test_that("market_impact_cost matches the hand-derived square-root-law formula", {
+  out <- market_impact_cost(order_usd = 1e6, adv_usd = 1e8, sigma = 0.02, eta = 1)
+  expect_equal(out, 0.002, tolerance = 1e-12)
+})
+
+test_that("market_impact_cost scales with sqrt(participation)", {
+  small <- market_impact_cost(order_usd = 1e6, adv_usd = 1e8, sigma = 0.02)
+  large <- market_impact_cost(order_usd = 4e6, adv_usd = 1e8, sigma = 0.02)
+  expect_equal(large, 2 * small, tolerance = 1e-9)
+})
+
+test_that("market_impact_cost rejects negative order_usd", {
+  expect_snapshot(error = TRUE, market_impact_cost(order_usd = -1, adv_usd = 1e8, sigma = 0.02))
+})
+
+test_that("market_impact_cost rejects non-positive adv_usd", {
+  expect_snapshot(error = TRUE, market_impact_cost(order_usd = 1e6, adv_usd = 0, sigma = 0.02))
+})
+
+test_that("market_impact_cost rejects negative sigma", {
+  expect_snapshot(error = TRUE, market_impact_cost(order_usd = 1e6, adv_usd = 1e8, sigma = -0.01))
+})
+
+test_that("market_impact_cost rejects non-positive eta", {
+  expect_snapshot(error = TRUE, market_impact_cost(order_usd = 1e6, adv_usd = 1e8, sigma = 0.02, eta = 0))
+})
+
+test_that("market_impact_cost function signature is stable", {
+  expect_snapshot(args(market_impact_cost))
+})
+
+# -- #490 Gap 4: portfolio_longshort_hrp() opt-in market-impact cost --------
+
+make_impact_fixture <- function() {
+  returns_wide <- tibble::tibble(
+    ym = c("2019-11", "2019-12"),
+    L1 = c(0.01, 0.01), L2 = c(0.01, 0.01),
+    S1 = c(0.01, 0.01), S2 = c(0.01, 0.01)
+  )
+  df <- tibble::tibble(
+    ym          = c(rep("2020-01", 4), rep("2020-02", 4)),
+    ticker      = rep(c("L1", "L2", "S1", "S2"), 2),
+    decile      = rep(c(1L, 1L, 10L, 10L), 2),
+    monthly_ret = c(0.02, 0.03, -0.01, 0.00, 0.01, 0.02, 0.00, 0.01)
+  )
+  adv_monthly <- tibble::tibble(
+    ym = c(rep("2020-01", 4), rep("2020-02", 4)),
+    ticker = rep(c("L1", "L2", "S1", "S2"), 2),
+    adv_dollars = rep(c(6e7, 4e7, 3e7, 2e7), 2)
+  )
+  list(returns_wide = returns_wide, df = df, adv_monthly = adv_monthly)
+}
+
+test_that("portfolio_longshort_hrp: impact_eta = NULL leaves impact_cost_frac at zero", {
+  fx <- make_impact_fixture()
+  out <- portfolio_longshort_hrp(fx$df, fx$returns_wide, lookback_months = 1L)
+  expect_equal(out$impact_cost_frac, rep(0, nrow(out)))
+  row1 <- out[out$ym == "2020-01", ]
+  expect_equal(row1$total_cost, row1$turnover * 0.005 * 4 + 0.03 / 12, tolerance = 1e-9)
+})
+
+test_that("portfolio_longshort_hrp: impact_eta adds a hand-derived cost term (month 1)", {
+  fx <- make_impact_fixture()
+  out <- portfolio_longshort_hrp(
+    fx$df, fx$returns_wide, lookback_months = 1L,
+    adv_monthly = fx$adv_monthly, adv_pct_cap = 1,
+    impact_eta = 1, impact_aum = 1e7, impact_sigma = 0.02
+  )
+  row1 <- out[out$ym == "2020-01", ]
+  impact_long  <- 1 * 0.02 * sqrt(1e7 / 1e8)
+  impact_short <- 1 * 0.02 * sqrt(1e7 / 5e7)
+  expected_impact <- 2 * (impact_long + impact_short)
+  expect_equal(row1$impact_cost_frac, expected_impact, tolerance = 1e-9)
+
+  long_ret  <- 0.5 * 0.02 + 0.5 * 0.03
+  short_ret <- 0.5 * -0.01 + 0.5 * 0.00
+  trade_cost  <- 1.0 * 0.005 * 4
+  borrow_cost <- 0.03 / 12
+  expected_port_ret <- long_ret - short_ret - (trade_cost + borrow_cost + expected_impact)
+  expect_equal(row1$port_ret, expected_port_ret, tolerance = 1e-9)
+})
+
+test_that("portfolio_longshort_hrp: higher impact_eta strictly increases impact_cost_frac", {
+  fx <- make_impact_fixture()
+  low <- portfolio_longshort_hrp(
+    fx$df, fx$returns_wide, lookback_months = 1L,
+    adv_monthly = fx$adv_monthly, adv_pct_cap = 1, impact_eta = 0.5, impact_aum = 1e7, impact_sigma = 0.02
+  )
+  high <- portfolio_longshort_hrp(
+    fx$df, fx$returns_wide, lookback_months = 1L,
+    adv_monthly = fx$adv_monthly, adv_pct_cap = 1, impact_eta = 2, impact_aum = 1e7, impact_sigma = 0.02
+  )
+  row_low  <- low[low$ym == "2020-01", ]
+  row_high <- high[high$ym == "2020-01", ]
+  expect_true(row_high$impact_cost_frac > row_low$impact_cost_frac)
+  expect_true(row_high$port_ret < row_low$port_ret)
+})
+
+test_that("portfolio_longshort_hrp: impact_eta requires adv_monthly", {
+  fx <- make_impact_fixture()
+  expect_snapshot(
+    error = TRUE,
+    portfolio_longshort_hrp(fx$df, fx$returns_wide, lookback_months = 1L,
+                             impact_eta = 1, impact_aum = 1e7, impact_sigma = 0.02)
+  )
+})
+
+test_that("portfolio_longshort_hrp: impact_eta requires impact_aum", {
+  fx <- make_impact_fixture()
+  expect_snapshot(
+    error = TRUE,
+    portfolio_longshort_hrp(fx$df, fx$returns_wide, lookback_months = 1L,
+                             adv_monthly = fx$adv_monthly, impact_eta = 1, impact_sigma = 0.02)
+  )
+})
+
+test_that("portfolio_longshort_hrp: impact_eta requires impact_sigma", {
+  fx <- make_impact_fixture()
+  expect_snapshot(
+    error = TRUE,
+    portfolio_longshort_hrp(fx$df, fx$returns_wide, lookback_months = 1L,
+                             adv_monthly = fx$adv_monthly, impact_eta = 1, impact_aum = 1e7)
+  )
+})
+
+test_that("portfolio_longshort_hrp: invalid impact_eta value errors", {
+  fx <- make_impact_fixture()
+  expect_snapshot(
+    error = TRUE,
+    portfolio_longshort_hrp(fx$df, fx$returns_wide, lookback_months = 1L,
+                             adv_monthly = fx$adv_monthly, impact_eta = -1,
+                             impact_aum = 1e7, impact_sigma = 0.02)
+  )
+})
+
+test_that("portfolio_longshort_hrp: function signature is stable (impact params present)", {
+  expect_snapshot(args(portfolio_longshort_hrp))
+})
+
+# -- #490 Gap 4: market_impact_sensitivity() -- Sharpe-vs-eta panel ---------
+
+test_that("market_impact_sensitivity returns one row per eta_grid element", {
+  fx <- make_impact_fixture()
+  out <- market_impact_sensitivity(
+    fx$df, fx$returns_wide, eta_grid = c(0.5, 1, 2),
+    lookback_months = 1L, adv_monthly = fx$adv_monthly, adv_pct_cap = 1,
+    impact_aum = 1e7, impact_sigma = 0.02
+  )
+  expect_equal(nrow(out), 3L)
+  expect_setequal(names(out), c("eta", "months", "sharpe", "cagr", "vol", "avg_impact_cost_frac"))
+  expect_equal(out$eta, c(0.5, 1, 2))
+})
+
+test_that("market_impact_sensitivity: avg_impact_cost_frac is strictly increasing in eta", {
+  fx <- make_impact_fixture()
+  out <- market_impact_sensitivity(
+    fx$df, fx$returns_wide, eta_grid = c(0.5, 1, 2, 4),
+    lookback_months = 1L, adv_monthly = fx$adv_monthly, adv_pct_cap = 1,
+    impact_aum = 1e7, impact_sigma = 0.02
+  )
+  diffs <- diff(out$avg_impact_cost_frac)
+  expect_true(all(diffs > 0))
+})
+
+test_that("market_impact_sensitivity rejects an empty eta_grid", {
+  fx <- make_impact_fixture()
+  expect_snapshot(
+    error = TRUE,
+    market_impact_sensitivity(
+      fx$df, fx$returns_wide, eta_grid = numeric(0),
+      lookback_months = 1L, adv_monthly = fx$adv_monthly,
+      impact_aum = 1e7, impact_sigma = 0.02
+    )
+  )
+})
+
+test_that("market_impact_sensitivity requires adv_monthly", {
+  fx <- make_impact_fixture()
+  expect_snapshot(
+    error = TRUE,
+    market_impact_sensitivity(
+      fx$df, fx$returns_wide, eta_grid = 1,
+      lookback_months = 1L, adv_monthly = NULL,
+      impact_aum = 1e7, impact_sigma = 0.02
+    )
+  )
+})
+
+test_that("market_impact_sensitivity function signature is stable", {
+  expect_snapshot(args(market_impact_sensitivity))
 })


### PR DESCRIPTION
## Summary

Issue #490, Gap 4 only: "Add an optional square-root / linear market-impact
term parameterised by ADV participation, and a sensitivity panel (Sharpe vs
impact coefficient)."

- `market_impact_cost()`: local square-root-law helper (Almgren et al. 2005),
  the same formula as `historicaldata::hd_market_impact()` (from earlier
  #508/#794 work) but kept local since root R/ helpers here are unit-tested
  via `sys.source()` with no `pkgload::load_all()` step.
- `portfolio_longshort_hrp(impact_eta=, impact_aum=, impact_sigma=)`: adds
  the square-root-law impact cost as an opt-in term on top of the existing
  `cost_per_trade` constant-bps proxy. Off by default (`impact_eta = NULL`)
  -- every existing pipeline target's output is unchanged byte-for-byte.
- `market_impact_sensitivity()`: sweeps `eta_grid` through
  `portfolio_longshort_hrp()`, reporting Sharpe/CAGR/vol/avg impact cost per
  eta -- the Gap 4 sensitivity panel.

## Why this was still a real gap

`hd_market_impact()` / `hd_capacity_curve()`
(`packages/historicaldata/R/capacity.R`) already exist from earlier
#508/#794 work and provide the square-root-law formula plus an
AUM-vs-Sharpe sweep. Neither is wired into the actual backtest cost model
at `portfolio_longshort_hrp()` (the constant-bps + ADV-cap proxy Gap 4
specifically names), and neither sweeps the impact coefficient (`eta`) --
`hd_capacity_curve()` sweeps AUM at a *fixed* eta, the inverse of what Gap 4
asks for. Both gaps are closed by this PR.

## Scope note

No pipeline target is wired into `docs/_targets.R` -- regenerating that
file is documented as main-checkout-only in `.claude/CLAUDE.md`'s
"Verifying a change" table, to avoid a worktree racing the main checkout's
targets store. These are pure, dependency-free, fully unit-tested functions
ready for a follow-up main-checkout session to wire into a target (e.g.
`stk_max_impact_sensitivity`, using `stk_monthly_adv` as the ADV input) --
same deferred-wiring pattern `capacity.R` already documents for
`hd_capacity_curve()`.

## Test plan

- [x] 20 new `test_that()` blocks in `tests/testthat/test-stock-backtest.R`
- [x] Hand-derived exact-value test: a 2-tickers-per-leg fixture forces
      HRP's `ncol(sub) < 3` guard, so `hrp_weights_for_tickers()` always
      returns `NULL` and the function falls back to a deterministic
      equal weight (0.5/0.5) -- every expected number in that test is
      hand-computed, not re-derived through the code under test
- [x] Monotonicity test: higher `impact_eta` strictly increases
      `impact_cost_frac` and strictly decreases `port_ret`
- [x] Backward-compatibility test: `impact_eta = NULL` leaves
      `impact_cost_frac` at exactly zero and `total_cost` unchanged
- [x] Validation + snapshot coverage for every new `cli_abort()`
      (`validate_impact_args()`, `validate_eta_grid()`) per
      `snapshot-test-policy.md`
- [x] Function-signature stability snapshots for all 3 new/changed
      public-facing functions
- [x] `scripts/verify.sh` PASS -- root suite 3/3 baseline failures match
      exactly (0 new), package suite 1/1 baseline failure matches exactly,
      skip count 15/15 matches baseline

Refs #490
