### PR TITLE
feat(leverage): production leverage allocator with detection-power gate (#626)

### DIFF
--- a/R/plan_leverage.R
+++ b/R/plan_leverage.R
@@ -173,6 +173,136 @@ compute_regime_stress_ratio <- function(vpug_df) {
     dplyr::arrange(dplyr::desc(stress_ratio))
 }
 
+# ── Allocator gross-exposure target (#626 production implementation) ───────
+#
+# #626's own 2026-08-03 comment adopted a LAYERED construction, confirmed
+# again in the #626 comment thread the day this landed: a vol-normalised
+# allocator sets each strategy's RELATIVE sizing; a gross-exposure cap is the
+# backstop that binds the TOTAL. Net-exposure and cash-borrowing
+# formulations were explicitly rejected. This section implements that layer
+# pair as live targets, replacing the throwaway prototype in
+# docs/_prototypes/leverage-allocator-prototype.qmd (#827) with the real
+# thing, approved via that PR's Phase 0 sign-off.
+#
+#   G_implied = sigma_target / vol_per_unit_gross_i        (relative sizing)
+#   G_capped  = min(G_implied, backstop)                   (the cap/backstop)
+#
+# The backstop LEVEL is explicitly PROVISIONAL (#626 decision D1 is still
+# open at the time this lands) -- see LEVERAGE_GROSS_BACKSTOP_DEFAULT below.
+# The #827 prototype's live read of the leaderboard found a p90-based
+# candidate near 1.8x-2.0x (materially below the stale 3.5x #626's
+# 2026-08-05 hand-derivation used, before the #717/#722 CMR
+# vol-annualisation fixes) -- 2.0x is adopted here as a clearly-labelled,
+# overridable default, not a decision this file makes on D1's behalf.
+
+#' PROVISIONAL default gross-exposure backstop (#626 decision D1 -- NOT
+#' finalized)
+#'
+#' See the header comment above `plan_leverage()`'s allocator section for the
+#' derivation. Override via the `HD_LEVERAGE_GROSS_BACKSTOP` environment
+#' variable for sensitivity testing -- read and validated eagerly by
+#' `.leverage_gross_backstop()` below, per
+#' `.claude/rules/fail-loud-not-null.md`'s requirement that a malformed
+#' config value abort rather than silently fall back to the default.
+#' @noRd
+LEVERAGE_GROSS_BACKSTOP_DEFAULT <- 2.0
+
+#' Resolve the gross-exposure backstop, validating any override eagerly
+#'
+#' `as.numeric()` on a non-numeric string returns `NA` with a coercion
+#' warning that `tar_make()` output can easily bury -- this function
+#' `cli_abort()`s instead, naming the offending value, rather than letting a
+#' typo'd env var silently fall back to the default (or worse, silently
+#' produce an `NA` backstop that `compute_allocator_gross()` would then
+#' reject one layer downstream with a less specific message).
+#'
+#' @param env_var Character. Defaults to reading
+#'   `Sys.getenv("HD_LEVERAGE_GROSS_BACKSTOP", "")`.
+#' @return Numeric scalar: the validated override if set, else
+#'   `LEVERAGE_GROSS_BACKSTOP_DEFAULT`.
+#' @noRd
+.leverage_gross_backstop <- function(env_var = Sys.getenv("HD_LEVERAGE_GROSS_BACKSTOP", "")) {
+  if (!nzchar(env_var)) {
+    return(LEVERAGE_GROSS_BACKSTOP_DEFAULT)
+  }
+  val <- suppressWarnings(as.numeric(env_var))
+  if (is.na(val) || val <= 0) {
+    cli::cli_abort(c(
+      "x" = "HD_LEVERAGE_GROSS_BACKSTOP = {.val {env_var}} is not a positive number.",
+      "i" = paste0(
+        "Unset it to use the default ", LEVERAGE_GROSS_BACKSTOP_DEFAULT,
+        "x (PROVISIONAL, #626 D1), or set a positive numeric override."
+      )
+    ))
+  }
+  val
+}
+
+#' Per-strategy allocator gross exposure under the vol-normalised allocator,
+#' capped by a gross-exposure backstop (#626)
+#'
+#' Restricted to Full Period rows -- the allocator sizes against the whole
+#' available sample, matching every #635 hand-derivation and the #827
+#' prototype this replaces. `is_cap` is carried through unchanged (same
+#' meaning as `compute_vol_per_unit_gross()`'s own `is_cap`: a strategy whose
+#' OWN construction gross is itself a ceiling, e.g. Managed Futures'
+#' vol-targeting 3.0x cap -- independent of whether the ALLOCATOR's backstop
+#' also binds for that strategy).
+#'
+#' @param vpug_df Tibble -- the output of `compute_vol_per_unit_gross()`
+#'   (needs `strategy`, `period`, `vol_per_unit_gross`, `is_cap`).
+#' @param sigma_target Numeric scalar > 0 -- the Full Period budget-neutral
+#'   sigma_target (`compute_budget_neutral_sigma()`'s `is_headline` row).
+#' @param backstop Numeric scalar > 0 -- the gross-exposure ceiling. Defaults
+#'   to `.leverage_gross_backstop()` (PROVISIONAL, #626 D1).
+#' @return Tibble: `strategy`, `is_cap`, `vol_per_unit_gross`, `G_implied`,
+#'   `G_capped`, `backstop_binds`, `backstop_used`, `sigma_target_used` --
+#'   one row per strategy with a measurable `vol_per_unit_gross`, sorted
+#'   descending by `G_implied`.
+#' @noRd
+compute_allocator_gross <- function(vpug_df, sigma_target,
+                                     backstop = .leverage_gross_backstop()) {
+  required_cols <- c("strategy", "period", "vol_per_unit_gross", "is_cap")
+  missing_cols <- setdiff(required_cols, names(vpug_df))
+  if (length(missing_cols) > 0) {
+    cli::cli_abort(c(
+      "x" = "{.arg vpug_df} is missing required column{?s}: {.field {missing_cols}}.",
+      "i" = "compute_allocator_gross() needs {.field {required_cols}} (see compute_vol_per_unit_gross())."
+    ))
+  }
+  if (!is.numeric(sigma_target) || length(sigma_target) != 1L || is.na(sigma_target) || sigma_target <= 0) {
+    cli::cli_abort(c(
+      "x" = "{.arg sigma_target} must be a single positive number, not {.val {sigma_target}}.",
+      "i" = "compute_allocator_gross() expects the Full Period sigma_target_budget_neutral from compute_budget_neutral_sigma()."
+    ))
+  }
+  if (!is.numeric(backstop) || length(backstop) != 1L || is.na(backstop) || backstop <= 0) {
+    cli::cli_abort(c(
+      "x" = "{.arg backstop} must be a single positive number, not {.val {backstop}}.",
+      "i" = "compute_allocator_gross() expects a positive gross-exposure ceiling -- see LEVERAGE_GROSS_BACKSTOP_DEFAULT (PROVISIONAL, #626 D1)."
+    ))
+  }
+
+  full <- vpug_df[vpug_df$period == "Full Period", , drop = FALSE]
+  if (nrow(full) == 0L) {
+    cli::cli_abort(c(
+      "x" = "{.arg vpug_df} has no Full Period rows.",
+      "i" = "compute_allocator_gross() sizes against the whole available sample, not a sub-partition."
+    ))
+  }
+
+  full |>
+    dplyr::transmute(
+      strategy, is_cap, vol_per_unit_gross,
+      G_implied = sigma_target / vol_per_unit_gross,
+      G_capped = pmin(G_implied, backstop),
+      backstop_binds = G_implied > backstop,
+      backstop_used = backstop,
+      sigma_target_used = sigma_target
+    ) |>
+    dplyr::arrange(dplyr::desc(G_implied))
+}
+
 plan_leverage <- function() {
   list(
     # Per-(strategy, period) vol_per_unit_gross -- the intermediate #635's
@@ -192,6 +322,22 @@ plan_leverage <- function() {
     # the live replacement for #635's hand-run regime check.
     targets::tar_target(leverage_regime_stress_ratio, {
       compute_regime_stress_ratio(leverage_vol_per_unit_gross)
+    }),
+
+    # PROVISIONAL gross-exposure backstop actually used this build (#626 D1
+    # not finalized) -- a target (not a bare constant) so it is visible in
+    # `tar_meta()`/`tar_read()` and any change to HD_LEVERAGE_GROSS_BACKSTOP
+    # correctly invalidates leverage_allocator_gross downstream.
+    targets::tar_target(leverage_gross_backstop, {
+      .leverage_gross_backstop()
+    }),
+
+    # Per-strategy allocator gross exposure (#626 production implementation,
+    # replacing the #827 prototype). Reads the Full Period headline
+    # sigma_target from leverage_sigma_target.
+    targets::tar_target(leverage_allocator_gross, {
+      sigma_headline <- leverage_sigma_target$sigma_target_budget_neutral[leverage_sigma_target$is_headline]
+      compute_allocator_gross(leverage_vol_per_unit_gross, sigma_headline, leverage_gross_backstop)
     })
   )
 }

--- a/R/plan_qa_gates.R
+++ b/R/plan_qa_gates.R
@@ -2700,6 +2700,118 @@ check_leaderboard_plausibility_amber <- function(
 }
 
 
+#' Declared overrides for the leverage-allocator detection-power gate (S31,
+#' #626/#719 Layer 2 narrow slice)
+#'
+#' Per `.claude/rules/detection-power-required.md`'s allocation-gating rule:
+#' "A strategy may not receive gross above 1.0x while
+#' `detection_underpowered` is TRUE or NA." This is Layer 2's core rule from
+#' #719 -- NOT the full provenance checklist (the remaining Layer 2 items
+#' stay separately scoped). Empty by design at this gate's introduction: the
+#' backstop LEVEL itself is provisional (#626 D1) and no override has been
+#' reviewed against real leaderboard data yet. Schema: `strategy`, `reason`.
+#' @noRd
+LEVERAGE_GROSS_DETECTION_OVERRIDE <- tibble::tibble(
+  strategy = character(0),
+  reason   = character(0)
+)
+
+#' Assert no strategy receives allocator gross above 1.0x while its
+#' detection-power verdict is underpowered or missing (S31, #626/#719 Layer
+#' 2 narrow slice, detection-power-required.md)
+#'
+#' A strategy whose own sample cannot distinguish its Sharpe from zero
+#' (`detection_underpowered == TRUE`) -- or whose verdict was never computed
+#' at all (`NA`, which S20 already treats as a defect on the leaderboard
+#' itself) -- must not be handed MORE than 1.0x gross by the allocator,
+#' however the vol-normalised arithmetic alone would size it.
+#' `detection_underpowered = NA` is deliberately treated the SAME as `TRUE`
+#' here (`fail-loud-not-null.md`: an unknown verdict must not silently
+#' permit what a known-bad verdict would forbid) -- distinct from S20's own
+#' handling of NA, which requires every positive-Sharpe leaderboard row to
+#' HAVE a verdict in the first place; this gate additionally refuses to
+#' lever on the absence of one.
+#'
+#' `G_capped`, not `G_implied`, is the column checked: the backstop-capped
+#' figure is what the allocator would actually assign. `G_implied` may
+#' exceed 1.0x for a strategy the backstop itself brings back under it, and
+#' that case is not an offence.
+#'
+#' @param allocator_gross Tibble -- the `leverage_allocator_gross` target
+#'   (needs `strategy`, `G_capped`).
+#' @param leaderboard Tibble -- the `leaderboard` target (needs `strategy`,
+#'   `period`, `detection_underpowered`).
+#' @param override_tbl Tibble with `strategy`, `reason` columns --
+#'   `LEVERAGE_GROSS_DETECTION_OVERRIDE` above.
+#' @return `TRUE` invisibly on success.
+#' @noRd
+check_leverage_gross_detection_gate <- function(allocator_gross, leaderboard,
+                                                 override_tbl = LEVERAGE_GROSS_DETECTION_OVERRIDE) {
+  required_alloc_cols <- c("strategy", "G_capped")
+  missing_alloc <- setdiff(required_alloc_cols, names(allocator_gross))
+  if (length(missing_alloc) > 0L) {
+    cli::cli_abort(c(
+      "x" = "{.arg allocator_gross} is missing required column{?s}: {.field {missing_alloc}}.",
+      "i" = "check_leverage_gross_detection_gate() (S31) needs {.field {required_alloc_cols}} (see compute_allocator_gross())."
+    ))
+  }
+  required_lb_cols <- c("strategy", "period", "detection_underpowered")
+  missing_lb <- setdiff(required_lb_cols, names(leaderboard))
+  if (length(missing_lb) > 0L) {
+    cli::cli_abort(c(
+      "x" = "{.arg leaderboard} is missing required column{?s}: {.field {missing_lb}}.",
+      "i" = "check_leverage_gross_detection_gate() (S31) needs {.field {required_lb_cols}}."
+    ))
+  }
+  if (!all(c("strategy", "reason") %in% names(override_tbl))) {
+    cli::cli_abort(c(
+      "x" = "{.arg override_tbl} is missing required column(s): strategy, reason.",
+      "i" = "check_leverage_gross_detection_gate() (S31) requires LEVERAGE_GROSS_DETECTION_OVERRIDE's strategy, reason columns."
+    ))
+  }
+
+  det_full <- leaderboard[leaderboard$period == "Full Period",
+                           c("strategy", "detection_underpowered"), drop = FALSE]
+  joined <- dplyr::left_join(allocator_gross, det_full, by = "strategy")
+
+  # NA detection_underpowered is treated the same as TRUE -- see roxygen.
+  blocked <- is.na(joined$detection_underpowered) | (joined$detection_underpowered %in% TRUE)
+
+  offenders <- joined[
+    !is.na(joined$G_capped) & joined$G_capped > 1.0 & blocked &
+      !(joined$strategy %in% override_tbl$strategy),
+    , drop = FALSE
+  ]
+
+  if (nrow(offenders) > 0L) {
+    msgs <- sprintf(
+      "  %s -- G_capped = %.2fx, detection_underpowered = %s",
+      offenders$strategy, offenders$G_capped,
+      ifelse(is.na(offenders$detection_underpowered), "NA (not computed)",
+             as.character(offenders$detection_underpowered))
+    )
+    cli::cli_abort(c(
+      "x" = paste0(
+        "{nrow(offenders)} strategy/strategies would receive allocator gross ",
+        "above 1.0x while detection-underpowered or unverified (#626/#719 ",
+        "Layer 2, detection-power-required.md):"
+      ),
+      setNames(msgs, rep("i", length(msgs))),
+      "i" = paste0(
+        "A strategy that cannot be distinguished from a zero Sharpe (or has ",
+        "no verdict at all) must not be levered above 1.0x gross. Either fix ",
+        "the underlying detection verdict, lower the strategy's allocator ",
+        "input (leverage_gross_backstop / HD_LEVERAGE_GROSS_BACKSTOP), or add ",
+        "a written row to LEVERAGE_GROSS_DETECTION_OVERRIDE (R/plan_qa_gates.R) ",
+        "with an explicit reason."
+      )
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+
 # ---- QA gate plan ----
 
 plan_qa_gates <- function() {
@@ -3313,6 +3425,26 @@ plan_qa_gates <- function() {
           "qa_leaderboard_plausibility_amber: S30 ran (STAGED report-only ",
           "unless HD_ENFORCE_PLAUSIBILITY_AMBER=1 -- see cli_inform/cli_warn ",
           "output above for any flags, #719 Layer 1)"
+        )))
+        TRUE
+      },
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    # QA gate: no strategy receives allocator gross above 1.0x while
+    # detection-underpowered or unverified (S31, #626/#719 Layer 2 narrow
+    # slice, detection-power-required.md's allocation-gating rule). This is
+    # NOT the full Layer 2 provenance checklist (#719) -- only the
+    # detection-power slice of it; the remaining provenance facts remain
+    # separately scoped and are not enforced here.
+    targets::tar_target(
+      qa_leverage_gross_detection_gate,
+      command = {
+        check_leverage_gross_detection_gate(leverage_allocator_gross, leaderboard)
+        cli::cli_inform(c("v" = paste0(
+          "qa_leverage_gross_detection_gate: S31 passed (no detection-",
+          "underpowered/unverified strategy above 1.0x allocator gross, ",
+          "#626/#719 Layer 2 narrow slice)"
         )))
         TRUE
       },

--- a/docs/DASHBOARDS.md
+++ b/docs/DASHBOARDS.md
@@ -15,7 +15,7 @@
 | Dashboard | Objective | Primary visible outputs | Data source |
 |---|---|---|---|
 | `index.qmd` | Portal + dataset catalogue | Headline stat block (tickers/rows/datasets/years/functions); 4 dataset cards; card grid → downstream dashboards | `hd_datasets()`, `hd_tickers()`, `hd_factors()` |
-| `leaderboard.qmd` | Rank all strategies by risk-adjusted return; central output | Ranking table (Sharpe/**Detection**/CAGR/MaxDD/CVaR95/Vol/SSR/**Rigour**/Top5%/Credible), with detection-power and rigour-coverage verdicts inline (#726/#728, badges + always-visible summary callout); partition table; equity-curve plotly (range slider); monthly-returns heatmap; bootstrap-CI table; alpha-decay; regime-adjusted Sharpe; Kelly table; structural-breaks dot plot; correlation matrix | `tar_read(leaderboard)`, `strat_deflated_sharpe` (Rigour tooltip only), `boot_ci_summary`, `structural_breaks_summary`, `strategy_correlation` |
+| `leaderboard.qmd` | Rank all strategies by risk-adjusted return; central output | Ranking table (Sharpe/**Detection**/CAGR/MaxDD/CVaR95/Vol/**Gross (now)**/**Gross (target)**/SSR/**Rigour**/Top5%/Credible), with detection-power and rigour-coverage verdicts and vol-normalised leverage-allocator target inline (#726/#728, #626, badges + always-visible summary callout); partition table; equity-curve plotly (range slider); monthly-returns heatmap; bootstrap-CI table; alpha-decay; regime-adjusted Sharpe; Kelly table; structural-breaks dot plot; correlation matrix | `tar_read(leaderboard)`, `strat_deflated_sharpe` (Rigour tooltip only), `leverage_allocator_gross` (Gross (target) badge only), `boot_ci_summary`, `structural_breaks_summary`, `strategy_correlation` |
 | `falsification.qmd` | Test causal integrity / robustness gauntlet + **Failed Strategies section (#514 merge 3/3)** | Scorecard (Verdict/HAC t/Sharpe/Alpha/R²); null-rejection heatmap (6 envs × strats); FF5+Mom alpha scatter; HAC t comparison; multiplicity K_eff table; WFC 2×2; **covariance regularisation table + conditioning/OOS dot plots (#498)**; causal DAG (Mermaid/D3, tabbed); implication tests; risk-architecture table; **failed-strategy filtered scorecard + pattern table + portfolio implications**; **Liquidity tab: ADV-cap on/off impact table (#625, discharges the standing `backtest-robustness.md` reporting requirement); dashboard-universe liquidity summary + volume stats, computed against `stk_universe` rather than the ingestion-side `consolidated_equity` (#625 Option A, wired but not yet `tar_make()`-verified)** | `fals_vig_*`, `wfc_all_summary`, `cov_diag_vig_table`, `cg_dag`, `cg_test_implications`, `fals_summary`, `fals_vig_names`, `stk_max_adv_cap_impact`, `equity_daily_liquidity_summary_tbl`, `equity_daily_volume_stats` |
 | `evidence.qmd` | Negative results + 155-yr pervasiveness | Failed-strategies scorecard; pattern-analysis table; negative-result cards; JST pervasiveness table (18 countries); equity-premium heatmap; crisis timeline; crisis-frequency table | `fals_summary`, `jst_equity_premium`, `jst_pervasiveness`, `jst_crises` |
 | ~~`factor-max.qmd`~~ | ~~MAX signal at factor level~~ | ~~Cumulative-return plotly (log); metrics table (IS/OOS/Full); factor-selection bar chart; MAX-signal heatmap; ETF comparison~~ | ~~`fm_cumret_plot`, `fm_metrics`, `fm_selection_freq`, `fm_heatmap`~~ **→ merged into `stock-backtest.qmd#factor-level-deep-dive` (#514 merge 2/3)** |
@@ -99,3 +99,23 @@ Kelly Sizing). The Mermaid relationship diagram from the #735 prototype
 row) is **not** wired into `causal-diagrams.js` in this pass — that is a
 separate, larger change (migrating node→file:line links into
 `R/diagram_node_links.R`) tracked as a follow-up, not part of this build.
+
+**Consolidation decision, #626 (leverage allocator, production
+implementation following the #827 prototype's approved Phase 0):** no change
+to dashboard count (11). The vol-normalised allocator's per-strategy gross
+target (`R/plan_leverage.R`'s `compute_allocator_gross()`) is folded into a
+single new `Gross (target)` badge column on the existing `leaderboard.qmd`
+ranking table, immediately beside the renamed `Gross (now)` (was `Gross`)
+column — the same "one badge column, not three raw ones" consolidation
+`falsification.qmd`'s Detection/Rigour precedent (#726/#728) already
+established, applied to the #827 prototype's own three-raw-column proposal
+(Implied G_i / G_i @ backstop / Backstop binds?). Net column count on the
+ranking table grows by one. The regime-stress-ratio diagnostic
+(`compute_regime_stress_ratio()`) and the #827 prototype's relationship
+diagram are **not** wired into a dashboard in this pass — they remain
+future work for `falsification.qmd`'s existing "Strategy & Dashboard
+Relationship Map" tab (`dag-portcons-mount`), tracked against #626/#719
+rather than shipped speculatively here. The gross-exposure backstop level
+itself is explicitly PROVISIONAL (#626 decision D1 remains open) and is
+disclosed as such in both the badge tooltip and the table's dynamic
+disclosure note — never presented as settled.

--- a/docs/leaderboard.qmd
+++ b/docs/leaderboard.qmd
@@ -163,6 +163,24 @@ if (!is.null(lb)) {
   }
   if (!"sharpe_haircut_pct" %in% names(full)) full$sharpe_haircut_pct <- NA_real_
 
+  # ── Leverage allocator gross-exposure target (#626 production
+  # implementation, replacing the #827 prototype) -- the vol-normalised
+  # allocator's per-strategy gross target, capped at a PROVISIONAL
+  # backstop (#626 D1 not finalized). NA for strategies with no measurable
+  # gross_convention (Value (HML), PSO Optimal), same exclusion as
+  # Gross (now) below.
+  lev_gross <- safe_tar_read("leverage_allocator_gross")
+  if (!is.null(lev_gross) && "G_capped" %in% names(lev_gross)) {
+    full <- full |> left_join(
+      lev_gross |> select(strategy, G_capped, backstop_binds, backstop_used, sigma_target_used),
+      by = "strategy"
+    )
+  }
+  for (.col in c("G_capped", "backstop_binds", "backstop_used", "sigma_target_used")) {
+    if (!.col %in% names(full)) full[[.col]] <- NA
+  }
+  rm(.col)
+
   detection_badge <- function(sr, under, dmin, under_mt, dmin_mt) {
     # 5-state verdict, symbol AND text on every state (never colour alone,
     # `accessibility` rule). States 1/2 both come from a single-test
@@ -269,6 +287,63 @@ if (!is.null(lb)) {
     )
   }
 
+  # ── Gross (target) badge (#626, R/plan_leverage.R) ─────────────────────
+  # The vol-normalised allocator's per-strategy gross target, distinct from
+  # the "Gross (now)" column below: that column reports what a strategy's
+  # OWN construction implements today; this one reports what the allocator
+  # WOULD assign -- the gap the whole allocator design (#626) exists to
+  # close. G_capped is the backstop-capped figure actually shown; a
+  # `backstop_binds = TRUE` strategy had a higher uncapped implied leverage.
+  # The backstop LEVEL is PROVISIONAL (#626 D1 not finalized) -- always
+  # disclosed in the tooltip and in gross_target_note below, never presented
+  # as settled. A strategy whose detection verdict is underpowered or
+  # unverified (NA) is additionally flagged as BLOCKED by QA gate S31
+  # (detection-power-required.md) when its G_capped exceeds 1.0x -- the
+  # badge still shows the allocator's raw figure for transparency, but the
+  # tooltip states plainly that gate S31 forbids actually granting it.
+  gross_target_badge <- function(g_capped, binds, backstop, underpowered) {
+    if (is.na(g_capped)) {
+      return(list(
+        html = paste0(
+          "<span class='gross-target-badge napp' title='No measurable ",
+          "gross_convention for this strategy -- same exclusion as Gross ",
+          "(now) (Value (HML), PSO Optimal: pre-computed factor series or ",
+          "meta-portfolio blend, no explicit weight vector to measure).",
+          "'>&ndash; n/a</span>"
+        ),
+        rank = -Inf
+      ))
+    }
+    blocked <- is.na(underpowered) || isTRUE(underpowered)
+    block_txt <- if (blocked && g_capped > 1.0) {
+      paste0(
+        " BLOCKED at 1.0x by QA gate S31 (#626/#719 Layer 2, detection-",
+        "power-required.md) -- this strategy is detection-underpowered or ",
+        "has no detection verdict; the figure shown is the allocator&#39;s ",
+        "unblocked value for transparency, not what would actually be ",
+        "granted."
+      )
+    } else ""
+    binds_txt <- if (isTRUE(binds)) {
+      sprintf(
+        " Gross backstop (%.1fx, PROVISIONAL -- #626 D1 not finalized) binds: uncapped implied leverage was higher.",
+        backstop
+      )
+    } else ""
+    cls <- if (blocked && g_capped > 1.0) "blocked" else if (isTRUE(binds)) "capped" else "ok"
+    list(
+      html = sprintf(
+        paste0(
+          "<span class='gross-target-badge %s' title='Vol-normalised ",
+          "allocator target (sigma_target / vol_per_unit_gross, capped at ",
+          "a PROVISIONAL %.1fx backstop).%s%s'>%.2fx%s</span>"
+        ),
+        cls, backstop, binds_txt, block_txt, g_capped, if (isTRUE(binds)) "*" else ""
+      ),
+      rank = g_capped
+    )
+  }
+
   # ── Breach-risk badge (#586 G1, historicaldata::hd_first_passage()) ───────
   # SECONDARY, DE-EMPHASISED diagnostic: "what is the probability this
   # strategy's return path hits a -20% drawdown floor before a +20% profit
@@ -302,6 +377,8 @@ if (!is.null(lb)) {
   rig <- mapply(rigour_badge, full$strategy, full$deflated_sharpe, full$dsr_pvalue,
                 full$k_eff_leaderboard, full$k_raw_leaderboard, full$sharpe,
                 full$dsr_haircut_pct, full$sharpe_haircut_pct, SIMPLIFY = FALSE)
+  gt <- mapply(gross_target_badge, full$G_capped, full$backstop_binds, full$backstop_used,
+               full$detection_underpowered, SIMPLIFY = FALSE)
   fp_html <- if ("fp_breach_prob_20pct" %in% names(full)) {
     vapply(full$fp_breach_prob_20pct, fp_badge, character(1))
   } else {
@@ -370,11 +447,22 @@ if (!is.null(lb)) {
       `Max DD`   = paste0(round(max_dd * 100, 1), "%"),
       `CVaR 95%` = ifelse(is.na(cvar_95),      "not computed", paste0(round(cvar_95 * 100, 1), "%")),
       Vol        = paste0(round(vol * 100, 1), "%"),
-      Gross      = dplyr::case_when(
+      # Renamed from "Gross" to "Gross (now)" (#626): what a strategy's own
+      # construction implements TODAY, as distinct from the new
+      # "Gross (target)" column below (what the vol-normalised allocator
+      # would assign). Same case_when logic, unchanged.
+      `Gross (now)` = dplyr::case_when(
         !("gross_convention" %in% names(full)) | is.na(gross_convention) ~ "—",
         is_cap ~ paste0(format(gross_convention, nsmall = 1), "x*"),
         TRUE   ~ paste0(format(gross_convention, nsmall = 1), "x")
       ),
+      # Allocator target under the vol-normalised leverage design (#626,
+      # R/plan_leverage.R) -- see gross_target_badge() above. Placed
+      # immediately beside Gross (now) per the #827 prototype's Step 3
+      # comparable-output audit and Step 5 consolidation review (one badge
+      # column, not three raw ones).
+      `Gross (target)` = vapply(gt, function(x) x$html, character(1)),
+      .grosstgt_rank    = vapply(gt, function(x) x$rank, double(1)),
       `Cost (bps)` = dplyr::case_when(
         !("cost_per_trade_bps" %in% names(full)) | is.na(cost_per_trade_bps) ~ "—",
         cost_per_trade_bps == 0 ~ "0*",
@@ -453,7 +541,8 @@ if (!is.null(lb)) {
     # immediately left of Net CAGR (gross, then net of cost) per item B of
     # the presentation-fix pass this column set belongs to.
     select(Strategy = strategy, Credible, .credible_rank, Sharpe, .sharpe_rank, Detection, .det_rank,
-           CAGR, `Net CAGR`, `Max DD`, `CVaR 95%`, Vol, Gross, `Cost (bps)`, SSR, Rigour, .rig_rank,
+           CAGR, `Net CAGR`, `Max DD`, `CVaR 95%`, Vol, `Gross (now)`, `Gross (target)`, .grosstgt_rank,
+           `Cost (bps)`, SSR, Rigour, .rig_rank,
            `Top5% Share`, Redundant, .redundant_rank, `Incremental Sharpe`,
            `Breach Risk (±20% DD)`)
 
@@ -516,11 +605,58 @@ if (!is.null(lb)) {
     " strategies are built dollar-neutral long-short at 2.0x gross while others run long-only at 1.0x, ",
     "so Vol, Net CAGR, and Max DD are not directly comparable across rows even when Sharpe is similar ",
     "(Sharpe is leverage-invariant under proportional scaling; the other three columns are not). ",
-    "A trailing `*` on the Gross column (", n_capped,
+    "A trailing `*` on the Gross (now) column (", n_capped,
     " strategies) marks a construction ceiling the strategy can reach but does not realise every period ",
     "(e.g. Managed Futures targets volatility and only hits its 3.0x cap in low-vol regimes) — treat those as upper bounds, not realised averages. ",
-    if (n_na_gross > 0) paste0(n_na_gross, " strategy row(s) show — for Gross: either the return is assembled from a pre-computed factor series with no explicit weight vector to measure, or the row is a meta-portfolio blend of other rows.") else ""
+    if (n_na_gross > 0) paste0(n_na_gross, " strategy row(s) show — for Gross (now): either the return is assembled from a pre-computed factor series with no explicit weight vector to measure, or the row is a meta-portfolio blend of other rows.") else ""
   )
+
+  # ── Leverage allocator gross-target disclosure note (#626) — dynamically
+  # computed, never hardcoded. Distinct from gross_note above: that note
+  # describes Gross (now) (what a strategy's own construction implements
+  # today); this one describes Gross (target) (what the vol-normalised
+  # allocator would assign) and explicitly flags the backstop level as
+  # PROVISIONAL, per #626 decision D1.
+  leverage_plan_link <- hd_link(
+    htmltools::tags$code("compute_allocator_gross()"),
+    sprintf("%s/blob/%s/R/plan_leverage.R", gh_base, git_sha)
+  )
+  issue_626_link <- htmltools::tags$a(
+    href = "https://github.com/JohnGavin/historical/issues/626",
+    target = "_blank", rel = "noopener noreferrer", "#626"
+  )
+  n_gross_target <- sum(!is.na(full$G_capped))
+  n_binds <- sum(full$backstop_binds, na.rm = TRUE)
+  n_blocked_s31 <- sum(
+    !is.na(full$G_capped) & full$G_capped > 1.0 &
+      (is.na(full$detection_underpowered) | full$detection_underpowered),
+    na.rm = TRUE
+  )
+  sigma_used_vals <- full$sigma_target_used[!is.na(full$sigma_target_used)]
+  backstop_used_vals <- full$backstop_used[!is.na(full$backstop_used)]
+
+  gross_target_note <- if (n_gross_target > 0) {
+    htmltools::tagList(
+      " Gross (target) (", leverage_plan_link, ", ", issue_626_link,
+      ") is the leverage the vol-normalised allocator would assign this build: sigma_target = ",
+      sprintf("%.4f", sigma_used_vals[1]),
+      " divided by each strategy's own vol-per-unit-gross, capped at a PROVISIONAL gross-exposure ",
+      "backstop of ", sprintf("%.1f", backstop_used_vals[1]),
+      "x (issue #626 decision D1 — this LEVEL is not yet finalized; override with HD_LEVERAGE_GROSS_BACKSTOP). ",
+      "The backstop binds for ", n_binds, " strateg", if (n_binds == 1) "y" else "ies", " (", n_gross_target,
+      " strategies have a measurable target). ",
+      if (n_blocked_s31 > 0) {
+        paste0(
+          n_blocked_s31, " strategy row(s) show a BLOCKED badge — QA gate S31 (R/plan_qa_gates.R) forbids ",
+          "actually granting more than 1.0x gross to a detection-underpowered or unverified strategy ",
+          "(detection-power-required.md); the figure displayed is the allocator's raw, unblocked output, ",
+          "shown for transparency only."
+        )
+      } else {
+        "No strategy is currently blocked by the detection-power gate (S31)."
+      }
+    )
+  } else ""
 
   # ── Transaction-cost disclosure note (#624) — dynamically computed, never hardcoded ──
   cost_registry_link <- hd_link(
@@ -649,7 +785,7 @@ if (!is.null(lb)) {
     "CVaR 95% columns share this exact same \"not computed\" scope (", n_net_covered, " of ",
     nrow(full), " strategies covered) — all three come from the same cost_rows join and are ",
     "jointly present or jointly absent per row (QA gate S23, R/plan_qa_gates.R).",
-    flag_note, bias_note, gross_note, cost_note, diversification_note, detection_note,
+    flag_note, bias_note, gross_note, gross_target_note, cost_note, diversification_note, detection_note,
     sharpe_ci_note
   )
 
@@ -679,6 +815,8 @@ if (!is.null(lb)) {
   rig_rank_col  <- which(names(metrics_table) == ".rig_rank") - 1L
   sharpe_col    <- which(names(metrics_table) == "Sharpe") - 1L
   sharpe_rank_col <- which(names(metrics_table) == ".sharpe_rank") - 1L
+  grosstgt_col      <- which(names(metrics_table) == "Gross (target)") - 1L
+  grosstgt_rank_col <- which(names(metrics_table) == ".grosstgt_rank") - 1L
   numeric_cols <- which(sapply(metrics_table, function(x) is.numeric(x) ||
                                   grepl("^[0-9.%$,-]+$", as.character(x[1]))))
 
@@ -701,12 +839,13 @@ if (!is.null(lb)) {
       search = list(regex = TRUE, caseInsensitive = TRUE),
       columnDefs = list(
         list(className = 'dt-right', targets = numeric_cols - 1),
-        list(visible = FALSE, targets = c(cred_rank_col, red_rank_col, det_rank_col, rig_rank_col, sharpe_rank_col)),
+        list(visible = FALSE, targets = c(cred_rank_col, red_rank_col, det_rank_col, rig_rank_col, sharpe_rank_col, grosstgt_rank_col)),
         list(orderData = cred_rank_col, targets = credible_col),
         list(orderData = red_rank_col, targets = redundant_col),
         list(orderData = det_rank_col, targets = det_col),
         list(orderData = rig_rank_col, targets = rig_col),
-        list(orderData = sharpe_rank_col, targets = sharpe_col)
+        list(orderData = sharpe_rank_col, targets = sharpe_col),
+        list(orderData = grosstgt_rank_col, targets = grosstgt_col)
       ),
       initComplete = DT::JS(
         "function(settings, json) {",
@@ -741,6 +880,15 @@ if (!is.null(lb)) {
    det-badge/rig-badge it carries no severity-coded colour variants. */
 .fp-badge { color: #6c757d; font-style: italic; font-weight: 400; white-space: nowrap; }
 .sharpe-ci-flag         { color: #c0392b; font-weight: 700; }
+/* gross-target-badge (#626): mirrors det-badge/rig-badge's severity-coded
+   shape -- ok (below backstop), capped (backstop binds, informational),
+   blocked (QA gate S31 would forbid actually granting this), napp (no
+   measurable allocator input, same population as Gross (now)'s "—"). */
+.gross-target-badge     { font-weight: 600; padding: 1px 6px; border-radius: 3px; white-space: nowrap; }
+.gross-target-badge.ok      { color: #1a7f37; }
+.gross-target-badge.capped  { color: #9a5b00; }
+.gross-target-badge.blocked { color: #fff; background: #c0392b; }
+.gross-target-badge.napp    { color: #6c757d; font-style: italic; font-weight: 400; }
 
 [data-bs-theme="dark"] .det-badge.detectable,   body.dark-mode .det-badge.detectable   { color: #4ade80; }
 [data-bs-theme="dark"] .det-badge.mtfail,       body.dark-mode .det-badge.mtfail       { color: #c084fc; }
@@ -751,6 +899,9 @@ if (!is.null(lb)) {
 [data-bs-theme="dark"] .rig-badge.excluded,     body.dark-mode .rig-badge.excluded     { color: #9ca3af; }
 [data-bs-theme="dark"] .fp-badge,               body.dark-mode .fp-badge               { color: #9ca3af; }
 [data-bs-theme="dark"] .sharpe-ci-flag,         body.dark-mode .sharpe-ci-flag         { color: #ff6b6b; }
+[data-bs-theme="dark"] .gross-target-badge.ok,     body.dark-mode .gross-target-badge.ok     { color: #4ade80; }
+[data-bs-theme="dark"] .gross-target-badge.capped, body.dark-mode .gross-target-badge.capped { color: #fbbf24; }
+[data-bs-theme="dark"] .gross-target-badge.napp,   body.dark-mode .gross-target-badge.napp   { color: #9ca3af; }
 @media (prefers-color-scheme: dark) {
   .det-badge.detectable   { color: #4ade80; }
   .det-badge.mtfail       { color: #c084fc; }
@@ -759,6 +910,8 @@ if (!is.null(lb)) {
   .rig-badge.partial      { color: #fbbf24; }
   .fp-badge                { color: #9ca3af; }
   .sharpe-ci-flag         { color: #ff6b6b; }
+  .gross-target-badge.ok      { color: #4ade80; }
+  .gross-target-badge.capped  { color: #fbbf24; }
 }
 </style>
 ```

--- a/tests/testthat/_snaps/leverage-gross-detection-gate.md
+++ b/tests/testthat/_snaps/leverage-gross-detection-gate.md
@@ -1,0 +1,48 @@
+# check_leverage_gross_detection_gate throws when an underpowered strategy exceeds 1.0x
+
+    Code
+      check_leverage_gross_detection_gate(bad, lb)
+    Condition
+      Error in `check_leverage_gross_detection_gate()`:
+      x 1 strategy/strategies would receive allocator gross above 1.0x while detection-underpowered or unverified (#626/#719 Layer 2, detection-power-required.md):
+      i  Underpowered -- G_capped = 1.50x, detection_underpowered = TRUE
+      i A strategy that cannot be distinguished from a zero Sharpe (or has no verdict at all) must not be levered above 1.0x gross. Either fix the underlying detection verdict, lower the strategy's allocator input (leverage_gross_backstop / HD_LEVERAGE_GROSS_BACKSTOP), or add a written row to LEVERAGE_GROSS_DETECTION_OVERRIDE (R/plan_qa_gates.R) with an explicit reason.
+
+# check_leverage_gross_detection_gate treats a missing (NA) detection verdict as blocking
+
+    Code
+      check_leverage_gross_detection_gate(bad, lb)
+    Condition
+      Error in `check_leverage_gross_detection_gate()`:
+      x 1 strategy/strategies would receive allocator gross above 1.0x while detection-underpowered or unverified (#626/#719 Layer 2, detection-power-required.md):
+      i  Unverified -- G_capped = 1.20x, detection_underpowered = NA (not computed)
+      i A strategy that cannot be distinguished from a zero Sharpe (or has no verdict at all) must not be levered above 1.0x gross. Either fix the underlying detection verdict, lower the strategy's allocator input (leverage_gross_backstop / HD_LEVERAGE_GROSS_BACKSTOP), or add a written row to LEVERAGE_GROSS_DETECTION_OVERRIDE (R/plan_qa_gates.R) with an explicit reason.
+
+# check_leverage_gross_detection_gate throws when allocator_gross is missing required columns
+
+    Code
+      check_leverage_gross_detection_gate(bad, leaderboard_fixture)
+    Condition
+      Error in `check_leverage_gross_detection_gate()`:
+      x `allocator_gross` is missing required column: G_capped.
+      i check_leverage_gross_detection_gate() (S31) needs strategy and G_capped (see compute_allocator_gross()).
+
+# check_leverage_gross_detection_gate throws when leaderboard is missing required columns
+
+    Code
+      check_leverage_gross_detection_gate(allocator_gross, bad_lb)
+    Condition
+      Error in `check_leverage_gross_detection_gate()`:
+      x `leaderboard` is missing required column: detection_underpowered.
+      i check_leverage_gross_detection_gate() (S31) needs strategy, period, and detection_underpowered.
+
+# check_leverage_gross_detection_gate throws when override_tbl is missing required columns
+
+    Code
+      check_leverage_gross_detection_gate(allocator_gross, leaderboard_fixture,
+        override_tbl = bad_override)
+    Condition
+      Error in `check_leverage_gross_detection_gate()`:
+      x `override_tbl` is missing required column(s): strategy, reason.
+      i check_leverage_gross_detection_gate() (S31) requires LEVERAGE_GROSS_DETECTION_OVERRIDE's strategy, reason columns.
+

--- a/tests/testthat/_snaps/leverage.md
+++ b/tests/testthat/_snaps/leverage.md
@@ -68,3 +68,83 @@
       function (vpug_df) 
       NULL
 
+# .leverage_gross_backstop: errors on a non-numeric override
+
+    Code
+      .leverage_gross_backstop("banana")
+    Condition
+      Error in `.leverage_gross_backstop()`:
+      x HD_LEVERAGE_GROSS_BACKSTOP = "banana" is not a positive number.
+      i Unset it to use the default 2x (PROVISIONAL, #626 D1), or set a positive numeric override.
+
+# .leverage_gross_backstop: errors on a non-positive override
+
+    Code
+      .leverage_gross_backstop("0")
+    Condition
+      Error in `.leverage_gross_backstop()`:
+      x HD_LEVERAGE_GROSS_BACKSTOP = "0" is not a positive number.
+      i Unset it to use the default 2x (PROVISIONAL, #626 D1), or set a positive numeric override.
+
+---
+
+    Code
+      .leverage_gross_backstop("-1.5")
+    Condition
+      Error in `.leverage_gross_backstop()`:
+      x HD_LEVERAGE_GROSS_BACKSTOP = "-1.5" is not a positive number.
+      i Unset it to use the default 2x (PROVISIONAL, #626 D1), or set a positive numeric override.
+
+# compute_allocator_gross: errors on missing required columns
+
+    Code
+      compute_allocator_gross(bad, sigma_target = 0.11)
+    Condition
+      Error in `compute_allocator_gross()`:
+      x `vpug_df` is missing required column: is_cap.
+      i compute_allocator_gross() needs strategy, period, vol_per_unit_gross, and is_cap (see compute_vol_per_unit_gross()).
+
+# compute_allocator_gross: errors on a non-positive sigma_target
+
+    Code
+      compute_allocator_gross(vpug, sigma_target = -0.1)
+    Condition
+      Error in `compute_allocator_gross()`:
+      x `sigma_target` must be a single positive number, not -0.1.
+      i compute_allocator_gross() expects the Full Period sigma_target_budget_neutral from compute_budget_neutral_sigma().
+
+---
+
+    Code
+      compute_allocator_gross(vpug, sigma_target = NA_real_)
+    Condition
+      Error in `compute_allocator_gross()`:
+      x `sigma_target` must be a single positive number, not NA.
+      i compute_allocator_gross() expects the Full Period sigma_target_budget_neutral from compute_budget_neutral_sigma().
+
+# compute_allocator_gross: errors on a non-positive backstop
+
+    Code
+      compute_allocator_gross(vpug, sigma_target = 0.11, backstop = 0)
+    Condition
+      Error in `compute_allocator_gross()`:
+      x `backstop` must be a single positive number, not 0.
+      i compute_allocator_gross() expects a positive gross-exposure ceiling -- see LEVERAGE_GROSS_BACKSTOP_DEFAULT (PROVISIONAL, #626 D1).
+
+# compute_allocator_gross: errors when no Full Period rows are present
+
+    Code
+      compute_allocator_gross(no_full, sigma_target = 0.11)
+    Condition
+      Error in `compute_allocator_gross()`:
+      x `vpug_df` has no Full Period rows.
+      i compute_allocator_gross() sizes against the whole available sample, not a sub-partition.
+
+# compute_allocator_gross: function signature is stable (catches API drift)
+
+    Code
+      args(compute_allocator_gross)
+    Output
+      function (vpug_df, sigma_target, backstop = .leverage_gross_backstop()) 
+      NULL
+

--- a/tests/testthat/test-leverage-gross-detection-gate.R
+++ b/tests/testthat/test-leverage-gross-detection-gate.R
@@ -1,0 +1,117 @@
+testthat::local_edition(3)
+# Tests for check_leverage_gross_detection_gate() — QA gate S31
+# (#626/#719 Layer 2 narrow slice, .claude/rules/detection-power-required.md)
+#
+# The function is defined in R/plan_qa_gates.R. It implements the narrow
+# slice of #719's Layer 2 provenance-gating rule that #626's allocator work
+# has enough pieces to enforce today: a strategy may not receive allocator
+# gross (G_capped) above 1.0x while its Full-Period detection_underpowered
+# verdict is TRUE or NA (unverified). NA is deliberately treated the same as
+# TRUE — see the roxygen in R/plan_qa_gates.R for the fail-loud-not-null.md
+# rationale.
+
+source(here::here("R/plan_qa_gates.R"))
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+# "Detectable" clears the detection bar and is levered above 1.0x -- should
+# pass. "Underpowered" fails the detection bar and is levered above 1.0x --
+# should be blocked. "Unverified" has NO detection verdict (NA) and is
+# levered above 1.0x -- should ALSO be blocked (NA treated as TRUE).
+# "UnderCapped" is underpowered but its G_capped is <= 1.0x -- not an
+# offence regardless of detection status.
+allocator_gross <- tibble::tibble(
+  strategy = c("Detectable", "Underpowered", "Unverified", "UnderCapped"),
+  G_capped = c(1.8, 1.5, 1.2, 0.9)
+)
+
+leaderboard_fixture <- tibble::tibble(
+  strategy = c("Detectable", "Underpowered", "Unverified", "UnderCapped", "IgnoredOtherPeriod"),
+  period = c("Full Period", "Full Period", "Full Period", "Full Period", "Training"),
+  detection_underpowered = c(FALSE, TRUE, NA, TRUE, NA)
+)
+
+test_that("check_leverage_gross_detection_gate passes when only detectable strategies exceed 1.0x", {
+  ok <- allocator_gross[allocator_gross$strategy %in% c("Detectable", "UnderCapped"), ]
+  lb <- leaderboard_fixture[leaderboard_fixture$strategy %in% c("Detectable", "UnderCapped", "IgnoredOtherPeriod"), ]
+  expect_true(check_leverage_gross_detection_gate(ok, lb))
+})
+
+test_that("check_leverage_gross_detection_gate does not flag underpowered strategies capped at or below 1.0x", {
+  under_capped <- allocator_gross[allocator_gross$strategy == "UnderCapped", ]
+  lb <- leaderboard_fixture[leaderboard_fixture$strategy == "UnderCapped", ]
+  expect_true(check_leverage_gross_detection_gate(under_capped, lb))
+})
+
+test_that("check_leverage_gross_detection_gate throws when an underpowered strategy exceeds 1.0x", {
+  bad <- allocator_gross[allocator_gross$strategy == "Underpowered", ]
+  lb <- leaderboard_fixture[leaderboard_fixture$strategy == "Underpowered", ]
+  expect_error(check_leverage_gross_detection_gate(bad, lb), regexp = "Underpowered")
+  expect_snapshot(error = TRUE, check_leverage_gross_detection_gate(bad, lb))
+})
+
+test_that("check_leverage_gross_detection_gate treats a missing (NA) detection verdict as blocking", {
+  bad <- allocator_gross[allocator_gross$strategy == "Unverified", ]
+  lb <- leaderboard_fixture[leaderboard_fixture$strategy == "Unverified", ]
+  expect_error(check_leverage_gross_detection_gate(bad, lb), regexp = "Unverified")
+  expect_snapshot(error = TRUE, check_leverage_gross_detection_gate(bad, lb))
+})
+
+test_that("check_leverage_gross_detection_gate only scopes detection verdicts to Full Period rows", {
+  # IgnoredOtherPeriod has no Full Period row in leaderboard_fixture, so the
+  # left_join produces NA detection_underpowered for it if present in
+  # allocator_gross -- exercised implicitly by every test above via
+  # left_join's NA-on-no-match behaviour. This test makes the scoping
+  # explicit: a strategy present ONLY as a Training row must not borrow a
+  # Full Period verdict it doesn't have.
+  fixture <- tibble::tibble(strategy = "OnlyTraining", G_capped = 1.5)
+  lb <- tibble::tibble(
+    strategy = "OnlyTraining", period = "Training", detection_underpowered = FALSE
+  )
+  expect_error(check_leverage_gross_detection_gate(fixture, lb), regexp = "OnlyTraining")
+})
+
+test_that("check_leverage_gross_detection_gate respects a declared override", {
+  bad <- allocator_gross[allocator_gross$strategy == "Underpowered", ]
+  lb <- leaderboard_fixture[leaderboard_fixture$strategy == "Underpowered", ]
+  override <- tibble::tibble(strategy = "Underpowered", reason = "test override")
+  expect_true(check_leverage_gross_detection_gate(bad, lb, override_tbl = override))
+})
+
+test_that("check_leverage_gross_detection_gate ignores strategies with no measurable G_capped", {
+  na_gross <- tibble::tibble(strategy = "Underpowered", G_capped = NA_real_)
+  lb <- leaderboard_fixture[leaderboard_fixture$strategy == "Underpowered", ]
+  expect_true(check_leverage_gross_detection_gate(na_gross, lb))
+})
+
+# ── Required columns ────────────────────────────────────────────────────
+
+test_that("check_leverage_gross_detection_gate throws when allocator_gross is missing required columns", {
+  bad <- dplyr::select(allocator_gross, -G_capped)
+  expect_error(
+    check_leverage_gross_detection_gate(bad, leaderboard_fixture),
+    regexp = "G_capped"
+  )
+  expect_snapshot(error = TRUE, check_leverage_gross_detection_gate(bad, leaderboard_fixture))
+})
+
+test_that("check_leverage_gross_detection_gate throws when leaderboard is missing required columns", {
+  bad_lb <- dplyr::select(leaderboard_fixture, -detection_underpowered)
+  expect_error(
+    check_leverage_gross_detection_gate(allocator_gross, bad_lb),
+    regexp = "detection_underpowered"
+  )
+  expect_snapshot(error = TRUE, check_leverage_gross_detection_gate(allocator_gross, bad_lb))
+})
+
+test_that("check_leverage_gross_detection_gate throws when override_tbl is missing required columns", {
+  bad_override <- tibble::tibble(strategy = character(0))
+  expect_error(
+    check_leverage_gross_detection_gate(allocator_gross, leaderboard_fixture, override_tbl = bad_override),
+    regexp = "reason"
+  )
+  expect_snapshot(
+    error = TRUE,
+    check_leverage_gross_detection_gate(allocator_gross, leaderboard_fixture, override_tbl = bad_override)
+  )
+})

--- a/tests/testthat/test-leverage.R
+++ b/tests/testthat/test-leverage.R
@@ -200,3 +200,119 @@ test_that("compute_regime_stress_ratio: errors when Training/Testing partitions 
 test_that("compute_regime_stress_ratio: function signature is stable (catches API drift)", {
   expect_snapshot(args(compute_regime_stress_ratio))
 })
+
+# ── .leverage_gross_backstop() (#626) ───────────────────────────────────────
+
+test_that(".leverage_gross_backstop: returns the default when the env var is unset", {
+  expect_equal(.leverage_gross_backstop(""), LEVERAGE_GROSS_BACKSTOP_DEFAULT)
+})
+
+test_that(".leverage_gross_backstop: honours a valid positive numeric override", {
+  expect_equal(.leverage_gross_backstop("2.75"), 2.75)
+})
+
+test_that(".leverage_gross_backstop: errors on a non-numeric override", {
+  expect_snapshot(error = TRUE, .leverage_gross_backstop("banana"))
+})
+
+test_that(".leverage_gross_backstop: errors on a non-positive override", {
+  expect_snapshot(error = TRUE, .leverage_gross_backstop("0"))
+  expect_snapshot(error = TRUE, .leverage_gross_backstop("-1.5"))
+})
+
+# ── compute_allocator_gross() (#626) ────────────────────────────────────────
+# Full Period rows from .leaderboard_fixture(): A (vol=0.11, gross=2),
+# B (vol=0.22, gross=1), C (vol=0.05, gross=1), D (vol=0.33, gross=2).
+# vol_per_unit_gross: A=0.055, B=0.22, C=0.05, D=0.165.
+# Using sigma_target = 0.11 (chosen for easy hand-verification, not the
+# fixture's own budget-neutral value):
+#   G_implied: A = 0.11/0.055 = 2.0, B = 0.11/0.22 = 0.5,
+#              C = 0.11/0.05  = 2.2, D = 0.11/0.165 = 0.6667
+# With backstop = 1.5: A and C exceed it (G_capped = 1.5, backstop_binds = TRUE);
+# B and D do not (G_capped == G_implied, backstop_binds = FALSE).
+
+test_that("compute_allocator_gross: computes G_implied = sigma_target / vol_per_unit_gross", {
+  vpug <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  out <- compute_allocator_gross(vpug, sigma_target = 0.11, backstop = 1.5)
+
+  b_row <- out[out$strategy == "B", ]
+  expect_equal(b_row$G_implied, 0.5, tolerance = 1e-9)
+  d_row <- out[out$strategy == "D", ]
+  expect_equal(d_row$G_implied, 0.11 / (0.33 / 2), tolerance = 1e-9)
+})
+
+test_that("compute_allocator_gross: caps G_capped at the backstop and flags backstop_binds", {
+  vpug <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  out <- compute_allocator_gross(vpug, sigma_target = 0.11, backstop = 1.5)
+
+  a_row <- out[out$strategy == "A", ]
+  expect_equal(a_row$G_implied, 2.0, tolerance = 1e-9)
+  expect_equal(a_row$G_capped, 1.5, tolerance = 1e-9)
+  expect_true(a_row$backstop_binds)
+
+  b_row <- out[out$strategy == "B", ]
+  expect_equal(b_row$G_capped, b_row$G_implied, tolerance = 1e-9)
+  expect_false(b_row$backstop_binds)
+})
+
+test_that("compute_allocator_gross: only Full Period rows are returned", {
+  vpug <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  out <- compute_allocator_gross(vpug, sigma_target = 0.11, backstop = 1.5)
+  expect_false(any(c("Training", "Testing") %in% out$strategy))
+  expect_equal(sort(out$strategy), c("A", "B", "C", "D"))
+})
+
+test_that("compute_allocator_gross: is_cap is carried through unchanged", {
+  vpug <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  out <- compute_allocator_gross(vpug, sigma_target = 0.11, backstop = 1.5)
+  b_row <- out[out$strategy == "B", ]
+  expect_true(b_row$is_cap)
+})
+
+test_that("compute_allocator_gross: sorted descending by G_implied", {
+  vpug <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  out <- compute_allocator_gross(vpug, sigma_target = 0.11, backstop = 1.5)
+  expect_true(all(diff(out$G_implied) <= 0))
+  expect_equal(out$strategy[1], "C")  # highest G_implied (2.2)
+})
+
+test_that("compute_allocator_gross: backstop_used/sigma_target_used echo the inputs", {
+  vpug <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  out <- compute_allocator_gross(vpug, sigma_target = 0.11, backstop = 1.5)
+  expect_true(all(out$backstop_used == 1.5))
+  expect_true(all(out$sigma_target_used == 0.11))
+})
+
+test_that("compute_allocator_gross: errors on missing required columns", {
+  bad <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  bad$is_cap <- NULL
+  expect_snapshot(error = TRUE, compute_allocator_gross(bad, sigma_target = 0.11))
+})
+
+test_that("compute_allocator_gross: errors on a non-positive sigma_target", {
+  vpug <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  expect_snapshot(error = TRUE, compute_allocator_gross(vpug, sigma_target = -0.1))
+  expect_snapshot(error = TRUE, compute_allocator_gross(vpug, sigma_target = NA_real_))
+})
+
+test_that("compute_allocator_gross: errors on a non-positive backstop", {
+  vpug <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  expect_snapshot(error = TRUE, compute_allocator_gross(vpug, sigma_target = 0.11, backstop = 0))
+})
+
+test_that("compute_allocator_gross: errors when no Full Period rows are present", {
+  vpug <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  no_full <- vpug[vpug$period != "Full Period", ]
+  expect_snapshot(error = TRUE, compute_allocator_gross(no_full, sigma_target = 0.11))
+})
+
+test_that("compute_allocator_gross: default backstop is .leverage_gross_backstop()", {
+  vpug <- compute_vol_per_unit_gross(.leaderboard_fixture())
+  withr::local_envvar(c(HD_LEVERAGE_GROSS_BACKSTOP = "3"))
+  out <- compute_allocator_gross(vpug, sigma_target = 0.11)
+  expect_true(all(out$backstop_used == 3))
+})
+
+test_that("compute_allocator_gross: function signature is stable (catches API drift)", {
+  expect_snapshot(args(compute_allocator_gross))
+})


### PR DESCRIPTION
## Summary

Production implementation of the leverage allocator (#626), following the
Phase 0 sign-off in #827's prototype. This is the real thing, wired into
`docs/_targets.R` -- not a throwaway.

- **Allocator** (`R/plan_leverage.R`): `compute_allocator_gross()` computes
  per-strategy Full Period `G_implied = sigma_target / vol_per_unit_gross`,
  capped at a gross-exposure backstop. New targets: `leverage_gross_backstop`,
  `leverage_allocator_gross`.
- **Backstop is explicitly PROVISIONAL** (#626 decision D1 is still open):
  default 2.0x, a `targets` target (not a bare constant) so it shows up in
  `tar_meta()`, overridable via `HD_LEVERAGE_GROSS_BACKSTOP` with eager
  validation (a malformed value `cli_abort()`s rather than silently falling
  back, per `fail-loud-not-null.md`).
- **QA gate S31** (`R/plan_qa_gates.R`, `check_leverage_gross_detection_gate`):
  implements the narrow slice of #719 Layer 2 that `detection-power-required.md`
  already specifies verbatim -- *"A strategy may not receive gross above 1.0x
  while `detection_underpowered` is TRUE or NA."* `NA` is deliberately treated
  the same as `TRUE` (an unverified strategy is not licensed to lever just
  because nobody checked). Overridable via `LEVERAGE_GROSS_DETECTION_OVERRIDE`
  (empty by design -- no override has been reviewed against real data yet).
- **Dashboard** (`docs/leaderboard.qmd`): renames the existing `Gross` column
  to `Gross (now)` and adds one new `Gross (target)` badge column immediately
  beside it -- consolidating the prototype's own three proposed raw columns
  (Implied G_i / G_i @ backstop / Backstop binds?) into one badge, the same
  "one column, not three" simplification `falsification.qmd`'s
  Detection/Rigour precedent (#726/#728) already established. A strategy
  blocked by S31 shows a red BLOCKED badge with the raw (unblocked) figure
  disclosed for transparency, never presented as what would actually be
  granted. A dynamically-computed disclosure note states the current
  sigma_target, the PROVISIONAL backstop value, how many strategies it binds
  for, and how many are currently S31-blocked.
- **`docs/DASHBOARDS.md`**: updated inventory row + a Step-5 consolidation
  decision entry. Dashboard count unchanged at 11; ranking-table column count
  grows by one (not three).
- **Full TDD**: `compute_allocator_gross()`, `.leverage_gross_backstop()`, and
  `check_leverage_gross_detection_gate()` each have dedicated unit tests, plus
  `expect_snapshot()` coverage for every new `cli_abort()` message per
  `snapshot-test-policy.md`.

## Done vs remaining

**Done:**
- Layered allocator (vol-normalised sizing + gross-exposure backstop),
  matching #626's adopted design and rejecting the net-exposure/cash-borrow
  alternatives per the comment-thread confirmation.
- Live `sigma_target` reuse from `leverage_sigma_target` (#635/#824) -- no
  hardcoded value.
- Detection-power gating (S31) as specified by `detection-power-required.md`'s
  allocation-gating rule, wired against the real `detection_underpowered`
  column.
- Dashboard wiring into the real `leaderboard.qmd`, not a prototype.
- `scripts/verify.sh` full run: **exit 0**. Root suite 1009 total, 3 failed
  (matches the documented baseline exactly, 0 unexpected), 0 skipped. Package
  suite 857 total, 1 failed (matches baseline), 15 skipped (matches baseline).
  testthat edition 3 active. `docs/_targets.R` parses and `tar_validate()`s
  structurally clean.

**Remaining / explicitly NOT closed by this PR:**
- **#626 decision D1 (the backstop LEVEL) is still open.** This PR ships a
  clearly-labelled, overridable 2.0x default -- it does not decide D1. The
  #827 prototype's live read found a p90-based candidate nearer 1.8x-2.0x
  (materially below the stale 3.5x figure #626's 2026-08-05 hand-derivation
  used, before the #717/#722 CMR fixes), but that is evidence for D1's
  eventual decision, not this PR's decision to make.
- **#719 Layer 2's full provenance checklist remains separately scoped.**
  S31 implements only the detection-power slice explicitly named in
  `detection-power-required.md`. The remaining Layer 2 provenance facts are
  not enforced here.
- The #827 prototype's regime-stress-ratio table and relationship-diagram
  extension (`dag-portcons-mount` in `causal-diagrams.js`) are **not** wired
  into any dashboard in this pass -- `compute_regime_stress_ratio()` already
  existed pre-#626 and remains available for a follow-up.
- **Runtime confirmation against the live targets store still needs
  `scripts/build.sh` in the main checkout** (same caveat as other
  pipeline-body PRs this session) -- this worktree has no `docs/_targets`
  store, so `verify.sh`'s structural pass is necessary but not sufficient
  proof the pipeline builds clean end-to-end. Per `.claude/CLAUDE.md`'s
  verification table, `verify.sh` proves structure; only `build.sh` proves
  target bodies actually run.
- Per the same PR's precedent (#735 -> #741), the #827 prototype PR should be
  closed/its throwaway `.qmd` removed once this PR lands, to avoid the
  prototype outliving its production replacement.

## Test plan

- [x] `scripts/verify.sh` (full mode) -- exit 0, output attached below
- [x] Unit tests for `compute_allocator_gross()`, `.leverage_gross_backstop()`
- [x] Unit tests for `check_leverage_gross_detection_gate()` (S31), including
      the NA-treated-as-TRUE case and the override path
- [x] Snapshot coverage for every new `cli_abort()` message
- [ ] `scripts/build.sh` against the live store (main checkout only -- not run
      from this worktree per `agent-identity-and-task-scopes`)
- [ ] Manual render of `docs/leaderboard.qmd` to visually confirm the new
      badge column and disclosure note (no render-time check exists yet for
      `tar_read()` chunks, per `.claude/CLAUDE.md`'s documented gap)

```
=== root suite (tests/testthat/, 3 known baseline failure(s), issue #569) ===
SKIP count this run: 0
PASS: failures match the known baseline exactly

=== package suite (packages/historicaldata/, 1 known baseline failure(s), issue #569) ===
SKIP count this run: 15
PASS: failures match the known baseline exactly

=== scripts/verify.sh: PASS ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
